### PR TITLE
Fix github actions pytest xml path

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "Run Test"
         run: |
           source .venv/bin/activate
-          cd src && pytest -n 2 -m "not scenarioTest" --junitxml=junit/test-results.xml
+          cd src && pytest -n 2 -m "not scenarioTest" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
Right now `Upload pytest test results` step in github actions fail because of wrong path : 
![image](https://user-images.githubusercontent.com/120187203/214314151-50284b82-85ce-48a1-9566-2a117d3b3b51.png)
So changed where test-results-3.9.xml file is being saved to. 


## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
![image](https://user-images.githubusercontent.com/120187203/214315456-5b3fa6a2-d33a-4943-8611-5664482d95fc.png)

https://github.com/ephraim271/basilisk/actions/runs/3995079682/jobs/6853542172

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
N/A

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A
