### PR TITLE
Feature/bsk 103 imaging rate limit

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,6 +56,8 @@ Version |release|
 - Updated :ref:`spinningBodyStateEffector` to use the :ref:`HingedRigidBodyMsgPayload` output message type for compatibility with other modules
 - Added the ability to set an inertial heading in the :ref:`boreAngCalc` module. Changed the internal module logic to use ``Eigen`` library variables and functions instead of C-style arrays and methods.
 - Added support for Vizard v2.1.3
+- Updated :ref:`simpleInstrumentController` to provide the option to consider the angular velocity tracking error norm
+  when considering to take an image.
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.h
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.h
@@ -32,6 +32,8 @@
 typedef struct {
     /* User configurable variables */
     double attErrTolerance; //!< Normalized MRP attitude error tolerance
+    unsigned int useRateTolerance; //!< Flag to enable rate error tolerance
+    double rateErrTolerance; //!< Rate error tolerance in rad/s
     unsigned int imaged;    //!< Indicator for whether or not the image has already been captured
 
     /* declare module IO interfaces */

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.rst
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.rst
@@ -1,8 +1,8 @@
 Executive Summary
 -----------------
 This module generates a command in the form of a :ref:`DeviceCmdMsgPayload` that turns on a :ref:`simpleInstrument`
-if the spacecraft a.) has access to a :ref:`groundLocation` and b.) the associated attitude error from an attitude
-guidance message is within the given tolerance.
+if the spacecraft a.) has access to a :ref:`groundLocation` and b.) the associated attitude error and attitude rate
+error from an attitude guidance message is within the given tolerance.
 
 Message Connection Descriptions
 -------------------------------
@@ -49,3 +49,6 @@ It must be set at the beginning of the sim.
 The ``imaged`` variable is always initialized to 0 (i.e. the target has not been imaged). However, if the simulation
 is stopped and restarted again this variable should be reinitialized to 0 in between. If it is not and the previous
 target was imaged, the new target will not be imaged.
+
+Optionally, attitude rate error checking may be enabled by setting ``useRateTolerance`` to ``1``. If enabled,
+``rateErrTolerance`` should be set to the norm of the acceptable attitude rate error in rad/s when imaging.


### PR DESCRIPTION
* **Tickets addressed:** bsk-#103
* **Review:** By file
* **Merge strategy:** Merge (no squash)

## Description
The rate tolerance feature was added with a new threshold variable. A toggle variable that defaults to the feature being off was added to allow for backwards compatibility.

## Verification
Unit test was updated to enable new feature. Additionally, scripts (external to this repository) were run that are dependent on settling behavior; imaging tasks were observed to comply with the desired settling behavior..

## Documentation
simpleInstrumentController.rst was updated to reflect the new feature.

## Future work
N/A