### PR TITLE
Feature/63 unused msgheader pointer in recorder constructor

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -46,6 +46,8 @@ Version |release|
   :ref:`sim_model` module's API. They have been removed and the functions they provided are still found in
   ``Basilisk.utilities.orbitalMotion``, ``Basilisk.architecture.linearAlgebra``, and
   ``Basilisk.architecture.rigidBodyKinematics``.
+- Fixed an issued recording the ``timeWritten`` information of a C-wrapped message
+  with a ``recorder()`` module.
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/src/architecture/messaging/_UnitTest/test_CMsgTimeWritten.py
+++ b/src/architecture/messaging/_UnitTest/test_CMsgTimeWritten.py
@@ -1,0 +1,79 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import sys
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.moduleTemplates import cModuleTemplate
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+from Basilisk.utilities import unitTestSupport as uts
+
+
+def test_CMsgTimeWritten():
+    """
+    testing recording timeWritten in C-wrapped message
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    testFailCount = 0  # zero unit test result counter
+    testMessages = []  # create empty array to store test log messages
+
+    #  Create a sim module as an empty container
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    #  create the simulation process
+    dynProcess = scSim.CreateNewProcess("dynamicsProcess")
+
+    # create the dynamics task and specify the integration update time
+    dynProcess.addTask(scSim.CreateNewTask("dynamicsTask", macros.sec2nano(1.)))
+
+    # create modules
+    mod1 = cModuleTemplate.cModuleTemplateConfig()
+    mod1Wrap = scSim.setModelDataWrap(mod1)
+    mod1Wrap.ModelTag = "cModule1"
+    scSim.AddModelToTask("dynamicsTask", mod1Wrap, mod1)
+    mod1.dataInMsg.subscribeTo(mod1.dataOutMsg)
+
+    # setup message recording
+    msgRec = mod1.dataOutMsg.recorder()
+    scSim.AddModelToTask("dynamicsTask", msgRec)
+
+    #  initialize Simulation:
+    scSim.InitializeSimulation()
+
+    #   configure a simulation stop time time and execute the simulation run
+    scSim.ConfigureStopTime(macros.sec2nano(1.0))
+    scSim.ExecuteSimulation()
+
+    testFailCount, testMessages = uts.compareVector(msgRec.timesWritten()
+                                                    , msgRec.times()
+                                                    , 0.01
+                                                    , "recorded msg timesWritten was not correct."
+                                                    , testFailCount
+                                                    , testMessages)
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    assert testFailCount < 1, testMessages
+
+
+if __name__ == "__main__":
+    CMsgTimeWritten()
+

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -246,13 +246,13 @@ public:
     //! -- Use this to record C messages
     Recorder(void* message, uint64_t timeDiff = 0){
         this->timeInterval = timeDiff;
-        Msg2Header msgHeader;
 
-        Msg2Header* pt = (Msg2Header *) message;
+        Msg2Header* msgPt = (Msg2Header *) message;
+        Msg2Header *pt = msgPt;
         messageType* payloadPointer;
         payloadPointer = (messageType *) (++pt);
 
-        this->readMessage = ReadFunctor<messageType>(payloadPointer, &msgHeader);
+        this->readMessage = ReadFunctor<messageType>(payloadPointer, msgPt);
         this->ModelTag = "Rec:";
         Message<messageType> tempMsg;
         std::string msgName = typeid(tempMsg).name();

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -20,7 +20,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #include <memory>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include <vector>
-#include "architecture/messaging/msg2Header.h"
+#include "architecture/messaging/msgHeader.h"
 #include "architecture/utilities/bskLogging.h"
 #include <typeinfo>
 #include <stdlib.h>
@@ -37,7 +37,7 @@ template<typename messageType>
 class ReadFunctor{
 private:
     messageType* payloadPointer;    //!< -- pointer to the incoming msg data
-    Msg2Header *headerPointer;      //!< -- pointer to the incoming msg header
+    MsgHeader *headerPointer;      //!< -- pointer to the incoming msg header
     bool initialized;               //!< -- flag indicating if the input message is connect to another message
     
 public:
@@ -50,7 +50,7 @@ public:
     ReadFunctor() : initialized(false) {};
 
     //! constructor
-    ReadFunctor(messageType* payloadPtr, Msg2Header *headerPtr) : payloadPointer(payloadPtr), headerPointer(headerPtr), initialized(true){};
+    ReadFunctor(messageType* payloadPtr, MsgHeader *headerPtr) : payloadPointer(payloadPtr), headerPointer(headerPtr), initialized(true){};
 
     //! constructor
     const messageType& operator()(){
@@ -104,11 +104,11 @@ public:
     //! subscribe to a C message
     void subscribeToC(void* source){
         // this method works by knowing that the first member of a C message is the header.
-        this->headerPointer = (Msg2Header*) source;
+        this->headerPointer = (MsgHeader*) source;
 
         // advance the address to connect to C-wrapped message payload
         // this assumes the header memory is aligned with 0 additional padding
-        Msg2Header* pt = this->headerPointer;
+        MsgHeader* pt = this->headerPointer;
         this->payloadPointer = (messageType *) (++pt);
 
 
@@ -127,8 +127,8 @@ public:
     //! Check if self has been subscribed to a C message
     uint8_t isSubscribedToC(void *source){
         
-        int8_t firstCheck = (this->headerPointer == (Msg2Header*) source);
-        Msg2Header* pt = this->headerPointer;
+        int8_t firstCheck = (this->headerPointer == (MsgHeader*) source);
+        MsgHeader* pt = this->headerPointer;
         int8_t secondCheck = (this->payloadPointer == (messageType *) (++pt));
 
         return (this->initialized && firstCheck && secondCheck);
@@ -137,7 +137,7 @@ public:
     //! Check if self has been subscribed to a Cpp message
     uint8_t isSubscribedTo(Message<messageType> *source){
         
-        Msg2Header *dummyMsgPtr;
+        MsgHeader *dummyMsgPtr;
         int8_t firstCheck = (this->payloadPointer == source->getMsgPointers(&(dummyMsgPtr)));
         int8_t secondCheck = (this->headerPointer == dummyMsgPtr);
 
@@ -154,12 +154,12 @@ template<typename messageType>
 class WriteFunctor{
 private:
     messageType* payloadPointer;    //!< pointer to the message payload
-    Msg2Header* headerPointer;      //!< pointer to the message header
+    MsgHeader* headerPointer;       //!< pointer to the message header
 public:
     //! write functor constructor
     WriteFunctor(){};
     //! write functor constructor
-    WriteFunctor(messageType* payloadPointer, Msg2Header *headerPointer) : payloadPointer(payloadPointer), headerPointer(headerPointer){};
+    WriteFunctor(messageType* payloadPointer, MsgHeader *headerPointer) : payloadPointer(payloadPointer), headerPointer(headerPointer){};
     //! write functor constructor
     void operator()(messageType *payload, int64_t moduleID, uint64_t callTime){
         *this->payloadPointer = *payload;
@@ -180,7 +180,7 @@ template<typename messageType>
 class Message{
 private:
     messageType payload = {};   //!< struct defining message payload, zero'd on creation
-    Msg2Header header = {};     //!< struct defining the message header, zero'd on creation
+    MsgHeader header = {};      //!< struct defining the message header, zero'd on creation
     ReadFunctor<messageType> read = ReadFunctor<messageType>(&payload, &header);  //!< read functor instance
 public:
     //! write functor to this message
@@ -190,10 +190,10 @@ public:
     //! -- request write rights.
     WriteFunctor<messageType> addAuthor();
     //! for plain ole c modules
-    messageType* subscribeRaw(Msg2Header **msgPtr);
+    messageType* subscribeRaw(MsgHeader **msgPtr);
 
     //! for plain ole c modules
-    messageType* getMsgPointers(Msg2Header **msgPtr);
+    messageType* getMsgPointers(MsgHeader **msgPtr);
 
     //! Recorder object
     Recorder<messageType> recorder(uint64_t timeDiff = 0){return Recorder<messageType>(this, timeDiff);}
@@ -220,14 +220,14 @@ WriteFunctor<messageType> Message<messageType>::addAuthor(){
 }
 
 template<typename messageType>
-messageType* Message<messageType>::subscribeRaw(Msg2Header **msgPtr){
+messageType* Message<messageType>::subscribeRaw(MsgHeader **msgPtr){
     *msgPtr = &this->header;
     this->header.isLinked = 1;
     return &this->payload;
 }
 
 template<typename messageType>
-messageType* Message<messageType>::getMsgPointers(Msg2Header **msgPtr){
+messageType* Message<messageType>::getMsgPointers(MsgHeader **msgPtr){
     *msgPtr = &this->header;
     return &this->payload;
 }
@@ -247,8 +247,8 @@ public:
     Recorder(void* message, uint64_t timeDiff = 0){
         this->timeInterval = timeDiff;
 
-        Msg2Header* msgPt = (Msg2Header *) message;
-        Msg2Header *pt = msgPt;
+        MsgHeader* msgPt = (MsgHeader *) message;
+        MsgHeader *pt = msgPt;
         messageType* payloadPointer;
         payloadPointer = (messageType *) (++pt);
 

--- a/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
@@ -2,7 +2,7 @@
 #include "cMsgCInterface/{type}_C.h"
 %}}
 %include "cMsgCInterface/{type}_C.h"
-%include "architecture/messaging/msg2Header.h"
+%include "architecture/messaging/msgHeader.h"
 typedef struct {type};
 %extend {type}_C {{
     %pythoncode %{{

--- a/src/architecture/messaging/msgAutoSource/msg_C.cpp.in
+++ b/src/architecture/messaging/msgAutoSource/msg_C.cpp.in
@@ -100,7 +100,7 @@ int64_t {type}_C_moduleID({type}_C *data) {{
 //! method description
 void {type}_cpp_subscribe({type}_C *subscriber, void* source){{
     Message<{type}Payload>* source_t = (Message<{type}Payload>*) source;
-    Msg2Header *msgPtr;
+    MsgHeader *msgPtr;
     subscriber->payloadPointer = source_t->subscribeRaw(&(msgPtr));
     subscriber->headerPointer = msgPtr;
     subscriber->header.isLinked = 1;    // set input message as linked
@@ -111,7 +111,7 @@ void {type}_cpp_subscribe({type}_C *subscriber, void* source){{
 //! Cpp interface to check if subscriber is indeed subscribed to a message (1: subscribed, 0: not subscribed)
 int8_t {type}_cpp_isSubscribedTo({type}_C *subscriber, void* source) {{
 
-    Msg2Header *dummyMsgPtr;
+    MsgHeader *dummyMsgPtr;
     Message<{type}Payload>* source_t = (Message<{type}Payload>*) source;
     int8_t firstCheck = (subscriber->payloadPointer == source_t->getMsgPointers(&(dummyMsgPtr)));
     int8_t secondCheck = (subscriber->headerPointer == dummyMsgPtr);

--- a/src/architecture/messaging/msgAutoSource/msg_C.h.in
+++ b/src/architecture/messaging/msgAutoSource/msg_C.h.in
@@ -3,14 +3,14 @@
 
 #include <stdint.h>
 #include "architecture/{structHeader}"
-#include "architecture/messaging/msg2Header.h"
+#include "architecture/messaging/msgHeader.h"
 
 //! structure definition
 typedef struct {{
-    Msg2Header header;              //!< message header, zero'd on construction
+    MsgHeader header;              //!< message header, zero'd on construction
     {type}Payload payload;		        //!< message copy, zero'd on construction
     {type}Payload *payloadPointer;	    //!< pointer to message
-    Msg2Header *headerPointer;      //!< pointer to message header
+    MsgHeader *headerPointer;      //!< pointer to message header
 }} {type}_C;
 
 #ifdef __cplusplus

--- a/src/architecture/messaging/msgHeader.h
+++ b/src/architecture/messaging/msgHeader.h
@@ -16,8 +16,8 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
         OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#ifndef msg2Header_h
-#define msg2Header_h
+#ifndef msgHeader_h
+#define msgHeader_h
 
 /*! @brief message system 2 header information structure */
 typedef struct {
@@ -25,6 +25,6 @@ typedef struct {
     int64_t isWritten;      //!< flag if the message conntent has ever been written
     uint64_t timeWritten;   //!< [ns] time the message was written
     int64_t moduleID;       //!< ID of the module who wrote the message, negative value for Python module, non-negative for C/C++ modules
-}Msg2Header;
+}MsgHeader;
 
-#endif /* msg2Header_h */
+#endif /* msgHeader_h */


### PR DESCRIPTION
* **Tickets addressed:** resolves #63
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
If a `recorder()` is setup on a C-wrapped message, the `timeWritten` variable was not properly recorded. 
The msg header pointer was not being passed along properly.  

## Verification
Did a complete clean build, no compiler warnings, all unit tests passed.

## Documentation
A unit test is created that checks the expected behavior of recording the time a message is
written with a `recorder()` module.

## Future work
N/A
