### PR TITLE
Remove utility libraries from sim_model

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -39,9 +39,13 @@ Version |release|
 - Highlighted the challege of setting up a ``recorder`` on a re-directed message in :ref:`bskPrinciples-7`
 - added the ability to add a ``recorder()`` to a C-wrapped module input message
 - Fix an issue in in :ref:`magneticFieldWMM` where a fixed width array holding a file path would result in a cutoff
-    path when basilisk is located in a directory path of greater than 100 characters.
+  path when basilisk is located in a directory path of greater than 100 characters.
 - Updated the build system to use newer versions of ``eigen``, ``protobuf``, ``cppzmq``
   and ``opencv``.  This corrects some build issues with new compilers.
+- The ``linearAlgebra``, ``rigidBodyKinematics``, ``orbitalMotion`` were mistakenly exposed as part of the
+  :ref:`sim_model` module's API. They have been removed and the functions they provided are still found in
+  ``Basilisk.utilities.orbitalMotion``, ``Basilisk.architecture.linearAlgebra``, and
+  ``Basilisk.architecture.rigidBodyKinematics``.
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/src/architecture/system_model/sim_model.i
+++ b/src/architecture/system_model/sim_model.i
@@ -19,9 +19,6 @@
 %module sim_model
 %{
    #include "sim_model.h"
-   #include "architecture/utilities/linearAlgebra.h"
-   #include "architecture/utilities/rigidBodyKinematics.h"
-   #include "architecture/utilities/orbitalMotion.h"
 %}
 
 %include "std_vector.i"
@@ -79,8 +76,4 @@ namespace std {
 %include "sys_model_task.h"
 %include "sys_model.h"
 %include "sys_process.h"
-%include "architecture/utilities/linearAlgebra.h"
-%include "architecture/utilities/rigidBodyKinematics.h"
-%include "architecture/utilities/orbitalMotion.h"
-%include "architecture/msgPayloadDefC/ClassicElementsMsgPayload.h"
 %include "sim_model.h"

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
@@ -115,14 +115,13 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         OmegaArray.append(orbEl.Omega)
         omegaArray.append(orbEl.omega)
         if anomFlag == 1:
-            currentAnom = orbitalMotion.E2M(orbitalMotion.f2E(orbEl.f,orbEl.e),orbEl.e)
+            currentAnom = orbitalMotion.E2M(orbitalMotion.f2E(orbEl.f, orbEl.e), orbEl.e)
         else:
             currentAnom = orbEl.f
         if currentAnom < anomPrev:
             anomCount += 1
         anomArray.append(2*math.pi*anomCount + currentAnom)
         anomPrev = currentAnom
-
 
     tdrssPosList = numpy.array(tdrssPosList)
     tdrssVelList = numpy.array(tdrssVelList)
@@ -161,13 +160,13 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
     oeStateModel.ephArray[0].nChebCoeff = degChebCoeff + 1
     oeStateModel.ephArray[0].ephemTimeMid = etStart + curveDurationSeconds/2.0
     oeStateModel.ephArray[0].ephemTimeRad = curveDurationSeconds/2.0
+
     if not (anomFlag == -1):
         oeStateModel.ephArray[0].anomalyFlag = anomFlag
 
     clockCorrData = messaging.TDBVehicleClockCorrelationMsgPayload()
     clockCorrData.vehicleClockTime = 0.0
-    clockCorrData.ephemerisTime = oeStateModel.ephArray[0].ephemTimeMid - \
-        oeStateModel.ephArray[0].ephemTimeRad
+    clockCorrData.ephemerisTime = oeStateModel.ephArray[0].ephemTimeMid - oeStateModel.ephArray[0].ephemTimeRad
 
     clockInMsg = messaging.TDBVehicleClockCorrelationMsg().write(clockCorrData)
     oeStateModel.clockCorrInMsg.subscribeTo(clockInMsg)
@@ -175,8 +174,7 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
     dataLog = oeStateModel.stateFitOutMsg.recorder()
     sim.AddModelToTask(unitTaskName, dataLog)
 
-
-    if not validChebyCurveTime :
+    if not validChebyCurveTime:
         sim.InitializeSimulation()
         # increase the run time by one logging period so that the sim time is outside the
         # valid chebychev curve duration
@@ -196,28 +194,35 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         lastPos = posChebData[lastLogidx, 0:] - tdrssPosList[lastLogidx, :]
         if not numpy.array_equal(secondLastPos, lastPos):
             testFailCount += 1
-            testMessages.append("FAILED: Expected Chebychev position to rail high or low " + str(secondLastPos) + " != " + str(lastPos) )
+            testMessages.append("FAILED: Expected Chebychev position to rail high or low "
+                                + str(secondLastPos)
+                                + " != "
+                                + str(lastPos))
 
         secondLastVel = velChebData[lastLogidx + 1, 0:] - tdrssVelList[lastLogidx, :]
         lastVel = velChebData[lastLogidx, 0:] - tdrssVelList[lastLogidx, :]
         if not numpy.array_equal(secondLastVel, lastVel):
             testFailCount += 1
-            testMessages.append("FAILED: Expected Chebychev velocity to rail high or low " + str(secondLastVel) + " != " + str(lastVel) )
-
+            testMessages.append("FAILED: Expected Chebychev velocity to rail high or low "
+                                + str(secondLastVel)
+                                + " != "
+                                + str(lastVel))
     else:
         maxErrVec = [abs(max(posChebData[:, 0] - tdrssPosList[:, 0])),
-            abs(max(posChebData[:, 1] - tdrssPosList[:, 1])),
-            abs(max(posChebData[:,2] - tdrssPosList[:, 2]))]
+                     abs(max(posChebData[:, 1] - tdrssPosList[:, 1])),
+                     abs(max(posChebData[:,2] - tdrssPosList[:, 2]))]
         maxVelErrVec = [abs(max(velChebData[:, 0] - tdrssVelList[:, 0])),
-                 abs(max(velChebData[:, 1] - tdrssVelList[:, 1])),
-                 abs(max(velChebData[:, 2] - tdrssVelList[:, 2]))]
+                        abs(max(velChebData[:, 1] - tdrssVelList[:, 1])),
+                        abs(max(velChebData[:, 2] - tdrssVelList[:, 2]))]
 
         if max(maxErrVec) >= orbitPosAccuracy:
             testFailCount += 1
