### PR TITLE
Feature/bsk 106 PIDcontroller1D

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -54,6 +54,7 @@ Version |release|
 - Updated :ref:`scenarioGroundLocationImaging` to properly save off the ground location
   information for Vizard
 - Added a new helper function to convert C arrays to ``Eigen::MRPd`` and vice-versa inside ``avsEigenSupport``.
+- Created :ref:`PIDcontroller1D` to compute the commanded torque to :ref:`spinningBodyStateEffector` using a propotional-integral-derivative controller.
 
 
 Version 2.1.5 (Dec. 13, 2022)

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -104,4 +104,11 @@ void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime
     /*! update stored quantities */
     configData->priorThetaError = thetaError;
     configData->priorTime = callTime;
+
+    /*! compute torque */
+    double T = K * thetaError + P * thetaErrorDot + I * configData->intError;
+    motorTorqueOut.motorTorque[0] = T;
+
+    /*! write output message */
+    ArrayMotorTorqueMsg_C_write(&motorTorqueOut, &configData->motorTorqueOutMsg, moduleID, callTime);
 }

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -45,7 +45,14 @@ void SelfInit_PIDController1D(PIDController1DConfig *configData, int64_t moduleI
 */
 void Reset_PIDController1D(PIDController1DConfig *configData, uint64_t callTime, int64_t moduleID)
 {
-
+    // check if the required input message is included
+    if (!SpinningBodyMsg_C_isLinked(&configData->spinningBodyInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.spinningBodyInMsg wasn't connected.");
+    }
+    // check if the required input message is included
+    if (!SpinningBodyMsg_C_isLinked(&configData->spinningBodyRefInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.spinningBodyRefInMsg wasn't connected.");
+    }
 }
 
 /*! This method computes the control torque to the solar array drive based on a PD control law

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -63,5 +63,17 @@ void Reset_PIDController1D(PIDController1DConfig *configData, uint64_t callTime,
 */
 void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime, int64_t moduleID)
 {
+    /*! - Create buffer messages */
+    SpinningBodyMsgPayload      spinningBodyIn;
+    SpinningBodyMsgPayload      spinningBodyRefIn;
+    ArrayMotorTorqueMsgPayload  motorTorqueOut;
 
+    /*! - zero the output message */
+    motorTorqueOut = ArrayMotorTorqueMsg_C_zeroMsgPayload();
+
+    /*! read the solar array angle message */
+    spinningBodyIn = SpinningBodyMsg_C_read(&configData->spinningBodyInMsg);
+
+    /*! read the solar array reference angle message */
+    spinningBodyRefIn = SpinningBodyMsg_C_read(&configData->spinningBodyRefInMsg);
 }

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -23,6 +23,8 @@
 #include "string.h"
 #include <math.h>
 
+/* Support files */
+#include "architecture/utilities/macroDefinitions.h"
 
 /*!
     This method initializes the output messages for this module.
@@ -91,4 +93,15 @@ void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime
     K = configData->K;
     P = configData->P;
     I = configData->I;
+
+    /*! compute integral term */
+    double dt;
+    if (callTime != 0) {
+        dt = (callTime - configData->priorTime) * NANO2SEC;
+        configData->intError += (thetaError + configData->priorThetaError) * dt / 2;
+    }
+
+    /*! update stored quantities */
+    configData->priorThetaError = thetaError;
+    configData->priorTime = callTime;
 }

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -53,6 +53,10 @@ void Reset_PIDController1D(PIDController1DConfig *configData, uint64_t callTime,
     if (!SpinningBodyMsg_C_isLinked(&configData->spinningBodyRefInMsg)) {
         _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.spinningBodyRefInMsg wasn't connected.");
     }
+
+    /*! initialize module parameters to compute integral error via trapezoid integration */
+    configData->priorTime = 0;
+    configData->intError = 0;
 }
 
 /*! This method computes the control torque to the solar array drive based on a PD control law
@@ -87,6 +91,4 @@ void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime
     K = configData->K;
     P = configData->P;
     I = configData->I;
-
-    
 }

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -76,4 +76,17 @@ void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime
 
     /*! read the solar array reference angle message */
     spinningBodyRefIn = SpinningBodyMsg_C_read(&configData->spinningBodyRefInMsg);
+
+    /*! compute angle error and error rate */
+    double thetaError, thetaErrorDot;
+    thetaError    = spinningBodyRefIn.theta - spinningBodyIn.theta;
+    thetaErrorDot = spinningBodyRefIn.thetaDot - spinningBodyIn.thetaDot;
+
+    /*! extract gains from input */
+    double K, P, I;
+    K = configData->K;
+    P = configData->P;
+    I = configData->I;
+
+    
 }

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.c
@@ -1,0 +1,60 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+/* modify the path to reflect the new module names */
+#include "PIDController1D.h"
+#include "string.h"
+#include <math.h>
+
+
+/*!
+    This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_PIDController1D(PIDController1DConfig *configData, int64_t moduleID)
+{
+    ArrayMotorTorqueMsg_C_init(&configData->motorTorqueOutMsg);
+}
+
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_PIDController1D(PIDController1DConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}
+
+/*! This method computes the control torque to the solar array drive based on a PD control law
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param moduleID The module identifier
+*/
+void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.h
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.h
@@ -28,12 +28,17 @@
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
 
