### PR TITLE
Feature/bsk 113 prescribed motion

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -46,6 +46,8 @@ Version |release|
 - Created a :ref:`tempMeasurement` module to add sensor noise/bias and fault capabilities to temperature readings
 - Added a ``terminal`` flag to the event handlers that cause the simulation to terminate when triggered; demonstrated
   use of flag in update to :ref:`scenarioDragDeorbit`.
+- Created a :ref:`prescribedMotionStateEffector` dynamics module for appending rigid bodies with prescribed motion
+  to the spacecraft hub.
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/src/architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h
@@ -1,0 +1,35 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef prescribedMotionSimMsg_h
+#define prescribedMotionSimMsg_h
+
+
+ /*! @brief Structure used to define the individual prescribed motion state effector data message*/
+typedef struct {
+    double r_FM_M[3];                          //!< [m] position vector from the M frame origin to the F frame origin in M frame components
+    double rPrime_FM_M[3];                     //!< [m/s] B frame time derivative of r_FM_M
+    double rPrimePrime_FM_M[3];                //!< [m/s^2] B frame time derivative of rPrime_FM_M
+    double omega_FM_F[3];                      //!< [rad/s] Angular velocity of the F frame wrt the M frame in F frame components
+    double omegaPrime_FM_F[3];                 //!< [rad/s^2] B frame time derivative of omega_FM_F
+    double sigma_FM[3];                        //!< MRP attitude parameters for the F frame relative to the M frame
+}PrescribedMotionMsgPayload;
+
+
+#endif /* prescribedMotionSimMsg_h */

