### PR TITLE
BSK-185: Fixes case issue for builds with OpenCV on Linux

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,7 +32,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
-- Fixed CMake/conan case sensitivty issue when compiling Basilisk with `opNav`` flag set to `True`` on Linux platforms
+- Fixed CMake/conan case sensitivty issue when compiling Basilisk with `opNav` flag set to `True` on Linux platforms
 - Created fsw :ref:`hingedRigidBodyPIDMotor` to compute the commanded torque to :ref:`spinningBodyStateEffector` using a propotional-integral-derivative controller.
 - Added :ref:`torqueScheduler` to combine two :ref:`ArrayMotorTorqueMsgPayload` into one and implement effector locking logic.
 - Refactored how ``Custom.cmake`` files are included and how they are to be constructed. ``Custom.cmake`` files

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,6 +32,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
+- Fixed CMake/conan case sensitivty issue when compiling Basilisk with `opNav`` flag set to `True`` on Linux platforms
 - Created fsw :ref:`hingedRigidBodyPIDMotor` to compute the commanded torque to :ref:`spinningBodyStateEffector` using a propotional-integral-derivative controller.
 - Added :ref:`torqueScheduler` to combine two :ref:`ArrayMotorTorqueMsgPayload` into one and implement effector locking logic.
 - Refactored how ``Custom.cmake`` files are included and how they are to be constructed. ``Custom.cmake`` files

--- a/src/cmake/usingOpenCV.cmake
+++ b/src/cmake/usingOpenCV.cmake
@@ -1,5 +1,5 @@
-find_package(opencv REQUIRED)
-if (opencv_FOUND)
+find_package(OpenCV REQUIRED)
+if (OpenCV_FOUND)
   set_property(TARGET opencv::opencv PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${DIRECTORIES})
   target_link_libraries(${TARGET_NAME} PRIVATE opencv::opencv)
 


### PR DESCRIPTION
* **Tickets addressed:** BSK #185 
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
This implements the fix described in #185 .
## Verification
After making the fix, Basilisk was built using
`~/basilisk $python conanfile.py --opNav True`
and tests were run using 
` ~/basilisk/src $ python -m pytest .`
Tests passed.

## Documentation
Unknown and likely 0

## Future work
This could be caught by making sure all build options are run through CI/CD on all platforms. Alternatively, BSK's codebase should check for case sensitivity when dealing with file system operations, such as loading data or during builds. 
