### PR TITLE
fix typo in python BSK scenario scripts

### DIFF
--- a/docs/source/codeSamples/bsk-1.py
+++ b/docs/source/codeSamples/bsk-1.py
@@ -40,7 +40,7 @@ def run():
     #  initialize Simulation:
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(20.0))
     scSim.ExecuteSimulation()
 

--- a/docs/source/codeSamples/bsk-2.py
+++ b/docs/source/codeSamples/bsk-2.py
@@ -55,7 +55,7 @@ def run():
     scSim.InitializeSimulation()
     print("InitializeSimulation() completed...")
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(5.0))
     scSim.ExecuteSimulation()
 

--- a/docs/source/codeSamples/bsk-3.py
+++ b/docs/source/codeSamples/bsk-3.py
@@ -56,7 +56,7 @@ def run():
     #  initialize Simulation:
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(5.0))
     scSim.ExecuteSimulation()
 

--- a/docs/source/codeSamples/bsk-4.py
+++ b/docs/source/codeSamples/bsk-4.py
@@ -56,7 +56,7 @@ def run():
     #  initialize Simulation:
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(60.0))
     scSim.ExecuteSimulation()
 

--- a/docs/source/codeSamples/bsk-5.py
+++ b/docs/source/codeSamples/bsk-5.py
@@ -59,7 +59,7 @@ def run():
     #  initialize Simulation:
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(10.0))
     scSim.ExecuteSimulation()
 

--- a/docs/source/codeSamples/bsk-6.py
+++ b/docs/source/codeSamples/bsk-6.py
@@ -62,7 +62,7 @@ def run():
     #  initialize Simulation:
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(1.0))
     scSim.ExecuteSimulation()
 

