### PR TITLE
Feature/bsk 104 viz ground location

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -51,6 +51,8 @@ Version |release|
 - Updated :ref:`pullCloneBSK` to ask the user to first install ``lfs`` before pulling a copy
   of the Basilisk repo due to some large files being stored in the GitHub large file storage
   system.
+- Updated :ref:`scenarioGroundLocationImaging` to properly save off the ground location
+  information for Vizard
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -421,7 +421,7 @@ def run(show_plots):
 
         # Add the Boulder target
         vizSupport.addLocation(viz, stationName="Boulder Target"
-                               , parentBodyName=earth.planetName
+                               , parentBodyName=earth.displayName
                                , r_GP_P=imagingTarget.r_LP_P_Init
                                , fieldOfView=np.radians(160.)
                                , color='pink'
@@ -433,7 +433,7 @@ def run(show_plots):
 
         # Add the Santiago target
         vizSupport.addLocation(viz, stationName="Santiago Target"
-                               , parentBodyName=earth.planetName
+                               , parentBodyName=earth.displayName
                                , r_GP_P=[[1761771.6422437236], [-5022201.882030934], [-3515898.6046771165]]
                                , fieldOfView=np.radians(160.)
                                , color='pink'
@@ -442,7 +442,7 @@ def run(show_plots):
 
         # Add the Santiago target
         vizSupport.addLocation(viz, stationName="Singapore Station"
-                               , parentBodyName=earth.planetName
+                               , parentBodyName=earth.displayName
                                , r_GP_P=singaporeStation.r_LP_P_Init
                                , fieldOfView=np.radians(160.)
                                , color='green'


### PR DESCRIPTION
* **Tickets addressed:** bsk-104
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The example script `scenarioGroundLocationImaging.py` was not saving off the proper planet name for Vizard.  This has been corrected by using `earth.displayName`.

## Verification
The example script was run and the resulting Vizard binary tested in the latest Vizard.

## Documentation
None

## Future work
None
