### PR TITLE
Feature/bsk 99 docs lfs

### DIFF
--- a/docs/source/Install/pullCloneBSK.rst
+++ b/docs/source/Install/pullCloneBSK.rst
@@ -25,6 +25,8 @@ next :ref:`install <bskInstall>` and compile the code before you can run it.
 The Basilisk frameworke is developed using the Git version control system.  The following directions explain how to
 clone or pull a copy from the repository.
 
+#. If you have not already installed ``lfs`` (Large File Storage) system, go to `Git LFS Support Page <https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage>`__ to download and install ``lfs`` before pulling the Basilisk repo.
+
 #. If needed, create your own `github.org <http://github.com>`__ account
 
 #. Use a browser to go to the `Basilisk GitHub

--- a/docs/source/Install/pullCloneBSK.rst
+++ b/docs/source/Install/pullCloneBSK.rst
@@ -22,7 +22,7 @@ As this is the raw source code, you need to
 next :ref:`install <bskInstall>` and compile the code before you can run it.
 
 
-The Basilisk frameworke is developed using the Git version control system.  The following directions explain how to
+The Basilisk framework is developed using the Git version control system.  The following directions explain how to
 clone or pull a copy from the repository.
 
 #. If you have not already installed ``lfs`` (Large File Storage) system, go to `Git LFS Support Page <https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage>`__ to download and install ``lfs`` before pulling the Basilisk repo.
@@ -32,7 +32,7 @@ clone or pull a copy from the repository.
 #. Use a browser to go to the `Basilisk GitHub
    Repository <https://github.com/AVSLab/basilisk>`__
 
-#. In the "Quick setup" sectin select the ``https`` option instead of the ssh option
+#. In the "Quick setup" section select the ``https`` option instead of the ssh option
 
 #. Copy the project url ``https://github.com/AVSLab/basilisk.git`` from the GitHub clone panel
    

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -48,6 +48,9 @@ Version |release|
   ``Basilisk.architecture.rigidBodyKinematics``.
 - Fixed an issued recording the ``timeWritten`` information of a C-wrapped message
   with a ``recorder()`` module.
+- Updated :ref:`pullCloneBSK` to ask the user to first install ``lfs`` before pulling a copy
+  of the Basilisk repo due to some large files being stored in the GitHub large file storage
+  system.
 
 
 Version 2.1.5 (Dec. 13, 2022)


### PR DESCRIPTION
* **Tickets addressed:** bsk--099
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Some users were running into issues pulling the Basilisk repo from GitHub because we use the large file storage system.  This branch is updating the documentation to recommend installing the large file system software before pulling the repo.

## Verification
Did a clean build of the documentation system and didn't see any warnings or errors.

## Documentation
None

## Future work
None