--- a/docs/source/codeSamples/bsk-7.py
+++ b/docs/source/codeSamples/bsk-7.py
@@ -59,7 +59,7 @@ def run():
     #  initialize Simulation:
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(1.0))
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioAerocapture.py
+++ b/examples/scenarioAerocapture.py
@@ -296,7 +296,7 @@ def run(show_plots, planetCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAlbedo.py
+++ b/examples/scenarioAlbedo.py
@@ -360,7 +360,7 @@ def run(show_plots, albedoData, multipleInstrument, multiplePlanet, useEclipse, 
     #
     if multiplePlanet:
         velRef = scObject.dynManager.getStateObject("hubVelocity")
-        # Configure a simulation stop time time and execute the simulation run
+        # Configure a simulation stop time and execute the simulation run
         T1 = macros.sec2nano(500.)
         scSim.ConfigureStopTime(T1)
         scSim.ExecuteSimulation()
@@ -381,7 +381,7 @@ def run(show_plots, albedoData, multipleInstrument, multiplePlanet, useEclipse, 
         scSim.ExecuteSimulation()
         simulationTime = T1 + T2 + T3
     else:
-        # Configure a simulation stop time time and execute the simulation run
+        # Configure a simulation stop time and execute the simulation run
         scSim.ConfigureStopTime(simulationTime)
         scSim.ExecuteSimulation()
     #

--- a/examples/scenarioAttGuideHyperbolic.py
+++ b/examples/scenarioAttGuideHyperbolic.py
@@ -371,7 +371,7 @@ def run(show_plots, useAltBodyFrame):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttLocPoint.py
+++ b/examples/scenarioAttLocPoint.py
@@ -317,7 +317,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeConstrainedManeuver.py
+++ b/examples/scenarioAttitudeConstrainedManeuver.py
@@ -404,7 +404,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     # cross_init() and reset() routines on each module.
     scSim.InitializeSimulation()
 
-    # configure a simulation stop time time and execute the simulation run
+    # configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioAttitudeConstraintViolation.py
+++ b/examples/scenarioAttitudeConstraintViolation.py
@@ -442,7 +442,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     # cross_init() and reset() routines on each module.
     scSim.InitializeSimulation()
 
-    # configure a simulation stop time time and execute the simulation run
+    # configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioAttitudeFeedback.py
+++ b/examples/scenarioAttitudeFeedback.py
@@ -384,7 +384,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeFeedback2T.py
+++ b/examples/scenarioAttitudeFeedback2T.py
@@ -330,7 +330,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeFeedback2T_TH.py
+++ b/examples/scenarioAttitudeFeedback2T_TH.py
@@ -675,7 +675,7 @@ def run(show_plots, useDVThrusters):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeFeedback2T_stateEffTH.py
+++ b/examples/scenarioAttitudeFeedback2T_stateEffTH.py
@@ -587,7 +587,7 @@ def run(show_plots, useDVThrusters):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeFeedbackNoEarth.py
+++ b/examples/scenarioAttitudeFeedbackNoEarth.py
@@ -284,7 +284,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeFeedbackRW.py
+++ b/examples/scenarioAttitudeFeedbackRW.py
@@ -632,7 +632,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeFeedbackRWPower.py
+++ b/examples/scenarioAttitudeFeedbackRWPower.py
@@ -367,7 +367,7 @@ def run(show_plots, useRwPowerGeneration):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeGG.py
+++ b/examples/scenarioAttitudeGG.py
@@ -269,7 +269,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeGuidance.py
+++ b/examples/scenarioAttitudeGuidance.py
@@ -398,7 +398,7 @@ def run(show_plots, useAltBodyFrame):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudePointing.py
+++ b/examples/scenarioAttitudePointing.py
@@ -251,7 +251,7 @@ def run(show_plots, useLargeTumble):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudePointingPy.py
+++ b/examples/scenarioAttitudePointingPy.py
@@ -246,7 +246,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudePrescribed.py
+++ b/examples/scenarioAttitudePrescribed.py
@@ -240,7 +240,7 @@ def run(show_plots, useAltBodyFrame):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioAttitudeSteering.py
+++ b/examples/scenarioAttitudeSteering.py
@@ -510,7 +510,7 @@ def run(show_plots, simCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioBasicOrbit.py
+++ b/examples/scenarioBasicOrbit.py
@@ -426,7 +426,7 @@ def run(show_plots, orbitCase, useSphericalHarmonics, planetCase):
     #   and reset() routines on each module.
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
     # Note that this module simulates both the translational and rotational motion of the spacecraft.

--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -230,7 +230,7 @@ def run(show_plots, liveStream, timeStep, orbitCase, useSphericalHarmonics, plan
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioCSS.py
+++ b/examples/scenarioCSS.py
@@ -355,7 +355,7 @@ def run(show_plots, useCSSConstellation, usePlatform, useEclipse, useKelly):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioCSSFilters.py
+++ b/examples/scenarioCSSFilters.py
@@ -550,7 +550,7 @@ def run(saveFigures, show_plots, FilterType, simTime):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
 

--- a/examples/scenarioCentralBody.py
+++ b/examples/scenarioCentralBody.py
@@ -235,7 +235,7 @@ def run(show_plots, useCentral):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioCustomGravBody.py
+++ b/examples/scenarioCustomGravBody.py
@@ -224,7 +224,7 @@ def run(show_plots):
     #   initialize Simulation
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioDataToViz.py
+++ b/examples/scenarioDataToViz.py
@@ -202,7 +202,7 @@ def run(show_plots, attType):
     #   initialize Simulation
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -342,7 +342,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -447,7 +447,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioFuelSlosh.py
+++ b/examples/scenarioFuelSlosh.py
@@ -340,7 +340,7 @@ def run(show_plots, damping_parameter, timeStep):
             ".dynManager.getStateObject('linearSpringMassDamperRho3').getState()", simulationTimeStep, 0, 0, 'double')
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -459,7 +459,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioHingedRigidBody.py
+++ b/examples/scenarioHingedRigidBody.py
@@ -307,7 +307,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioInertialSpiral.py
+++ b/examples/scenarioInertialSpiral.py
@@ -270,7 +270,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioIntegrators.py
+++ b/examples/scenarioIntegrators.py
@@ -236,7 +236,7 @@ def run(show_plots, integratorCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioMagneticFieldCenteredDipole.py
+++ b/examples/scenarioMagneticFieldCenteredDipole.py
@@ -314,7 +314,7 @@ def run(show_plots, orbitCase, planetCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioMagneticFieldWMM.py
+++ b/examples/scenarioMagneticFieldWMM.py
@@ -276,7 +276,7 @@ def run(show_plots, orbitCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioMomentumDumping.py
+++ b/examples/scenarioMomentumDumping.py
@@ -420,7 +420,7 @@ def run(show_plots):
     # cross_init() and reset() routines on each module.
     scSim.InitializeSimulation()
 
-    # configure a simulation stop time time and execute the simulation run
+    # configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(macros.sec2nano(10.0))
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioMonteCarloAttRW.py
+++ b/examples/scenarioMonteCarloAttRW.py
@@ -630,7 +630,7 @@ def executeScenario(sim):
     #   initialize Simulation
     sim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     sim.ConfigureStopTime(simulationTime)
     sim.ExecuteSimulation()
 

--- a/examples/scenarioOrbitMultiBody.py
+++ b/examples/scenarioOrbitMultiBody.py
@@ -291,7 +291,7 @@ def run(show_plots, scCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -519,7 +519,7 @@ def run(show_plots):
         servicerVel.setState(unitTestSupport.np2EigenVectorXd(vd))
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     fswHillPointing()
     relOrbDrift()

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -513,7 +513,7 @@ def run(show_plots):
     waypointFeedback.K1 = unitTestSupport.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
     waypointFeedback.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
-    # configure a simulation stop time time and execute the simulation run
+    # configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime_1)
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -681,7 +681,7 @@ def run(show_plots):
     #   initialize Simulation
     scSim.InitializeSimulation()
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 

--- a/examples/scenarioSpacecraftLocation.py
+++ b/examples/scenarioSpacecraftLocation.py
@@ -253,7 +253,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioSpiceSpacecraft.py
+++ b/examples/scenarioSpiceSpacecraft.py
@@ -268,7 +268,7 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioTAM.py
+++ b/examples/scenarioTAM.py
@@ -279,7 +279,7 @@ def run(show_plots, orbitCase, planetCase, useBias, useBounds):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioTAMcomparison.py
+++ b/examples/scenarioTAMcomparison.py
@@ -357,7 +357,7 @@ def run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioVariableTimeStepIntegrators.py
+++ b/examples/scenarioVariableTimeStepIntegrators.py
@@ -212,7 +212,7 @@ def run(show_plots, integratorCase, relTol, absTol):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioVizPoint.py
+++ b/examples/scenarioVizPoint.py
@@ -347,7 +347,7 @@ def run(show_plots, missionType, saveVizardFile):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/dynamics/GravityGradientEffector/_UnitTest/test_gravityGradient.py
+++ b/src/simulation/dynamics/GravityGradientEffector/_UnitTest/test_gravityGradient.py
@@ -206,7 +206,7 @@ def run(show_plots, cmOffset, planetCase, simTime):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
@@ -159,7 +159,7 @@ def run(doUnitTests, show_plots, integratorCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/dynamics/MtbEffector/_UnitTest/test_MtbEffector.py
+++ b/src/simulation/dynamics/MtbEffector/_UnitTest/test_MtbEffector.py
@@ -195,7 +195,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
     # initialize Simulation
     scSim.InitializeSimulation()
 
-    # configure a simulation stop time time and execute the simulation run
+    # configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 

--- a/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
+++ b/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
@@ -156,7 +156,7 @@ def unitRadiationPressure(show_plots, modelType, eclipseOn):
 
     unitTestSim.InitializeSimulation()
 
-    # Configure a simulation stop time time and execute the simulation run
+    # Configure a simulation stop time and execute the simulation run
     unitTestSim.ConfigureStopTime(simulationTime)
     unitTestSim.ExecuteSimulation()
     srpDynEffector.computeForceTorque(unitTestSim.TotalSim.CurrentNanos, testTaskRate)

--- a/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiation_pressure_integrated.py
+++ b/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiation_pressure_integrated.py
@@ -130,7 +130,7 @@ def radiationPressureIntegratedTest(show_plots):
     sim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     sim.ConfigureStopTime(simulationTime)
     sim.ExecuteSimulation()

--- a/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
+++ b/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
@@ -239,7 +239,7 @@ def run(show_plots, orbitCase, planetCase):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/dynamics/facetDragEffector/_UnitTest/test_unitFacetDrag.py
+++ b/src/simulation/dynamics/facetDragEffector/_UnitTest/test_unitFacetDrag.py
@@ -184,7 +184,7 @@ def TestDragCalculation():
     scSim.AddVariableForLogging(newDrag.ModelTag + ".torqueExternalPntB_B",
                                       simulationTimeStep, 0, 2, 'double')
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
@@ -339,7 +339,7 @@ def TestShadowCalculation():
     scSim.AddVariableForLogging(newDrag.ModelTag + ".torqueExternalPntB_B",
                                 simulationTimeStep, 0, 2, 'double')
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_RWUpdate.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_RWUpdate.py
@@ -176,7 +176,7 @@ def RWUpdateTest(show_plots, accuracy):
     RW2.u_min = 0.2
     RW3.u_min = 0.2
 
-    # configure a simulation stop time time and execute the simulation run
+    # configure a simulation stop time and execute the simulation run
     unitTestSim.ConfigureStopTime(simulationTime)
     unitTestSim.ExecuteSimulation()
     numTests += 1
@@ -196,7 +196,7 @@ def RWUpdateTest(show_plots, accuracy):
     RW2.u_min = 0.05
     RW3.u_min = 0.05
 
-    # reconfigure a simulation stop time time and re-execute the simulation run
+    # reconfigure a simulation stop time and re-execute the simulation run
     unitTestSim.ConfigureStopTime(2*simulationTime)
     unitTestSim.ExecuteSimulation()
     numTests += 1
@@ -216,7 +216,7 @@ def RWUpdateTest(show_plots, accuracy):
     RW2.Omega_max = 100*macros.RPM
     RW3.Omega_max = 100*macros.RPM
 
-    # reconfigure a simulation stop time time and re-execute the simulation run
+    # reconfigure a simulation stop time and re-execute the simulation run
     unitTestSim.ConfigureStopTime(3*simulationTime)
     unitTestSim.ExecuteSimulation()
     numTests += 1

--- a/src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
+++ b/src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
@@ -214,7 +214,7 @@ def sphericalPendulumTest(show_plots, useFlag,testCase):
             "spacecraftBody.dynManager.getStateObject('sphericalPendulumMass2').getState()", simulationTimeStep, 0, 0, 'double')
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/environment/ExponentialAtmosphere/_UnitTest/test_integratedExponentialAtmosphere.py
+++ b/src/simulation/environment/ExponentialAtmosphere/_UnitTest/test_integratedExponentialAtmosphere.py
@@ -203,7 +203,7 @@ def TestExponentialAtmosphere():
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
+++ b/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
@@ -194,7 +194,7 @@ def run(show_plots, orbitCase, setEpoch):
     scSim.InitializeSimulation()
 
     #
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     #
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/utilities/MonteCarlo/_UnitTests/test_scenarioBasicOrbitMC.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_scenarioBasicOrbitMC.py
@@ -111,7 +111,7 @@ def myCreationFunction():
     sim.msgRecList[retainedMessageName] = scObject.scStateOutMsg.recorder(retainedRate)
     sim.AddModelToTask(simTaskName, sim.msgRecList[retainedMessageName])
 
-    #   configure a simulation stop time time and execute the simulation run
+    #   configure a simulation stop time and execute the simulation run
     sim.ConfigureStopTime(simulationTime)
 
     return sim


### PR DESCRIPTION
The word `time` is repeated as `time time`.  This commit

* **Tickets addressed:** bsk-081
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In some BSK scenario scripts there is the typo `time time` with a word repeated.  This has been copied and pasted across several scenarios.  This branch fixes this comment.

## Verification
Clean build and all tests pass.

## Documentation
Only comments in the BSK python scripts were edited.  This should have no impact on compiling BSK or running of the scripts.

## Future work
Make sure no new BSK scenario contains this `time time` typo.
