### PR TITLE
Feature/bsk 143 torque scheduler

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,6 +33,7 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Created fsw :ref:`hingedRigidBodyPIDMotor` to compute the commanded torque to :ref:`spinningBodyStateEffector` using a propotional-integral-derivative controller.
+- Added :ref:`torqueScheduler` to combine two :ref:`ArrayMotorTorqueMsgPayload` into one and implement effector locking logic.
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/src/architecture/msgPayloadDefC/ArrayEffectorLockMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/ArrayEffectorLockMsgPayload.h
@@ -1,0 +1,34 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef ARRAY_EFFECTOR_LOCK_H
+#define ARRAY_EFFECTOR_LOCK_H
+
+
+#include "architecture/utilities/macroDefinitions.h"
+
+
+
+/*! @brief Structure used to define the output definition for vehicle effectors*/
+typedef struct {
+    int effectorLockFlag[MAX_EFF_CNT];     //!< effector lock flag; 0 : do not lock; 1 : lock
+}ArrayEffectorLockMsgPayload;
+
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/_UnitTest/test_torqueScheduler.py
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/_UnitTest/test_torqueScheduler.py
@@ -1,0 +1,208 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        torqueScheduler
+#   Author:             Riccardo Calaon
+#   Creation Date:      January 25, 2023
+#
+
+import pytest
+import os, inspect, random
+import numpy as np
+
+
+# Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport                   # general support file with common unit test functions
+from Basilisk.fswAlgorithms import torqueScheduler       # import the module that is to be tested
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging                      # import the message definitions
+from Basilisk.architecture import bskLogging
+
+
+# Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
+# @pytest.mark.skipif(conditionstring)
+# Uncomment this line if this test has an expected failure, adjust message as needed.
+# @pytest.mark.xfail(conditionstring)
+# Provide a unique test method name, starting with 'test_'.
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.  Note that the order in that you add the parametrize method
+# matters for the documentation in that it impacts the order in which the test arguments are shown.
+# The first parametrize arguments are shown last in the pytest argument list
+@pytest.mark.parametrize("lockFlag", [0, 1, 2, 3])
+@pytest.mark.parametrize("tSwitch", [3, 6])
+@pytest.mark.parametrize("accuracy", [1e-12])
+
+
+def test_torqueScheduler(lockFlag, tSwitch, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test verifies the correctness of the output motor torque :ref:`torqueScheduler`.
+    The inputs provided are the lock flag and the time at which thr control is switched from 
+    one degree of freedom to the other.
+
+    **Test Parameters**
+
+    Args:
+        lockFlag (int): flag to determine which torque to use first;
+        tSwitch (double): time at which torque is to be switched from one d.o.f. to the other;
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the correctness of the output motor torque msg and the output effector lock msg:
+
+    - ``motorTorqueOutMsg``
+    - ``effectorLockOutMsg``.
+
+    The test checks that the output of ``motorTorqueOutMsg`` always matches the torques contained in the input msgs
+    and that the flags contained in ``effectorLockOutMsg`` are consistent with the schedule logic that the user is requesting.
+    """
+    # each test method requires a single assert method to be called
+    [testResults, testMessage] = torqueSchedulerTestFunction(lockFlag, tSwitch, accuracy)
+    assert testResults < 1, testMessage
+
+
+def torqueSchedulerTestFunction(lockFlag, tSwitch, accuracy):
+
+    testFailCount = 0                        # zero unit test result counter
+    testMessages = []                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C container
+    schedulerConfig = torqueScheduler.torqueSchedulerConfig()
+    schedulerWrap = unitTestSim.setModelDataWrap(schedulerConfig)
+    schedulerWrap.ModelTag = "torqueScheduler"
+    schedulerConfig.lockFlag = lockFlag
+    schedulerConfig.tSwitch = tSwitch
+    unitTestSim.AddModelToTask(unitTaskName, schedulerWrap, schedulerConfig)
+
+    # Create input array motor torque msg #1
+    motorTorque1InMsgData = messaging.ArrayMotorTorqueMsgPayload()
+    motorTorque1InMsgData.motorTorque = [1]
+    motorTorque1InMsg = messaging.ArrayMotorTorqueMsg().write(motorTorque1InMsgData)
+    schedulerConfig.motorTorque1InMsg.subscribeTo(motorTorque1InMsg)
+
+    # Create input array motor torque msg #2
+    motorTorque2InMsgData = messaging.ArrayMotorTorqueMsgPayload()
+    motorTorque2InMsgData.motorTorque = [3]
+    motorTorque2InMsg = messaging.ArrayMotorTorqueMsg().write(motorTorque2InMsgData)
+    schedulerConfig.motorTorque2InMsg.subscribeTo(motorTorque2InMsg)
+
+    # Setup logging on the test module output messages so that we get all the writes to it
+    torqueLog = schedulerConfig.motorTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, torqueLog)
+    lockLog = schedulerConfig.effectorLockOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, lockLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(10))        # seconds to stop simulation
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    # compare the module results to the truth values
+    time = torqueLog.times() * macros.NANO2SEC
+
+    for i in range(len(time)):
+        if not unitTestSupport.isDoubleEqual(torqueLog.motorTorque[i][0], motorTorque1InMsgData.motorTorque[0], accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at passing motor torque #1 value")
+        if not unitTestSupport.isDoubleEqual(torqueLog.motorTorque[i][1], motorTorque2InMsgData.motorTorque[0], accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at passing motor torque #2 value")
+
+        if lockFlag == 0:
+            if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][0], 0, accuracy):
+                testFailCount += 1
+                testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #1")
+            if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][1], 0, accuracy):
+                testFailCount += 1
+                testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #2")
+        elif lockFlag == 1:
+            if time[i] > tSwitch:
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][0], 1, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #1")
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][1], 0, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #2")
+            else:
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][0], 0, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #1")
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][1], 1, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #2")
+        elif lockFlag == 2:
+            if time[i] > tSwitch:
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][0], 0, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #1")
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][1], 1, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #2")
+            else:
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][0], 1, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #1")
+                if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][1], 0, accuracy):
+                    testFailCount += 1
+                    testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #2")
+        else:
+            if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][0], 1, accuracy):
+                testFailCount += 1
+                testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #1")
+            if not unitTestSupport.isDoubleEqual(lockLog.effectorLockFlag[i][1], 1, accuracy):
+                testFailCount += 1
+                testMessages.append("FAILED: " + schedulerWrap.ModelTag + " module failed at outputting effector flag #2")
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_torqueScheduler( 
+                 1,
+                 5,
+                 1e-12
+               )

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.c
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.c
@@ -1,0 +1,55 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#include "torqueScheduler.h"
+#include "string.h"
+
+
+/*! This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_torqueScheduler(torqueSchedulerConfig *configData, int64_t moduleID)
+{
+    ArrayMotorTorqueMsg_C_init(&configData->motorTorqueOutMsg);
+    ArrayEffectorLockMsg_C_init(&configData->effectorLockOutMsg);
+}
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_torqueScheduler(torqueSchedulerConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+}
+
+/*! This method computes the control torque to the solar array drive based on a PD control law
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param moduleID The module identifier
+*/
+void Update_torqueScheduler(torqueSchedulerConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+}

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.c
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.c
@@ -42,6 +42,14 @@ void SelfInit_torqueScheduler(torqueSchedulerConfig *configData, int64_t moduleI
 */
 void Reset_torqueScheduler(torqueSchedulerConfig *configData, uint64_t callTime, int64_t moduleID)
 {
+    if (!ArrayMotorTorqueMsg_C_isLinked(&configData->motorTorque1InMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "torqueScheduler.motorTorque1InMsg wasn't connected.");
+    }
+    if (!ArrayMotorTorqueMsg_C_isLinked(&configData->motorTorque2InMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "torqueScheduler.motorTorque2InMsg wasn't connected.");
+    }
+
+    configData->t0 = callTime;
 }
 
 /*! This method computes the control torque to the solar array drive based on a PD control law

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.h
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.h
@@ -1,0 +1,62 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _TORQUE_SCHEDULER_
+#define _TORQUE_SCHEDULER_
+
+#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/ArrayMotorTorqueMsg_C.h"
+#include "cMsgCInterface/ArrayEffectorLockMsg_C.h"
+
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* declare these user-defined inputs */
+    int    lockFlag;                               //!< flag to control the scheduler logic
+    double tSwitch;                                //!< [s] time at which controller switches to second angle
+
+    /* declare this quantity that is a module internal variable */
+    uint64_t t0;
+
+    /* declare module IO interfaces */
+    ArrayMotorTorqueMsg_C  motorTorque1InMsg;      //!< input motor torque message #1
+    ArrayMotorTorqueMsg_C  motorTorque2InMsg;      //!< input motor torque message #1
+    ArrayMotorTorqueMsg_C  motorTorqueOutMsg;      //!< output msg containing the motor torque to the array drive
+    ArrayEffectorLockMsg_C effectorLockOutMsg;     //!< output msg containing the flag to actuate or lock the motor
+
+    BSKLogger *bskLogger;                          //!< BSK Logging
+
+}torqueSchedulerConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void SelfInit_torqueScheduler(torqueSchedulerConfig *configData, int64_t moduleID);
+    void Reset_torqueScheduler(torqueSchedulerConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_torqueScheduler(torqueSchedulerConfig *configData, uint64_t callTime, int64_t moduleID);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.i
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.i
@@ -1,0 +1,43 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module torqueScheduler
+%{
+   #include "torqueScheduler.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_torqueScheduler(void*, uint64_t);
+%ignore SelfInit_torqueScheduler;
+%constant void Reset_torqueScheduler(void*, uint64_t, uint64_t);
+%ignore Reset_torqueScheduler;
+%constant void Update_torqueScheduler(void*, uint64_t, uint64_t);
+%ignore Update_torqueScheduler;
+
+%include "torqueScheduler.h"
+
+%include "architecture/msgPayloadDefC/ArrayMotorTorqueMsgPayload.h"
+struct ArrayMotorTorqueMsg_C;
+%include "architecture/msgPayloadDefC/ArrayEffectorLockMsgPayload.h"
+struct ArrayEffectorLockMsg_C;
+
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.rst
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.rst
@@ -1,0 +1,72 @@
+Executive Summary
+-----------------
+
+This module schedules two control torques such that they can be applied simultaneously, one at the time, or neither is applied, and combines them into one output msg. 
+This is useful in the case of a system with two coupled degrees of freedom, where the changes in one controlled variable can affect the other controlled variable and thus cause the system to not converge. 
+
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg connection is set by the
+user from python.  The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - motorTorqueOutMsg
+      - :ref:`ArrayMotorTorqueMsgPayload`
+      - Output Array Motor Torque Message.
+    * - effectorLockOutMsg
+      - :ref:`ArrayEffectorLockMsgPayload`
+      - Output Array Motor Torque Message.
+    * - motorTorque1InMsg
+      - :ref:`ArrayMotorTorqueMsgPayload`
+      - #1 Input Array Motor Torque Message.
+    * - motorTorque2InMsg
+      - :ref:`ArrayMotorTorqueMsgPayload`
+      - #2 Input Array Motor Torque Message. 
+
+
+Module Assumptions and Limitations
+----------------------------------
+The two input torques are always read and combined into a single ``motorTorqueOutMsg``. The logic to enable locking the effector or, on the contrary, reading the torque and applying it, is contained into the ``effectorLockOutMsg``.
+
+
+Detailed Module Description
+---------------------------
+This module receives a ``lockFlag`` and a a ``tSwitch`` parameter from the user. The first is used to decide how the input torques should be passed to the output torque message. If a torque is to be applied, its corresponding ``effectorLockOutMsg.effectorLockFlag`` is set to zero. If not, its corresponding ``effectorLockOutMsg.effectorLockFlag`` is set to 1. The following cases are possible:
+
+  - ``lockFlag = 0``: both motor torques are applied simultaneously;
+  - ``lockFlag = 1``: first motor torque is applied for ``t < tSwitch``, second motor torque is applied for ``t > tSwitch``;
+  - ``lockFlag = 2``: second motor torque is applied for ``t < tSwitch``, first motor torque is applied for ``t > tSwitch``;
+  - ``lockFlag = 3``: neither of the motor torques are applied. 
+
+
+User Guide
+----------
+The required module configuration is::
+
+    schedulerConfig = torqueScheduler.torqueSchedulerConfig()
+    schedulerWrap = unitTestSim.setModelDataWrap(schedulerConfig)
+    schedulerWrap.ModelTag = "torqueScheduler"
+    schedulerConfig.lockFlag = lockFlag
+    schedulerConfig.tSwitch = tSwitch
+    unitTestSim.AddModelToTask(unitTaskName, schedulerWrap, schedulerConfig)
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 34 66
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``lockFlag``
+     - flag to choose the logic according to which the motor torques are applied. If not provided, it defaults to zero.
+   * - ``tSwitch``
+     - time at which the torque is switched from input 1 to input 2. If not provided it defaults to zero, therefore only input torque is passed.


### PR DESCRIPTION
* **Tickets addressed:** #143 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The module implements some logic to merge two array motor torque msgs into one output msg of the same type. Additionally, it outputs an array effector lock msg containing flags that are used to determine wether such torques are to be applied, or wether the effector should be locked in place instead. Commit 1 adds a new message. Commit 2 initializes the module with its main functions left empty. Commit 3 checks if the required input msgs are connected. Commits 4 implements the scheduling logic and and writes the output msgs. Commits 5 and 6 contain the documentation and unit test, respectively.

## Verification
A unit test is provided. Such unit test verifies that the content of the output motor torque msg matches that of the input motor torque msgs. Moreover, it checks that the output effector lock msg is consistent with the scheduling logic requested.

## Documentation
This is a new module. New documentation is provided to describe how the module works.

## Future work
No future work is foreseen at the moment.
