### PR TITLE
Feature/bsk 128 save figure pdf fix

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -41,7 +41,7 @@ Version |release|
   a ``Custom.cmake`` file as ``${TARGET_NAME}``. This enables appropriate modularization of build target specific
   includes, dependencies, and compiler flags. For an example of the implications of this refactor review the before
   and after of the ``src/cmake/usingOpenCV.cmake`` file.
-
+- updated :ref:`unitTestSupport` to create the file path in a platform agnostic manner
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/src/utilities/unitTestSupport.py
+++ b/src/utilities/unitTestSupport.py
@@ -370,7 +370,7 @@ def writeTeXSnippet(snippetName, texSnippet, path):
 
 def saveScenarioFigure(figureName, plt, path, extension=".svg"):
     """save a python scenario result into the documentation image folder"""
-    imgFileName = path + "/../../docs/source/_images/Scenarios/" + figureName + extension
+    imgFileName = os.path.join(path, "..", "..", "docs", "source", "_images", "Scenarios", figureName + extension)
     if not os.path.exists(os.path.dirname(imgFileName)):
         try:
             os.makedirs(os.path.dirname(imgFileName))
@@ -382,7 +382,7 @@ def saveScenarioFigure(figureName, plt, path, extension=".svg"):
 
 def saveFigurePDF(figureName, plt, path):
     """Save a Figure as a PDF"""
-    figFileName = path + figureName + ".pdf"
+    figFileName = os.path.join(path, figureName + ".pdf")
     if not os.path.exists(os.path.dirname(figFileName)):
         try:
             os.makedirs(os.path.dirname(figFileName))
@@ -394,7 +394,7 @@ def saveFigurePDF(figureName, plt, path):
 
 def writeFigureLaTeX(figureName, caption, plt, format, path):
     """Save a figure and associated TeX code snippet"""
-    texFileName = path + "/../_Documentation/AutoTeX/" + figureName + ".tex"
+    texFileName = os.path.join(path, "..", "_Documentation", "AutoTeX", figureName + ".tex")
     if not os.path.exists(os.path.dirname(texFileName)):
         try:
             os.makedirs(os.path.dirname(texFileName))


### PR DESCRIPTION
* **Tickets addressed:** resolves #128
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The method `saveFigurePDF()` in `unitTestSupport.py` had a bug in it where the filename was appended to the parent folder name.  Further, that file was using Unix specific ways to create a file path string.  I updated this method, and the methods `saveScenarioFigure()` and `writeFigureLaTeX()` to use `os.path.join()` to create the proper path name.


## Verification
All unit tests passed and the documentation built without errors.

## Documentation
None

## Future work
None