-    /* declare these quantities that will eventually become input modules */
+    /*! declare these user-defined input parameters */
     double K;                 //!< proportional gain
     double P;                 //!< derivative gain
     double I;                 //!< integral gain
 
-    /* declare module IO interfaces */
+    /*! declare these variables for internal computations */
+    uint64_t priorTime;       //!< prior function call time for trapezoid integration
+    double   priorThetaError; //!< theta error at prior function call
+    double   intError;        //!< integral error
+
+    /*! declare module IO interfaces */
     SpinningBodyMsg_C      spinningBodyInMsg;      //!< input spinning body message
     SpinningBodyMsg_C      spinningBodyRefInMsg;   //!< output msg containing spinning body target angle and angle rate
     ArrayMotorTorqueMsg_C  motorTorqueOutMsg;      //!< output msg containing the motor torque to the array drive

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.h
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.h
@@ -1,0 +1,58 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _PID_CONTROLLER_1D_
+#define _PID_CONTROLLER_1D_
+
+#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/SpinningBodyMsg_C.h"
+#include "cMsgCInterface/ArrayMotorTorqueMsg_C.h"
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* declare these quantities that will eventually become input modules */
+    double K;                 //!< proportional gain
+    double P;                 //!< derivative gain
+    double I;                 //!< integral gain
+
+    /* declare module IO interfaces */
+    SpinningBodyMsg_C      spinningBodyInMsg;      //!< input spinning body message
+    SpinningBodyMsg_C      spinningBodyRefInMsg;   //!< output msg containing spinning body target angle and angle rate
+    ArrayMotorTorqueMsg_C  motorTorqueOutMsg;      //!< output msg containing the motor torque to the array drive
+
+    BSKLogger *bskLogger;                          //!< BSK Logging
+
+}PIDController1DConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void SelfInit_PIDController1D(PIDController1DConfig *configData, int64_t moduleID);
+    void Reset_PIDController1D(PIDController1DConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_PIDController1D(PIDController1DConfig *configData, uint64_t callTime, int64_t moduleID);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.i
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.i
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module PIDController1D
+%{
+   #include "PIDController1D.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_PIDController1D(void*, uint64_t);
+%ignore SelfInit_PIDController1D;
+%constant void Reset_PIDController1D(void*, uint64_t, uint64_t);
+%ignore Reset_PIDController1D;
+%constant void Update_PIDController1D(void*, uint64_t, uint64_t);
+%ignore Update_PIDController1D;
+
+%include "PIDController1D.h"
+
+%include "architecture/msgPayloadDefC/SpinningBodyMsgPayload.h"
+struct SpinningBodyMsg_C;
+%include "architecture/msgPayloadDefC/ArrayMotorTorqueMsgPayload.h"
+struct ArrayMotorTorqueMsg_C;
+
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.rst
+++ b/src/fswAlgorithms/attControl/PIDController1D/PIDController1D.rst
@@ -1,0 +1,71 @@
+Executive Summary
+-----------------
+
+This module implements a simple Proportional-Integral-Derivative (PID) control law to provide the commanded torque to a :ref:`spinningBodyStateEffector`.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg connection is set by the
+user from python.  The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - motorTorqueOutMsg
+      - :ref:`ArrayMotorTorqueMsgPayload`
+      - Output Spinning Body Reference Message.
+    * - spinningBodyInMsg
+      - :ref:`SpinningBodyMsgPayload`
+      - Input Spinning Body Message Message.
+    * - spinningBodyRefInMsg
+      - :ref:`SpinningBodyMsgPayload`
+      - Input Spinning Body Reference Message Message. 
+
+
+Module Assumptions and Limitations
+----------------------------------
+This module is very simple and does not make any assumptions. The only limitations are those inherent to a PID type of control law, here implemented. The type of response (underdamped, 
+overdamped, or critically damped) depends on the choice of gains provided as inputs to the module.
+
+
+Detailed Module Description
+---------------------------
+For this module to operate, the user needs to provide control gains ``K``, ``P`` and ``I``. Let's define :math:`\theta_R` and :math:`\dot{\theta}_R` the reference angle and angle rate contained in the
+``spinningBodyRefInMsg``, and :math:`\theta` and :math:`\dot{\theta}` the current solar array angle and angle rate contained in the ``spinningBodyInMsg``, which is provided as an output of the :ref:`spinningBodyStateEffector`. The control torque is obtained as follows:
+
+.. math::
+    T = K (\theta_R - \theta) + P (\dot{\theta}_R - \dot{\theta}) + I \int_0^t (\theta_R - \theta) \text{d}\tau.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    PIDControllerConfig = PIDController1D.PIDController1DConfig()
+    PIDControllerWrap = unitTestSim.setModelDataWrap(PIDControllerConfig)
+    PIDControllerWrap.ModelTag = "solarArrayPDController"  
+    PIDControllerConfig.K = K
+    PIDControllerConfig.P = P
+    PIDControllerConfig.P = I
+    unitTestSim.AddModelToTask(unitTaskName, PIDControllerWrap, PIDControllerConfig)
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 34 66
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``K``
+     - proportional gain; defaults to 0 if not provided
+   * - ``P``
+     - derivative gain; defaults to 0 if not provided
+   * - ``I``
+     - integral gain; defaults to 0 if not provided

--- a/src/fswAlgorithms/attControl/PIDController1D/_UnitTest/test_PIDController1D.py
+++ b/src/fswAlgorithms/attControl/PIDController1D/_UnitTest/test_PIDController1D.py
@@ -1,0 +1,182 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        solarArrayRotation
+#   Author:             Riccardo Calaon
+#   Creation Date:      January 12, 2023
+#
+
+import pytest
+import os, inspect, random
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+
+# Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport                   # general support file with common unit test functions
+from Basilisk.fswAlgorithms import PIDController1D               # import the module that is to be tested
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging                      # import the message definitions
+from Basilisk.architecture import bskLogging
+
+
+# Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
+# @pytest.mark.skipif(conditionstring)
+# Uncomment this line if this test has an expected failure, adjust message as needed.
+# @pytest.mark.xfail(conditionstring)
+# Provide a unique test method name, starting with 'test_'.
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.  Note that the order in that you add the parametrize method
+# matters for the documentation in that it impacts the order in which the test arguments are shown.
+# The first parametrize arguments are shown last in the pytest argument list
+@pytest.mark.parametrize("thetaR", [np.pi/2, np.pi/6])
+@pytest.mark.parametrize("thetaDotR", [0.1, 0.2])
+@pytest.mark.parametrize("theta", [7*np.pi/6, 3*np.pi/2])
+@pytest.mark.parametrize("thetaDot", [-0.1, -0.5])
+@pytest.mark.parametrize("K", [0, 2])
+@pytest.mark.parametrize("P", [0, 5])
+@pytest.mark.parametrize("I", [0, 1])
+@pytest.mark.parametrize("accuracy", [1e-12])
+
+
+# update "module" in this function name to reflect the module name
+def test_PIDController1D(show_plots, thetaR, thetaDotR, theta, thetaDot, K, P, I, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test verifies the correctness of the output motor torque :ref:`solarArrayPDController`.
+    The inputs provided are reference angle and angle rate, current angle and angle rate, proportiona,
+    derivative, and integral gain.
+
+    **Test Parameters**
+
+    Args:
+        thetaR (double): reference angle;
+        thetaDotR (double): reference angle rate;
+        theta (double): current angle;
+        thetaDot (double): current angle rate;
+        K (double): proportional gain;
+        P (double): derivative gain;
+        I (double): integral gain;
+        accuracy (float): absolute accuracy value used in the validation tests.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the correctness of the output motor torque
+
+    - ``motorTorqueOutMsg``
+
+    where in this case the output is one dimensional, since the spinning body is one dimensional. The unit test
+    only checks the output at the first time step, for which the integral term does not contribute.
+    """
+    # each test method requires a single assert method to be called
+    [testResults, testMessage] = PIDController1DTestFunction(show_plots, thetaR, thetaDotR, theta, thetaDot, K, P, I, accuracy)
+    assert testResults < 1, testMessage
+
+
+def PIDController1DTestFunction(show_plots, thetaR, thetaDotR, theta, thetaDot, K, P, I, accuracy):
+
+    testFailCount = 0                        # zero unit test result counter
+    testMessages = []                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    PIDControllerConfig = PIDController1D.PIDController1DConfig()
+    PIDControllerWrap = unitTestSim.setModelDataWrap(PIDControllerConfig)
+    PIDControllerWrap.ModelTag = "solarArrayPDController"  
+    PIDControllerConfig.K = K
+    PIDControllerConfig.P = P
+    PIDControllerConfig.I = I
+    unitTestSim.AddModelToTask(unitTaskName, PIDControllerWrap, PIDControllerConfig)
+
+    # Create input spinning body reference message
+    SpinningBodyRefInMsgData = messaging.SpinningBodyMsgPayload()
+    SpinningBodyRefInMsgData.theta = thetaR
+    SpinningBodyRefInMsgData.thetaDot = thetaDotR
+    SpinningBodyRefInMsg = messaging.SpinningBodyMsg().write(SpinningBodyRefInMsgData)
+    PIDControllerConfig.spinningBodyRefInMsg.subscribeTo(SpinningBodyRefInMsg)
+
+    # Create input spinning body message
+    SpinningBodyInMsgData = messaging.SpinningBodyMsgPayload()
+    SpinningBodyInMsgData.theta = theta
+    SpinningBodyInMsgData.thetaDot = thetaDot
+    SpinningBodyInMsg = messaging.SpinningBodyMsg().write(SpinningBodyInMsgData)
+    PIDControllerConfig.spinningBodyInMsg.subscribeTo(SpinningBodyInMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = PIDControllerConfig.motorTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))        # seconds to stop simulation
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    T = K * (thetaR - theta) + P * (thetaDotR - thetaDot)
+
+    # compare the module results to the truth values
+    if not unitTestSupport.isDoubleEqual(dataLog.motorTorque[0][0], T, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + PIDControllerWrap.ModelTag + "PIDController1D module failed unit test on T for thetaR = {}, thetaDotR  = {}, theta = {}, thetaDot = {}, K = {}, P = {} \n".format(thetaR, thetaDotR, theta, thetaDot, K, P))
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_PIDController1D( 
+                 False,
+                 np.pi/3,
+                 0,
+                 np.pi/2,
+                 0.1,
+                 1,
+                 5,
+                 1e-12        # accuracy
+               )


### PR DESCRIPTION
* **Tickets addressed:** bsk-106
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module reads in a SpinningBodyMsg containing the current angle and angle rate, and a SpinningBodyReferenceMsg containing reference angle and angle rates. Based on those, it computes a proportional-integral-derivative control torque that is delivered to the SpinningBodyStateEffector. Commit 1 initializes the module with its main functions left empty. Commit 2 checks if the required input msgs are connected. Commits 3 through 7 incrementally build the Update() function with the math that allows to derive the reference angle and angle rate, and write the output msg. Commits 8 and 9 contain the documentation and unit test, respectively.

## Verification
A unit test is provided. Such unit test verifies the module's output torque vs a torque computed using the same gains in python. Because the unit test is run for one single call of the Update() function, the integral term is always zero.

## Documentation
This is a new module. New documentation is provided to describe how the module works.

## Future work
No future work is foreseen at the moment.
