### PR TITLE
Fix for case when input data path longer than receiving array size

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -38,6 +38,8 @@ Version |release|
 - Added documentation in :ref:`bskPrinciples-4` on how to read the current message values
 - Highlighted the challege of setting up a ``recorder`` on a re-directed message in :ref:`bskPrinciples-7`
 - added the ability to add a ``recorder()`` to a C-wrapped module input message
+- Fix an issue in in :ref:`magneticFieldWMM` where a fixed width array holding a file path would result in a cutoff
+    path when basilisk is located in a directory path of greater than 100 characters.
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -24,7 +24,6 @@
 
 #define MAX_CHAR_LENGTH 100
 
-
 /*! The constructor method initializes the dipole parameters to zero, resuling in a zero magnetic field result by default.
  @return void
  */
@@ -45,7 +44,6 @@ MagneticFieldWMM::~MagneticFieldWMM()
         cleanupEarthMagFieldModel();
     }
 }
-
 
 /*! Custom Reset() method.  This loads the WMM coefficient file and gets the model setup.
  @return void
@@ -89,7 +87,7 @@ void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *g
     char Error[255];
     calendar.DecimalYear = this->epochDateFractionalYear;
     MAG_YearToDate(&calendar);
-    gregorian->tm_year = calendar.Year- 1900;
+    gregorian->tm_year = calendar.Year - 1900;
     gregorian->tm_mon = calendar.Month - 1;
     gregorian->tm_mday = calendar.Day;
 
@@ -102,15 +100,15 @@ void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *g
     //! - determine missing hours
     MAG_DateToYear(&calendar, Error);
     double diff = this->epochDateFractionalYear - calendar.DecimalYear;
-    this->epochDateTime.tm_hour = (int) round(diff*(24.*daysInYear));
+    this->epochDateTime.tm_hour = (int) round(diff * (24. * daysInYear));
     diff -= this->epochDateTime.tm_hour / ( 24. * daysInYear);
 
     //! - determine missing minutes
-    this->epochDateTime.tm_min = (int) round(diff*(24.*60*daysInYear));
+    this->epochDateTime.tm_min = (int) round(diff * (24. * 60 * daysInYear));
     diff -= this->epochDateTime.tm_min / (24. * 60 * daysInYear);
 
     //! - determine missing seconds
-    this->epochDateTime.tm_sec = (int) round(diff*(24.*60*60*daysInYear));
+    this->epochDateTime.tm_sec = (int) round(diff * (24. * 60 * 60 * daysInYear));
 
     //! - ensure that daylight saving flag is off
     this->epochDateTime.tm_isdst = 0;
@@ -154,7 +152,6 @@ double MagneticFieldWMM::gregorian2DecimalYear(double currentTime)
     return decimalYear;
 }
 
-
 /*! This method is evaluates the centered dipole magnetic field model.
  @param msg magnetic field message structure
  @param currentTime current time (s)
@@ -197,7 +194,6 @@ void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, 
     m33MultV3(NM, B_M, msg->magField_N);
 }
 
-
 /*! Performs memory cleanup necessary for magnetic field models
  @return void
  */
@@ -206,7 +202,6 @@ void MagneticFieldWMM::cleanupEarthMagFieldModel()
     MAG_FreeMagneticModelMemory(timedMagneticModel);
     MAG_FreeMagneticModelMemory(magneticModels[0]);
 }
-
 
 void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double lambda, double h, double B_M[3])
 {
@@ -238,7 +233,6 @@ void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double la
 
     v3Scale(1e-9, B_M, B_M); /* convert nano-Tesla to Tesla */
 }
