### PR TITLE
Feature/bsk 69 fix hub position in thruster module

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -34,6 +34,7 @@ Version |release|
 -----------------
 - Refactored :ref:`keplerianOrbit` to not depend on the ``gravityEffector`` class
 - Updated Basilisk install documentation to discuss accessing source code from GitHub.com
+- Fixed an issue where attaching a thruster to a body different than the hub when using ``zeroBase`` would yield very large offsets.
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
@@ -177,7 +177,8 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
     #  Create a Simulation
     testRate = int(rate) # Parametrized rate of test
     TotalSim = SimulationBaseClass.SimBaseClass()
-    #Create a new process for the unit test task and add the module to tasking
+
+    # Create a new process for the unit test task and add the module to tasking
     testProc = TotalSim.CreateNewProcess(unitProcessName)
     testProc.addTask(TotalSim.CreateNewTask(unitTaskName, testRate))
     TotalSim.AddModelToTask(unitTaskName, thrusterSet)
@@ -209,6 +210,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
     TotalSim.InitializeSimulation()
 
     #Configure the hub and link states
+    TotalSim.newManager.createProperty("r_BN_N", [[0], [0], [0]])  # manually create the property
     TotalSim.scObject.hub.registerStates(TotalSim.newManager)
     thrusterSet.linkInStates(TotalSim.newManager)
 

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -184,7 +184,7 @@ void ThrusterDynamicEffector::ConfigureThrustRequests(double currentTime)
 void ThrusterDynamicEffector::UpdateThrusterProperties()
 {
     // Save hub variables
-    Eigen::Vector3d r_BN_N = this->hubPosition->getState();
+    Eigen::Vector3d r_BN_N = (Eigen::Vector3d)*this->inertialPositionProperty;
     Eigen::Vector3d omega_BN_B = this->hubOmega->getState();
     Eigen::MRPd sigma_BN;
     sigma_BN = (Eigen::Vector3d)this->hubSigma->getState();
@@ -234,7 +234,7 @@ void ThrusterDynamicEffector::UpdateThrusterProperties()
 void ThrusterDynamicEffector::linkInStates(DynParamManager& states){
     this->hubSigma = states.getStateObject("hubSigma");
 	this->hubOmega = states.getStateObject("hubOmega");
-    this->hubPosition = states.getStateObject("hubPosition");
+    this->inertialPositionProperty = states.getPropertyReference("r_BN_N");
 }
 
 /*! This method computes the Forces on Torque on the Spacecraft Body.

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h
@@ -74,7 +74,8 @@ public:
 		std::vector<THRTimePair> *thrRamp);
 	StateData *hubSigma;                           //!< pointer to the hub attitude states
     StateData *hubOmega;                           //!< pointer to the hub angular velocity states
-    StateData *hubPosition;                        //!< pointer to the hub position states
+    Eigen::MatrixXd* inertialPositionProperty;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
+
     BSKLogger bskLogger;                      //!< -- BSK Logging
 
 private:

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -195,7 +195,7 @@ void ThrusterStateEffector::ConfigureThrustRequests()
 void ThrusterStateEffector::UpdateThrusterProperties()
 {
     // Save hub variables
-    Eigen::Vector3d r_BN_N = this->hubPosition->getState();
+    Eigen::Vector3d r_BN_N = (Eigen::Vector3d)*this->inertialPositionProperty;
     Eigen::Vector3d omega_BN_B = this->hubOmega->getState();
     Eigen::MRPd sigma_BN;
     sigma_BN = (Eigen::Vector3d) this->hubSigma->getState();
@@ -296,7 +296,7 @@ void ThrusterStateEffector::addThruster(THRSimConfig* newThruster, Message<SCSta
 void ThrusterStateEffector::linkInStates(DynParamManager& states){
     this->hubSigma = states.getStateObject("hubSigma");
 	this->hubOmega = states.getStateObject("hubOmega");
-    this->hubPosition = states.getStateObject("hubPosition");
+    this->inertialPositionProperty = states.getPropertyReference(this->nameOfSpacecraftAttachedTo + "r_BN_N");
 }
 
 /*! This method allows the thruster state effector to register its state kappa with the dyn param manager */

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
@@ -76,8 +76,9 @@ public:
     // State structures
 	StateData *hubSigma;        //!< pointer to hub attitude states
     StateData *hubOmega;        //!< pointer to hub angular velocity states
-    StateData* hubPosition;        //!< pointer to hub position states
     StateData* kappaState;      //!< -- state manager of theta for hinged rigid body
+    Eigen::MatrixXd* inertialPositionProperty;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
+
     BSKLogger bskLogger;        //!< -- BSK Logging
 
     // Mass flow rate


### PR DESCRIPTION
* **Tickets addressed:** bsk-69
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The changes lie with the way the module retrieves the variable r_BN_N. Previously, this was pulled from "hubPosition", but that doesn't account for the zeroBase command. Instead, a pointer to the r_BN_N property is used, which does account for the gravitational body used as zeroBase. Both thrusterStateEffector and thrusterDynamicEffector are affected by this, and each is addressed in their own commit.
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->

## Verification
Updated the thrusterDynamicsUnit test. Had to manually create the r_BN_N property because the test doesn't run the simulation.
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->

## Documentation
No documentation was changed, as this was a bug fix.
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->

## Future work
No further steps.
<!-- What next steps can we anticipate from here, if any? -->