--- a/src/architecture/msgPayloadDefC/PrescribedTransMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/PrescribedTransMsgPayload.h
@@ -1,0 +1,31 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef prescribedTransSimMsg_h
+#define prescribedTransSimMsg_h
+
+
+ /*! @brief Structure used to define the data message*/
+typedef struct {
+    double scalarPos;                   //!< [m], spinning body translational displacement
+    double scalarVel;                   //!< [m/s], spinning body translational displacement rate
+}PrescribedTransMsgPayload;
+
+
+#endif /* prescribedTransSimMsg_h */

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/_UnitTest/test_prescribed1DOF.py
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/_UnitTest/test_prescribed1DOF.py
@@ -1,0 +1,204 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        prescribedRot1DOF
+#   Author:             Leah Kiner
+#   Creation Date:      Nov 14, 2022
+#
+
+import pytest
+import inspect
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging
+from Basilisk.fswAlgorithms import prescribedRot1DOF  # import the module that is to be tested
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import unitTestSupport
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Vary the initial angle, reference angle, and maximum angular acceleration for pytest
+@pytest.mark.parametrize("thetaInit", [0, 2*np.pi/3])
+@pytest.mark.parametrize("thetaRef", [0, 2*np.pi/3])
+@pytest.mark.parametrize("thetaDDotMax", [0.008, 0.1])
+@pytest.mark.parametrize("accuracy", [1e-12])
+def test_prescribedRot1DOFTestFunction(show_plots, thetaInit, thetaRef, thetaDDotMax, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test ensures that the profiled 1 DOF attitude maneuver for a secondary rigid body connected
+    to the spacecraft hub is properly computed for a series of initial and reference PRV angles and maximum
+    angular accelerations. The final prescribed attitude and angular velocity magnitude are compared with
+    the reference values.
+
+    **Test Parameters**
+
+    Args:
+        thetaInit (float): [rad] Initial PRV angle of the F frame with respect to the M frame
+        thetaRef (float): [rad] Reference PRV angle of the F frame with respect to the M frame
+        thetaDDotMax (float): [rad/s^2] Maximum angular acceleration for the attitude maneuver
+        accuracy (float): absolute accuracy value used in the validation tests
+
+    **Description of Variables Being Tested**
+
+    This unit test ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
+    initial and reference PRV angles and maximum angular accelerations. The final prescribed angle ``theta_FM_Final``
+    and angular velocity magnitude ``thetaDot_Final`` are compared with the reference values ``theta_Ref`` and
+    ``thetaDot_Ref``, respectively.
+    """
+    [testResults, testMessage] = prescribedRot1DOFTestFunction(show_plots, thetaInit, thetaRef, thetaDDotMax, accuracy)
+
+    assert testResults < 1, testMessage
+
+
+def prescribedRot1DOFTestFunction(show_plots, thetaInit, thetaRef, thetaDDotMax, accuracy):
+    """Call this routine directly to run the unit test."""
+    testFailCount = 0                                        # Zero the unit test result counter
+    testMessages = []                                        # Create an empty array to store the test log messages
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create the test thread
+    testProcessRate = macros.sec2nano(0.1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create an instance of the prescribedRot1DOF module to be tested
+    PrescribedRot1DOFConfig = prescribedRot1DOF.PrescribedRot1DOFConfig()
+    PrescribedWrap = unitTestSim.setModelDataWrap(PrescribedRot1DOFConfig)
+    PrescribedWrap.ModelTag = "prescribedRot1DOF"
+
+    # Add the prescribedRot1DOF test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, PrescribedWrap, PrescribedRot1DOFConfig)
+
+    # Initialize the prescribedRot1DOF test module configuration data
+    rotAxisM = np.array([1.0, 0.0, 0.0])
+    prvInit_FM = thetaInit * rotAxisM
+    PrescribedRot1DOFConfig.r_FM_M = np.array([1.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.rotAxis_M = rotAxisM
+    PrescribedRot1DOFConfig.thetaDDotMax = thetaDDotMax
+    PrescribedRot1DOFConfig.omega_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.sigma_FM = rbk.PRV2MRP(prvInit_FM)
+
+    # Create the prescribedRot1DOF input message
+    thetaDotRef = 0.0  # [rad/s]
+    HingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
+    HingedRigidBodyMessageData.theta = thetaRef
+    HingedRigidBodyMessageData.thetaDot = thetaDotRef
+    HingedRigidBodyMessage = messaging.HingedRigidBodyMsg().write(HingedRigidBodyMessageData)
+    PrescribedRot1DOFConfig.spinningBodyInMsg.subscribeTo(HingedRigidBodyMessage)
+
+    # Log the test module output message for data comparison
+    dataLog = PrescribedRot1DOFConfig.prescribedMotionOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Initialize the simulation
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time
+    simTime = np.sqrt(((0.5 * np.abs(thetaRef - thetaInit)) * 8) / thetaDDotMax) + 1
+    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
+
+    # Begin the simulation
+    unitTestSim.ExecuteSimulation()
+
+    # Extract the logged data for plotting and data comparison
+    omega_FM_F = dataLog.omega_FM_F
+    sigma_FM = dataLog.sigma_FM
+    timespan = dataLog.times()
+
+    thetaDot_Final = np.linalg.norm(omega_FM_F[-1, :])
+    sigma_FM_Final = sigma_FM[-1, :]
+    theta_FM_Final = 4 * np.arctan(np.linalg.norm(sigma_FM_Final))
+
+    # Convert the logged sigma_FM MRPs to a scalar theta_FM array
+    n = len(timespan)
+    theta_FM = []
+    for i in range(n):
+        theta_FM.append(4 * np.arctan(np.linalg.norm(sigma_FM[i, :])))
+
+    # Plot theta_FM
+    thetaRef_plotting = np.ones(len(timespan)) * thetaRef
+    thetaInit_plotting = np.ones(len(timespan)) * thetaInit
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, theta_FM, label=r"$\Phi$")
+    plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * thetaRef_plotting, '--', label=r'$\Phi_{Ref}$')
+    plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * thetaInit_plotting, '--', label=r'$\Phi_{0}$')
+    plt.title(r'$\Phi_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(deg)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.legend(loc='center right', prop={'size': 16})
+
+    # Plot omega_FM_F
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_FM_F[:, 0], label=r'$\omega_{1}$')
+    plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_FM_F[:, 1], label=r'$\omega_{2}$')
+    plt.plot(timespan * macros.NANO2SEC, (180 / np.pi) * omega_FM_F[:, 2], label=r'$\omega_{3}$')
+    plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(deg/s)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.legend(loc='upper right', prop={'size': 16})
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # Check to ensure the initial angle rate converged to the reference angle rate
+    if not unitTestSupport.isDoubleEqual(thetaDot_Final, thetaDotRef, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + PrescribedWrap.ModelTag + "thetaDot_Final and thetaDotRef do not match")
+
+    # Check to ensure the initial angle converged to the reference angle
+    if not unitTestSupport.isDoubleEqual(theta_FM_Final, thetaRef, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + PrescribedWrap.ModelTag + "theta_FM_Final and thetaRef do not match")
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    prescribedRot1DOFTestFunction(
+                 True,
+                 np.pi/6,     # thetaInit
+                 2*np.pi/3,     # thetaRef
+                 0.008,       # thetaDDotMax
+                 1e-12        # accuracy
+               )

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.c
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.c
@@ -1,0 +1,189 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+/* Import the module header file */
+#include "prescribedRot1DOF.h"
+
+/* Other required files to import */
+#include <stdbool.h>
+#include <math.h>
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/macroDefinitions.h"
+
+/*! This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, int64_t moduleID)
+{
+    // Initialize the output messages
+    PrescribedMotionMsg_C_init(&configData->prescribedMotionOutMsg);
+    HingedRigidBodyMsg_C_init(&configData->spinningBodyOutMsg);
+}
+
+
+/*! This method performs a complete reset of the module. The input messages are checked to ensure they are linked.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] Time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+    // Check if the required input message is linked
+    if (!HingedRigidBodyMsg_C_isLinked(&configData->spinningBodyInMsg))
+    {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: prescribedRot1DOF.spinningBodyInMsg wasn't connected.");
+    }
+
+    // Set the initial time
+    configData->tInit = 0.0;
+
+    // Set the initial convergence to true to enter the required loop in Update_prescribedRot1DOF() on the first pass
+    configData->convergence = true;
+}
+
+
+/*! This method profiles the prescribed trajectory and updates the prescribed states as a function of time.
+The prescribed states are then written to the output message.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] Time the method is called
+ @param moduleID The module identifier
+*/
+void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+    // Create the buffer messages
+    HingedRigidBodyMsgPayload spinningBodyIn;
+    HingedRigidBodyMsgPayload spinningBodyOut;
+    PrescribedMotionMsgPayload prescribedMotionOut;
+
+    // Zero the output messages
+    spinningBodyOut = HingedRigidBodyMsg_C_zeroMsgPayload();
+    prescribedMotionOut = PrescribedMotionMsg_C_zeroMsgPayload();
+
+    // Read the input message
+    spinningBodyIn = HingedRigidBodyMsg_C_zeroMsgPayload();
+    if (HingedRigidBodyMsg_C_isWritten(&configData->spinningBodyInMsg))
+    {
+        spinningBodyIn = HingedRigidBodyMsg_C_read(&configData->spinningBodyInMsg);
+    }
+
+    /* This loop is entered (a) initially and (b) when each attitude maneuver is complete. The reference angle is updated
+    even if a new message is not written */
+    if (HingedRigidBodyMsg_C_timeWritten(&configData->spinningBodyInMsg) <= callTime && configData->convergence)
+    {
+        // Store the initial time as the current simulation time
+        configData->tInit = callTime * NANO2SEC;
+
+        // Calculate the current ange and angle rate
+        double prv_FM_array[3];
+        MRP2PRV(configData->sigma_FM, prv_FM_array);
+        configData->thetaInit = v3Dot(prv_FM_array, configData->rotAxis_M);
+        configData->thetaDotInit = v3Norm(configData->omega_FM_F);
+
+        // Store the reference angle and reference angle rate
+        configData->thetaRef = spinningBodyIn.theta;
+        configData->thetaDotRef = spinningBodyIn.thetaDot;
+
+        // Define temporal information for the maneuver
+        double convTime = sqrt(((0.5 * fabs(configData->thetaRef - configData->thetaInit)) * 8) / configData->thetaDDotMax);
+        configData->tf = configData->tInit + convTime;
+        configData->ts = configData->tInit + convTime / 2;
+
+        // Define the parabolic constants for the first and second half of the maneuver
+        configData->a = 0.5 * (configData->thetaRef - configData->thetaInit) / ((configData->ts - configData->tInit) * (configData->ts - configData->tInit));
+        configData->b = -0.5 * (configData->thetaRef - configData->thetaInit) / ((configData->ts - configData->tf) * (configData->ts - configData->tf));
+
+        // Set the convergence to false until the attitude maneuver is complete
+        configData->convergence = false;
+    }
+
+    // Store the current simulation time
+    double t = callTime * NANO2SEC;
+
+    // Define the scalar prescribed states
+    double thetaDDot;
+    double thetaDot;
+    double theta;
+
+    // Compute the prescribed scalar states at the current simulation time
+    if ((t < configData->ts || t == configData->ts) && configData->tf - configData->tInit != 0) // Entered during the first half of the maneuver
+    {
+        thetaDDot = configData->thetaDDotMax;
+        thetaDot = thetaDDot * (t - configData->tInit) + configData->thetaDotInit;
+        theta = configData->a * (t - configData->tInit) * (t - configData->tInit) + configData->thetaInit;
+    }
+    else if ( t > configData->ts && t <= configData->tf && configData->tf - configData->tInit != 0) // Entered during the second half of the maneuver
+    {
+        thetaDDot = -1 * configData->thetaDDotMax;
+        thetaDot = thetaDDot * (t - configData->tInit) + configData->thetaDotInit - thetaDDot * (configData->tf - configData->tInit);
+        theta = configData->b * (t - configData->tf) * (t - configData->tf) + configData->thetaRef;
+    }
+    else // Entered when the maneuver is complete
+    {
+        thetaDDot = 0.0;
+        thetaDot = configData->thetaDotRef;
+        theta = configData->thetaRef;
+        configData->convergence = true;
+    }
+
+    // Determine the prescribed parameters: omega_FM_F and omegaPrime_FM_F
+    v3Normalize(configData->rotAxis_M, configData->rotAxis_M);
+    v3Scale(thetaDot, configData->rotAxis_M, configData->omega_FM_F);
+    v3Scale(thetaDDot, configData->rotAxis_M, configData->omegaPrime_FM_F);
+
+    // Determine dcm_FF0
+    double dcm_FF0[3][3];
+    double prv_FF0_array[3];
+    double theta_FF0 = theta - configData->thetaInit;
+    v3Scale(theta_FF0, configData->rotAxis_M, prv_FF0_array);
+    PRV2C(prv_FF0_array, dcm_FF0);
+
+    // Determine dcm_F0M
+    double dcm_F0M[3][3];
+    double prv_F0M_array[3];
+    v3Scale(configData->thetaInit, configData->rotAxis_M, prv_F0M_array);
+    PRV2C(prv_F0M_array, dcm_F0M);
+
+    // Determine dcm_FM
+    double dcm_FM[3][3];
+    m33MultM33(dcm_FF0, dcm_F0M, dcm_FM);
+
+    // Determine the prescribed parameter: sigma_FM
+    C2MRP(dcm_FM, configData->sigma_FM);
+
+    // Copy the module variables to the prescribedMotionOut output message
+    v3Copy(configData->r_FM_M, prescribedMotionOut.r_FM_M);
+    v3Copy(configData->rPrime_FM_M, prescribedMotionOut.rPrime_FM_M);
+    v3Copy(configData->rPrimePrime_FM_M, prescribedMotionOut.rPrimePrime_FM_M);
+    v3Copy(configData->omega_FM_F, prescribedMotionOut.omega_FM_F);
+    v3Copy(configData->omegaPrime_FM_F, prescribedMotionOut.omegaPrime_FM_F);
+    v3Copy(configData->sigma_FM, prescribedMotionOut.sigma_FM);
+
+    // Copy the local scalar variables to the spinningBodyOut output message
+    spinningBodyOut.theta = theta;
+    spinningBodyOut.thetaDot = thetaDot;
+
+    // Write the output messages
+    HingedRigidBodyMsg_C_write(&spinningBodyOut, &configData->spinningBodyOutMsg, moduleID, callTime);
+    PrescribedMotionMsg_C_write(&prescribedMotionOut, &configData->prescribedMotionOutMsg, moduleID, callTime);
+}

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.h
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.h
@@ -1,0 +1,72 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _PRESCRIBEDROT1DOF_
+#define _PRESCRIBEDROT1DOF_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/HingedRigidBodyMsg_C.h"
+#include "cMsgCInterface/PrescribedMotionMsg_C.h"
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* User configurable variables */
+    double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of spinning body
+    double rotAxis_M[3];                                        //!< Rotation axis for the maneuver in M frame components
+    double r_FM_M[3];                                           //!< [m] Position of the F frame origin with respect to the M frame origin in M frame components (fixed)
+    double rPrime_FM_M[3];                                      //!< [m/s] B frame time derivative of r_FM_M in M frame components (fixed)
+    double rPrimePrime_FM_M[3];                                 //!< [m/s^2] B frame time derivative of rPrime_FM_M in M frame components (fixed)
+    double omega_FM_F[3];                                       //!< [rad/s] Angular velocity of frame F wrt frame M in F frame components
+    double omegaPrime_FM_F[3];                                  //!< [rad/s^2] B frame time derivative of omega_FM_F in F frame components
+    double sigma_FM[3];                                         //!< MRP attitude of frame F with respect to frame M
+
+    /* Private variables */
+    bool convergence;                                           //!< Boolean variable is true when the maneuver is complete
+    double tInit;                                               //!< [s] Simulation time at the beginning of the maneuver
+    double thetaInit;                                           //!< [rad] Initial spinning body angle from frame M to frame F about rotAxis_M
+    double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate between frame M to frame F
+    double thetaRef;                                            //!< [rad] Reference angle from frame M to frame F about rotAxis_M
+    double thetaDotRef;                                         //!< [rad/s] Reference angle rate between frame M to frame F
+    double ts;                                                  //!< [s] The simulation time halfway through the maneuver (switch time for ang accel)
+    double tf;                                                  //!< [s] Simulation time when the maneuver is finished
+    double a;                                                   //!< Parabolic constant for the first half of the maneuver
+    double b;                                                   //!< Parabolic constant for the second half of the maneuver
+
+    BSKLogger *bskLogger;                                       //!< BSK Logging
+
+    /* Messages */
+    HingedRigidBodyMsg_C    spinningBodyInMsg;                  //!< Input msg for the spinning body reference angle and angle rate
+    HingedRigidBodyMsg_C    spinningBodyOutMsg;                 //!< Output msg for the spinning body angle and angle rate
+    PrescribedMotionMsg_C prescribedMotionOutMsg;               //!< Output msg for the spinning body prescribed states
+
+}PrescribedRot1DOFConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void SelfInit_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, int64_t moduleID);                     //!< Method for module initialization
+    void Reset_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID);     //!< Method for module reset
+    void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID);    //!< Method for module time update
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.i
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.i
@@ -1,0 +1,42 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module prescribedRot1DOF
+%{
+   #include "prescribedRot1DOF.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_prescribedRot1DOF(void*, uint64_t);
+%ignore SelfInit_prescribedRot1DOF;
+%constant void Reset_prescribedRot1DOF(void*, uint64_t, uint64_t);
+%ignore Reset_prescribedRot1DOF;
+%constant void Update_prescribedRot1DOF(void*, uint64_t, uint64_t);
+%ignore Update_prescribedRot1DOF;
+
+%include "prescribedRot1DOF.h"
+
+%include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
+struct HingedRigidBodyMsg_C;
+%include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
+struct PrescribedMotionMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.rst
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.rst
@@ -1,0 +1,172 @@
+Executive Summary
+-----------------
+This module profiles a :ref:`PrescribedMotionMsgPayload` message for a specified 1 DOF rotational attitude maneuver
+for a secondary rigid body connected to a rigid spacecraft hub at a hub-fixed location, :math:`\mathcal{M}`. The body
+frame for the prescribed body is designated by the frame :math:`\mathcal{F}`. Accordingly, the prescribed states for the
+secondary body are written with respect to the mount frame, :math:`\mathcal{M}`. The prescribed states are: ``r_FM_M``,
+``rPrime_FM_M``, ``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. Because this is a
+purely rotational profiler, the translational states ``r_FM_M``, ``rPrime_FM_M``, and ``rPrimePrime_FM_M`` are held
+constant in this module.
+
+To use this module for prescribed motion purposes, it must be connected to the :ref:`PrescribedMotionStateEffector`
+dynamics module in order to profile the states of the secondary body. The required maneuver is determined from the
+user-specified scalar maximum angular acceleration for the attitude maneuver :math:`\alpha_{\text{max}}`, prescribed
+body's initial attitude with respect to the mount frame as the Principal Rotation Vector ``prv_F0M``
+:math:`(\Phi_0, \hat{\textbf{{e}}}_0)`, and the prescribed body's reference attitude with respect to the mount frame as
+the Principal Rotation Vector ``prv_F1M`` :math:`(\Phi_1, \hat{\textbf{{e}}}_1)`.
+
+The maximum scalar angular acceleration is applied constant and positively for the first half of the maneuver and
+constant negatively for the second half of the maneuver. The resulting angular velocity of the prescribed body is
+linear, approaching a maximum magnitude halfway through the maneuver and ending with zero residual velocity.
+The corresponding angle the prescribed body moves through during the maneuver is parabolic in time.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  
+The module msg connection is set by the user from python.  
+The msg type contains a link to the message structure definition, while the description 
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - spinningBodyInMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - input msg with the spinning body reference states
+    * - spinningBodyOutMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - output message with the scalar spinning body states
+    * - prescribedMotionOutMsg
+      - :ref:`PrescribedMotionMsgPayload`
+      - output message with the prescribed spinning body states
+
+
+
+Detailed Module Description
+---------------------------
+This 1 DOF rotational motion flight software module is written to profile spinning body motion with respect to a 
+body-fixed mount frame. The inputs to the profiler are the scalar maximum angular acceleration for the attitude maneuver 
+:math:`\alpha_{\text{max}}`, the prescribed body's initial attitude with respect to the mount frame as the Principal 
+Rotation Vector ``prv_F0M`` :math:`(\Phi_0, \hat{\textbf{{e}}}_0)`, and the prescribed body's reference attitude with respect to the
+mount frame as the Principal Rotation Vector ``prv_F1M`` :math:`(\Phi_1, \hat{\textbf{{e}}}_1)`. The prescribed body is
+assumed to be non-rotating at the beginning of the attitude maneuver.
+    
+Subtracting the initial principal rotation vector from the reference principal rotation vector gives the required 
+rotation angle and axis for the maneuver:
+
+.. math::
+    \Phi_{\text{ref}} = 2 \cos^{-1} \left ( \cos \frac{\Phi_1}{2} \cos \frac{\Phi_0}{2} + \sin \frac{\Phi_1}{2} \sin \frac {\Phi_0}{2} \hat{\textbf{{e}}}_1 \cdot \hat{\textbf{{e}}}_0 \right )
+
+.. math::
+    \hat{\textbf{{e}}} = \frac{\cos \frac{\Phi_0}{2} \sin \frac{\Phi_1}{2} \hat{\textbf{{e}}}_1 - \cos \frac{\Phi_1}{2} \sin \frac{\Phi_0}{2} \hat{\textbf{{e}}}_0 + \sin \frac{\Phi_1}{2} \sin \frac{\Phi_0}{2} \hat{\textbf{{e}}}_1 \times \hat{\textbf{{e}}}_0 }{\sin \frac{\Phi_{\text{ref}}}{2}}
+
+During the first half of the attitude maneuver, the prescribed body is constantly accelerated with the given maximum 
+angular acceleration. The prescribed body's angular velocity increases linearly during the acceleration phase and 
+reaches a maximum magnitude halfway through the attitude maneuver. The switch time :math:`t_s` is the simulation time 
+halfway through the maneuver:
+    
+.. math::
+    t_s = t_0 + \frac{\Delta t}{2}
+
+where the time required for the maneuver :math:`\Delta t` is determined using the inputs to the profiler:
+    
+.. math::
+    \Delta t = t_f - t_0 = 2 \sqrt{ \Phi_{\text{ref}} / \ddot{\Phi}_{\text{max}}}
+
+The resulting trajectory of the angle :math:`\Phi` swept during the first half of the maneuver is parabolic. The profiled 
+motion is concave upwards if the reference angle :math:`\Phi_{\text{ref}}` is greater than zero. If the converse is true, 
+the profiled motion is instead concave downwards. The described motion during the first half of the attitude maneuver 
+is characterized by the expressions:
+ 
+.. math::
+    \omega_{\mathcal{F} / \mathcal{M}}(t) = \alpha_{\text{max}}
+
+.. math::
+    \dot{\Phi}(t) = \alpha_{\text{max}} (t - t_0)
+
+.. math::
+    \Phi(t) = c_1 (t - t_0)^2
+
+where 
+
+.. math::
+    c_1 = \frac{\Phi_{\text{ref}}}{2(t_s - t_0)^2}
+
+Similarly, the second half of the attitude maneuver decelerates the prescribed body constantly until it reaches a 
+non-rotating state. The prescribed body angular velocity decreases linearly from its maximum magnitude back to zero. 
+The trajectory swept during the second half of the maneuver is quadratic and concave downwards if the reference angle 
+:math:`\Phi_{\text{ref}}` is positive. If :math:`\Phi_{\text{ref}}` is negative, the profiled motion is instead concave upwards. 
+The described motion during the second half of the attitude maneuver is characterized by the expressions:
+    
+.. math::
+    \ddot{\Phi}(t) = -\alpha_{\text{max}}
+
+.. math::
+    \dot{\Phi}(t) = \alpha_{\text{max}} (t - t_f)
+
+.. math::
+    \Phi(t) = c_2 (t - t_f)^2  + \Phi_{\text{ref}}
+
+ where 
+
+.. math::
+    c_2 = \frac{\Phi_{\text{ref}}}{2(t_s - t_f)^2}
+
+Module Testing
+^^^^^^^^^^^^^^
+The unit test for this module ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
+initial and reference PRV angles and maximum angular accelerations. The final prescribed angle ``theta_FM_Final``
+and angular velocity magnitude ``thetaDot_Final`` are compared with the reference values ``theta_Ref`` and
+``thetaDot_Ref``, respectively.
+
+User Guide
+----------
+The user-configurable inputs to the profiler are the scalar maximum angular acceleration for the attitude maneuver
+:math:`\alpha_{\text{max}}`, the prescribed body's initial attitude with respect to the mount frame as the Principal
+Rotation Vector ``prv_F0M`` :math:`(\Phi_0, \hat{\textbf{{e}}}_0)`, and the prescribed body's reference attitude with
+respect to the mount frame as the Principal Rotation Vector ``prv_F1M`` :math:`(\Phi_1, \hat{\textbf{{e}}}_1)`.
+
+This module provides two output messages in the form of :ref:`HingedRigidBodyMsgPayload` and
+:ref:`PrescribedMotionMsgPayload`. The first guidance message, describing the spinning body's scalar states relative to
+the body-fixed mount frame can be directly connected to an attitude feedback control module. The second prescribed
+motion output message can be connected to the :ref:`PrescribedMotionStateEffector` dynamics module to directly profile
+a state effector's rotational motion.
+
+This section is to outline the steps needed to setup a prescribed 1 DOF rotational module in python using Basilisk.
+
+#. Import the prescribedRot1DOF class::
+
+    from Basilisk.fswAlgorithms import prescribedRot1DOF
+
+#. Create an instantiation of a prescribed rotational 1 DOF C module and the associated C++ container::
+
+    PrescribedRot1DOFConfig = prescribedRot1DOF.PrescribedRot1DOFConfig()
+    PrescribedWrap = unitTestSim.setModelDataWrap(PrescribedRot1DOFConfig)
+    PrescribedWrap.ModelTag = "prescribedRot1DOF"
+
+#. Define all of the configuration data associated with the module. For example::
+
+    thetaInit = 0.0  # [rad]
+    rotAxis_M = np.array([1.0, 0.0, 0.0])
+    prvInit_FM = thetaInit * rotAxisM
+    PrescribedRot1DOFConfig.r_FM_M = np.array([1.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.rotAxis_M = rotAxis_M
+    PrescribedRot1DOFConfig.thetaDDotMax = 0.01  # [rad/s^2]
+    PrescribedRot1DOFConfig.omega_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedRot1DOFConfig.sigma_FM = rbk.PRV2MRP(prvInit_FM)
+
+The user is required to set the above configuration data parameters, as they are not initialized in the module.
+
+#. Make sure to connect the required messages for this module.
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, PrescribedWrap, PrescribedRot1DOFConfig)
+

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/_UnitTest/test_prescribedTrans.py
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/_UnitTest/test_prescribedTrans.py
@@ -1,0 +1,203 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        prescribedTrans
+#   Author:             Leah Kiner
+#   Creation Date:      Jan 2, 2023
+#
+
+import inspect
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import pytest
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging  # import the message definitions
+from Basilisk.fswAlgorithms import prescribedTrans  # import the module that is to be tested
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Vary the initial angle, reference angle, and maximum angular acceleration for pytest
+@pytest.mark.parametrize("scalarPosInit", [0, 2*np.pi/3])
+@pytest.mark.parametrize("scalarPosRef", [0, 2*np.pi/3])
+@pytest.mark.parametrize("scalarAccelMax", [0.0005, 0.002])
+@pytest.mark.parametrize("accuracy", [1e-12])
+# update "module" in this function name to reflect the module name
+def test_prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarAccelMax, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test ensures that the profiled translational maneuver for a secondary rigid body connected
+    to the spacecraft hub is properly computed for a series of initial and reference positions and maximum
+    accelerations. The final prescribed position and velocity magnitudes are compared with the reference values.
+
+    **Test Parameters**
+
+    Args:
+        scalarPosInit (float): [m] Initial scalar position of the F frame with respect to the M frame
+        scalarPosRef (float): [m] Reference scalar position of the F frame with respect to the M frame
+        scalarAccelMax (float): [m/s^2] Maximum acceleration for the translational maneuver
+        accuracy (float): absolute accuracy value used in the validation tests
+
+    **Description of Variables Being Tested**
+
+    This unit test ensures that the profiled translational maneuver is properly computed for a series of initial and
+    reference positions and maximum accelerations. The final prescribed position magnitude ``r_FM_M_Final`` and
+    velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values ``r_FM_M_Ref`` and
+    ``rPrime_FM_M_Ref``, respectively.
+    """
+
+    [testResults, testMessage] = prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarAccelMax, accuracy)
+
+    assert testResults < 1, testMessage
+
+
+def prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarAccelMax, accuracy):
+    """Call this routine directly to run the unit test."""
+    testFailCount = 0                                        # zero unit test result counter
+    testMessages = []                                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"                          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    PrescribedTransConfig = prescribedTrans.PrescribedTransConfig()
+    PrescribedTransWrap = unitTestSim.setModelDataWrap(PrescribedTransConfig)
+    PrescribedTransWrap.ModelTag = "prescribedTrans"                                 # update python name of test module
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, PrescribedTransWrap, PrescribedTransConfig)
+
+    # Initialize the test module configuration data
+    transAxis_M = np.array([0.5, 0.0, 0.5 * np.sqrt(3)])
+    PrescribedTransConfig.transAxis_M = transAxis_M
+    PrescribedTransConfig.scalarAccelMax = scalarAccelMax  # [rad/s^2]
+    PrescribedTransConfig.r_FM_M = scalarPosInit * transAxis_M
+    PrescribedTransConfig.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.omega_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.sigma_FM = np.array([0.0, 0.0, 0.0])
+
+    # Create input message
+    scalarVelRef = 0.0  # [m/s]
+    PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
+    PrescribedTransMessageData.scalarPos = scalarPosRef
+    PrescribedTransMessageData.scalarVel = scalarVelRef
+    PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
+    PrescribedTransConfig.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = PrescribedTransConfig.prescribedMotionOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time
+    simTime = np.sqrt(((0.5 * np.abs(scalarPosRef - scalarPosInit)) * 8) / scalarAccelMax) + 5
+    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    # Extract logged data
+    r_FM_M = dataLog.r_FM_M
+    rPrime_FM_M = dataLog.rPrime_FM_M
+    timespan = dataLog.times()
+
+    scalarVel_Final = np.linalg.norm(rPrime_FM_M[-1, :])
+    scalarPos_Final = np.linalg.norm(r_FM_M[-1, :])
+
+    # Plot r_FM_F
+    r_FM_M_Ref = scalarPosRef * transAxis_M
+    r_FM_M_1_Ref = np.ones(len(timespan)) * r_FM_M_Ref[0]
+    r_FM_M_2_Ref = np.ones(len(timespan)) * r_FM_M_Ref[1]
+    r_FM_M_3_Ref = np.ones(len(timespan)) * r_FM_M_Ref[2]
+
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 0], label=r'$r_{1}$')
+    plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 1], label=r'$r_{2}$')
+    plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 2], label=r'$r_{3}$')
+    plt.plot(timespan * macros.NANO2SEC, r_FM_M_1_Ref, '--', label=r'$r_{1 Ref}$')
+    plt.plot(timespan * macros.NANO2SEC, r_FM_M_2_Ref, '--', label=r'$r_{2 Ref}$')
+    plt.plot(timespan * macros.NANO2SEC, r_FM_M_3_Ref, '--', label=r'$r_{3 Ref}$')
+    plt.title(r'${}^\mathcal{M} r_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(m)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.legend(loc='center left', prop={'size': 16})
+
+    # Plot rPrime_FM_F
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 0], label='$r\'_{1}$')
+    plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 1], label='$r\'_{2}$')
+    plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 2], label='$r\'_{3}$')
+    plt.title(r'${}^\mathcal{M} r\'_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(m/s)', fontsize=16)
+    plt.xlabel('Time (s)', fontsize=16)
+    plt.legend(loc='upper left', prop={'size': 16})
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # set the filtered output truth states
+    if not unitTestSupport.isDoubleEqual(scalarVel_Final, scalarVelRef, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + PrescribedTransWrap.ModelTag + "scalarVel_Final and scalarVelRef do not match")
+
+    if not unitTestSupport.isDoubleEqual(scalarPos_Final, scalarPosRef, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + PrescribedTransWrap.ModelTag + "scalarPos_Final and scalarPosRef do not match")
+
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    prescribedTransTestFunction(
+                 True,
+                 0.0,         # scalarPosInit
+                 0.25,        # scalarPosRef
+                 0.001,       # scalarAccelMax
+                 1e-12        # accuracy
+               )

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.c
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.c
@@ -1,0 +1,156 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+/*! Import the module header file */
+#include "prescribedTrans.h"
+
+/*! Import other required files */
+#include <math.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
+
+/*! This method initializes the output message for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_prescribedTrans(PrescribedTransConfig *configData, int64_t moduleID)
+{
+    // Initialize the module output message
+    PrescribedMotionMsg_C_init(&configData->prescribedMotionOutMsg);
+}
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values. This method also checks
+ if the module input message is linked.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] Time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+    // Check if the input message is connected
+    if (!PrescribedTransMsg_C_isLinked(&configData->prescribedTransInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: prescribedTrans.prescribedTransInMsg wasn't connected.");
+    }
+
+    // Set the initial time
+    configData->tInit = 0.0;
+
+    // Set the initial convergence to true to enter the correct loop in the Update() method on the first pass
+    configData->convergence = true;
+}
+
+/*! This method uses the given initial and reference attitudes to compute the required attitude maneuver as
+a function of time. The profiled translational trajectory is updated in time and written to the module's prescribed
+motion output message.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] Time the method is called
+ @param moduleID The module identifier
+*/
+void Update_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+    // Create the buffer messages
+    PrescribedTransMsgPayload prescribedTransIn;
+    PrescribedMotionMsgPayload prescribedMotionOut;
+
+    // Zero the output message
+    prescribedMotionOut = PrescribedMotionMsg_C_zeroMsgPayload();
+
+    // Read the input message
+    prescribedTransIn = PrescribedTransMsg_C_zeroMsgPayload();
+    if (PrescribedTransMsg_C_isWritten(&configData->prescribedTransInMsg))
+    {
+        prescribedTransIn = PrescribedTransMsg_C_read(&configData->prescribedTransInMsg);
+    }
+
+    // This loop is entered when a new maneuver is requested after all previous maneuvers are completed
+    if (PrescribedTransMsg_C_timeWritten(&configData->prescribedTransInMsg) <= callTime && configData->convergence)
+    {
+        // Store the initial information
+        configData->tInit = callTime * NANO2SEC;
+        configData->scalarPosInit = v3Norm(configData->r_FM_M);
+        configData->scalarVelInit = v3Norm(configData->rPrime_FM_M);
+
+        // Store the reference information
+        configData->scalarPosRef = prescribedTransIn.scalarPos;
+        configData->scalarVelRef = 0.0;
+
+        // Define temporal information
+        double convTime = sqrt(((0.5 * fabs(configData->scalarPosRef - configData->scalarPosInit)) * 8) / configData->scalarAccelMax);
+        configData->tf = configData->tInit + convTime;
+        configData->ts = configData->tInit + convTime / 2;
+
+        // Define the parabolic constants for the maneuver
+        configData->a = 0.5 * (configData->scalarPosRef - configData->scalarPosInit) / ((configData->ts - configData->tInit) * (configData->ts - configData->tInit));
+        configData->b = -0.5 * (configData->scalarPosRef - configData->scalarPosInit) / ((configData->ts - configData->tf) * (configData->ts - configData->tf));
+
+        // Set the convergence to false to execute the maneuver
+        configData->convergence = false;
+    }
+
+    // Store the current simulation time
+    double t = callTime * NANO2SEC;
+
+    // Define scalar prescribed states
+    double scalarAccel;
+    double scalarVel;
+    double scalarPos;
+
+    // Compute the prescribed scalar states: scalarAccel, scalarVel, and scalarPos
+    if ((t < configData->ts || t == configData->ts) && configData->tf - configData->tInit != 0)  // Entered during the first half of the maneuver
+    {
+        scalarAccel = configData->scalarAccelMax;
+        scalarVel = scalarAccel * (t - configData->tInit) + configData->scalarVelInit;
+        scalarPos = configData->a * (t - configData->tInit) * (t - configData->tInit) + configData->scalarPosInit;
+    }
+    else if ( t > configData->ts && t <= configData->tf && configData->tf - configData->tInit != 0)  // Entered during the second half of the maneuver
+    {
+        scalarAccel = -1 * configData->scalarAccelMax;
+        scalarVel = scalarAccel * (t - configData->tInit) + configData->scalarVelInit - scalarAccel * (configData->tf - configData->tInit);
+        scalarPos = configData->b * (t - configData->tf) * (t - configData->tf) + configData->scalarPosRef;
+    }
+    else  // Entered when the maneuver is complete
+    {
+        scalarAccel = 0.0;
+        scalarVel = configData->scalarVelRef;
+        scalarPos = configData->scalarPosRef;
+        configData->convergence = true;
+    }
+
+    // Convert the scalar variables to the prescribed parameters
+    v3Scale(scalarPos, configData->transAxis_M, configData->r_FM_M);
+    v3Scale(scalarVel, configData->transAxis_M, configData->rPrime_FM_M);
+    v3Scale(scalarAccel, configData->transAxis_M, configData->rPrimePrime_FM_M);
+
+    // Copy the local variables to the output message
+    v3Copy(configData->r_FM_M, prescribedMotionOut.r_FM_M);
+    v3Copy(configData->rPrime_FM_M, prescribedMotionOut.rPrime_FM_M);
+    v3Copy(configData->rPrimePrime_FM_M, prescribedMotionOut.rPrimePrime_FM_M);
+    v3Copy(configData->omega_FM_F, prescribedMotionOut.omega_FM_F);
+    v3Copy(configData->omegaPrime_FM_F, prescribedMotionOut.omegaPrime_FM_F);
+    v3Copy(configData->sigma_FM, prescribedMotionOut.sigma_FM);
+
+    // Write the prescribed motion output message
+    PrescribedMotionMsg_C_write(&prescribedMotionOut, &configData->prescribedMotionOutMsg, moduleID, callTime);
+}

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.h
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.h
@@ -1,0 +1,71 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _PRESCRIBEDTRANS_
+#define _PRESCRIBEDTRANS_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/PrescribedMotionMsg_C.h"
+#include "cMsgCInterface/PrescribedTransMsg_C.h"
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* User configurable variables */
+    double scalarAccelMax;                                          //!< [m/s^2] Maximum acceleration mag
+    double transAxis_M[3];                                          //!< Axis along the direction of translation
+    double r_FM_M[3];                                               //!< [m] Position of the frame F origin with respect to the M frame origin expressed in M frame components
+    double rPrime_FM_M[3];                                          //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
+    double rPrimePrime_FM_M[3];                                     //!< [m/s^] B frame time derivative of rPrime_FM_M expressed in M frame components
+    double omega_FM_F[3];                                           //!< [rad/s] Angular velocity of frame F with respect to frame M expressed in F frame components
+    double omegaPrime_FM_F[3];                                      //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components
+    double sigma_FM[3];                                             //!< MRP attitude of frame F with respect to frame M
+
+    /* Private variables */
+    bool convergence;                                               //!< Boolean variable is true when the maneuver is complete
+    double tInit;                                                   //!< [s] Simulation time at the start of the maneuver
+    double scalarPosInit;                                           //!< [m] Initial distance between the frame F and frame M origin
+    double scalarVelInit;                                           //!< [m/s] Initial velocity between the frame F and frame M origin
+    double scalarPosRef;                                            //!< [m] Magnitude of the reference position vector
+    double scalarVelRef;                                            //!< [m/s] Magnitude of the reference velocity vector
+    double ts;                                                      //!< [s] Simulation time halfway through the maneuver
+    double tf;                                                      //!< [s] Simulation time at the time the maneuver is complete
+    double a;                                                       //!< Parabolic constant for the first half of the maneuver
+    double b;                                                       //!< Parabolic constant for the second half of the maneuver
+
+    // Messages
+    PrescribedTransMsg_C prescribedTransInMsg;                      //!< Input message for the reference states
+    PrescribedMotionMsg_C prescribedMotionOutMsg;                   //!< Output message for the prescribed states
+
+    BSKLogger *bskLogger;                                           //!< BSK Logging
+
+}PrescribedTransConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void SelfInit_prescribedTrans(PrescribedTransConfig *configData, int64_t moduleID);
+    void Reset_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.i
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.i
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module prescribedTrans
+%{
+   #include "prescribedTrans.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_prescribedTrans(void*, uint64_t);
+%ignore SelfInit_prescribedTrans;
+%constant void Reset_prescribedTrans(void*, uint64_t, uint64_t);
+%ignore Reset_prescribedTrans;
+%constant void Update_prescribedTrans(void*, uint64_t, uint64_t);
+%ignore Update_prescribedTrans;
+
+%include "prescribedTrans.h"
+
+%include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
+struct PrescribedMotionMsg_C;
+
+%include "architecture/msgPayloadDefC/PrescribedTransMsgPayload.h"
+struct PrescribedTransMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.rst
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.rst
@@ -1,0 +1,171 @@
+Executive Summary
+-----------------
+This module profiles a :ref:`PrescribedMotionMsgPayload` message for a specified translational maneuver
+for a secondary rigid body connected to a rigid spacecraft hub at a hub-fixed location, :math:`\mathcal{M}`. The body
+frame for the prescribed body is designated by the frame :math:`\mathcal{F}`. Accordingly, the prescribed states for the
+secondary body are written with respect to the mount frame, :math:`\mathcal{M}`. The prescribed states are: ``r_FM_M``,
+``rPrime_FM_M``, ``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. Because this is a
+purely translational profiler, the states ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM`` are held
+constant in this module.
+
+To use this module for prescribed motion purposes, it must be connected to the :ref:`PrescribedMotionStateEffector`
+dynamics module in order to profile the states of the secondary body. The required maneuver is determined from the
+user-specified scalar maximum acceleration :math:`a_{\text{max}}`, the mount frame axis for the translational motion,
+the prescribed body's initial position vector with respect to the mount frame :math:`\boldsymbol{r}_{F/M}(t_0)`, and
+the reference position vector or the prescribed body with respect to the mount frame
+:math:`\boldsymbol{r}_{F/M} (\text{ref})`.
+
+The maximum scalar acceleration is applied constant and positively for the first half of the maneuver and
+constant negatively for the second half of the maneuver. The resulting velocity of the prescribed body is
+linear, approaching a maximum magnitude halfway through the maneuver and ending with zero residual velocity.
+The corresponding translational trajectory the prescribed body moves through during the maneuver is parabolic in time.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  
+The module msg connection is set by the user from python.  
+The msg type contains a link to the message structure definition, while the description 
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - prescribedTransInMsg
+      - :ref:`PrescribedTransMsgPayload`
+      - input msg with the prescribed body reference states
+    * - prescribedTransOutMsg
+      - :ref:`PrescribedTransMsgPayload`
+      - output message with the scalar prescribed body states
+    * - prescribedMotionOutMsg
+      - :ref:`PrescribedMotionMsgPayload`
+      - output message with the prescribed body states
+
+
+
+Detailed Module Description
+---------------------------
+This translational motion flight software module is written to profile a rigid body's motion with respect to a hub-fixed
+mount frame. The inputs to the profiler are the scalar maximum acceleration for the maneuver :math:`a_{\text{max}}`,
+the mount frame axis for the translational motion, the prescribed body's initial position vector with respect to
+the mount frame :math:`\boldsymbol{r}_{F/M}(t_0)`, and the reference position vector or the prescribed body with respect
+to the mount frame :math:`\boldsymbol{r}_{F/M} (\text{ref})`. The magnitudes of the initial and final position vectors
+are denoted :math:`r_0` and :math:`r_{\text{ref}}`, respectively. The prescribed body is assumed to be at rest at the
+beginning of the attitude maneuver.
+
+Subtracting the initial position from the reference position vector gives the required relative position vector in the
+direction of translation:
+
+.. math::
+    \Delta \boldsymbol{r} = \boldsymbol{r}_{F/M}(\text{ref}) - \boldsymbol{r}_{F/M}(t_0)
+
+The magnitude of the determined relative position vector gives the required translational distance :math:`\Delta r`.
+During the first half of the maneuver, the prescribed body is constantly accelerated with the given maximum acceleration.
+The prescribed body's velocity increases linearly during the acceleration phase and reaches a maximum magnitude halfway
+through the maneuver.
+
+The switch time, :math:`t_s` is the simulation time halfway through the maneuver:
+
+.. math::
+    t_s = t_0 + \frac{\Delta t}{2}
+
+The time required for the maneuver :math:`\Delta t` is determined using the inputs to the profiler:
+
+.. math::
+    \Delta t = \sqrt{\frac{4 r_{\text{ref}} - 8 r_0}{\ddot{a}_{\text{max}}}}
+
+The resulting trajectory of the position vector :math:`r = || \boldsymbol{r}_{F/M} ||_2` magnitude during the first half of the
+maneuver is parabolic. The profiled motion is concave upwards if the reference position magnitude :math:`r_{\text{ref}}`
+is greater than the initial position magnitude :math:`r_0`. If the converse is true, the profiled motion is instead concave
+downwards. The described motion during the first half of the maneuver is characterized by the expressions:
+
+.. math::
+    r^{''}_{F / M}(t) = a_{\text{max}}
+
+.. math::
+    r^{'}_{F / M}(t) = a_{\text{max}} (t - t_0)
+
+.. math::
+    r_{F / M}(t) = c_1 (t - t_0)^2  + r_0
+
+where
+
+.. math::
+    c_1 = \frac{r_{\text{ref}} - r_0}{2(t_s - t_0)^2}
+
+
+Similarly, the second half of the maneuver decelerates the prescribed body constantly until it reaches the desired
+position with zero velocity. The prescribed body velocity decreases linearly from its maximum magnitude back to zero.
+The trajectory during the second half of the maneuver is quadratic and concave downwards if the reference position
+magnitude is greater than the initial position magnitude. If the converse is true, the profiled motion is instead
+concave upwards. The described motion during the second half of the maneuver is characterized by the expressions:
+
+.. math::
+    r^{''}_{F / M}(t) = -a_{\text{max}}
+
+.. math::
+    r^{'}_{F / M}(t) = a_{\text{max}} (t - t_f)
+
+.. math::
+    r_{F / M}(t) = c_2 (t - t_f)^2  + r_{\text{ref}}
+
+where
+
+.. math::
+    c_2 = \frac{r_{\text{ref}} - r_0}{2 (t_s - t_f)^2}
+
+Module Testing
+^^^^^^^^^^^^^^
+This unit test for this module ensures that the profiled translational maneuver is properly computed for a series of
+initial and reference positions and maximum accelerations. The final prescribed position magnitude ``r_FM_M_Final`` and
+velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values ``r_FM_M_Ref`` and
+``rPrime_FM_M_Ref``, respectively.
+
+User Guide
+----------
+The user-configurable inputs to the profiler are the scalar maximum acceleration for the maneuver :math:`a_{\text{max}}`,
+the mount frame axis for the translational motion, the prescribed body's initial position vector with respect to
+the mount frame :math:`\boldsymbol{r}_{F/M}(t_0)`, and the reference position vector of the prescribed body with respect
+to the mount frame :math:`\boldsymbol{r}_{F/M} (\text{ref})`.
+
+This module provides two output messages in the form of :ref:`PrescribedTransMsgPayload` and
+:ref:`PrescribedMotionMsgPayload`. The first guidance message, describing the prescribed body's scalar states relative to
+the hub-fixed mount frame can be directly connected to a feedback control module. The second prescribed
+motion output message can be connected to the :ref:`PrescribedMotionStateEffector` dynamics module to directly profile
+a state effector's translational motion.
+
+This section is to outline the steps needed to setup a prescribed translational module in python using Basilisk.
+
+#. Import the prescribedTrans class::
+
+    from Basilisk.fswAlgorithms import prescribedTrans
+
+#. Create an instantiation of a prescribed translational C module and the associated C++ container::
+
+    PrescribedTransConfig = prescribedTrans.PrescribedTransConfig()
+    PrescribedTransWrap = unitTestSim.setModelDataWrap(PrescribedTransConfig)
+    PrescribedTransWrap.ModelTag = "prescribedTrans"
+
+#. Define all of the configuration data associated with the module. For example::
+
+    PrescribedTransConfig.transAxis_M = np.array([1.0, 0.0, 0.0])
+    PrescribedTransConfig.scalarAccelMax = 0.01  # [m/s^2]
+    PrescribedTransConfig.r_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.omega_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedTransConfig.sigma_FM = np.array([0.0, 0.0, 0.0])
+
+The user is required to set the above configuration data parameters, as they are not initialized in the module.
+
+#. Make sure to connect the required messages for this module.
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, PrescribedTransWrap, PrescribedTransConfig)
+

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -1,0 +1,666 @@
+# ISC License
+#
+# Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+#
+#   Unit Test Script
+#   Module Name:        prescribedMotion integrated unit test with prescribedRot1DOF and prescribedTranslation
+#   Author:             Leah Kiner
+#   Creation Date:      Jan 10, 2022
+#
+
+import pytest
+import inspect
+import os
+import numpy as np
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport
+import matplotlib
+import matplotlib.pyplot as plt
+from Basilisk.fswAlgorithms import prescribedRot1DOF, prescribedTrans
+from Basilisk.simulation import spacecraft, prescribedMotionStateEffector, gravityEffector
+from Basilisk.utilities import macros, RigidBodyKinematics as rbk
+from Basilisk.architecture import messaging
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+splitPath = path.split('simulation')
+
+matplotlib.rc('xtick', labelsize=16)
+matplotlib.rc('ytick', labelsize=16)
+
+# Vary the simulation parameters for pytest
+@pytest.mark.parametrize("rotTest", [True, False])
+@pytest.mark.parametrize("thetaInit", [0, np.pi/18])
+@pytest.mark.parametrize("theta_Ref", [np.pi/36])
+@pytest.mark.parametrize("posInit", [0, 0.2])
+@pytest.mark.parametrize("posRef", [0.1])
+@pytest.mark.parametrize("accuracy", [1e-8])
+def test_PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posInit, posRef, accuracy):
+    r"""
+    **Validation Test Description**
+
+    The unit test for this module is an integrated test with two flight software profiler modules. This is required
+    because the dynamics module must be connected to a flight software profiler module to define the states of the
+    prescribed secondary body that is connected to the rigid spacecraft hub. The integrated test for this module has
+    two simple scenarios it is testing. The first scenario prescribes a 1 DOF rotational attitude maneuver for the
+    prescribed body using the :ref:`prescribedRot1DOF` flight software module. The second scenario prescribes a
+    translational maneuver for the prescribed body using the :ref:`prescribedTrans` flight software module.
+
+    This unit test ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
+    initial and reference PRV angles and maximum angular accelerations. The final prescribed attitude and angular
+    velocity magnitude are compared with the reference values. This unit test also ensures that the profiled
+    translational maneuver is properly computed for a series of initial and reference positions and maximum
+    accelerations. The final prescribed position and velocity magnitudes are compared with the reference values.
+    Additionally for each scenario, the conservation quantities of orbital angular momentum, rotational angular
+    momentum, and orbital energy are checked to validate the module dynamics.
+
+    **Test Parameters**
+
+    Args:
+        rotTest (bool): (True) Runs the rotational motion test. (False) Runs the translational motion test.
+        thetaInit (float): [rad] Initial PRV angle of the F frame with respect to the M frame
+        theta_Ref (float): [rad] Reference PRV angle of the F frame with respect to the M frame
+        thetaDDotMax (float): [rad/s^2] Maximum angular acceleration for the attitude maneuver
+        scalarPosInit (float): [m] Initial scalar position of the F frame with respect to the M frame
+        scalarPosRef (float): [m] Reference scalar position of the F frame with respect to the M frame
+        scalarAccelMax (float): [m/s^2] Maximum acceleration for the translational maneuver
+        accuracy (float): absolute accuracy value used in the validation tests
+
+    **Description of Variables Being Tested**
+
+    This unit test ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
+    initial and reference PRV angles and maximum angular accelerations. The final prescribed angle ``theta_FM_Final``
+    and angular velocity magnitude ``thetaDot_Final`` are compared with the reference values ``theta_Ref`` and
+    ``thetaDot_Ref``, respectively. This unit test also ensures that the profiled translational maneuver is properly
+    computed for a series of initial and reference positions and maximum accelerations. The final prescribed position
+    magnitude ``r_FM_M_Final`` and velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values
+    ``r_FM_M_Ref`` and ``rPrime_FM_M_Ref``, respectively. Additionally for each scenario, the conservation quantities
+    of orbital angular momentum, rotational angular momentum, and orbital energy are checked to validate the module
+    dynamics.
+    """
+
+    [testResults, testMessage] = PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posInit, posRef, accuracy)
+
+    assert testResults < 1, testMessage
+
+
+def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posInit, posRef, accuracy):
+    """Call this routine directly to run the unit test."""
+    __tracebackhide__ = True
+
+    testFailCount = 0  # zero unit test result counter
+    testMessages = []  # create empty list to store test log messages
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testIncrement = 0.5
+    testProcessRate = macros.sec2nano(testIncrement)  # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Add the spacecraft module to test file
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+
+    # Define the mass properties of the rigid spacecraft hub
+    scObject.hub.mHub = 750.0
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]
+
+    # Set the initial inertial hub states
+    scObject.hub.r_CN_NInit = [[-4020338.690396649], [7490566.741852513], [5248299.211589362]]
+    scObject.hub.v_CN_NInit = [[-5199.77710904224], [-3436.681645356935], [1041.576797498721]]
+    scObject.hub.omega_BN_BInit = np.array([0.0, 0.0, 0.0])
+    scObject.hub.sigma_BNInit = [[0.0], [0.0], [0.0]]
+
+    # Add the scObject to the runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+
+    # Add the prescribedMotion dynamics module to test file
+    platform = prescribedMotionStateEffector.PrescribedMotionStateEffector()
+
+    # Define the state effector properties
+    transAxis_M = np.array([1.0, 0.0, 0.0])
+    rotAxis_M = np.array([1.0, 0.0, 0.0])
+    r_FM_M = posInit * transAxis_M
+    prvInit_FM = thetaInit * rotAxis_M
+    sigma_FM = rbk.PRV2MRP(prvInit_FM)
+
+    platform.mass = 100.0
+    platform.IPntFc_F = [[50.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]
+    platform.r_MB_B = [0.0, 0.0, 0.0]
+    platform.r_FcF_F = [0.0, 0.0, 0.0]
+    platform.r_FM_M = r_FM_M
+    platform.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    platform.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+    platform.omega_FM_F = np.array([0.0, 0.0, 0.0])
+    platform.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    platform.sigma_FM = sigma_FM
+    platform.omega_MB_B = [0.0, 0.0, 0.0]
+    platform.omegaPrime_MB_B = [0.0, 0.0, 0.0]
+    platform.sigma_MB = [0.0, 0.0, 0.0]
+    platform.ModelTag = "Platform"
+
+    # Add platform to spacecraft
+    scObject.addStateEffector(platform)
+
+    # Add the test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, platform)
+
+    if rotTest:
+    
+        # ** ** ** ** ** ROTATIONAL 1 DOF INTEGRATED TEST: ** ** ** ** **
+
+        # Create an instance of the prescribedRot1DOF module to be tested
+        PrescribedRot1DOFConfig = prescribedRot1DOF.PrescribedRot1DOFConfig()
+        PrescribedRot1DOFWrap = unitTestSim.setModelDataWrap(PrescribedRot1DOFConfig)
+        PrescribedRot1DOFWrap.ModelTag = "prescribedRot1DOF"
+
+        # Add the prescribedRot1DOF test module to runtime call list
+        unitTestSim.AddModelToTask(unitTaskName, PrescribedRot1DOFWrap, PrescribedRot1DOFConfig)
+
+        # Initialize the prescribedRot1DOF test module configuration data
+        accelMax = 0.01 # [rad/s^2]
+        #accelMax = np.pi / 180  # [rad/s^2]
+        PrescribedRot1DOFConfig.r_FM_M = r_FM_M
+        PrescribedRot1DOFConfig.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+        PrescribedRot1DOFConfig.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+        PrescribedRot1DOFConfig.rotAxis_M = rotAxis_M
+        PrescribedRot1DOFConfig.thetaDDotMax = accelMax
+        PrescribedRot1DOFConfig.omega_FM_F = np.array([0.0, 0.0, 0.0])
+        PrescribedRot1DOFConfig.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+        PrescribedRot1DOFConfig.sigma_FM = sigma_FM
+
+        # Create the prescribedRot1DOF input message
+        thetaDot_Ref = 0.0  # [rad/s]
+        SpinningBodyMessageData = messaging.HingedRigidBodyMsgPayload()
+        SpinningBodyMessageData.theta = theta_Ref
+        SpinningBodyMessageData.thetaDot = thetaDot_Ref
+        SpinningBodyMessage = messaging.HingedRigidBodyMsg().write(SpinningBodyMessageData)
+        PrescribedRot1DOFConfig.spinningBodyInMsg.subscribeTo(SpinningBodyMessage)
+        
+        # Connect the PrescribedRot1DOF module's prescribedMotion output message to the prescribedMotion module's prescribedMotion input message
+        platform.prescribedMotionInMsg.subscribeTo(PrescribedRot1DOFConfig.prescribedMotionOutMsg)
+
+        # Add Earth gravity to the simulation
+        earthGravBody = gravityEffector.GravBodyData()
+        earthGravBody.planetName = "earth_planet_data"
+        earthGravBody.mu = 0.3986004415E+15
+        earthGravBody.isCentralBody = True
+        earthGravBody.useSphericalHarmParams = False
+        scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+
+        # Add energy and momentum variables to log
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
+
+        # Add other states to log
+        scStateData = scObject.scStateOutMsg.recorder()
+        prescribedStateData = platform.prescribedMotionOutMsg.recorder()
+        dataLog = PrescribedRot1DOFConfig.prescribedMotionOutMsg.recorder()
+        unitTestSim.AddModelToTask(unitTaskName, scStateData)
+        unitTestSim.AddModelToTask(unitTaskName, prescribedStateData)
+        unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+        # Initialize the simulation
+        unitTestSim.InitializeSimulation()
+
+        # Set the simulation time
+        simTime = np.sqrt(((0.5 * np.abs(theta_Ref - thetaInit)) * 8) / accelMax) + 3 * testIncrement
+        unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
+
+        # Begin the simulation
+        unitTestSim.ExecuteSimulation()
+
+        # Extract the logged data
+        orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
+        orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
+        rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+        rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
+        omega_BN_B = scStateData.omega_BN_B
+        r_BN_N = scStateData.r_BN_N
+        sigma_BN = scStateData.sigma_BN
+        omega_FM_F = dataLog.omega_FM_F
+        omegaPrime_FM_F = dataLog.omegaPrime_FM_F
+        sigma_FM = dataLog.sigma_FM
+        timespan = dataLog.times()
+        thetaDot_Final = np.linalg.norm(omega_FM_F[-1, :])
+        sigma_FM_Final = sigma_FM[-1, :]
+        theta_FM_Final = 4 * np.arctan(np.linalg.norm(sigma_FM_Final))
+
+        # Setup the conservation quantities
+        initialOrbAngMom_N = [[orbAngMom_N[0, 1], orbAngMom_N[0, 2], orbAngMom_N[0, 3]]]
+        finalOrbAngMom = [orbAngMom_N[-1]]
+        initialRotAngMom_N = [[rotAngMom_N[0, 1], rotAngMom_N[0, 2], rotAngMom_N[0, 3]]]
+        finalRotAngMom = [rotAngMom_N[-1]]
+        initialOrbEnergy = [[orbEnergy[0, 1]]]
+        finalOrbEnergy = [orbEnergy[-1]]
+
+        # Convert the logged sigma_FM MRPs to a scalar theta_FM array
+        n = len(timespan)
+        theta_FM = []
+        for i in range(n):
+            theta_FM.append((180 / np.pi) * (4 * np.arctan(np.linalg.norm(sigma_FM[i, :]))))
+
+        plt.close("all")
+
+        # Plot theta_FM
+        theta_Ref_plotting = np.ones(len(timespan)) * theta_Ref
+        thetaInit_plotting = np.ones(len(timespan)) * thetaInit
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, theta_FM, label=r'$\Phi$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * theta_Ref_plotting, '--', label=r'$\Phi_{Ref}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * thetaInit_plotting, '--', label=r'$\Phi_{0}$')
+        plt.title(r'$\Phi_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.ylabel('(deg)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='center right', prop={'size': 16})
+
+        # Plot omega_FM_F
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_FM_F[:, 0], label=r'$\omega_{1}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_FM_F[:, 1], label=r'$\omega_{2}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_FM_F[:, 2], label=r'$\omega_{3}$')
+        plt.title(r'${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.ylabel('(deg/s)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='upper right', prop={'size': 16})
+
+        # Plotting omegaPrime_FM_F
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omegaPrime_FM_F[:, 0], label=r'$\omega \'_{1}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omegaPrime_FM_F[:, 1], label=r'$\omega \'_{2}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omegaPrime_FM_F[:, 2], label=r'$\omega \'_{3}$')
+        plt.title(r'${}^\mathcal{F} \omega \'_{\mathcal{F}/\mathcal{M}}$ Profiled Angular Acceleration', fontsize=14)
+        plt.ylabel(r'(deg/$s^2$)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='upper right', prop={'size': 16})
+
+        # Plot r_BN_N
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, r_BN_N[:, 0], label=r'$r_{1}$')
+        plt.plot(timespan * 1e-9, r_BN_N[:, 1], label=r'$r_{2}$')
+        plt.plot(timespan * 1e-9, r_BN_N[:, 2], label=r'$r_{3}$')
+        plt.title(r'${}^\mathcal{N} r_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial Trajectory', fontsize=14)
+        plt.ylabel('(m)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='center left', prop={'size': 16})
+
+        # Plot sigma_BN
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, sigma_BN[:, 0], label=r'$\sigma_{1}$')
+        plt.plot(timespan * 1e-9, sigma_BN[:, 1], label=r'$\sigma_{2}$')
+        plt.plot(timespan * 1e-9, sigma_BN[:, 2], label=r'$\sigma_{3}$')
+        plt.title(r'$\sigma_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial MRP Attitude', fontsize=14)
+        plt.ylabel('', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='center left', prop={'size': 16})
+
+        # Plot omega_BN_B
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_BN_B[:, 0], label=r'$\omega_{1}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_BN_B[:, 1], label=r'$\omega_{2}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_BN_B[:, 2], label=r'$\omega_{3}$')
+        plt.title(r'Spacecraft Hub Angular Velocity ${}^\mathcal{B} \omega_{\mathcal{B}/\mathcal{N}}$', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.ylabel('(deg/s)', fontsize=16)
+        plt.legend(loc='lower right', prop={'size': 16})
+
+        # Plotting: Conservation quantities
+        plt.figure()
+        plt.clf()
+        plt.plot(orbAngMom_N[:, 0] * 1e-9, (orbAngMom_N[:, 1] - orbAngMom_N[0, 1]) / orbAngMom_N[0, 1],
+                 orbAngMom_N[:, 0] * 1e-9, (orbAngMom_N[:, 2] - orbAngMom_N[0, 2]) / orbAngMom_N[0, 2],
+                 orbAngMom_N[:, 0] * 1e-9, (orbAngMom_N[:, 3] - orbAngMom_N[0, 3]) / orbAngMom_N[0, 3])
+        plt.title('Orbital Angular Momentum Relative Difference', fontsize=14)
+        plt.ylabel('(Nms)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        plt.figure()
+        plt.clf()
+        plt.plot(orbEnergy[:, 0] * 1e-9, (orbEnergy[:, 1] - orbEnergy[0, 1]) / orbEnergy[0, 1])
+        plt.title('Orbital Energy Relative Difference', fontsize=14)
+        plt.ylabel('(Nm)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        plt.figure()
+        plt.clf()
+        plt.plot(rotAngMom_N[:, 0] * 1e-9, (rotAngMom_N[:, 1] - rotAngMom_N[0, 1]),
+                 rotAngMom_N[:, 0] * 1e-9, (rotAngMom_N[:, 2] - rotAngMom_N[0, 2]),
+                 rotAngMom_N[:, 0] * 1e-9, (rotAngMom_N[:, 3] - rotAngMom_N[0, 3]))
+        plt.title('Rotational Angular Momentum Difference', fontsize=14)
+        plt.ylabel('(Nms)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        plt.figure()
+        plt.clf()
+        plt.plot(rotEnergy[:, 0] * 1e-9, (rotEnergy[:, 1] - rotEnergy[0, 1]))
+        plt.title('Rotational Energy Difference', fontsize=14)
+        plt.ylabel('(Nm)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        if show_plots:
+            plt.show()
+        plt.close("all")
+
+        # Begin the the test analysis
+        finalOrbAngMom = np.delete(finalOrbAngMom, 0, axis=1)  # remove the time column
+        finalRotAngMom = np.delete(finalRotAngMom, 0, axis=1)  # remove the time column
+        finalOrbEnergy = np.delete(finalOrbEnergy, 0, axis=1)  # remove the time column
+
+        for i in range(0, len(initialOrbAngMom_N)):
+            if not unitTestSupport.isArrayEqualRelative(finalOrbAngMom[i], initialOrbAngMom_N[i], 3, accuracy):
+                testFailCount += 1
+                testMessages.append(
+                    "FAILED: Prescribed Motion integrated test failed orbital angular momentum unit test")
+
+        for i in range(0, len(initialRotAngMom_N)):
+            if not unitTestSupport.isArrayEqual(finalRotAngMom[i], initialRotAngMom_N[i], 3, accuracy):
+                testFailCount += 1
+                testMessages.append(
+                    "FAILED: Prescribed Motion integrated test failed rotational angular momentum unit test")
+
+        for i in range(0, len(initialOrbEnergy)):
+            if not unitTestSupport.isArrayEqualRelative(finalOrbEnergy[i], initialOrbEnergy[i], 1, accuracy):
+                testFailCount += 1
+                testMessages.append("FAILED: Prescribed Motion integrated test failed orbital energy unit test")
+
+        # Check to ensure the initial angle rate converged to the reference angle rate
+        if not unitTestSupport.isDoubleEqual(thetaDot_Final, thetaDot_Ref, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + PrescribedRot1DOFWrap.ModelTag + "thetaDot_Final and thetaDot_Ref do not match")
+
+        # Check to ensure the initial angle converged to the reference angle
+        if not unitTestSupport.isDoubleEqual(theta_FM_Final, theta_Ref, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + PrescribedRot1DOFWrap.ModelTag + "theta_FM_Final and theta_Ref do not match")
+            # testMessages.append("theta_FM_Final: " + str(theta_FM_Final) + " theta_Ref: " + str(theta_Ref))
+
+        if testFailCount == 0:
+            print("PASSED: " + "prescribedMotion and prescribedRot1DOF integrated test")
+
+    else:
+
+        # ** ** ** ** ** TRANSLATIONAL INTEGRATED TEST ** ** ** ** **
+
+        # Create an instance of the prescribedTrans module to be tested
+        PrescribedTransConfig = prescribedTrans.PrescribedTransConfig()
+        PrescribedTransWrap = unitTestSim.setModelDataWrap(PrescribedTransConfig)
+        PrescribedTransWrap.ModelTag = "prescribedTrans"
+
+        # Add the prescribedTrans test module to runtime call list
+        unitTestSim.AddModelToTask(unitTaskName, PrescribedTransWrap, PrescribedTransConfig)
+
+        # Initialize the prescribedTrans test module configuration data
+        accelMax = 0.005 # [m/s^2]
+        #accelMax = 0.25/1000  # [m/s^2]
+        PrescribedTransConfig.r_FM_M = r_FM_M
+        PrescribedTransConfig.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+        PrescribedTransConfig.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+        PrescribedTransConfig.transAxis_M = transAxis_M
+        PrescribedTransConfig.scalarAccelMax = accelMax
+        PrescribedTransConfig.omega_FM_F = np.array([0.0, 0.0, 0.0])
+        PrescribedTransConfig.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+        PrescribedTransConfig.sigma_FM = sigma_FM
+
+        # Create the prescribedTrans input message
+        velRef = 0.0  # [m/s]
+        PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
+        PrescribedTransMessageData.scalarPos = posRef
+        PrescribedTransMessageData.scalarVel = velRef
+        PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
+        PrescribedTransConfig.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
+
+        # Connect the PrescribedTrans module's prescribedMotion output message to the prescribedMotion module's prescribedMotion input message
+        platform.prescribedMotionInMsg.subscribeTo(PrescribedTransConfig.prescribedMotionOutMsg)
+
+        # Add Earth gravity to the simulation
+        earthGravBody = gravityEffector.GravBodyData()
+        earthGravBody.planetName = "earth_planet_data"
+        earthGravBody.mu = 0.3986004415E+15
+        earthGravBody.isCentralBody = True
+        earthGravBody.useSphericalHarmParams = False
+        scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+
+        # Add energy and momentum variables to log
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
+
+        # Add other states to log
+        scStateData = scObject.scStateOutMsg.recorder()
+        prescribedStateData = platform.prescribedMotionOutMsg.recorder()
+        dataLog = PrescribedTransConfig.prescribedMotionOutMsg.recorder()
+        unitTestSim.AddModelToTask(unitTaskName, scStateData)
+        unitTestSim.AddModelToTask(unitTaskName, prescribedStateData)
+        unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+        # Initialize the simulation
+        unitTestSim.InitializeSimulation()
+
+        # Set the simulation time
+        simTime = np.sqrt(((0.5 * np.abs(posRef - posInit)) * 8) / accelMax) + 3 * testIncrement
+        unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
+
+        # Begin the simulation
+        unitTestSim.ExecuteSimulation()
+
+        # Extract the logged data
+        orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
+        orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
+        rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+        rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
+        r_BN_N = scStateData.r_BN_N
+        sigma_BN = scStateData.sigma_BN
+        omega_BN_B = scStateData.omega_BN_B
+        r_FM_M = dataLog.r_FM_M
+        rPrime_FM_M = dataLog.rPrime_FM_M
+        rPrimePrime_FM_M = dataLog.rPrimePrime_FM_M
+        timespan = dataLog.times()
+        r_FM_M_Final = r_FM_M[-1, :]
+        rPrime_FM_M_Final = rPrime_FM_M[-1, :]
+
+        # Setup the conservation quantities
+        initialOrbAngMom_N = [[orbAngMom_N[0, 1], orbAngMom_N[0, 2], orbAngMom_N[0, 3]]]
+        finalOrbAngMom = [orbAngMom_N[-1]]
+        initialRotAngMom_N = [[rotAngMom_N[0, 1], rotAngMom_N[0, 2], rotAngMom_N[0, 3]]]
+        finalRotAngMom = [rotAngMom_N[-1]]
+        initialOrbEnergy = [[orbEnergy[0, 1]]]
+        finalOrbEnergy = [orbEnergy[-1]]
+        initialRotEnergy = [[rotEnergy[0, 1]]]
+        finalRotEnergy = [rotEnergy[-1]]
+
+        # Plot r_FM_F
+        r_FM_M_Ref = posRef * transAxis_M
+        r_FM_M_1_Ref = np.ones(len(timespan)) * r_FM_M_Ref[0]
+        r_FM_M_2_Ref = np.ones(len(timespan)) * r_FM_M_Ref[1]
+        r_FM_M_3_Ref = np.ones(len(timespan)) * r_FM_M_Ref[2]
+
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, r_FM_M[:, 0], label='$r_{1}$')
+        plt.plot(timespan * 1e-9, r_FM_M[:, 1], label='$r_{2}$')
+        plt.plot(timespan * 1e-9, r_FM_M[:, 2], label='$r_{3}$')
+        plt.plot(timespan * 1e-9, r_FM_M_1_Ref, '--', label='$r_{1 Ref}$')
+        plt.plot(timespan * 1e-9, r_FM_M_2_Ref, '--', label='$r_{2 Ref}$')
+        plt.plot(timespan * 1e-9, r_FM_M_3_Ref, '--', label='$r_{3 Ref}$')
+        plt.title(r'${}^\mathcal{M} r_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.ylabel('(m)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='center left', prop={'size': 16})
+
+        # Plot rPrime_FM_F
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, rPrime_FM_M[:, 0], label='$r\'_{1}$')
+        plt.plot(timespan * 1e-9, rPrime_FM_M[:, 1], label='$r\'_{2}$')
+        plt.plot(timespan * 1e-9, rPrime_FM_M[:, 2], label='$r\'_{3}$')
+        plt.title(r'${}^\mathcal{M} r\'_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+        plt.ylabel('(m/s)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='upper left', prop={'size': 16})
+
+        # Plotting rPrimePrime_FM_M
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, (180 / np.pi) * rPrimePrime_FM_M[:, 0], label='$r\'\'_{1}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * rPrimePrime_FM_M[:, 1], label='$r\'\'_{2}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * rPrimePrime_FM_M[:, 2], label='$r\'\'_{3}$')
+        plt.title(r'${}^\mathcal{M} r\'\'_{\mathcal{F}/\mathcal{M}}$ Profiled Acceleration', fontsize=14)
+        plt.ylabel('(m/s$^2$)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='lower left', prop={'size': 16})
+
+        # Plot r_BN_N
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, r_BN_N[:, 0], label='$r_{1}$')
+        plt.plot(timespan * 1e-9, r_BN_N[:, 1], label='$r_{2}$')
+        plt.plot(timespan * 1e-9, r_BN_N[:, 2], label='$r_{3}$')
+        plt.title(r'${}^\mathcal{N} r_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial Trajectory', fontsize=14)
+        plt.ylabel('(m)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='center left', prop={'size': 16})
+
+        # Plot sigma_BN
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, sigma_BN[:, 0], label=r'$\sigma_{1}$')
+        plt.plot(timespan * 1e-9, sigma_BN[:, 1], label=r'$\sigma_{2}$')
+        plt.plot(timespan * 1e-9, sigma_BN[:, 2], label=r'$\sigma_{3}$')
+        plt.title(r'$\sigma_{\mathcal{B}/\mathcal{N}}$ Spacecraft Inertial MRP Attitude', fontsize=14)
+        plt.ylabel('', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='lower left', prop={'size': 16})
+
+        # Plot omega_BN_B
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_BN_B[:, 0], label=r'$\omega_{1}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_BN_B[:, 1], label=r'$\omega_{2}$')
+        plt.plot(timespan * 1e-9, (180 / np.pi) * omega_BN_B[:, 2], label=r'$\omega_{3}$')
+        plt.title(r'Spacecraft Hub Angular Velocity ${}^\mathcal{B} \omega_{\mathcal{B}/\mathcal{N}}$', fontsize=14)
+        plt.ylabel('(deg/s)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+        plt.legend(loc='lower left', prop={'size': 16})
+
+        # Plotting: Conservation quantities
+        plt.figure()
+        plt.clf()
+        plt.plot(orbAngMom_N[:, 0] * 1e-9, (orbAngMom_N[:, 1] - orbAngMom_N[0, 1]) / orbAngMom_N[0, 1],
+                 orbAngMom_N[:, 0] * 1e-9, (orbAngMom_N[:, 2] - orbAngMom_N[0, 2]) / orbAngMom_N[0, 2],
+                 orbAngMom_N[:, 0] * 1e-9, (orbAngMom_N[:, 3] - orbAngMom_N[0, 3]) / orbAngMom_N[0, 3])
+        plt.title('Orbital Angular Momentum Relative Difference', fontsize=14)
+        plt.ylabel('(Nms)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        plt.figure()
+        plt.clf()
+        plt.plot(orbEnergy[:, 0] * 1e-9, (orbEnergy[:, 1] - orbEnergy[0, 1]) / orbEnergy[0, 1])
+        plt.title('Orbital Energy Relative Difference', fontsize=14)
+        plt.ylabel('(Nm)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        plt.figure()
+        plt.clf()
+        plt.plot(rotAngMom_N[:, 0] * 1e-9, (rotAngMom_N[:, 1] - rotAngMom_N[0, 1]),
+                 rotAngMom_N[:, 0] * 1e-9, (rotAngMom_N[:, 2] - rotAngMom_N[0, 2]),
+                 rotAngMom_N[:, 0] * 1e-9, (rotAngMom_N[:, 3] - rotAngMom_N[0, 3]))
+        plt.title('Rotational Angular Momentum Difference', fontsize=14)
+        plt.ylabel('(Nms)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        plt.figure()
+        plt.clf()
+        plt.plot(rotEnergy[:, 0] * 1e-9, (rotEnergy[:, 1] - rotEnergy[0, 1]))
+        plt.title('Rotational Energy Difference', fontsize=14)
+        plt.ylabel('(Nm)', fontsize=16)
+        plt.xlabel('Time (s)', fontsize=16)
+
+        if show_plots:
+            plt.show()
+        plt.close("all")
+
+        # Begin the the test analysis
+        finalOrbAngMom = np.delete(finalOrbAngMom, 0, axis=1)  # remove the time column
+        finalRotAngMom = np.delete(finalRotAngMom, 0, axis=1)  # remove the time column
+        finalOrbEnergy = np.delete(finalOrbEnergy, 0, axis=1)  # remove the time column
+
+        for i in range(0, len(initialOrbAngMom_N)):
+            if not unitTestSupport.isArrayEqualRelative(finalOrbAngMom[i], initialOrbAngMom_N[i], 3, accuracy):
+                testFailCount += 1
+                testMessages.append(
+                    "FAILED: Prescribed Motion integrated test failed orbital angular momentum unit test")
+
+        for i in range(0, len(initialRotAngMom_N)):
+            if not unitTestSupport.isArrayEqual(finalRotAngMom[i], initialRotAngMom_N[i], 3, accuracy):
+                testFailCount += 1
+                testMessages.append(
+                    "FAILED: Prescribed Motion integrated test failed rotational angular momentum unit test")
+
+        for i in range(0, len(initialOrbEnergy)):
+            if not unitTestSupport.isArrayEqualRelative(finalOrbEnergy[i], initialOrbEnergy[i], 1, accuracy):
+                testFailCount += 1
+                testMessages.append("FAILED: Prescribed Motion integrated test failed orbital energy unit test")
+
+        # Check to ensure the initial velocity converged to the reference velocity
+        rPrime_FM_M_Ref = np.array([0.0, 0.0, 0.0])
+        if not unitTestSupport.isArrayEqual(rPrime_FM_M_Final, rPrime_FM_M_Ref, 3, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + PrescribedTransWrap.ModelTag + "rPrime_FM_M_Final and rPrime_FM_M_Ref do not match")
+            testMessages.append("rPrime_FM_M_Final: " + str(rPrime_FM_M_Final) + " rPrime_FM_M_Ref: " + str(rPrime_FM_M_Ref))
+
+        # Check to ensure the initial position converged to the reference position
+        r_FM_M_Ref = np.array([posRef, 0.0, 0.0])
+        if not unitTestSupport.isArrayEqual(r_FM_M_Final, r_FM_M_Ref, 3, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + PrescribedTransWrap.ModelTag + "r_FM_M_Final and r_FM_M_Ref do not match")
+            testMessages.append("r_FM_M_Final: " + str(r_FM_M_Final) + " r_FM_M_Ref: " + str(r_FM_M_Ref))
+
+        if testFailCount == 0:
+            print("PASSED: " + "prescribedMotion and prescribedTrans integrated test")
+
+    return [testFailCount, ''.join(testMessages)]
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    PrescribedMotionTestFunction(
+        True,        # show_plots
+        True,        # rotTest, (True: prescribedRot1DOF integrated test,
+                     #           False: prescribedTrans integrated test)
+         0.0,        # thetaInit [rad]
+         np.pi/6,    # theta_Ref [rad]
+         0.0,        # posInit [m]
+         0.5,        # posRef [m]
+         1e-8        # accuracy
+       )

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -240,7 +240,19 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime, Eigen::
 */
 void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B)
 {
+    // Update omega_BN_B and omega_FN_B
+    this->omega_BN_B = omega_BN_B;
+    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
+    this->omega_FN_B = this->omega_FB_B + this->omega_BN_B;
 
+    // Compute rDot_FcB_B
+    this->rDot_FcB_B = this->rPrime_FcB_B + this->omegaTilde_BN_B * this->r_FcB_B;
+
+    // Find the rotational angular momentum contribution from hub
+    rotAngMomPntCContr_B = this->IPntFc_B * this->omega_FN_B + this->mass * this->rTilde_FcB_B * this->rDot_FcB_B;
+
+    // Find the rotational energy contribution from the hub
+    rotEnergyContr = 0.5 * this->omega_FN_B.dot(this->IPntFc_B * this->omega_FN_B) + 0.5 * this->mass * this->rDot_FcB_B.dot(this->rDot_FcB_B);
 }
 
 /*! This method computes the effector states relative to the inertial frame.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -89,6 +89,20 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t CurrentClo
         eigenVector3d2CArray(sigma_FM_loc, prescribedMotionBuffer.sigma_FM);
         this->prescribedMotionOutMsg.write(&prescribedMotionBuffer, this->moduleID, CurrentClock);
     }
+
+    // Write the config log message if it is linked
+    if (this->prescribedMotionConfigLogOutMsg.isLinked())
+    {
+        SCStatesMsgPayload configLogMsg;
+        configLogMsg = this->prescribedMotionConfigLogOutMsg.zeroMsgPayload;
+
+        // Note that the configLogMsg B frame represents the effector body frame (frame F)
+        eigenVector3d2CArray(this->r_FcN_N, configLogMsg.r_BN_N);
+        eigenVector3d2CArray(this->v_FcN_N, configLogMsg.v_BN_N);
+        eigenVector3d2CArray(this->sigma_FN, configLogMsg.sigma_BN);
+        eigenVector3d2CArray(this->omega_FN_F, configLogMsg.omega_BN_B);
+        this->prescribedMotionConfigLogOutMsg.write(&configLogMsg, this->moduleID, CurrentClock);
+    }
 }
 
 /*! This method allows the effector to have access to the hub states.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -205,4 +205,7 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t CurrentSimNanos)
         this->omegaPrime_FM_F = cArray2EigenVector3d(incomingPrescribedStates.omegaPrime_FM_F);
         this->sigma_FM = cArray2EigenVector3d(incomingPrescribedStates.sigma_FM);
     }
+
+    // Call the method to write the output messages
+    this->writeOutputStateMessages(CurrentSimNanos);
 }

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "prescribedMotionStateEffector.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include <string>
 
 /*! This is the constructor, setting variables to default values. */
 PrescribedMotionStateEffector::PrescribedMotionStateEffector()
@@ -55,7 +57,11 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t CurrentClo
 */
 void PrescribedMotionStateEffector::linkInStates(DynParamManager& statesIn)
 {
-
+    // Get access to the hub states needed for dynamic coupling
+    this->hubSigma = statesIn.getStateObject("hubSigma");
+    this->hubOmega = statesIn.getStateObject("hubOmega");
+    this->inertialPositionProperty = statesIn.getPropertyReference("r_BN_N");
+    this->inertialVelocityProperty = statesIn.getPropertyReference("v_BN_N");
 }
 
 /*! This method allows the state effector to register its states with the dynamic parameter manager. (unused)

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -24,7 +24,29 @@
 /*! This is the constructor, setting variables to default values. */
 PrescribedMotionStateEffector::PrescribedMotionStateEffector()
 {
+    // Zero the mass props and mass prop rate contributions
+    this->effProps.mEff = 0.0;
+    this->effProps.rEff_CB_B.fill(0.0);
+    this->effProps.IEffPntB_B.fill(0.0);
+    this->effProps.rEffPrime_CB_B.fill(0.0);
+    this->effProps.IEffPrimePntB_B.fill(0.0);
 
+    // Initialize the prescribed variables
+    this->r_FM_M.setZero();
+    this->rPrime_FM_M.setZero();
+    this->rPrimePrime_FM_M.setZero();
+    this->omega_FM_F.setZero();
+    this->omegaPrime_FM_F.setZero();
+    this->sigma_FM.setIdentity();
+
+    // Initialize the other module variables
+    this->mass = 0.0;
+    this->IPntFc_F.Identity();
+    this->r_MB_B.setZero();
+    this->r_FcF_F.setZero();
+    this->omega_MB_B.setZero();
+    this->omegaPrime_MB_B.setZero();
+    this->sigma_MB.setIdentity();
 }
 
 /*! This is the destructor. */

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -74,7 +74,21 @@ void PrescribedMotionStateEffector::Reset(uint64_t CurrentClock)
 */
 void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
-
+    // Write the prescribed motion output message if it is linked
+    if (this->prescribedMotionOutMsg.isLinked())
+    {
+        PrescribedMotionMsgPayload prescribedMotionBuffer;
+        prescribedMotionBuffer = this->prescribedMotionOutMsg.zeroMsgPayload;
+        eigenVector3d2CArray(this->r_FM_M, prescribedMotionBuffer.r_FM_M);
+        eigenVector3d2CArray(this->rPrime_FM_M, prescribedMotionBuffer.rPrime_FM_M);
+        eigenVector3d2CArray(this->rPrimePrime_FM_M, prescribedMotionBuffer.rPrimePrime_FM_M);
+        eigenVector3d2CArray(this->omega_FM_F, prescribedMotionBuffer.omega_FM_F);
+        eigenVector3d2CArray(this->omegaPrime_FM_F, prescribedMotionBuffer.omegaPrime_FM_F);
+        Eigen::Vector3d sigma_FM_loc;
+        sigma_FM_loc = eigenMRPd2Vector3d(this->sigma_FM);
+        eigenVector3d2CArray(sigma_FM_loc, prescribedMotionBuffer.sigma_FM);
+        this->prescribedMotionOutMsg.write(&prescribedMotionBuffer, this->moduleID, CurrentClock);
+    }
 }
 
 /*! This method allows the effector to have access to the hub states.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -77,15 +77,14 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t CurrentClo
     // Write the prescribed motion output message if it is linked
     if (this->prescribedMotionOutMsg.isLinked())
     {
-        PrescribedMotionMsgPayload prescribedMotionBuffer;
-        prescribedMotionBuffer = this->prescribedMotionOutMsg.zeroMsgPayload;
+        PrescribedMotionMsgPayload prescribedMotionBuffer = this->prescribedMotionOutMsg.zeroMsgPayload;
         eigenVector3d2CArray(this->r_FM_M, prescribedMotionBuffer.r_FM_M);
         eigenVector3d2CArray(this->rPrime_FM_M, prescribedMotionBuffer.rPrime_FM_M);
         eigenVector3d2CArray(this->rPrimePrime_FM_M, prescribedMotionBuffer.rPrimePrime_FM_M);
         eigenVector3d2CArray(this->omega_FM_F, prescribedMotionBuffer.omega_FM_F);
         eigenVector3d2CArray(this->omegaPrime_FM_F, prescribedMotionBuffer.omegaPrime_FM_F);
-        Eigen::Vector3d sigma_FM_loc;
-        sigma_FM_loc = eigenMRPd2Vector3d(this->sigma_FM);
+
+        Eigen::Vector3d sigma_FM_loc = eigenMRPd2Vector3d(this->sigma_FM);
         eigenVector3d2CArray(sigma_FM_loc, prescribedMotionBuffer.sigma_FM);
         this->prescribedMotionOutMsg.write(&prescribedMotionBuffer, this->moduleID, CurrentClock);
     }
@@ -93,8 +92,7 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t CurrentClo
     // Write the config log message if it is linked
     if (this->prescribedMotionConfigLogOutMsg.isLinked())
     {
-        SCStatesMsgPayload configLogMsg;
-        configLogMsg = this->prescribedMotionConfigLogOutMsg.zeroMsgPayload;
+        SCStatesMsgPayload configLogMsg = this->prescribedMotionConfigLogOutMsg.zeroMsgPayload;
 
         // Note that the configLogMsg B frame represents the effector body frame (frame F)
         eigenVector3d2CArray(this->r_FcN_N, configLogMsg.r_BN_N);
@@ -178,8 +176,10 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
 
     // Find the B frame time derivative of IPntFc_B
     Eigen::Matrix3d rPrimeTilde_FcB_B = eigenTilde(this->rPrime_FcB_B);
-    this->effProps.IEffPrimePntB_B = this->omegaTilde_FB_B* this->IPntFc_B - this->IPntFc_B * this->omegaTilde_FB_B
-        + this->mass * (rPrimeTilde_FcB_B * this->rTilde_FcB_B.transpose() + this->rTilde_FcB_B * rPrimeTilde_FcB_B.transpose());
+    this->effProps.IEffPrimePntB_B = this->omegaTilde_FB_B * this->IPntFc_B
+                                     - this->IPntFc_B * this->omegaTilde_FB_B
+                                     + this->mass * (rPrimeTilde_FcB_B * this->rTilde_FcB_B.transpose()
+                                     + this->rTilde_FcB_B * rPrimeTilde_FcB_B.transpose());
 }
 
 /*! This method allows the state effector to give its contributions to the matrices needed for the back-sub.
@@ -192,7 +192,11 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
  components
  @param g_N [m/s^2] Gravitational acceleration in N frame components
 */
-void PrescribedMotionStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void PrescribedMotionStateEffector::updateContributions(double integTime,
+                                                        BackSubMatrices & backSubContr,
+                                                        Eigen::Vector3d sigma_BN,
+                                                        Eigen::Vector3d omega_BN_B,
+                                                        Eigen::Vector3d g_N)
 {
     // Compute dcm_BN
     this->sigma_BN = sigma_BN;
@@ -213,10 +217,13 @@ void PrescribedMotionStateEffector::updateContributions(double integTime, BackSu
 
     // Rotation contributions
     Eigen::Matrix3d IPrimePntFc_B = this->omegaTilde_FB_B * this->IPntFc_B - this->IPntFc_B * this->omegaTilde_FB_B;
-    backSubContr.vecRot = - (this->mass * this->rTilde_FcB_B * this->rPrimePrime_FcB_B)  - (IPrimePntFc_B + this->omegaTilde_BN_B * this->IPntFc_B ) * this->omega_FB_B - this->IPntFc_B * this->omegaPrime_FB_B - this->mass * this->omegaTilde_BN_B * rTilde_FcB_B * this->rPrime_FcB_B;
+    backSubContr.vecRot = -(this->mass * this->rTilde_FcB_B * this->rPrimePrime_FcB_B)
+                          - (IPrimePntFc_B + this->omegaTilde_BN_B * this->IPntFc_B) * this->omega_FB_B
+                          - this->IPntFc_B * this->omegaPrime_FB_B
+                          - this->mass * this->omegaTilde_BN_B * rTilde_FcB_B * this->rPrime_FcB_B;
 }
 
-/*! This method is empty because the equations of motion of the effector are prescribed.
+/*!
  @return void
  @param integTime [s] Time the method is called
  @param rDDot_BN_N [m/s^2] Acceleration of the vector pointing from the inertial frame origin to the B frame origin,
@@ -225,7 +232,10 @@ void PrescribedMotionStateEffector::updateContributions(double integTime, BackSu
  inertial frame, expressed in B frame components
  @param sigma_BN Current B frame attitude with respect to the inertial frame
 */
-void PrescribedMotionStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void PrescribedMotionStateEffector::computeDerivatives(double integTime,
+                                                       Eigen::Vector3d rDDot_BN_N,
+                                                       Eigen::Vector3d omegaDot_BN_B,
+                                                       Eigen::Vector3d sigma_BN)
 {
     // This method is empty because the equations of motion of the effector are prescribed.
 }
@@ -238,7 +248,10 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime, Eigen::
  @param omega_BN_B [rad/s] Angular velocity of the B frame with respect to the inertial frame, expressed in B frame
  components
 */
-void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B)
+void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTime,
+                                                                 Eigen::Vector3d & rotAngMomPntCContr_B,
+                                                                 double & rotEnergyContr,
+                                                                 Eigen::Vector3d omega_BN_B)
 {
     // Update omega_BN_B and omega_FN_B
     this->omega_BN_B = omega_BN_B;
@@ -252,7 +265,8 @@ void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTim
     rotAngMomPntCContr_B = this->IPntFc_B * this->omega_FN_B + this->mass * this->rTilde_FcB_B * this->rDot_FcB_B;
 
     // Find the rotational energy contribution from the hub
-    rotEnergyContr = 0.5 * this->omega_FN_B.dot(this->IPntFc_B * this->omega_FN_B) + 0.5 * this->mass * this->rDot_FcB_B.dot(this->rDot_FcB_B);
+    rotEnergyContr = 0.5 * this->omega_FN_B.dot(this->IPntFc_B * this->omega_FN_B)
+                     + 0.5 * this->mass * this->rDot_FcB_B.dot(this->rDot_FcB_B);
 }
 
 /*! This method computes the effector states relative to the inertial frame.
@@ -260,16 +274,15 @@ void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTim
 */
 void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
 {
-     // Compute the effector's attitude with respect to the inertial frame
-    Eigen::Matrix3d dcm_FN;
-    dcm_FN = (this->dcm_BF).transpose() * this->dcm_BN;
+    // Compute the effector's attitude with respect to the inertial frame
+    Eigen::Matrix3d dcm_FN = (this->dcm_BF).transpose() * this->dcm_BN;
     this->sigma_FN = eigenMRPd2Vector3d(eigenC2MRP(dcm_FN));
 
     // Compute the effector's inertial position vector
-    this->r_FcN_N = (Eigen::Vector3d)(*this->inertialPositionProperty) + this->dcm_BN.transpose() * this->r_FcB_B;
+    this->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * this->r_FcB_B;
 
     // Compute the effector's inertial velocity vector
-    this->v_FcN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty) + this->dcm_BN.transpose() * this->rDot_FcB_B;
+    this->v_FcN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * this->rDot_FcB_B;
 }
 
 /*! This method updates the effector state at the dynamics frequency.
@@ -281,8 +294,7 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t CurrentSimNanos)
     // Read the input message if it is linked and written
     if (this->prescribedMotionInMsg.isLinked() && this->prescribedMotionInMsg.isWritten())
     {
-        PrescribedMotionMsgPayload incomingPrescribedStates;
-        incomingPrescribedStates = this->prescribedMotionInMsg();
+        PrescribedMotionMsgPayload incomingPrescribedStates = this->prescribedMotionInMsg();
         this->r_FM_M = cArray2EigenVector3d(incomingPrescribedStates.r_FM_M);
         this->rPrime_FM_M = cArray2EigenVector3d(incomingPrescribedStates.rPrime_FM_M);
         this->rPrimePrime_FM_M = cArray2EigenVector3d(incomingPrescribedStates.rPrimePrime_FM_M);

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -165,5 +165,16 @@ void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
 */
 void PrescribedMotionStateEffector::UpdateState(uint64_t CurrentSimNanos)
 {
-
+    // Read the input message if it is linked and written
+    if (this->prescribedMotionInMsg.isLinked() && this->prescribedMotionInMsg.isWritten())
+    {
+        PrescribedMotionMsgPayload incomingPrescribedStates;
+        incomingPrescribedStates = this->prescribedMotionInMsg();
+        this->r_FM_M = cArray2EigenVector3d(incomingPrescribedStates.r_FM_M);
+        this->rPrime_FM_M = cArray2EigenVector3d(incomingPrescribedStates.rPrime_FM_M);
+        this->rPrimePrime_FM_M = cArray2EigenVector3d(incomingPrescribedStates.rPrimePrime_FM_M);
+        this->omega_FM_F = cArray2EigenVector3d(incomingPrescribedStates.omega_FM_F);
+        this->omegaPrime_FM_F = cArray2EigenVector3d(incomingPrescribedStates.omegaPrime_FM_F);
+        this->sigma_FM = cArray2EigenVector3d(incomingPrescribedStates.sigma_FM);
+    }
 }

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -47,12 +47,16 @@ PrescribedMotionStateEffector::PrescribedMotionStateEffector()
     this->omega_MB_B.setZero();
     this->omegaPrime_MB_B.setZero();
     this->sigma_MB.setIdentity();
+
+    PrescribedMotionStateEffector::effectorID++;
 }
+
+uint64_t PrescribedMotionStateEffector::effectorID = 1;
 
 /*! This is the destructor. */
 PrescribedMotionStateEffector::~PrescribedMotionStateEffector()
 {
-
+    PrescribedMotionStateEffector::effectorID = 1;
 }
 
 /*! This method is used to reset the module.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -248,7 +248,16 @@ void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTim
 */
 void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
 {
+     // Compute the effector's attitude with respect to the inertial frame
+    Eigen::Matrix3d dcm_FN;
+    dcm_FN = (this->dcm_BF).transpose() * this->dcm_BN;
+    this->sigma_FN = eigenMRPd2Vector3d(eigenC2MRP(dcm_FN));
 
+    // Compute the effector's inertial position vector
+    this->r_FcN_N = (Eigen::Vector3d)(*this->inertialPositionProperty) + this->dcm_BN.transpose() * this->r_FcB_B;
+
+    // Compute the effector's inertial velocity vector
+    this->v_FcN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty) + this->dcm_BN.transpose() * this->rDot_FcB_B;
 }
 
 /*! This method updates the effector state at the dynamics frequency.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -1,0 +1,137 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "prescribedMotionStateEffector.h"
+
+/*! This is the constructor, setting variables to default values. */
+PrescribedMotionStateEffector::PrescribedMotionStateEffector()
+{
+
+}
+
+/*! This is the destructor. */
+PrescribedMotionStateEffector::~PrescribedMotionStateEffector()
+{
+
+}
+
+/*! This method is used to reset the module.
+ @return void
+ @param CurrentClock [ns] Time the method is called
+*/
+void PrescribedMotionStateEffector::Reset(uint64_t CurrentClock)
+{
+    // This method is empty because the modules doesn't have any state to reset
+}
+
+/*! This method takes the computed states and outputs them to the messaging system.
+ @return void
+ @param CurrentClock [ns] Time the method is called
+*/
+void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
+{
+
+}
+
+/*! This method allows the effector to have access to the hub states.
+ @return void
+ @param statesIn Pointer to give the state effector access the hub states
+*/
+void PrescribedMotionStateEffector::linkInStates(DynParamManager& statesIn)
+{
+
+}
+
+/*! This method allows the state effector to register its states with the dynamic parameter manager. (unused)
+ @return void
+ @param states Pointer to give the state effector access the hub states
+*/
+void PrescribedMotionStateEffector::registerStates(DynParamManager& states)
+{
+    // This method is empty because this module does not register any states
+}
+
+/*! This method allows the state effector to provide its contributions to the mass props and mass prop rates of the
+ spacecraft.
+ @return void
+ @param integTime [s] Time the method is called
+*/
+void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
+{
+
+}
+
+/*! This method allows the state effector to give its contributions to the matrices needed for the back-sub.
+ method
+ @return void
+ @param integTime [s] Time the method is called
+ @param backSubContr State effector contribution matrices for back-substitution
+ @param sigma_BN Current B frame attitude with respect to the inertial frame
+ @param omega_BN_B [rad/s] Angular velocity of the B frame with respect to the inertial frame, expressed in B frame
+ components
+ @param g_N [m/s^2] Gravitational acceleration in N frame components
+*/
+void PrescribedMotionStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+{
+
+}
+
+/*! This method is empty because the equations of motion of the effector are prescribed.
+ @return void
+ @param integTime [s] Time the method is called
+ @param rDDot_BN_N [m/s^2] Acceleration of the vector pointing from the inertial frame origin to the B frame origin,
+ expressed in inertial frame components
+ @param omegaDot_BN_B [rad/s^2] Inertial time derivative of the angular velocity of the B frame with respect to the
+ inertial frame, expressed in B frame components
+ @param sigma_BN Current B frame attitude with respect to the inertial frame
+*/
+void PrescribedMotionStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+{
+    // This method is empty because the equations of motion of the effector are prescribed.
+}
+
+/*! This method is for calculating the contributions of the effector to the energy and momentum of the spacecraft.
+ @return void
+ @param integTime [s] Time the method is called
+ @param rotAngMomPntCContr_B [kg m^2/s] Contribution of stateEffector to total rotational angular mom
+ @param rotEnergyContr [J] Contribution of stateEffector to total rotational energy
+ @param omega_BN_B [rad/s] Angular velocity of the B frame with respect to the inertial frame, expressed in B frame
+ components
+*/
+void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B)
+{
+
+}
+
+/*! This method computes the effector states relative to the inertial frame.
+ @return void
+*/
+void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
+{
+
+}
+
+/*! This method updates the effector state at the dynamics frequency.
+ @return void
+ @param CurrentSimNanos [ns] Time the method is called
+*/
+void PrescribedMotionStateEffector::UpdateState(uint64_t CurrentSimNanos)
+{
+
+}

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -279,6 +279,9 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t CurrentSimNanos)
         this->sigma_FM = cArray2EigenVector3d(incomingPrescribedStates.sigma_FM);
     }
 