-
 
 void MagneticFieldWMM::initializeWmm(const char *dataPath)
 {

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -172,7 +172,7 @@ void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, 
     double M2[3][3];                    // []    2nd axis rotation DCM
     double M3[3][3];                    // []    3rd axis rotation DCM
 
-    if (this->magneticModels[0] == NULL) {
+    if (this->magneticModels[0] == nullptr) {
         // no magnetic field was setup, set field to zero and return
         v3SetZero(msg->magField_N);
         return;
@@ -263,7 +263,7 @@ void MagneticFieldWMM::initializeWmm(const char *dataPath)
     nTerms = ((nMax + 1) * (nMax + 2) / 2);
     /* For storing the time modified WMM Model parameters */
     this->timedMagneticModel = MAG_AllocateModelMemory(nTerms);
-    if(this->magneticModels[0] == NULL || this->timedMagneticModel == NULL) {
+    if(this->magneticModels[0] == nullptr || this->timedMagneticModel == nullptr) {
         MAG_Error(2);
     }
     /* Set default values and constants */

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -125,7 +125,7 @@ void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *g
 double MagneticFieldWMM::gregorian2DecimalYear(double currentTime)
 {
     double decimalYear;                 // [years]  fraction year date/time format
-    struct tm localDateTime;            // []       date/time structure
+    struct tm localDateTime{};            // []       date/time structure
 
     //! - compute current decimalYear value
     MAGtype_Date calendar;
@@ -210,10 +210,10 @@ void MagneticFieldWMM::cleanupEarthMagFieldModel()
 
 void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double lambda, double h, double B_M[3])
 {
-    MAGtype_CoordSpherical      coordSpherical;
-    MAGtype_CoordGeodetic       coordGeodetic;
-    MAGtype_GeoMagneticElements geoMagneticElements;
-    MAGtype_GeoMagneticElements errors;
+    MAGtype_CoordSpherical      coordSpherical{};
+    MAGtype_CoordGeodetic       coordGeodetic{};
+    MAGtype_GeoMagneticElements geoMagneticElements{};
+    MAGtype_GeoMagneticElements errors{};
 
     this->userDate.DecimalYear = decimalYear;
 

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -34,8 +34,6 @@ MagneticFieldWMM::MagneticFieldWMM()
     this->planetRadius = REQ_EARTH*1000.;   // must be the radius of Earth for WMM
     this->magneticModels[0] = nullptr;      // a nullptr means no WMM coefficients have been loaded
     this->epochDateFractionalYear = -1;     // negative value means this variable has not been set
-
-    return;
 }
 
 /*! Clean up any memory allocations.
@@ -46,8 +44,6 @@ MagneticFieldWMM::~MagneticFieldWMM()
     if (this->magneticModels[0] != nullptr) {
         cleanupEarthMagFieldModel();
     }
-
-    return;
 }
 
 
@@ -70,8 +66,6 @@ void MagneticFieldWMM::customReset(uint64_t CurrentClock)
 
     //! - Initialize the WMM evaluation routines
     initializeWmm(this->dataPath.c_str());
-
-    return;
 }
 
 /*! Custom customSetEpochFromVariable() method.  This allows specifying epochDateFractionYear directly from Python.  If an epoch message is set then this variable is not used.
@@ -83,8 +77,6 @@ void MagneticFieldWMM::customSetEpochFromVariable()
     if (this->epochDateFractionalYear > 0.0) {
         decimalYear2Gregorian(this->epochDateFractionalYear, &this->epochDateTime);
     }
-
-    return;
 }
 
 /*! Convert a fraction year double value into a time structure with gregorian date/time information
@@ -125,8 +117,6 @@ void MagneticFieldWMM::decimalYear2Gregorian(double fractionalYear, struct tm *g
 
     //! - make sure a proper time structure is setup
     mktime(&this->epochDateTime);
-
-    return;
 }
 
 /*! Convert a time structure with gregorian date/time information into a fraction year value.
@@ -205,8 +195,6 @@ void MagneticFieldWMM::evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, 
     m33MultM33(M3, M2, PM);
     m33tMultM33(this->planetState.J20002Pfix, PM, NM);
     m33MultV3(NM, B_M, msg->magField_N);
-
-    return;
 }
 
 
@@ -253,8 +241,6 @@ void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double la
     v3Set(geoMagneticElements.X, geoMagneticElements.Y, geoMagneticElements.Z, B_M);
 
     v3Scale(1e-9, B_M, B_M); /* convert nano-Tesla to Tesla */
-
-    return;
 }
 
 

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -22,8 +22,6 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "EGM9615.h"
 
-#define MAX_CHAR_LENGTH 100
-
 /*! The constructor method initializes the dipole parameters to zero, resuling in a zero magnetic field result by default.
  @return void
  */
@@ -63,7 +61,7 @@ void MagneticFieldWMM::customReset(uint64_t CurrentClock)
     }
 
     //! - Initialize the WMM evaluation routines
-    initializeWmm(this->dataPath.c_str());
+    initializeWmm();
 }
 
 /*! Custom customSetEpochFromVariable() method.  This allows specifying epochDateFractionYear directly from Python.  If an epoch message is set then this variable is not used.
@@ -234,16 +232,16 @@ void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double la
     v3Scale(1e-9, B_M, B_M); /* convert nano-Tesla to Tesla */
 }
 
