### PR TITLE
Feature/bsk 84 solar array reference fsw module

### DIFF
--- a/src/fswAlgorithms/attGuidance/solarArrayReference/_UnitTest/test_solarArrayReference.py
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/_UnitTest/test_solarArrayReference.py
@@ -1,0 +1,227 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        solarArrayRotation
+#   Author:             Riccardo Calaon
+#   Creation Date:      January 9, 2023
+#
+
+import pytest
+import os, inspect, random
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+
+# Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport                   # general support file with common unit test functions
+from Basilisk.fswAlgorithms import solarArrayReference           # import the module that is to be tested
+from Basilisk.utilities import macros
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.architecture import messaging                      # import the message definitions
+from Basilisk.architecture import bskLogging
+
+
+def computeRotationAngle(sigma_RN, rS_N, a1_R, a2_R, theta0):
+
+    RN = rbk.MRP2C(sigma_RN)
+    rS_R = np.matmul(RN, rS_N)
+
+    a2_R_prime = []
+    dotP = np.dot(rS_R, a1_R)
+    for n in range(3):
+        a2_R_prime.append(rS_R[n] - dotP * a1_R[n])
+    a2_R_prime = np.array(a2_R_prime)
+    a2_R_norm = np.linalg.norm(a2_R_prime)
+    if a2_R_norm > 1e-6:
+        a2_R_prime = a2_R_prime / a2_R_norm
+        theta = np.arccos(min(max(np.dot(a2_R, a2_R_prime),-1),1))
+        if np.dot(a1_R, np.cross(a2_R, a2_R_prime)) < 0:
+            theta = -theta
+    else:
+        theta = theta0
+
+    return theta
+
+
+# Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
+# @pytest.mark.skipif(conditionstring)
+# Uncomment this line if this test has an expected failure, adjust message as needed.
+# @pytest.mark.xfail(conditionstring)
+# Provide a unique test method name, starting with 'test_'.
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.  Note that the order in that you add the parametrize method
+# matters for the documentation in that it impacts the order in which the test arguments are shown.
+# The first parametrize arguments are shown last in the pytest argument list
+@pytest.mark.parametrize("rS_N", [[1, 0, 0],
+                                  [0, 0, 1]])
+@pytest.mark.parametrize("sigma_BN", [[0.1, 0.2, 0.3],
+                                      [0.5, 0.4, 0.3]])
+@pytest.mark.parametrize("sigma_RN", [[0.3, 0.2, 0.1],
+                                      [0.9, 0.7, 0.8]])
+@pytest.mark.parametrize("bodyFrame", [0, 1])                                      
+@pytest.mark.parametrize("accuracy", [1e-12])
+
+
+# update "module" in this function name to reflect the module name
+def test_solarArrayRotation(show_plots, rS_N, sigma_BN, sigma_RN, bodyFrame, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test verifies the correctness of the output reference angle computed by the :ref:`solarArrayRotation`.
+    The inputs provided are the inertial Sun direction, current attitude of the hub, and reference frame. Based on
+    current attitude, the sun direction vector is mapped into body frame coordinates and passed into the Attitude
+    Navigation Message.
+
+    **Test Parameters**
+
+    Args:
+        rS_N[3] (double): Sun direction vector, in inertial frame components;
+        sigma_BN[3] (double): spacecraft hub attitude with respect to the inertial frame, in MRP;
+        sigma_RN[3] (double): reference frame attitude with respect to the inertial frame, in MRP;
+        bodyFrame (int): 0 to calculate reference rotation angle w.r.t. reference frame, 1 to calculate it w.r.t the current spacecraft attitude;
+        accuracy (float): absolute accuracy value used in the validation tests.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the correctness of the output attitude reference message 
+
+    - ``spinningBodyRefOutMsg``
+
+    in all its parts. The reference angle ``theta`` is checked versus the value computed by a python function that computes the same angle. 
+    The reference angle derivative ``thetaDot`` is checked versus zero, as the module is run for only one Update call.
+    """
+    # each test method requires a single assert method to be called
+    [testResults, testMessage] = solarArrayRotationTestFunction(show_plots, rS_N, sigma_BN, sigma_RN, bodyFrame, accuracy)
+    assert testResults < 1, testMessage
+
+
+def solarArrayRotationTestFunction(show_plots, rS_N, sigma_BN, sigma_RN, bodyFrame, accuracy):
+
+    a1_B = np.array([1, 0, 0])
+    a2_B = np.array([0, 1, 0])
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rS_N)
+    thetaC = 0
+    thetaDotC = 0
+
+    testFailCount = 0                        # zero unit test result counter
+    testMessages = []                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    solarArrayConfig = solarArrayReference.solarArrayReferenceConfig()                 # update with current values
+    solarArrayWrap = unitTestSim.setModelDataWrap(solarArrayConfig)
+    solarArrayWrap.ModelTag = "solarArrayRotation"                                     # update python name of test module
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, solarArrayWrap, solarArrayConfig)
+
+    # Initialize the test module configuration data
+    solarArrayConfig.a1_B = a1_B
+    solarArrayConfig.a2_B = a2_B
+    solarArrayConfig.bodyFrame = bodyFrame
+
+    # Create input attitude navigation message
+    NatAttInMsgData = messaging.NavAttMsgPayload()
+    NatAttInMsgData.sigma_BN = sigma_BN
+    NatAttInMsgData.vehSunPntBdy = rS_B
+    NatAttInMsg = messaging.NavAttMsg().write(NatAttInMsgData)
+    solarArrayConfig.attNavInMsg.subscribeTo(NatAttInMsg)
+
+    # Create input attitude reference message
+    AttRefInMsgData = messaging.AttRefMsgPayload()
+    AttRefInMsgData.sigma_RN = sigma_RN
+    AttRefInMsg = messaging.AttRefMsg().write(AttRefInMsgData)
+    solarArrayConfig.attRefInMsg.subscribeTo(AttRefInMsg)
+
+    # Create input spinning body message
+    SpinningBodyInMsgData = messaging.SpinningBodyMsgPayload()
+    SpinningBodyInMsgData.theta = thetaC
+    SpinningBodyInMsgData.thetaDot = thetaDotC
+    SpinningBodyInMsg = messaging.SpinningBodyMsg().write(SpinningBodyInMsgData)
+    solarArrayConfig.spinningBodyInMsg.subscribeTo(SpinningBodyInMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = solarArrayConfig.spinningBodyRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))        # seconds to stop simulation
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    if bodyFrame == 0:
+        thetaR = computeRotationAngle(sigma_RN, rS_N, a1_B, a2_B, thetaC)
+    else:
+        thetaR = computeRotationAngle(sigma_BN, rS_N, a1_B, a2_B, thetaC)
+    if thetaR-thetaC > np.pi:
+        thetaR -= np.pi
+    elif thetaR-thetaC < -np.pi:
+        thetaR += np.pi
+    # compare the module results to the truth values
+    if not unitTestSupport.isDoubleEqual(dataLog.theta[0], thetaR, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + solarArrayWrap.ModelTag + "solarArrayRotation module failed unit test on thetaR for sigma_BN = [{},{},{}], sigma_RN = [{},{},{}] and bodyFrame = {} \n".format(sigma_BN[0],sigma_BN[1],sigma_BN[2],sigma_RN[0],sigma_RN[1],sigma_RN[2],bodyFrame))
+    if not unitTestSupport.isDoubleEqual(dataLog.thetaDot[0], 0, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + solarArrayWrap.ModelTag + "solarArrayRotation module failed unit test on thetaDotR for sigma_BN = [{},{},{}], sigma_RN = [{},{},{}] and bodyFrame = {} \n".format(sigma_BN[0],sigma_BN[1],sigma_BN[2],sigma_RN[0],sigma_RN[1],sigma_RN[2],bodyFrame))
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_solarArrayRotation(              # update "module" in function name
+                 False,
+                 np.array([1, 0, 0]),
+                 np.array([0.1, 0.2, 0.3]),
+                 np.array([0.3, 0.2, 0.1]),
+                 0,
+                 1e-12        # accuracy
+               )

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -1,0 +1,65 @@
+/*
+ ISC License
+
+ Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+/* modify the path to reflect the new module names */
+#include "solarArrayReference.h"
+#include "string.h"
+#include <math.h>
+
+/* Support files.  Be sure to use the absolute path relative to Basilisk directory. */
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/astroConstants.h"
+
+
+/*!
+    This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_solarArrayReference(solarArrayReferenceConfig *configData, int64_t moduleID)
+{
+    SpinningBodyMsg_C_init(&configData->spinningBodyRefOutMsg);
+}
+
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}
+
+/*! This method computes the updated rotation angle reference based on current attitude, reference attitude, and current rotation angle
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param moduleID The module identifier
+*/
+void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+    
+}

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -171,4 +171,7 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
     configData->priorThetaR = thetaR;
     configData->priorT = callTime;
     configData->count += 1;
+
+    /* write output message */
+    SpinningBodyMsg_C_write(&spinningBodyRefOut, &configData->spinningBodyRefOutMsg, moduleID, callTime);
 }

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -89,4 +89,24 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
 
     /*! read the solar array angle message */
     spinningBodyIn = SpinningBodyMsg_C_read(&configData->spinningBodyInMsg);
+
+    /* read Sun direction in B frame from the attNav message and map it to R frame */
+    double rS_B[3], rS_R[3], BN[3][3], RN[3][3], RB[3][3];
+    v3Normalize(attNavIn.vehSunPntBdy, rS_B);
+    switch (configData->bodyFrame) {
+
+        case 0:
+        MRP2C(attNavIn.sigma_BN, BN);
+        MRP2C(attRefIn.sigma_RN, RN);
+        m33MultM33t(RN, BN, RB);
+        m33MultV3(RB, rS_B, rS_R);
+        break;
+
+        case 1:
+        v3Copy(rS_B, rS_R);
+        break;
+
+        default:
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.bodyFrame input can be either 0 or 1.");
+    }
 }

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -50,7 +50,18 @@ void SelfInit_solarArrayReference(solarArrayReferenceConfig *configData, int64_t
 */
 void Reset_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
 {
-
+    // check if the required input message is included
+    if (!NavAttMsg_C_isLinked(&configData->attNavInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayReference.attNavInMsg wasn't connected.");
+    }
+    // check if the required input message is included
+    if (!AttRefMsg_C_isLinked(&configData->attRefInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayReference.attRefInMsg wasn't connected.");
+    }
+    // check if the required input message is included
+    if (!SpinningBodyMsg_C_isLinked(&configData->spinningBodyInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayReference.spinningBodyInMsg wasn't connected.");
+    }
 }
 
 /*! This method computes the updated rotation angle reference based on current attitude, reference attitude, and current rotation angle

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -90,7 +90,7 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
     /*! read the solar array angle message */
     spinningBodyIn = SpinningBodyMsg_C_read(&configData->spinningBodyInMsg);
 
-    /* read Sun direction in B frame from the attNav message and map it to R frame */
+    /*! read Sun direction in B frame from the attNav message and map it to R frame */
     double rS_B[3], rS_R[3], BN[3][3], RN[3][3], RB[3][3];
     v3Normalize(attNavIn.vehSunPntBdy, rS_B);
     switch (configData->bodyFrame) {
@@ -109,4 +109,22 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
         default:
         _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.bodyFrame input can be either 0 or 1.");
     }
+
+    /*! store solar array drive axis and solar array normal axis at zero rotation */
+    double a1_R[3], a2_R[3], a3_R[3], a1_R_prime[3], a2_R_prime[3];
+    v3Normalize(configData->a1_B, a1_R);
+    v3Cross(a1_R, configData->a2_B, a3_R);
+    v3Normalize(a3_R, a3_R);
+    v3Cross(a3_R, a1_R, a2_R);
+
+    /* compute a2_R_prime */
+    double dotP = v3Dot(a1_R, rS_R);
+    for (int n = 0; n < 3; n++) {
+        a2_R_prime[n] = rS_R[n] - dotP * a1_R[n];
+    }
+    v3Normalize(a2_R_prime, a2_R_prime);
+
+    /* compute a1_R_prime */
+    v3Cross(a2_R, a2_R_prime, a1_R_prime);
+    
 }

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -27,6 +27,7 @@
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/macroDefinitions.h"
 
 
 /*!
@@ -156,4 +157,18 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
             spinningBodyRefOut.theta = spinningBodyIn.theta + thetaR - thetaC;
         }
     }
+
+    /*! implement finite differences to compute thetaDotR */
+    double dt;
+    if (configData->count == 0) {
+        spinningBodyRefOut.thetaDot = 0;
+    }
+    else {
+        dt = (double) (callTime - configData->priorT) * NANO2SEC;
+        spinningBodyRefOut.thetaDot = (thetaR - configData->priorThetaR) / dt;
+    }
+    // update stored variables
+    configData->priorThetaR = thetaR;
+    configData->priorT = callTime;
+    configData->count += 1;
 }

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.c
@@ -72,5 +72,21 @@ void Reset_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t c
 */
 void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
 {
-    
+     /*! - Create buffer messages */
+    NavAttMsgPayload         attNavIn;
+    AttRefMsgPayload         attRefIn;
+    SpinningBodyMsgPayload   spinningBodyIn;
+    SpinningBodyMsgPayload   spinningBodyRefOut;
+
+    /*! - zero the output message */
+    spinningBodyRefOut = SpinningBodyMsg_C_zeroMsgPayload();
+
+    /*! read the attitude navigation message */
+    attNavIn = NavAttMsg_C_read(&configData->attNavInMsg);
+
+    /*! read the attitude reference message */
+    attRefIn = AttRefMsg_C_read(&configData->attRefInMsg);
+
+    /*! read the solar array angle message */
+    spinningBodyIn = SpinningBodyMsg_C_read(&configData->spinningBodyInMsg);
 }

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
@@ -32,7 +32,9 @@
 typedef struct {
 
     /* declare these user-defined quantities */
-    int bodyFrame;                  //!< flag = 1: compute theta reference based on current attitude instead of attitude reference
+    double a1_B[3];                 //!< solar array drive axis in body frame coordinates
+    double a2_B[3];                 //!< solar array surface normal at zero rotation
+    int    bodyFrame;               //!< flag = 1: compute theta reference based on current attitude instead of attitude reference
 
     /* declare module IO interfaces */
     NavAttMsg_C         attNavInMsg;               //!< input msg measured attitude

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
@@ -31,6 +31,9 @@
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
 
+    /* declare these user-defined quantities */
+    int bodyFrame;                  //!< flag = 1: compute theta reference based on current attitude instead of attitude reference
+
     /* declare module IO interfaces */
     NavAttMsg_C         attNavInMsg;               //!< input msg measured attitude
     AttRefMsg_C         attRefInMsg;               //!< input attitude reference message

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
@@ -36,6 +36,11 @@ typedef struct {
     double a2_B[3];                 //!< solar array surface normal at zero rotation
     int    bodyFrame;               //!< flag = 1: compute theta reference based on current attitude instead of attitude reference
 
+    /* declare these variables for internal computations */
+    int                 count;                    //!< counter variable for finite differences
+    uint64_t            priorT;                   //!< prior call time for finite differences
+    double              priorThetaR;              //!< prior output msg for finite differences
+
     /* declare module IO interfaces */
     NavAttMsg_C         attNavInMsg;               //!< input msg measured attitude
     AttRefMsg_C         attRefInMsg;               //!< input attitude reference message

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.h
@@ -1,0 +1,57 @@
+/*
+ ISC License
+
+ Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _SOLAR_ARRAY_REFERENCE_
+#define _SOLAR_ARRAY_REFERENCE_
+
+#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/NavAttMsg_C.h"
+#include "cMsgCInterface/AttRefMsg_C.h"
+#include "cMsgCInterface/SpinningBodyMsg_C.h"
+
+#define EPS 1e-6                    //!< accuracy to check if a variable is zero
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* declare module IO interfaces */
+    NavAttMsg_C         attNavInMsg;               //!< input msg measured attitude
+    AttRefMsg_C         attRefInMsg;               //!< input attitude reference message
+    SpinningBodyMsg_C   spinningBodyInMsg;         //!< input spinning body message
+    SpinningBodyMsg_C   spinningBodyRefOutMsg;     //!< output msg containing spinning body target angle and angle rate
+
+    BSKLogger *bskLogger;                         //!< BSK Logging
+
+}solarArrayReferenceConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void SelfInit_solarArrayReference(solarArrayReferenceConfig *configData, int64_t moduleID);
+    void Reset_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.i
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.i
@@ -1,0 +1,44 @@
+/*
+ ISC License
+
+ Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module solarArrayReference
+%{
+   #include "solarArrayReference.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_solarArrayReference(void*, uint64_t);
+%ignore SelfInit_solarArrayReference;
+%constant void Reset_solarArrayReference(void*, uint64_t, uint64_t);
+%ignore Reset_solarArrayReference;
+%constant void Update_solarArrayReference(void*, uint64_t, uint64_t);
+%ignore Update_solarArrayReference;
+
+%include "solarArrayReference.h"
+
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+struct AttRefMsg_C;
+%include "architecture/msgPayloadDefC/SpinningBodyMsgPayload.h"
+struct SpinningBodyMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.rst
+++ b/src/fswAlgorithms/attGuidance/solarArrayReference/solarArrayReference.rst
@@ -1,0 +1,89 @@
+Executive Summary
+-----------------
+
+This module is used to calculate the required rotation angle for a solar array that is able to rotate about its drive axis. The degree of freedom associated with the rotation of the array about the drive axis makes it such that it is possible to improve the incidence angle between the sun and the array surface, thus ensuring maximum power generation.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg connection is set by the user from python.  The msg type contains a link to the message structure definition, while the description provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - spinningBodyRefOutMsg
+      - :ref:`SpinningBodyMsgPayload`
+      - Output Spinning Body Reference Message.
+    * - attNavInMsg
+      - :ref:`NavAttMsgPayload`
+      - Input Attitude Navigation Message.
+    * - attRefInMsg
+      - :ref:`AttRefMsgPayload`
+      - Input Attitude Reference Message.
+    * - spinningBodyInMsg
+      - :ref:`SpinningBodyMsgPayload`
+      - Input Spinning Body Message Message.
+
+
+Module Assumptions and Limitations
+----------------------------------
+This module computes the rotation angle required to achieve the best incidence angle between the Sun direction and the solar array surface. This does not mean that
+perfect incidence (Sun direction perpendicular to array surface) is guaranteed. This module assumes that the solar array has only one surface that is able to generate power. This bounds the output reference angle :math:`\theta_R` between :math:`0` and :math:`2\pi`. Perfect incidence is achievable when the solar array drive direction and the Sun direction are perpendicular. Conversely, when they are parallel, no power generation is possible, and the reference angle is set to the current angle, to avoid pointless energy consumption attempting to rotate the array.
+
+The Sun direction in body-frame components is extracted from the ``attNavInMsg``. The output reference angle :math:`\theta_R`, however, can be computed either based on the reference attitude contained in ``attRefInMsg``, or the current spacecraft attitude contained also in ``attNavInMsg``. This depends on the frequency with which the arrays need to be actuated, in comparison with the frequency with which the motion of the spacecraft hub is controlled. The module input ``bodyFrame`` allows the user to set whether to compute the reference angle based on the reference attitude or current spacecraft attitude.
+
+
+Detailed Module Description
+---------------------------
+For this module to operate, the user needs to provide two unit directions as inputs:
+
+- :math:`{}^\mathcal{B}\boldsymbol{\hat{a}}_1`: direction of the solar array drive, about which the rotation happens;
+- :math:`{}^\mathcal{B}\boldsymbol{\hat{a}}_2`: direction perpendicular to the solar array surface, with the array at a zero rotation.
+
+To compute the reference rotation :math:`\theta_R`, the module computes the unit vector :math:`{}^\mathcal{R}\boldsymbol{\hat{a}}_2'`, which is coplanar with 
+:math:`{}^\mathcal{R}\boldsymbol{\hat{a}}_1` and the Sun direction :math:`{}^\mathcal{R}\boldsymbol{\hat{r}}_S`. This is obtained as:
+
+.. math::
+    {}^\mathcal{R}\boldsymbol{a}_2' = {}^\mathcal{R}\boldsymbol{\hat{r}}_S - ({}^\mathcal{R}\boldsymbol{\hat{r}}_S \cdot {}^\mathcal{B}\boldsymbol{\hat{a}}_1) {}^\mathcal{B}\boldsymbol{\hat{a}}_1
+
+and then normalizing to obtain :math:`{}^\mathcal{R}\boldsymbol{\hat{a}}_2'`. The reference angle :math:`\theta_R` is the angle between :math:`{}^\mathcal{R}\boldsymbol{\hat{a}}_2` and :math:`{}^\mathcal{R}\boldsymbol{\hat{a}}_2'`:
+
+.. math::
+    \theta_R = \arccos ({}^\mathcal{R}\boldsymbol{\hat{a}}_2 \cdot {}^\mathcal{R}\boldsymbol{\hat{a}}_2').
+
+The same math applies to the case where the body reference is used. In that case, the same vectors are expressed in body-frame coordinates. Note that the unit directions 
+:math:`\boldsymbol{\hat{a}}_i` have the same components in both the body and reference frame, because they are body-fixed and rotate with the spacecraft hub.
+
+Some logic is implemented such that the computed reference angle :math:`\theta_R` and the current rotation angle :math:`\theta_C` received as input from the ``spinningBodyInMsg`` are never more than 360 degrees apart.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    solarArrayConfig = solarArrayRotation.solarArrayRotationConfig()
+    solarArrayWrap = unitTestSim.setModelDataWrap(solarArrayConfig)
+    solarArrayWrap.ModelTag = "solarArrayRotation"  
+    solarArrayConfig.a1_B = [1, 0, 0]
+    solarArrayConfig.a2_B = [0, 0, 1]
+    solarArrayConfig.bodyFrame = 0
+    unitTestSim.AddModelToTask(unitTaskName, solarArrayWrap, solarArrayConfig)
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 34 66
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``a1_B``
+     - solar array drive direction in B-frame coordinates
+   * - ``a2_B``
+     - solar array zero-rotation direction, in B-frame coordinates
+   * - ``bodyFrame``
+     - 0 for reference angle computed w.r.t reference frame; 1 for reference angle computed w.r.t. body frame; defaults to 0 if not specified


### PR DESCRIPTION
* **Tickets addressed:** bsk-084
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The module computes a reference angle and angle rate for a solar array mounted on a body-fixed axis on the spacecraft hub. The solar array can rotate about such axis. Given the direction of the Sun, the reference angle is computed such that the array surface is kept perpendicular to the Sun direction. Commit 1 initializes the module with its main functions left empty. Commit 2 checks if the required input msgs are connected. Commits 3 through 8 incrementally build the Update() function with the math that allows to derive the reference angle and angle rate, and write the output msg. Commits 9 and 10 contain the documentation and unit test, respectively.

## Verification
A unit test is provided. Such unit test verifies the module's output msg content versus the output of a python function that carries out the same calculations. The unit test is ran for two different Sun orientations, two different hub and reference frames, and for both the cases where the reference angle is computed with respect to the current body attitude and the targeted reference attitude.

## Documentation
This is a new module. New documentation is provided to describe how the module works.

## Future work
No future work is foreseen at the moment.
