### PR TITLE
add missing structure variable definition

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.h
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.h
@@ -31,10 +31,10 @@ typedef struct {
 
     /* declare these user-defined inputs */
     int    lockFlag;                               //!< flag to control the scheduler logic
-    double tSwitch;                                //!< [s] time at which controller switches to second angle
+    double tSwitch;                                //!< [s] time span after t0 at which controller switches to second angle
 
     /* declare this quantity that is a module internal variable */
-    uint64_t t0;
+    uint64_t t0;                                   //!< [ns] epoch time where module is reset
 
     /* declare module IO interfaces */
     ArrayMotorTorqueMsg_C  motorTorque1InMsg;      //!< input motor torque message #1


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Small fix in the torqueScheduler variable document.  There was a missing variable definition.

## Verification
Made a clean documentation build and the new warnings are now gone.

## Documentation
None

## Future work
None
