### PR TITLE
BSK-173: Add terminal event flag and demonstrate use in scenario.

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -44,6 +44,8 @@ Version |release|
 - updated :ref:`unitTestSupport` to create the file path in a platform agnostic manner
 - Created a :ref:`sensorThermal` module to model the temperature of a sensor using radiative heat transfer
 - Created a :ref:`tempMeasurement` module to add sensor noise/bias and fault capabilities to temperature readings
+- Added a ``terminal`` flag to the event handlers that cause the simulation to terminate when triggered; demonstrated
+  use of flag in update to :ref:`scenarioDragDeorbit`.
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/src/tests/test_scenarioDragDeorbit.py
+++ b/src/tests/test_scenarioDragDeorbit.py
@@ -48,8 +48,8 @@ import scenarioDragDeorbit
 # The following 'parametrize' function decorator provides the parameters and expected results for each
 #   of the multiple test runs for this test.
 @pytest.mark.parametrize("initialAlt, deorbitAlt, model", [
-    (250, 200, "exponential"),
-    (250, 200, "msis")
+    (250, 100, "exponential"),
+    (250, 100, "msis")
 ])
 @pytest.mark.scenarioTest
 def test_scenarioDragDeorbit(show_plots, initialAlt, deorbitAlt, model):
@@ -87,6 +87,6 @@ if __name__ == "__main__":
     test_scenarioDragDeorbit(
         False,  # show_plots
         initialAlt=250,
-        deorbitAlt=180,
+        deorbitAlt=100,
         model="msis"
     )


### PR DESCRIPTION
* **Tickets addressed:** #173
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
A terminal event flag was added to the event handler. When a terminal event is triggered, a terminate flag is raised in the simBaseClass, which stops further propagation. The terminate flag is then reset to false so that the simulation can be restarted when desired. All events and python processes that should happen at the terminal simulation time step are allowed to complete before the simulation stops.

## Verification
The drag deorbit scenario was modified to use a terminal event to check altitude. The change should have no impact on other scenarios, so their tests should not be impacted.

## Documentation
Release notes and drag deorbit scenario documentation were updated. As far as I can tell, the event handler is not explicitly documented anywhere so it did not have documentation to update, other than some inline comments.

## Future work
N/A