+    // Call the method to compute the effector's inertial states
+    this->computePrescribedMotionInertialStates();
+
     // Call the method to write the output messages
     this->writeOutputStateMessages(CurrentSimNanos);
 }

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -41,7 +41,7 @@ PrescribedMotionStateEffector::PrescribedMotionStateEffector()
 
     // Initialize the other module variables
     this->mass = 0.0;
-    this->IPntFc_F.Identity();
+    this->IPntFc_F.setIdentity();
     this->r_MB_B.setZero();
     this->r_FcF_F.setZero();
     this->omega_MB_B.setZero();

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -32,10 +32,70 @@
 /*! @brief prescribed motion state effector class */
 class PrescribedMotionStateEffector: public StateEffector, public SysModel {
 public:
+    double mass;                                        //!< [kg] Effector mass
+    Eigen::Matrix3d IPntFc_F;                           //!< [kg-m^2] Inertia of the effector about its center of mass in F frame components
+    Eigen::Vector3d r_MB_B;                             //!< [m] Position of point M relative to point B in B frame components
+    Eigen::Vector3d r_FcF_F;                            //!< [m] Position of the effector center of mass relative to point F in F frame components
+    Eigen::Vector3d omega_MB_B;                         //!< [rad/s] Angular velocity of frame M with respect to frame B in B frame components
+    Eigen::Vector3d omegaPrime_MB_B;                    //!< [rad/s^2] B frame time derivative of omega_MB_B in B frame components
+    Eigen::MRPd sigma_MB;                               //!< MRP attitude of frame M relative to frame B
+
+    // Prescribed parameters
+    Eigen::Vector3d r_FM_M;                             //!< [m] Position of point F relative to point M in M frame components
+    Eigen::Vector3d rPrime_FM_M;                        //!< [m/s] B frame time derivative of r_FM_M in M frame components
+    Eigen::Vector3d rPrimePrime_FM_M;                   //!< [m/s^2] B frame time derivative of rPrime_FM_M in M frame components
+    Eigen::Vector3d omega_FM_F;                         //!< [rad/s] Angular velocity of frame F relative to frame M in F frame components
+    Eigen::Vector3d omegaPrime_FM_F;                    //!< [rad/s^2] B frame time derivative of omega_FM_F in F frame components
+    Eigen::MRPd sigma_FM;                               //!< MRP attitude of frame F relative to frame M
+
     ReadFunctor<PrescribedMotionMsgPayload> prescribedMotionInMsg;      //!< Input message for the effector's prescribed states
     Message<PrescribedMotionMsgPayload> prescribedMotionOutMsg;         //!< Output message for the effector's prescribed states
     Message<SCStatesMsgPayload> prescribedMotionConfigLogOutMsg;        //!< Output config log message for the effector's states
+
 private:
+    static uint64_t effectorID;                                         //!< ID number of this panel
+
+    // Given quantities from user in python
+    Eigen::Matrix3d IPntFc_B;                           //!< [kg-m^2] Inertia of the effector about its center of mass in B frame components
+    Eigen::Vector3d r_FB_B;                             //!< [m] Position of point F relative to point B in B frame components
+    Eigen::Vector3d r_FcF_B;                            //!< [m] Position of the effector center of mass relative to point F in B frame components
+
+    // Prescribed parameters in body frame components
+    Eigen::Vector3d r_FM_B;                             //!< [m] Position of point F relative to point M in B frame components
+    Eigen::Vector3d rPrime_FM_B;                        //!< [m/s] B frame time derivative of position r_FM_B in B frame components
+    Eigen::Vector3d rPrimePrime_FM_B;                   //!< [m/s^2] B frame time derivative of rPrime_FM_B in B frame components
+    Eigen::Vector3d omega_FM_B;                         //!< [rad/s] Angular velocity of F frame relative to the M frame in B frame components
+    Eigen::Vector3d omegaPrime_FM_B;                    //!< [rad/s^2] B frame time derivative of omega_FB_B in B frame components
+    Eigen::Vector3d omega_FB_B;                         //!< [rad/s] Angular velocity of frame F relative to frame B in B frame components
+    Eigen::Vector3d omegaPrime_FB_B;                    //!< [rad/s^2] B frame time derivative of omega_FB_B in B frame components
+
+    // Other vector quantities
+    Eigen::Vector3d r_FcM_B;                            //!< [m] Position of frame F center of mass relative to point M in B frame components
+    Eigen::Vector3d r_FcB_B;                            //!< [m] Position of frame F center of mass relative to point B in B frame components
+    Eigen::Vector3d rPrime_FcM_B;                       //!< [m/s] B frame time derivative of r_FcM_B in B frame components
+    Eigen::Vector3d rPrime_FcB_B;                       //!< [m/s] B frame time derivative of r_FcB_B in B frame components
+    Eigen::Vector3d rPrimePrime_FcB_B;                  //!< [m/s^2] B frame time derivative of rPrime_FcB_B in B frame components
+    Eigen::Vector3d omega_BN_B;                         //!< [rad/s] Angular velocity of frame B relative to the inertial frame in B frame components
+    Eigen::Vector3d omega_FN_B;                         //!< [rad/s] Angular velocity of frame F relative to the inertial frame in B frame components
+    Eigen::Vector3d rDot_FcB_B;                         //!< [m/s] Inertial time derivative of r_FcB_B in B frame components
+    Eigen::MRPd sigma_BN;                               //!< MRP attitude of frame B relative to the inertial frame
+
+    // DCMs
+    Eigen::Matrix3d dcm_BN;                             //!< DCM from inertial frame to frame B
+    Eigen::Matrix3d dcm_BM;                             //!< DCM from frame M to frame B
+    Eigen::Matrix3d dcm_FM;                             //!< DCM from frame M to frame F
+    Eigen::Matrix3d dcm_BF;                             //!< DCM from frame F to frame B
+
+    // Other matrix quantities
+    Eigen::Matrix3d rTilde_FcB_B;                       //!< [m] Tilde cross product matrix of r_FcB_B
+    Eigen::Matrix3d omegaTilde_BN_B;                    //!< [rad/s] Tilde cross product matrix of omega_BN_B
+    Eigen::Matrix3d omegaTilde_FB_B;                    //!< [rad/s] Tilde cross product matrix of omega_FB_B
+
+    // Effector properties relative to the inertial frame
+    Eigen::Vector3d r_FcN_N;                            //!< [m] Position of frame F center of mass relative to the inertial frame in inertial frame components
+    Eigen::Vector3d v_FcN_N;                            //!< [m/s] Inertial velocity of frame F center of mass relative to the inertial frame in inertial frame components
+    Eigen::Vector3d sigma_FN;                           //!< MRP attitude of frame F relative to the inertial frame
+    Eigen::Vector3d omega_FN_F;                         //!< [rad/s] Angular velocity of frame F relative to the inertial frame in F frame components
 
     // Hub states
     StateData *hubSigma;                                //!< Hub attitude relative to the inertial frame represented by MRP

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -32,6 +32,29 @@
 /*! @brief prescribed motion state effector class */
 class PrescribedMotionStateEffector: public StateEffector, public SysModel {
 public:
+    PrescribedMotionStateEffector();
+    ~PrescribedMotionStateEffector();
+    void Reset(uint64_t CurrentClock) override;                      //!< Method for reset
+    void writeOutputStateMessages(uint64_t CurrentClock) override;   //!< Method for writing the output messages
+	void UpdateState(uint64_t CurrentSimNanos) override;             //!< Method for updating the effector states
+    void registerStates(DynParamManager& statesIn) override;         //!< Method for registering the effector's states
+    void linkInStates(DynParamManager& states) override;             //!< Method for giving the effector access to hub states
+    void updateContributions(double integTime,
+                             BackSubMatrices & backSubContr,
+                             Eigen::Vector3d sigma_BN,
+                             Eigen::Vector3d omega_BN_B,
+                             Eigen::Vector3d g_N) override; //!< Method for computing the effector's back-substitution contributions
+    void computeDerivatives(double integTime,
+                            Eigen::Vector3d rDDot_BN_N,
+                            Eigen::Vector3d omegaDot_BN_B,
+                            Eigen::Vector3d sigma_BN) override; //!< Method for effector to compute its state derivatives
+    void updateEffectorMassProps(double integTime) override; //!< Method for calculating the effector mass props and prop rates
+    void updateEnergyMomContributions(double integTime,
+                                      Eigen::Vector3d & rotAngMomPntCContr_B,
+                                      double & rotEnergyContr,
+                                      Eigen::Vector3d omega_BN_B); //!< Method for computing the energy and momentum of the effector
+    void computePrescribedMotionInertialStates(); //!< Method for computing the effector's states relative to the inertial frame
+
     double mass;                                        //!< [kg] Effector mass
     Eigen::Matrix3d IPntFc_F;                           //!< [kg-m^2] Inertia of the effector about its center of mass in F frame components
     Eigen::Vector3d r_MB_B;                             //!< [m] Position of point M relative to point B in B frame components
@@ -102,20 +125,6 @@ private:
     StateData *hubOmega;                                //!< [rad/s] Hub angular velocity in B frame components relative to the inertial frame
     Eigen::MatrixXd* inertialPositionProperty;          //!< [m] r_N Inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialVelocityProperty;          //!< [m] v_N Inertial velocity relative to system spice zeroBase/refBase
-
-public:
-    PrescribedMotionStateEffector();                        //!< Constructor
-    ~PrescribedMotionStateEffector();                       //!< Destructor
-    void Reset(uint64_t CurrentClock);                      //!< Method for reset
-    void writeOutputStateMessages(uint64_t CurrentClock);   //!< Method for writing the output messages
-	void UpdateState(uint64_t CurrentSimNanos);             //!< Method for updating the effector states
-    void registerStates(DynParamManager& statesIn);         //!< Method for registering the effector's states
-    void linkInStates(DynParamManager& states);             //!< Method for giving the effector access to hub states
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< Method for computing the effector's back-substitution contributions
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);                         //!< Method for effector to compute its state derivatives
-    void updateEffectorMassProps(double integTime);         //!< Method for calculating the effector mass props and prop rates
-    void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B);       //!< Method for computing the energy and momentum of the effector
-    void computePrescribedMotionInertialStates();           //!< Method for computing the effector's states relative to the inertial frame
 };
 
 #endif /* PRESCRIBED_MOTION_STATE_EFFECTOR_H */

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -22,9 +22,12 @@
 
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 #include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/avsEigenMRP.h"
 
 /*! @brief prescribed motion state effector class */
 class PrescribedMotionStateEffector: public StateEffector, public SysModel {
@@ -33,6 +36,12 @@ public:
     Message<PrescribedMotionMsgPayload> prescribedMotionOutMsg;         //!< Output message for the effector's prescribed states
     Message<SCStatesMsgPayload> prescribedMotionConfigLogOutMsg;        //!< Output config log message for the effector's states
 private:
+
+    // Hub states
+    StateData *hubSigma;                                //!< Hub attitude relative to the inertial frame represented by MRP
+    StateData *hubOmega;                                //!< [rad/s] Hub angular velocity in B frame components relative to the inertial frame
+    Eigen::MatrixXd* inertialPositionProperty;          //!< [m] r_N Inertial position relative to system spice zeroBase/refBase
+    Eigen::MatrixXd* inertialVelocityProperty;          //!< [m] v_N Inertial velocity relative to system spice zeroBase/refBase
 
 public:
     PrescribedMotionStateEffector();                        //!< Constructor

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -1,0 +1,47 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef PRESCRIBED_MOTION_STATE_EFFECTOR_H
+#define PRESCRIBED_MOTION_STATE_EFFECTOR_H
+
+#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+
+/*! @brief prescribed motion state effector class */
+class PrescribedMotionStateEffector: public StateEffector, public SysModel {
+public:
+
+private:
+
+public:
+    PrescribedMotionStateEffector();                        //!< Constructor
+    ~PrescribedMotionStateEffector();                       //!< Destructor
+    void Reset(uint64_t CurrentClock);                      //!< Method for reset
+    void writeOutputStateMessages(uint64_t CurrentClock);   //!< Method for writing the output messages
+	void UpdateState(uint64_t CurrentSimNanos);             //!< Method for updating the effector states
+    void registerStates(DynParamManager& statesIn);         //!< Method for registering the effector's states
+    void linkInStates(DynParamManager& states);             //!< Method for giving the effector access to hub states
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< Method for computing the effector's back-substitution contributions
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);                         //!< Method for effector to compute its state derivatives
+    void updateEffectorMassProps(double integTime);         //!< Method for calculating the effector mass props and prop rates
+    void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B);       //!< Method for computing the energy and momentum of the effector
+    void computePrescribedMotionInertialStates();           //!< Method for computing the effector's states relative to the inertial frame
+};
+
+#endif /* PRESCRIBED_MOTION_STATE_EFFECTOR_H */

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -22,11 +22,16 @@
 
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+#include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
 
 /*! @brief prescribed motion state effector class */
 class PrescribedMotionStateEffector: public StateEffector, public SysModel {
 public:
-
+    ReadFunctor<PrescribedMotionMsgPayload> prescribedMotionInMsg;      //!< Input message for the effector's prescribed states
+    Message<PrescribedMotionMsgPayload> prescribedMotionOutMsg;         //!< Output message for the effector's prescribed states
+    Message<SCStatesMsgPayload> prescribedMotionConfigLogOutMsg;        //!< Output config log message for the effector's states
 private:
 
 public:

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
@@ -1,0 +1,40 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+%module prescribedMotionStateEffector
+%{
+   #include "prescribedMotionStateEffector.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "swig_conly_data.i"
+
+%include "sys_model.h"
+%include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+%include "prescribedMotionStateEffector.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
@@ -27,11 +27,14 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 
+%include "std_string.i"
 %include "swig_conly_data.i"
+%include "swig_eigen.i"
 
 %include "sys_model.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "prescribedMotionStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
@@ -34,6 +34,11 @@ from Basilisk.architecture.swig_common_model import *
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "prescribedMotionStateEffector.h"
 
+%include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+struct SCStatesMsg_C;
+%include "architecture/msgPayloadDefC/PrescribedMotionMsgPayload.h"
+struct PrescribedMotionMsg_C;
+
 %pythoncode %{
 import sys
 protectAllClasses(sys.modules[__name__])

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
@@ -1,0 +1,125 @@
+
+Executive Summary
+-----------------
+The prescribed motion class is an instantiation of the state effector abstract class. This module describes the dynamics
+of a six-degree of freedom (6 DOF) prescribed rigid body connected to a central rigid spacecraft hub. The body frame
+for the prescribed body is designated by the frame :math:`\mathcal{F}`. The prescribed body is mounted onto a hub-fixed
+interface described by a mount frame :math:`\mathcal{M}` that is fixed with respect to the hub. The prescribed body may
+be commanded to translate and rotate in three-dimensional space with respect to the interface it is mounted on.
+Accordingly, the prescribed states for the secondary body are written with respect to the mount frame, :math:`\mathcal{M}`. The
+prescribed states are: ``r_FM_M``, ``rPrime_FM_M``, ``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and
+``sigma_FM``.
+
+The states of the prescribed body are not defined in this module. Therefore, a flight software profiler module must be
+connected to this module's :ref:`PrescribedMotionMsgPayload` input message to profile the prescribed body's states as a
+function of time. This message connection is required to provide the prescribed body's states to this dynamics module.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg variable name is set by the
+user from python.  The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - prescribedMotionInMsg
+      - :ref:`PrescribedMotionMsgPayload`
+      - Input message for the effector's prescribed states
+    * - prescribedMotionOutMsg
+      - :ref:`PrescribedMotionMsgPayload`
+      - Output message for the effector's prescribed states
+    * - prescribedMotionConfigLogOutMsg
+      - :ref:`SCStatesMsgPayload`
+      - Output message containing the effector's inertial position and attitude states
+
+
+Detailed Module Description
+---------------------------
+
+Mathematical Modeling
+^^^^^^^^^^^^^^^^^^^^^
+See Kiner et al.'s paper: `Spacecraft Simulation Software Implementation of General Prescribed Motion Dynamics of Two Connected Rigid Bodies <http://hanspeterschaub.info/Papers/Kiner2023.pdf>`__
+for a detailed description of the derived prescribed dynamics.
+
+The translational equations of motion are:
+
+.. math::
+    m_{\text{sc}} \left [ \ddot{\boldsymbol{r}}_{B/N} + \boldsymbol{c}^{''} + 2 \left ( \boldsymbol{\omega}_{\mathcal{B}/\mathcal{N}} \times \boldsymbol{c}^{'} \right ) + \left ( \dot{\boldsymbol{\omega}}_{\mathcal{B}/\mathcal{N}} \times \boldsymbol{c} \right ) + \boldsymbol{\omega}_{\mathcal{B}/\mathcal{N}} \times \left ( \boldsymbol{\omega}_{\mathcal{B}/\mathcal{N}} \times \boldsymbol{c} \right ) \right ] = \sum \boldsymbol{F}_{\text{ext}}
+
+The rotational equations of motion are:
+
+.. math::
+    m_{\text{sc}} [\tilde{\boldsymbol{c}}] \ddot{\boldsymbol{r}}_{B/N} + [I_{\text{sc},B}] \dot{\boldsymbol{\omega}}_{\mathcal{B}/\mathcal{N}} =  \boldsymbol{L}_B -  m_{\text{P}} [\tilde{\boldsymbol{r}}_{F_c/B}] \boldsymbol{r}^{''}_{F_c/B} - \left ( [I^{'}_{\text{sc},B}] + [\tilde{\boldsymbol{\omega}}_{\mathcal{B}/\mathcal{N}}][I_{\text{sc},B}] \right ) \boldsymbol{\omega}_{\mathcal{B}/\mathcal{N}} \\ - \left ( [I^{'}_{\text{P},F_c}] + [\tilde{\boldsymbol{\omega}}_{\mathcal{B}/\mathcal{N}}] [I_{\text{P},F_c}] \right ) \boldsymbol{\omega}_{\mathcal{F}/\mathcal{B}} \ - \ [I_{\text{P},F_c}] \boldsymbol{\omega}^{'}_{\mathcal{F}/\mathcal{B}} \ - \ m_{\text{P}} [\tilde{\boldsymbol{\omega}}_{\mathcal{B}/\mathcal{N}}] [\tilde{\boldsymbol{r}}_{F_c/B}] \boldsymbol{r}^{'}_{F_c/B}
+
+Module Testing
+^^^^^^^^^^^^^^
+The unit test for this module is an integrated test with two flight software profiler modules. This is required
+because the dynamics module must be connected to a flight software profiler module to define the states of the
+prescribed secondary body that is connected to the rigid spacecraft hub. The integrated test for this module has
+two simple scenarios it is testing. The first scenario prescribes a 1 DOF rotational attitude maneuver for the
+prescribed body using the :ref:`prescribedRot1DOF` flight software module. The second scenario prescribes a
+translational maneuver for the prescribed body using the :ref:`prescribedTrans` flight software module.
+
+The unit test ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
+initial and reference PRV angles and maximum angular accelerations. The final prescribed angle ``theta_FM_Final``
+and angular velocity magnitude ``thetaDot_Final`` are compared with the reference values ``theta_Ref`` and
+``thetaDot_Ref``, respectively. The unit test also ensures that the profiled translational maneuver is properly computed for a
+series of initial and reference positions and maximum accelerations. The final prescribed position magnitude
+``r_FM_M_Final`` and velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values ``r_FM_M_Ref``
+and ``rPrime_FM_M_Ref``, respectively. Additionally for each scenario, the conservation quantities of orbital angular momentum,
+rotational angular momentum, and orbital energy are checked to validate the module dynamics.
+
+User Guide
+----------
+This section is to outline the steps needed to setup a Prescribed Motion State Effector in python using Basilisk.
+
+#. Import the prescribedMotionStateEffector class::
+
+    from Basilisk.simulation import prescribedMotionStateEffector
+
+#. Create an instantiation of a prescribed body::
+
+    platform = prescribedMotionStateEffector.PrescribedMotionStateEffector()
+
+#. Define all physical parameters for the state effector::
+
+    platform.mass = 100.0
+    platform.IPntFc_F = [[50.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]
+    platform.r_MB_B = np.array([0.0, 0.0, 0.0])
+    platform.r_FcF_F = np.array([0.0, 0.0, 0.0])
+    platform.r_FM_M = np.array([1.0, 0.0, 0.0])
+    platform.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
+    platform.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+    platform.omega_FM_F = np.array([0.0, 0.0, 0.0])
+    platform.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    platform.sigma_FM = np.array([0.0, 0.0, 0.0])
+    platform.omega_MB_B = np.array([0.0, 0.0, 0.0])
+    platform.omegaPrime_MB_B = np.array([0.0, 0.0, 0.0])
+    platform.sigma_MB = np.array([0.0, 0.0, 0.0])
+    platform.ModelTag = "Platform"
+
+Do this for all of the public parameters in the prescribed motion state effector module. Note that if these parameters
+are not set by the user, all scalar and vector quantities are set to zero and all matrices are set to identity by
+default.
+
+#. Add the prescribed state effector to your spacecraft::
+
+    scObject.addStateEffector(platform)
+
+   See :ref:`spacecraft` documentation on how to set up a spacecraft object.
+
+#. Make sure to connect the required messages for this module.
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, platform)
+
+
+
+


### PR DESCRIPTION
* **Tickets addressed:** #113
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
The prescribed motion class is an instantiation of the state effector abstract class. The module is used when the states of a rigid body attached to the spacecraft hub are completely known and hence may be prescribed. Additional modules are added to this branch to perform two integrated unit tests to validate the interaction between the prescribed motion module and the rigid body hub that it is attached to. A new `prescribedMotionMsgPayload` message is added to this branch that contains the prescribed effector's states.

## Verification
No changes were made to existing code. Two integrated tests are performed to validate the interaction between the prescribed motion module and the rigid body hub that it is attached to. The first integrated test incorporates a 1 DOF rotational flight software module to profile the effector's rotational motion with respect to the hub. The second integrated test incorporates a translational flight software module to profile the effector's translational motion with respect to the hub.

## Documentation
An RST documentation file was added to this branch that summarizes the purpose and use of this module. A short summary of the dynamics derivation is included in the documentation. A link is provided for the full mathematical derivation outlined in the 2023 AAS GNC conference paper "Spacecraft Simulation Software Implementation of General Prescribed Motion Dynamics of Two Connected Rigid Bodies" by Kiner et al.

## Future work
Other modules may be written in the future to profile the new effector motion with respect to the hub. Additional integrated tests may be added to validate the dynamics and the conservation quantities.
