### PR TITLE
Feature/bsk 144 one axis solar array point

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,6 +56,8 @@ Version |release|
 - Added two new unit tests to :ref:`spinningBodyOneDOFStateEffector`.
 - Updated :ref:`magneticFieldWMM` to use the latest WMM coefficient file and evaluation software
 - Added a :ref:`spinningBodyTwoDOFStateEffector` module that simulates a two-axis rotating rigid component.
+- Created :ref:`oneAxisSolarArrayPoint` to generate the reference attitude for a spacecraft that needs to point a body-fixed 
+  axis along an inertial direction while ensuring maximum power generation on the solar arrays
 
 
 Version 2.1.6 (Jan. 21, 2023)

--- a/src/architecture/msgPayloadDefC/InertialHeadingMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/InertialHeadingMsgPayload.h
@@ -1,0 +1,33 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef inertialHeadingSimMsg_h
+#define inertialHeadingSimMsg_h
+
+
+//!@brief Inertial heading message definition.
+/*! This message contains the unit direction vector of a certain direction
+  expressed in inertial frame coordinates.
+ */
+typedef struct {
+    double rHat_XN_N[3];  //!< [] unit heading vector to any thing "X" in space, "N", inertial frame
+}InertialHeadingMsgPayload;
+
+
+#endif /* inertialHeadingSimMsg_h */

--- a/src/architecture/utilities/linearAlgebra.c
+++ b/src/architecture/utilities/linearAlgebra.c
@@ -618,6 +618,28 @@ void v3Cross(double v1[3],
     result[2] = v1c[0] * v2c[1] - v1c[1] * v2c[0];
 }
 