-void MagneticFieldWMM::initializeWmm(const char *dataPath)
+void MagneticFieldWMM::initializeWmm()
 {
-    char fileName[MAX_CHAR_LENGTH];
     int nMax = 0;
     int nTerms;
+    auto fileName = this->dataPath + "WMM.COF";
 
-    strcpy(fileName, dataPath);
-    strcat(fileName, "WMM.COF");
-    if (!MAG_robustReadMagModels(fileName, &(this->magneticModels), 1)) {
-        bskLogger.bskLog(BSK_ERROR, "WMM unable to load file %s", fileName);
+    if (!MAG_robustReadMagModels(const_cast<char*>(fileName.c_str()),
+                                 &(this->magneticModels),
+                                 1)) {
+        bskLogger.bskLog(BSK_ERROR, "WMM unable to load file %s", fileName.c_str());
         return;
     }
 

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.cpp
@@ -224,10 +224,6 @@ void MagneticFieldWMM::computeWmmField(double decimalYear, double phi, double la
     coordGeodetic.HeightAboveEllipsoid = h; /* km */
 
     this->geoid.UseGeoid = 0;
-    /* If height is given above MSL */
-    //coordGeodetic.HeightAboveGeoid = h; /* km */
-    //geoid.UseGeoid = 1;
-    //MAG_ConvertGeoidToEllipsoidHeight(&coordGeodetic, &geoid);
 
     /* Convert from geodetic to Spherical Equations: 17-18, WMM Technical report */
     MAG_GeodeticToSpherical(this->ellip, coordGeodetic, &coordSpherical);

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.h
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.h
@@ -37,7 +37,7 @@ public:
 
 private:
     void evaluateMagneticFieldModel(MagneticFieldMsgPayload *msg, double currentTime);
-    void initializeWmm(const char *dataPath);
+    void initializeWmm();
     void cleanupEarthMagFieldModel();
     void computeWmmField(double decimalYear, double phi, double lambda, double h, double B_M[3]);
     void customReset(uint64_t CurrentClock);

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.h
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.h
@@ -27,7 +27,7 @@
 #include "architecture/utilities/astroConstants.h"
 #include "GeomagnetismHeader.h"
 #include "architecture/utilities/bskLogging.h"
-#include <time.h>
+#include <ctime>
 
 /*! @brief magnetic field WMM class */
 class MagneticFieldWMM:  public MagneticFieldBase {

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.h
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.h
@@ -16,8 +16,6 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-
-
 #ifndef WMM_MAGNETIC_FIELD_H
 #define WMM_MAGNETIC_FIELD_H
 
@@ -46,14 +44,14 @@ private:
     void customSetEpochFromVariable();
     void decimalYear2Gregorian(double fractionalYear, struct tm *gregorian);
     double gregorian2DecimalYear(double currentTime);
+
 public:
     std::string dataPath;                   //!< -- String with the path to the WMM coefficient file
     double      epochDateFractionalYear;    //!< Specified epoch date as a fractional year
-    BSKLogger bskLogger;                      //!< -- BSK Logging
-
+    BSKLogger bskLogger;                    //!< -- BSK Logging
 
 private:
-    MAGtype_MagneticModel * magneticModels[1];
+    MAGtype_MagneticModel *magneticModels[1];
     MAGtype_MagneticModel *timedMagneticModel;
     MAGtype_Ellipsoid      ellip;
     MAGtype_Geoid          geoid;


### PR DESCRIPTION
* **Tickets addressed:** resolves #74 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The fileName local variable in `MagneticFieldWMM::initializeWmm` is a fixed length char array. When basilisk is located in a folder tree depth whith a path string length of great than the fixed 100 characters, the module fails to find the WMM.COF because the path is malformed (cut off). The first seven commits are general clean up. The last commit is the fix. The char array has been changed to a std::string and the `MagneticFieldWMM::initializeWmm` signature has been adjusted with the redundant parameter removed.

## Verification
The issue is demonstrable before the fix. All tests pass after the fix. There's no need for a specific test as the existing integrated tests exercise the code path with loads the WMM.COF file.

## Documentation
No changes needed.

## Future work
A quick look through the code base shows other locations where this same issue could occur, or general the use of fixed size char arrays may pose a problem/danger. I'll raise a separate ticket for each case.
