### PR TITLE
Feature/bsk 106 hinged rigid body PID motor

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,7 +32,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
-- text here
+- Created fsw :ref:`hingedRigidBodyPIDMotor` to compute the commanded torque to :ref:`spinningBodyStateEffector` using a propotional-integral-derivative controller.
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/_UnitTest/test_hingedRigidBodyPIDMotor.py
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/_UnitTest/test_hingedRigidBodyPIDMotor.py
@@ -1,0 +1,183 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        solarArrayRotation
+#   Author:             Riccardo Calaon
+#   Creation Date:      January 12, 2023
+#
+
+import pytest
+import os, inspect, random
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+
+# Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport                   # general support file with common unit test functions
+from Basilisk.fswAlgorithms import hingedRigidBodyPIDMotor       # import the module that is to be tested
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging                      # import the message definitions
+from Basilisk.architecture import bskLogging
+
+
+# Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
+# @pytest.mark.skipif(conditionstring)
+# Uncomment this line if this test has an expected failure, adjust message as needed.
+# @pytest.mark.xfail(conditionstring)
+# Provide a unique test method name, starting with 'test_'.
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.  Note that the order in that you add the parametrize method
+# matters for the documentation in that it impacts the order in which the test arguments are shown.
+# The first parametrize arguments are shown last in the pytest argument list
+@pytest.mark.parametrize("thetaR", [np.pi/2, np.pi/6])
+@pytest.mark.parametrize("thetaDotR", [0.1, 0.2])
+@pytest.mark.parametrize("theta", [7*np.pi/6, 3*np.pi/2])
+@pytest.mark.parametrize("thetaDot", [-0.1, -0.5])
+@pytest.mark.parametrize("K", [0, 2])
+@pytest.mark.parametrize("P", [0, 5])
+@pytest.mark.parametrize("I", [0, 1])
+@pytest.mark.parametrize("accuracy", [1e-8])
+
+
+# update "module" in this function name to reflect the module name
+def test_hingedRigidBodyPIDMotor(show_plots, thetaR, thetaDotR, theta, thetaDot, K, P, I, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test verifies the correctness of the output motor torque :ref:`hingedRigidBodyPIDMotor`.
+    The inputs provided are reference angle and angle rate, current angle and angle rate, proportional,
+    derivative, and integral gain.
+
+    **Test Parameters**
+
+    Args:
+        thetaR (double): reference angle;
+        thetaDotR (double): reference angle rate;
+        theta (double): current angle;
+        thetaDot (double): current angle rate;
+        K (double): proportional gain;
+        P (double): derivative gain;
+        I (double): integral gain;
+        accuracy (float): absolute accuracy value used in the validation tests.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the correctness of the output motor torque
+
+    - ``motorTorqueOutMsg``
+
+    where in this case the output is one dimensional, since the spinning body is one dimensional. The unit test
+    only checks the output at the first time step, for which the integral term does not contribute.
+    """
+    # each test method requires a single assert method to be called
+    [testResults, testMessage] = hingedRigidBodyPIDMotorTestFunction(show_plots, thetaR, thetaDotR, theta, thetaDot, K, P, I, accuracy)
+    assert testResults < 1, testMessage
+
+
+def hingedRigidBodyPIDMotorTestFunction(show_plots, thetaR, thetaDotR, theta, thetaDot, K, P, I, accuracy):
+
+    testFailCount = 0                        # zero unit test result counter
+    testMessages = []                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    motorConfig = hingedRigidBodyPIDMotor.hingedRigidBodyPIDMotorConfig()
+    motorWrap = unitTestSim.setModelDataWrap(motorConfig)
+    motorWrap.ModelTag = "hingedRigidBodyPIDMotor"  
+    motorConfig.K = K
+    motorConfig.P = P
+    motorConfig.I = I
+    unitTestSim.AddModelToTask(unitTaskName, motorWrap, motorConfig)
+
+    # Create input spinning body reference message
+    refInMsgData = messaging.HingedRigidBodyMsgPayload()
+    refInMsgData.theta = thetaR
+    refInMsgData.thetaDot = thetaDotR
+    refInMsg = messaging.HingedRigidBodyMsg().write(refInMsgData)
+    motorConfig.hingedRigidBodyRefInMsg.subscribeTo(refInMsg)
+
+    # Create input spinning body message
+    stateInMsgData = messaging.HingedRigidBodyMsgPayload()
+    stateInMsgData.theta = theta
+    stateInMsgData.thetaDot = thetaDot
+    stateInMsg = messaging.HingedRigidBodyMsg().write(stateInMsgData)
+    motorConfig.hingedRigidBodyInMsg.subscribeTo(stateInMsg)
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = motorConfig.motorTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))        # seconds to stop simulation
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    T = K * (thetaR - theta) + P * (thetaDotR - thetaDot)
+
+    # compare the module results to the truth values
+    if not unitTestSupport.isDoubleEqual(dataLog.motorTorque[0][0], T, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + motorWrap.ModelTag + " module failed unit test for thetaR = {}, thetaDotR  = {}, theta = {}, thetaDot = {}, K = {}, P = {} \n".format(thetaR, thetaDotR, theta, thetaDot, K, P))
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_hingedRigidBodyPIDMotor( 
+                 False,
+                 np.pi/3,
+                 0,
+                 np.pi/2,
+                 0.1,
+                 1,
+                 5,
+                 0,
+                 1e-12        # accuracy
+               )

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
@@ -1,0 +1,60 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+/* modify the path to reflect the new module names */
+#include "hingedRigidBodyPIDMotor.h"
+#include "string.h"
+#include <math.h>
+
+
+/*!
+    This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, int64_t moduleID)
+{
+    ArrayMotorTorqueMsg_C_init(&configData->motorTorqueOutMsg);
+}
+
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}
+
+/*! This method computes the control torque to the solar array drive based on a PD control law
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param moduleID The module identifier
+*/
+void Update_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
@@ -45,7 +45,12 @@ void SelfInit_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData,
 */
 void Reset_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, uint64_t callTime, int64_t moduleID)
 {
-
+    if (!HingedRigidBodyMsg_C_isLinked(&configData->hingedRigidBodyInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.hingedRigidBodyInMsg wasn't connected.");
+    }
+    if (!HingedRigidBodyMsg_C_isLinked(&configData->hingedRigidBodyRefInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "Error: solarArrayAngle.hingedRigidBodyRefInMsg wasn't connected.");
+    }
 }
 
 /*! This method computes the control torque to the solar array drive based on a PD control law

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.h
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.h
@@ -33,6 +33,11 @@ typedef struct {
     double P;                 //!< derivative gain
     double I;                 //!< integral gain
 
+    /*! declare these variables for internal computations */
+    uint64_t priorTime;       //!< prior function call time for trapezoid integration
+    double   priorThetaError; //!< theta error at prior function call
+    double   intError;        //!< integral error
+
     /* declare module IO interfaces */
     HingedRigidBodyMsg_C   hingedRigidBodyInMsg;      //!< input spinning body message
     HingedRigidBodyMsg_C   hingedRigidBodyRefInMsg;   //!< output msg containing spinning body target angle and angle rate

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.h
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.h
@@ -1,0 +1,58 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _HINGED_RIGID_BODY_PID_MOTOR_
+#define _HINGED_RIGID_BODY_PID_MOTOR_
+
+#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/HingedRigidBodyMsg_C.h"
+#include "cMsgCInterface/ArrayMotorTorqueMsg_C.h"
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /*! declare these user-defined input parameters */
+    double K;                 //!< proportional gain
+    double P;                 //!< derivative gain
+    double I;                 //!< integral gain
+
+    /* declare module IO interfaces */
+    HingedRigidBodyMsg_C   hingedRigidBodyInMsg;      //!< input spinning body message
+    HingedRigidBodyMsg_C   hingedRigidBodyRefInMsg;   //!< output msg containing spinning body target angle and angle rate
+    ArrayMotorTorqueMsg_C  motorTorqueOutMsg;         //!< output msg containing the motor torque to the array drive
+
+    BSKLogger *bskLogger;                             //!< BSK Logging
+
+}hingedRigidBodyPIDMotorConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void SelfInit_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, int64_t moduleID);
+    void Reset_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, uint64_t callTime, int64_t moduleID);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.i
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.i
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module hingedRigidBodyPIDMotor
+%{
+   #include "hingedRigidBodyPIDMotor.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_hingedRigidBodyPIDMotor(void*, uint64_t);
+%ignore SelfInit_hingedRigidBodyPIDMotor;
+%constant void Reset_hingedRigidBodyPIDMotor(void*, uint64_t, uint64_t);
+%ignore Reset_hingedRigidBodyPIDMotor;
+%constant void Update_hingedRigidBodyPIDMotor(void*, uint64_t, uint64_t);
+%ignore Update_hingedRigidBodyPIDMotor;
+
+%include "hingedRigidBodyPIDMotor.h"
+
+%include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
+struct HingedRigidBodyMsg_C;
+%include "architecture/msgPayloadDefC/ArrayMotorTorqueMsgPayload.h"
+struct ArrayMotorTorqueMsg_C;
+
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.rst
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.rst
@@ -1,0 +1,71 @@
+Executive Summary
+-----------------
+
+This module implements a simple Proportional-Integral-Derivative (PID) control law to provide the commanded torque to a :ref:`spinningBodyStateEffector`.
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg connection is set by the
+user from python.  The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - motorTorqueOutMsg
+      - :ref:`ArrayMotorTorqueMsgPayload`
+      - Output Spinning Body Reference Message.
+    * - hingedRigidBodyInMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - Input Spinning Body Message Message.
+    * - hingedRigidBodyRefInMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - Input Spinning Body Reference Message Message. 
+
+
+Module Assumptions and Limitations
+----------------------------------
+This module is very simple and does not make any assumptions. The only limitations are those inherent to a PID type of control law, here implemented. The type of response (underdamped, 
+overdamped, or critically damped) depends on the choice of gains provided as inputs to the module.
+
+
+Detailed Module Description
+---------------------------
+For this module to operate, the user needs to provide control gains ``K``, ``P`` and ``I``. Let's define :math:`\theta_R` and :math:`\dot{\theta}_R` the reference angle and angle rate contained in the
+``hingedRigidBodyRefInMsg``, and :math:`\theta` and :math:`\dot{\theta}` the current solar array angle and angle rate contained in the ``hingedRigidBodyInMsg``, which is provided as an output of the :ref:`spinningBodyStateEffector`. The control torque is obtained as follows:
+
+.. math::
+    T = K (\theta_R - \theta) + P (\dot{\theta}_R - \dot{\theta}) + I \int_0^t (\theta_R - \theta) \text{d}\tau.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    motorConfig = hingedRigidBodyPIDMotorConfig.hingedRigidBodyPIDMotorConfig()
+    motorWrap = unitTestSim.setModelDataWrap(motorConfig)
+    motorWrap.ModelTag = "solarArrayPDController"  
+    motorConfig.K = K
+    motorConfig.P = P
+    motorConfig.P = I
+    unitTestSim.AddModelToTask(unitTaskName, motorWrap, motorConfig)
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 34 66
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``K``
+     - proportional gain; defaults to 0 if not provided
+   * - ``P``
+     - derivative gain; defaults to 0 if not provided
+   * - ``I``
+     - integral gain; defaults to 0 if not provided


### PR DESCRIPTION
* **Tickets addressed:** resolves #106
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module reads in a HingedRigidBodyMsg containing the current angle and angle rate, and a HingedRigidBodyReferenceMsg containing reference angle and angle rates. Based on those, it computes a proportional-integral-derivative control torque that is delivered to the SpinningBodyStateEffector. Commit 1 initializes the module with its main functions left empty. Commit 2 checks if the required input msgs are connected. Commit 3 builds the Update() function with the math that allows to derive the reference angle and angle rate, compute the control torque and write the output msg. Commits 4 and 5 contain the documentation and unit test, respectively.

## Verification
A unit test is provided. Such unit test verifies the module's output torque vs a torque computed using the same gains in python. Because the unit test is run for one single call of the Update() function, the integral term is always zero.

## Documentation
This is a new module. New documentation is provided to describe how the module works.

## Future work
No future work is foreseen at the moment.