-            testMessages.append("FAILED: maxErrVec >= orbitPosAccuracy, TDRSS Orbit Accuracy: " + str(max(maxErrVec)))
+            testMessages.append("FAILED: maxErrVec >= orbitPosAccuracy, TDRSS Orbit Accuracy: "
+                                + str(max(maxErrVec)))
         if max(maxVelErrVec) >= orbitVelAccuracy:
             testFailCount += 1
-            testMessages.append("FAILED: maxVelErrVec >= orbitVelAccuracy, TDRSS Velocity Accuracy: " + str(max(maxVelErrVec)))
+            testMessages.append("FAILED: maxVelErrVec >= orbitVelAccuracy, TDRSS Velocity Accuracy: "
+                                + str(max(maxVelErrVec)))
 
         plt.close("all")
         # plot the fitted and actual position coordinates
@@ -226,11 +231,13 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         ax = fig.gca()
         ax.ticklabel_format(useOffset=False, style='plain')
         for idx in range(0, 3):
-            plt.plot(dataLog.times()*macros.NANO2HOUR, posChebData[:, idx]/1000,
+            plt.plot(dataLog.times()*macros.NANO2HOUR,
+                     posChebData[:, idx]/1000,
                      color=unitTestSupport.getLineColor(idx, 3),
                      linewidth=0.5,
                      label='$r_{fit,' + str(idx) + '}$')
-            plt.plot(dataLog.times()*macros.NANO2HOUR, tdrssPosList[:, idx]/1000,
+            plt.plot(dataLog.times()*macros.NANO2HOUR,
+                     tdrssPosList[:, idx]/1000,
                      color=unitTestSupport.getLineColor(idx, 3),
                      linestyle='dashed', linewidth=2,
                      label='$r_{true,' + str(idx) + '}$')
@@ -241,11 +248,13 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         # plot the fitted and actual velocity coordinates
         plt.figure(2)
         for idx in range(0, 3):
-            plt.plot(dataLog.times()*macros.NANO2HOUR, velChebData[:, idx]/1000,
+            plt.plot(dataLog.times()*macros.NANO2HOUR,
+                     velChebData[:, idx]/1000,
                      color=unitTestSupport.getLineColor(idx, 3),
                      linewidth=0.5,
                      label='$v_{fit,' + str(idx) + '}$')
-            plt.plot(dataLog.times()*macros.NANO2HOUR, tdrssVelList[:, idx]/1000,
+            plt.plot(dataLog.times()*macros.NANO2HOUR,
+                     tdrssVelList[:, idx]/1000,
                      color=unitTestSupport.getLineColor(idx, 3),
                      linestyle='dashed', linewidth=2,
                      label='$v_{true,' + str(idx) + '}$')
@@ -257,14 +266,19 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         plt.figure(3)
         arrayLength = posChebData[:, 0].size
         for idx in range(0,3):
-            plt.plot(dataLog.times() * macros.NANO2HOUR, posChebData[:, idx]  - tdrssPosList[:, idx],
+            plt.plot(dataLog.times() * macros.NANO2HOUR,
+                     posChebData[:, idx] - tdrssPosList[:, idx],
                      color=unitTestSupport.getLineColor(idx, 3),
                      linewidth=0.5,
                      label=r'$\Delta r_{' + str(idx) + '}$')
-        plt.plot(dataLog.times() * macros.NANO2HOUR, orbitPosAccuracy*numpy.ones(arrayLength),
-                 color='r', linewidth=1)
-        plt.plot(dataLog.times() * macros.NANO2HOUR, -orbitPosAccuracy * numpy.ones(arrayLength),
-                 color='r', linewidth=1)
+        plt.plot(dataLog.times() * macros.NANO2HOUR,
+                 orbitPosAccuracy*numpy.ones(arrayLength),
+                 color='r',
+                 linewidth=1)
+        plt.plot(dataLog.times() * macros.NANO2HOUR,
+                 -orbitPosAccuracy * numpy.ones(arrayLength),
+                 color='r',
+                 linewidth=1)
         plt.legend(loc='lower right')
         plt.xlabel('Time [h]')
         plt.ylabel('Position Difference [m]')
@@ -273,14 +287,19 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         plt.figure(4)
         arrayLength = velChebData[:, 0].size
         for idx in range(0,3):
-            plt.plot(dataLog.times() * macros.NANO2HOUR, velChebData[:, idx]  - tdrssVelList[:, idx],
+            plt.plot(dataLog.times() * macros.NANO2HOUR,
+                     velChebData[:, idx] - tdrssVelList[:, idx],
                      color=unitTestSupport.getLineColor(idx, 3),
                      linewidth=0.5,
                      label=r'$\Delta v_{' + str(idx) + '}$')
-        plt.plot(dataLog.times() * macros.NANO2HOUR, orbitVelAccuracy*numpy.ones(arrayLength),
-                 color='r', linewidth=1)
-        plt.plot(dataLog.times() * macros.NANO2HOUR, -orbitVelAccuracy * numpy.ones(arrayLength),
-                 color='r', linewidth=1)
+        plt.plot(dataLog.times() * macros.NANO2HOUR,
+                 orbitVelAccuracy*numpy.ones(arrayLength),
+                 color='r',
+                 linewidth=1)
+        plt.plot(dataLog.times() * macros.NANO2HOUR,
+                 -orbitVelAccuracy * numpy.ones(arrayLength),
+                 color='r',
+                 linewidth=1)
         plt.legend(loc='lower right')
         plt.xlabel('Time [h]')
         plt.ylabel('Velocity Difference [m/s]')

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
@@ -16,19 +16,22 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-import os, inspect
-import numpy
+import inspect
 import math
+import os
+
+import matplotlib.pyplot as plt
+import numpy
 import pytest
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import macros
+
+from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import oeStateEphem
 from Basilisk.topLevelModules import pyswice
-from Basilisk.utilities.pyswice_spk_utilities import spkRead
-import matplotlib.pyplot as plt
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
-from Basilisk.architecture import messaging
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities.pyswice_spk_utilities import spkRead
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
@@ -39,9 +39,6 @@ splitPath = path.split('fswAlgorithms')
 from Basilisk import __path__
 bskPath = __path__[0]
 
-filename = inspect.getframeinfo(inspect.currentframe()).filename
-path = os.path.dirname(os.path.abspath(filename))
-
 orbitPosAccuracy = 10000.0
 orbitVelAccuracy = 1.0
 unitTestSupport.writeTeXSnippet("tolerancePosValue", str(orbitPosAccuracy), path)


### PR DESCRIPTION
* **Tickets addressed:** resolves #76 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR removes utility libraries that snuck into the `sim_model` component, yet should not be included. They are otherwise provided to users via focused python packages and utilities. `sim_model` is ostensibly the simulation driver component of Basilisk (and I advocate that it be renamed to that end so it is very clear the function and significance of this code, but that's for another day :) ). `sim_model` is a core component of the Basilisk internals and not a user facing component. This is further demonstrated by the fact that `sim_model` is abstracted away from the user via `SimulationBaseClass`. 

## Verification
Only one test was using the APIs exposed via the inclusion of these libraries in `sim_model`. This test has been refactored to use `Basilisk.utilities.orbitalMotion` 

## Documentation
None.

## Future work
None