+void v3Perpendicular(double v[3],
+                     double result[3])
+{
+    if (fabs(v[0]) > DB0_EPS) {
+        result[0] = -(v[1]+v[2]) / v[0];
+        result[1] = 1;
+        result[2] = 1;
+    }
+    else if (fabs(v[1]) > DB0_EPS) {
+        result[0] = 1;
+        result[1] = -(v[0]+v[2]) / v[1];
+        result[2] = 1;
+    }
+    else {
+        result[0] = 1;
+        result[1] = 1;
+        result[2] = -(v[0]+v[1]) / v[2];
+    }
+    v3Normalize(result, result);
+}
+
+
 void v3Tilde(double v[3],
              double result[3][3])
 {

--- a/src/architecture/utilities/linearAlgebra.h
+++ b/src/architecture/utilities/linearAlgebra.h
@@ -89,6 +89,7 @@ extern "C" {
     int     v3IsZero(double v[3], double accuracy);
     void    v3Print(FILE *pFile, const char *name, double v[3]);
     void    v3Cross(double v1[3], double v2[3], double result[3]);
+    void    v3Perpendicular(double v[3], double result[3]);
     void    v3Tilde(double v[3], double result[3][3]);
     void    v3Sort(double v[3], double result[3]);
     void    v3PrintScreen(const char *name, double v[3]);

--- a/src/architecture/utilitiesSelfCheck/avsLibrarySelfCheck.c
+++ b/src/architecture/utilitiesSelfCheck/avsLibrarySelfCheck.c
@@ -398,6 +398,15 @@ int testLinearAlgebra(double accuracy)
         errorCount++;
     }
 
+    v3Set(2, 1, 1, v3_0);
+    v3Set(-1, 1, 1, v3_1);
+    v3Normalize(v3_1, v3_1);
+    v3Perpendicular(v3_0, v3_2);
+    if(!v3IsEqual(v3_2, v3_1, accuracy)) {
+        printf("v3Perpendicular failed\n");
+        errorCount++;
+    }
+
     v3Set(1, 2, 3, v3_0);
     v3Tilde(v3_0, m33_0);
     m33Set(0, -3, 2,

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
@@ -1,0 +1,265 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        SEPPointing
+#   Author:             Riccardo Calaon
+#   Creation Date:      February 15, 2023
+#
+
+import pytest
+import os
+import inspect
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.fswAlgorithms import oneAxisSolarArrayPoint
+from Basilisk.utilities import macros
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+def computeGamma(alpha, delta):
+
+    if alpha >= 0 and alpha <= np.pi/2:
+        if delta < np.pi/2 - alpha:
+            gamma = np.pi/2 - alpha - delta
+        elif delta > alpha + np.pi/2:
+            gamma = - np.pi/2 - alpha + delta
+        else:
+            gamma = 0
+    else:
+        if delta < alpha - np.pi/2:
+            gamma = - np.pi/2 + alpha - delta 
+        elif delta > 3/2*np.pi - alpha:
+            gamma = alpha + delta - 3/2*np.pi
+        else:
+            gamma = 0
+
+    return gamma
+
+# The 'ang' array spans the interval from 0 to pi. 0 and pi are excluded because 
+# the code is less accurate around those points; it still provides accurate results at 1e-6
+ang = np.linspace(0, np.pi, 5, endpoint=True)
+ang = list(ang)
+
+@pytest.mark.parametrize("alpha", ang)
+@pytest.mark.parametrize("delta", ang)
+@pytest.mark.parametrize("bodyAxisInput", [0,1])
+@pytest.mark.parametrize("inertialAxisInput", [0,1,2])
+@pytest.mark.parametrize("alignmentPriority", [0,1])
+@pytest.mark.parametrize("accuracy", [1e-10])
+
+def test_oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, inertialAxisInput, alignmentPriority, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the reference attitude computed by :ref:`oneAxisSolarArrayPoint`.
+    The correctness of the output is determined based on whether the reference attitude causes the solar array drive
+    axis :math:`\hat{a}_1` to be at an angle :math:`\gamma` from the Sun direction :math:`\hat{r}_{S/B}`.
+
+    **Test Parameters**
+
+    This test generates an array ``ang`` of linearly-spaced points between 0 and :math:`\pi`. Values of 
+    :math:`\alpha` and :math:`\delta` are drawn from all possible combinations of such lineaarly spaced values.
+    In the test, values of :math:`\alpha` and :math:`\delta` are used to set the angular distance between the vectors
+    :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`, and :math:`{}^\mathcal{B}\hat{h}_1`
+    and :math:`{}^\mathcal{B}\hat{a}_1`. All possible inputs are provided to the module, in terms of input parameters
+    and input messages, using the same combinations of inertial and body-fixed direction vectors.
+
+    Args:
+        alpha (rad): angle between :math:`{}^\mathcal{N}\hat{r}_{S/B}` and :math:`{}^\mathcal{N}\hat{h}_\text{ref}`
+        delta (rad): angle between :math:`{}^\mathcal{B}\hat{h}_1` and :math:`{}^\mathcal{B}\hat{a}_1`
+        bodyAxisInput (int): passes the body axis input as parameter or as input msg
+        inertialAxisInput (int): passes the inertial axis input as parameter, as input msg, or with :ref:`NavTransMsgPayload` and :ref:`EphemerisMsgPayload`
+        alignmentPriority (int): 0 to prioritize body heading alignment, 1 to prioritize solar array power; if 1, correct result is :math:`\gamma = 0`.
+
+    **Description of Variables Being Tested**
+
+    The angle :math:`\gamma` is a function of the angles :math:`\alpha` and :math:`\delta`, where :math:`\alpha` is the
+    angle between the Sun direction :math:`{}^\mathcal{N}\hat{r}_{S/B}` and the reference inertial heading
+    :math:`{}^\mathcal{N}\hat{h}_\text{ref}`, whereas :math:`\delta` is the angle between the body-frame heading
+    :math:`{}^\mathcal{B}\hat{h}_1` and the solar array axis drive :math:`{}^\mathcal{B}\hat{a}_1`.
+    The angle :math:`\gamma` is computed from the output reference attitude and compared with the results of a 
+    python function that computes the correct output based on the geometry of the problem. For a description of how
+    such correct result is obtained, see `Calaon et al. <http://hanspeterschaub.info/Papers/Calaon2023.pdf>`__.
+
+    **General Documentation Comments**
+
+    This unit test verifies the correctness of the generated reference attitude. It does not test the correctness of the
+    reference angular rates and accelerations contained in the ``attRefOutMsg``, because this would require to run the
+    module for multiple update calls. To ensure fast execution of the unit test, this is avoided.
+    """
+    # each test method requires a single assert method to be called
+    [testResults, testMessage] = oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, inertialAxisInput, alignmentPriority, accuracy)
+
+    assert testResults < 1, testMessage
+
+
+def oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, inertialAxisInput, alignmentPriority, accuracy):
+
+    gamma_true = computeGamma(alpha, delta)
+
+    rHat_SB_N = np.array([1, 2, 3])                            # Sun direction in inertial coordinates
+    rHat_SB_N = rHat_SB_N / np.linalg.norm(rHat_SB_N)
+    a1Hat_B = np.array([9, 8, 7])                            # array axis direction in body frame
+    a1Hat_B = a1Hat_B / np.linalg.norm(a1Hat_B)
+
+    a = np.cross(rHat_SB_N, [4, 5, 6])
+    a = a / np.linalg.norm(a)
+    
+    d = np.cross(a1Hat_B, [6, 5, 4])
+    d = d / np.linalg.norm(d)
+    
+    DCM1 = rbk.PRV2C(a * alpha)
+    DCM2 = rbk.PRV2C(d * delta)
+
+    hHat_N = np.matmul(DCM1, rHat_SB_N)             # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+    hHat_B = np.matmul(DCM2, a1Hat_B)               # required thrust direction in inertial frame, at an angle alpha from rHat_SB_N
+
+    testFailCount = 0                                        # zero unit test result counter
+    testMessages = []                                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"                          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    attReferenceCongfig = oneAxisSolarArrayPoint.OneAxisSolarArrayPointConfig()
+    attReferenceWrap = unitTestSim.setModelDataWrap(attReferenceCongfig)
+    attReferenceWrap.ModelTag = "oneAxisSolarArrayPoint"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, attReferenceWrap, attReferenceCongfig)
+
+    # Initialize the test module configuration data
+    # These will eventually become input messages
+    attReferenceCongfig.a1Hat_B = a1Hat_B
+    attReferenceCongfig.alignmentPriority = alignmentPriority
+
+    # Create input navigation message
+    sigma_BN = np.array([0, 0, 0])
+    BN = rbk.MRP2C(sigma_BN)
+    rS_B = np.matmul(BN, rHat_SB_N)
+    NavAttMessageData = messaging.NavAttMsgPayload()     
+    NavAttMessageData.sigma_BN = sigma_BN
+    NavAttMessageData.vehSunPntBdy = rS_B
+    NavAttMsg = messaging.NavAttMsg().write(NavAttMessageData)
+    attReferenceCongfig.attNavInMsg.subscribeTo(NavAttMsg)
+
+    if bodyAxisInput == 0:
+        attReferenceCongfig.h1Hat_B = hHat_B
+    else:
+        # Create input bodyHeadingMsg
+        bodyHeadingData = messaging.BodyHeadingMsgPayload()
+        bodyHeadingData.rHat_XB_B = hHat_B
+        bodyHeadingMsg = messaging.BodyHeadingMsg().write(bodyHeadingData)
+        attReferenceCongfig.bodyHeadingInMsg.subscribeTo(bodyHeadingMsg)
+
+    if inertialAxisInput == 0:
+        attReferenceCongfig.hHat_N = hHat_N
+    elif inertialAxisInput == 1:
+        # Create input inertialHeadingMsg
+        inertialHeadingData = messaging.InertialHeadingMsgPayload()
+        inertialHeadingData.rHat_XN_N = hHat_N
+        inertialHeadingMsg = messaging.InertialHeadingMsg().write(inertialHeadingData)
+        attReferenceCongfig.inertialHeadingInMsg.subscribeTo(inertialHeadingMsg)
+    else:
+        # Create input translation navigation
+        transNavData = messaging.NavTransMsgPayload()
+        transNavData.r_BN_N = [0, 0, 0]
+        transNavMsg = messaging.NavTransMsg().write(transNavData)
+        attReferenceCongfig.transNavInMsg.subscribeTo(transNavMsg)
+        ephemerisData = messaging.EphemerisMsgPayload()
+        ephemerisData.r_BdyZero_N = hHat_N
+        ephemerisMsg = messaging.EphemerisMsg().write(ephemerisData)
+        attReferenceCongfig.ephemerisInMsg.subscribeTo(ephemerisMsg)
+
+
+    # Setup logging on the test module output message so that we get all the writes to it
+    dataLog = attReferenceCongfig.attRefOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    moduleOutput = dataLog.sigma_RN
+    sigma_RN = moduleOutput[0]
+    RN = rbk.MRP2C(sigma_RN)
+    NR = RN.transpose()
+    a1Hat_N = np.matmul(NR, a1Hat_B)
+    gamma_sim = np.arcsin( abs( np.clip( np.dot(rHat_SB_N, a1Hat_N), -1, 1 ) ) )
+
+    # set the filtered output truth states
+    if alignmentPriority == 0:
+        if not unitTestSupport.isDoubleEqual(gamma_sim, gamma_true, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + attReferenceWrap.ModelTag + " Module failed incidence angle for " 
+                "bodyAxisInput = {}, inertialAxisInput = {} and priorityFlag = {}".format(
+                    bodyAxisInput, inertialAxisInput, alignmentPriority))
+    else:
+        if not unitTestSupport.isDoubleEqual(gamma_sim, 0, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + attReferenceWrap.ModelTag + " Module failed incidence angle for " 
+                "bodyAxisInput = {}, inertialAxisInput = {} and priorityFlag = {}".format(
+                    bodyAxisInput, inertialAxisInput, alignmentPriority))
+
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    oneAxisSolarArrayPointTestFunction(
+                 False,
+                 np.pi,     # alpha
+                 np.pi,     # delta
+                 0,           # flagB
+                 1,           # flagN
+                 0,           # priorityFlag
+                 1e-10         # accuracy
+               )

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
@@ -1,0 +1,62 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#include "oneAxisSolarArrayPoint.h"
+#include "string.h"
+#include <math.h>
+
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/astroConstants.h"
+
+
+/*! This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, int64_t moduleID)
+{
+    AttRefMsg_C_init(&configData->attRefOutMsg);
+}
+
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}
+
+/*! The Update() function computes the reference MRP attitude, reference angular rate and acceleration
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param moduleID The module identifier
+*/
+void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -1,0 +1,95 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _ONE_AXIS_SOLAR_ARRAY_POINT_
+#define _ONE_AXIS_SOLAR_ARRAY_POINT_
+
+#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/AttRefMsg_C.h"
+#include "cMsgCInterface/BodyHeadingMsg_C.h"
+#include "cMsgCInterface/InertialHeadingMsg_C.h"
+#include "cMsgCInterface/NavTransMsg_C.h"
+#include "cMsgCInterface/EphemerisMsg_C.h"
+#include "cMsgCInterface/NavAttMsg_C.h"
+
+#define EPS 1e-12
+
+typedef enum alignmentPriority{
+    prioritizeAxisAlignment = 0,
+    prioritizeSolarArrayAlignment = 1
+} AlignmentPriority;
+
+typedef enum bodyAxisInput{
+    inputBodyHeadingParameter = 0,
+    inputBodyHeadingMsg = 1
+} BodyAxisInput;
+
+typedef enum inertialAxisInput{
+    inputInertialHeadingParameter = 0,
+    inputInertialHeadingMsg = 1,
+    inputEphemerisMsg = 2
+} InertialAxisInput;
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* declare these quantities that always must be specified as flight software parameters */
+    double a1Hat_B[3];                           //!< arrays axis direction in B frame
+    AlignmentPriority  alignmentPriority;        //!< flag to indicate which constraint must be prioritized
+
+    /* declare these optional quantities */
+    double h1Hat_B[3];                           //!< main heading in B frame coordinates
+    double h2Hat_B[3];                           //!< secondary heading in B frame coordinates
+    double hHat_N[3];                            //!< main heading in N frame coordinates
+    double a2Hat_B[3];                           //!< body frame heading that should remain as close as possible to Sun heading
+
+    /* declare these internal variables that are used by the module and should not be declared by the user */
+    BodyAxisInput      bodyAxisInput;            //!< flag variable to determine how the body axis input is specified
+    InertialAxisInput  inertialAxisInput;        //!< flag variable to determine how the inertial axis input is specified
+    int      updateCallCount;                    //!< count variable used in the finite difference logic
+    uint64_t T1NanoSeconds;                      //!< callTime one update step prior
+    uint64_t T2NanoSeconds;                      //!< callTime two update steps prior
+    double   sigma_RN_1[3];                      //!< reference attitude one update step prior
+    double   sigma_RN_2[3];                      //!< reference attitude two update steps prior
+    NavAttMsg_C          attNavInMsg;             //!< input msg measured attitude
+    BodyHeadingMsg_C     bodyHeadingInMsg;        //!< input body heading msg
+    InertialHeadingMsg_C inertialHeadingInMsg;    //!< input inertial heading msg
+    NavTransMsg_C        transNavInMsg;           //!< input msg measured position
+    EphemerisMsg_C       ephemerisInMsg;          //!< input ephemeris msg
+    AttRefMsg_C          attRefOutMsg;            //!< output attitude reference message
+
+    BSKLogger *bskLogger;                         //!< BSK Logging
+
+}OneAxisSolarArrayPointConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void SelfInit_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, int64_t moduleID);
+    void Reset_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -87,6 +87,11 @@ extern "C" {
     void Reset_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID);
     void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID);
 
+    void computeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3]);
+    void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3]);
+    void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3]);
+    void computeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.i
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.i
@@ -1,0 +1,50 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module oneAxisSolarArrayPoint
+%{
+   #include "oneAxisSolarArrayPoint.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_oneAxisSolarArrayPoint(void*, uint64_t);
+%ignore SelfInit_oneAxisSolarArrayPoint;
+%constant void Reset_oneAxisSolarArrayPoint(void*, uint64_t, uint64_t);
+%ignore Reset_oneAxisSolarArrayPoint;
+%constant void Update_oneAxisSolarArrayPoint(void*, uint64_t, uint64_t);
+%ignore Update_oneAxisSolarArrayPoint;
+
+%include "oneAxisSolarArrayPoint.h"
+
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/BodyHeadingMsgPayload.h"
+struct BodyHeadingMsg_C;
+%include "architecture/msgPayloadDefC/InertialHeadingMsgPayload.h"
+struct InertialHeadingMsg_C;
+%include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
+struct NavTransMsg_C;
+%include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
+struct EphemerisMsg_C;
+%include "architecture/msgPayloadDefC/AttRefMsgPayload.h"
+struct AttRefMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.rst
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.rst
@@ -1,0 +1,91 @@
+Executive Summary
+-----------------
+This module computes a reference attitude frame that simultaneously satisfies multiple pointing constraints. The first constraint consists of aligning a body-frame direction :math:`{}^\mathcal{B}\hat{h}_1` with a certain inertial reference direction :math:`{}^\mathcal{N}\hat{h}_\text{ref}`. This locks two out of three degrees of freedom that characterize a rigid body rotation. The second constraints consists in achieving maximum power generation on the solar arrays, assuming that the solar arrays can rotate about their drive axis. This condition is obtained ensuring that the body-fixed solar array drive direction :math:`{}^\mathcal{B}\hat{a}_1` is as close to perpendicular as possible to the Sun direction. When maximum power generation is possible, two solutions can be found that satisfy the previous two constraints simultaneously. When this happens, it is possible to consider a third body-fixed direction :math:`{}^\mathcal{B}\hat{a}_2` which should remain as close as possible to the Sun direction, while maintaining the other two constraints satisfied. This allows to discriminate between the two frames, and to pick the one that drives :math:`{}^\mathcal{B}\hat{a}_2` closer to the Sun. It is possible to provide a second body frame direction :math:`{}^\mathcal{B}\hat{h}_2` as an optional parameter: in this case the module chooses whether to align :math:`{}^\mathcal{B}\hat{h}_1` or :math:`{}^\mathcal{B}\hat{h}_2` with :math:`{}^\mathcal{N}\hat{h}_\text{ref}` depending on which provides a better alignment of :math:`{}^\mathcal{B}\hat{a}_2` with the Sun direction.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages. The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - attNavInMsg
+      - :ref:`NavAttMsgPayload`
+      - Input message containing current attitude and Sun direction in body-frame coordinates. Note that, for the Sun direction to appear in the message, the :ref:`SpicePlanetStateMsgPayload` must be provided as input msg to :ref:`simpleNav`, otherwise the Sun direction is zeroed by default.
+    * - bodyHeadingInMsg
+      - :ref:`BodyHeadingMsgPayload`
+      - (optional) Input message containing the body-frame direction :math:`{}^\mathcal{B}\hat{h}`. Alternatively, the direction can be specified as input parameter ``h1Hat_B``. When this input msg is connected, the input parameter is neglected in favor of the input msg.
+    * - inertialHeadingInMsg
+      - :ref:`InertialHeadingMsgPayload`
+      - (optional) Input message containing the inertial-frame direction :math:`{}^\mathcal{N}\hat{h}_\text{ref}`. Alternatively, the direction can be specified as input parameter ``hHat_N``. When this input msg is connected, the input parameter is neglected in favor of the input msg.
+    * - ephemerisInMsg
+      - :ref:`EphemerisMsgPayload`
+      - (optional) Input message containing the inertial position of a celestial object, whose direction with respect to the spacecraft serves as the inertial reference direction :math:`{}^\mathcal{N}\hat{h}_\text{ref}`. This input msg must be provided together with ``transNavInMsg`` to compute the relative position of the celestial object to the spacecraft. If both ``inertialHeadingInMsg`` and ``ephemerisInMsg`` are connected, the inertial reference direction :math:`{}^\mathcal{N}\hat{h}_\text{ref}` is computed according to ``inertialHeadingInMsg``.
+    * - transNavInMsg
+      - :ref:`NavTransMsgPayload`
+      - (optional) Input message containing the inertial position and velocity of the spacecraft. This message must be connected together with ``ephemerisInMsg`` to allow to compute :math:`{}^\mathcal{N}\hat{h}_\text{ref}`.
+    * - attRefOutMsg
+      - :ref:`AttRefMsgPayload`
+      - Output attitude reference message containing reference attitude, reference angular rates and accelerations.
+
+
+Detailed Module Description
+---------------------------
+A detailed mathematical derivation of the equations applied by this module can be found in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints," In preparation for Journal of Spacecraft and Rockets.
+The input parameter ``alignmentPriority`` allows to choose whether the first or the second constraint is strictly enforced. When ``alignmentPriority = 0``, the body heading :math:`{}^\mathcal{B}\hat{h}` and the inertial heading :math:`{}^\mathcal{N}\hat{h}_\text{ref}` match exactly, while the incidence angle on the solar arrays is as close to optimal as possible. On the contrary, when ``alignmentPriority = 1``, the solar array drive :math:`{}^\mathcal{B}\hat{a}_1` is perpendicular to the Sun direction, to ensure maximum power generation, while the body heading and the inertial heading are as close to parallel as possible.
+
+Attention must be paid to how these pieces of input information is provided:
+
+  - Input body-frame heading: this can be specified either via the input parameter ``h1Hat_B``, or connecting the input message ``bodyHeadingInMsg``. Specifying the body-frame heading via the input parameter is desirable when such direction does not change over time; vice versa, when the body-frame heading is time varying, this needs to be passed via the ``bodyHeadingInMsg``. When both ``h1Hat_B`` and ``bodyHeadingInMsg`` are provided, the module ignores ``h1Hat_B`` and reads the body-frame direction from the input message.
+  - Input inertial-frame heading: this can be specified via the input parameter ``hHat_N``, connecting the message ``inertialHeadingInMsg``, or connecting both the messages ``ephemerisInMsg`` and ``transNavInMsg``. The input parameter ``hHat_N`` is desirable when the inertial heading is fixed in time. The message ``inertialHeadingInMsg`` is needed when the heading direction is time-varying. Finally, providing ``ephemerisInMsg`` and ``transNavInMsg`` allows to compute the inertial heading as the vector difference between the inertial position of a celestial object and the position of the spacecraft: this is useful when the spacecraft needs to point a body-frame heading towards a celestial object. When all of these input messages are connected, the inertial heading is computed from the ``inertialHeadingInMsg``.
+
+Module Assumptions and Limitations
+----------------------------------
+The limitations of this module are inherent to the geometry of the problem, which determines whether or not all the constraints can be satisfied. For example, as shown in  in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints," In preparation for Journal of Spacecraft and Rockets, depending on the relative orientation of :math:`{}^\mathcal{B}h` and :math:`{}^\mathcal{B}a_1`, it may not be possible to  achieve perfect incidence angle on the solar arrays. Only when perfect incidence is obtained, it is possible to solve for the solution that also drives the body-fixed direction :math:`{}^\mathcal{B}a_2` close to the Sun. When perfect incidence is achievable, two solutions exist. If :math:`{}^\mathcal{B}a_2` is provided as input, this is used to determine which solution to pick. If this input is not provided, one of the two solution is chosen arbitrarily.
+
+Due to the difficulty in developing an analytical formulation for the reference angular rate and angular acceleration vectors, these are computed via second-order finite differences. At every time step, the current reference attitude and time stamp are stored in a module variable and used in the following time updates to compute angular rates and accelerations via finite differences.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    attReferenceCongfig = oneAxisSolarArrayPoint.oneAxisSolarArrayPointConfig()
+    attReferenceWrap = unitTestSim.setModelDataWrap(threeAxConfig)
+    attReferenceWrap.ModelTag = "threeAxesPoint"
+    attReferenceCongfig.a1Hat_B = a1_B
+    attReferenceCongfig.alignmentPriority = 0
+    scSim.AddModelToTaskAddModelToTask(simTaskName, attReferenceWrap, attReferenceCongfig)
+	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``a1Hat_B``
+     - [0, 0, 0]
+     - solar array drive direction, it must be specified by the user
+   * - ``alignmentPriority``
+     - 0
+     - 0 to prioritize first constraint, 1 to prioritize second constraint
+   * - ``h1Hat_B`` (optional)
+     - [0, 0, 0]
+     - body-frame heading
+   * - ``hHat_N`` (optional)
+     - [0, 0, 0]
+     - inertial-frame heading
+   * - ``a2Hat_B`` (optional)
+     - [0, 0, 0]
+     - third body frame direction that should be as close as possible to Sun direction.
+   * - ``h2Hat_B`` (optional)
+     - [0, 0, 0]
+     - second body-frame heading


### PR DESCRIPTION
* **Tickets addressed:** #144
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module computes a reference attitude for a spacecraft with multiple pointing constraints. Such constraints consist in aligning a body-frame direction with an inertial direction, while at the same time maximizing the incidence of sunlight on the solar arrays. The second constraint is ensured by making the solar array drive axis be perpendicular to the direction of the Sun. Commit 1 creates an inertial heading message, needed to provide the inertial heading direction. Commit 2 adds a function to the basilisk linearAlgebra library. Commit 3 initializes the module functions. Commit 4 checks which input msgs are connected. Commit 5 reads the input msgs and parameters and discriminates on how to collect the input information. Commit 6 populates the Update function with the routine to compute the reference attitude. Commit 7 performs finite differences to compute reference angular rates and accelerations. Commits 8 and 9 contain documentation and unit test, respectively.

## Verification
A unit test is provided. Such unit test verifies the output of the generated output versus the output of a function that generates the exact result, obtained via experimental verification. The input direction vectors are randomly generated to test the accuracy of the module against any possible input.

## Documentation
This is a new module. New documentation is provided to describe how the module works. 

## Future work
The documentation currently references a paper that has not yet been published. The documentation will need to be updated in the future, to reference such paper.
