### PR TITLE
Feature/bsk 68 facet srp dynamic effector

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -51,6 +51,7 @@ Version |release|
   radius of Mars. 
 - Added custom planet name to :ref:`eclipse` in case the user wants to use a body not contained within the module.
 - Removed all instances of using ``unitTestSupport.np2EigenVectorXd()``, as this function is now unneeded.
+- Created a :ref:`facetSRPDynamicEffector` dynamics module to calculate the B frame SRP force and torque acting on a static spacecraft.
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h
@@ -35,10 +35,10 @@ public:
     
 public:
     Eigen::VectorXd stateDerivContribution; //!< -- DynamicEffectors contribution to a stateEffector
-    Eigen::Vector3d forceExternal_N;        //!< [N] External force applied by this effector in inertial components
-    Eigen::Vector3d forceExternal_B;        //!< [N] External force applied by this effector in body frame components
-    Eigen::Vector3d torqueExternalPntB_B;   //!< [Nm] External torque applied by this effector
-    BSKLogger bskLogger;                      //!< -- BSK Logging
+    Eigen::Vector3d forceExternal_N = Eigen::Vector3d::Zero();      //!< [N] External force applied by this effector in inertial components
+    Eigen::Vector3d forceExternal_B = Eigen::Vector3d::Zero();      //!< [N] External force applied by this effector in body frame components
+    Eigen::Vector3d torqueExternalPntB_B = Eigen::Vector3d::Zero(); //!< [Nm] External torque applied by this effector
+    BSKLogger bskLogger;                    //!< -- BSK Logging
 };
 
 

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -68,7 +68,6 @@ private:
 public:
     uint64_t numFacets;                             //!< number of facets
     ReadFunctor<AtmoPropsMsgPayload> atmoDensInMsg; //!< atmospheric density input message
-    //std::string atmoDensInMsgName;                  //!< -- message used to read command inputs
     StateData *hubSigma;                            //!< -- Hub/Inertial attitude represented by MRP
     StateData *hubVelocity;                         //!< m/s Hub inertial velocity vector
     Eigen::Vector3d v_B;                            //!< m/s local variable to hold the inertial velocity

--- a/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
@@ -1,0 +1,407 @@
+
+# ISC License
+#
+# Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#
+# Purpose:  Test the facetSRPDynamicEffector module.
+# Author:   Leah Kiner
+# Creation Date:  Dec 18 2022
+#
+
+
+import os
+import pytest
+import inspect
+import numpy as np
+from Basilisk import __path__
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport
+import matplotlib
+import matplotlib.pyplot as plt
+from Basilisk.utilities import orbitalMotion, simIncludeGravBody
+from Basilisk.simulation import spacecraft, facetSRPDynamicEffector
+from Basilisk.utilities import macros, RigidBodyKinematics as rbk
+from Basilisk.architecture import messaging
+bskPath = __path__[0]
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+splitPath = path.split('simulation')
+matplotlib.rc('xtick', labelsize=12)
+matplotlib.rc('ytick', labelsize=12)
+
+def test_facetSRPDynamicEffector(show_plots):
+    r"""
+    **Validation Test Description**
+
+    The unit test for this module ensures that the calculated Solar Radiation Pressure (SRP) force and torque acting
+    on the spacecraft about the body-fixed point B is properly computed for a static spacecraft. The spacecraft
+    geometry defined in this test consists of a cubic hub and two circular solar arrays. Six square facets represent
+    the cubic hub and four circular facets describe the solar arrays. The SRP force and torque module values are
+    checked with values computed in python both initially and at a time halfway through the simulation.
+
+    **Test Parameters**
+
+    Args:
+        show_plots (bool): (True) Show plots, (False) Do not show plots
+
+    **Description of Variables Being Tested**
+
+    The initial module-computed SRP force value ``SRPDataForce_B`` is checked with the value computed in
+    python ``forceTest1Val``. The initial module-computed SRP torque value ``SRPDataTorque_B`` is also checked
+    with the value computed in python ``torqueTest1Val``. Similarly, these values halfway through the simulation
+    are checked to match.
+    """
+    testResults = []
+    testMessage = []
+
+    srpRes, srpMsg = TestfacetSRPDynamicEffector(False)
+    testMessage.append(srpMsg)
+    testResults.append(srpRes)
+
+    testSum = sum(testResults)
+    snippetName = "unitTestPassFail"
+
+    if testSum == 0:
+        colorText = 'ForestGreen'
+        print("PASSED")
+        passedText = r'\textcolor{' + colorText + '}{' + "PASSED" + '}'
+    else:
+        colorText = 'Red'
+        print("Failed")
+        passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
+
+    unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+
+    assert testSum < 1, testMessage
+
+def checkFacetSRPForce(index, area, specCoeff, diffCoeff, normal_B, sigma_BN, scPos, sunPos):
+    """This function calculates the per-facet SRP force acting on the spacecraft."""
+    # Define required constants
+    speedLight = 299792458.0
+    AstU = 149597870700.0
+    solarRadFlux = 1368.0
+
+    # Compute dcm_BN using MRP transformation
+    dcm_BN = rbk.MRP2C(sigma_BN)
+
+    # Convert vectors from the N frame to the B frame
+    r_BN_B = np.matmul(dcm_BN, scPos)
+    r_SN_B = np.matmul(dcm_BN, sunPos)
+    r_SB_B = r_SN_B - r_BN_B
+
+    # Determine unit direction vector pointing from point B on the spacecraft to the Sun
+    sHat = r_SB_B / np.linalg.norm(r_SB_B)
+
+    # Calculate the incidence angle theta between the facet normal vector and the Sun-direction vector
+    cosTheta = np.dot(sHat, normal_B)
+    intermediate = np.cross(sHat, normal_B)
+    sinTheta = np.linalg.norm(intermediate)
+    theta = np.arctan2(sinTheta, cosTheta)
+
+    # Calculate the facet projected area onto the plane whose normal vector is the Sun-direction vector
+    projArea = area * np.cos(theta)
+
+    # Calculate the solar radiation pressure acting on the facet
+    numAU = AstU / np.linalg.norm(r_SB_B)
+    SRPPressure = (solarRadFlux / speedLight) * numAU * numAU
+
+    # Compute the SRP force acting on the facet only if the facet is illuminated by the Sun
+    if projArea > 0:
+        srp_force = -SRPPressure * projArea * np.cos(theta) * ( (1-specCoeff) * sHat + 2 * ( (diffCoeff / 3) + specCoeff * np.cos(theta)) * normal_B )
+    else:
+        srp_force = np.zeros([3,])
+
+    return srp_force
+
+def checkFacetSRPTorque(index, area, specCoeff, diffCoeff, normal_B, locationPntB_B, sigma_BN, scPos, sunPos):
+    """This function calculates the per-facet SRP torque acting on the spacecraft."""
+    # Define required constants
+    speedLight = 299792458.0
+    AstU = 149597870700.0
+    solarRadFlux = 1368.0
+
+    # Compute dcm_BN using MRP transformation
+    dcm_BN = rbk.MRP2C(sigma_BN)
+
+    # Convert vectors from the N frame to the B frame
+    r_BN_B = np.matmul(dcm_BN, scPos)
+    r_SN_B = np.matmul(dcm_BN, sunPos)
+    r_SB_B = r_SN_B - r_BN_B
+
+    # Determine unit direction vector pointing from point B on the spacecraft to the Sun
+    sHat = r_SB_B / np.linalg.norm(r_SB_B)
+
+    # Calculate the incidence angle theta between the facet normal vector and the Sun-direction vector
+    cosTheta = np.dot(sHat, normal_B)
+    intermediate = np.cross(sHat, normal_B)
+    sinTheta = np.linalg.norm(intermediate)
+    theta = np.arctan2(sinTheta, cosTheta)
+
+    # Calculate the facet projected area onto the plane whose normal vector is the Sun-direction vector
+    projArea = area * np.cos(theta)
+
+    # Calculate the solar radiation pressure acting on the facet
+    numAU = AstU / np.linalg.norm(r_SB_B)
+    SRPPressure = (solarRadFlux / speedLight) * numAU * numAU
+
+    # Compute the SRP force contribution from the facet only if the facet is illuminated by the Sun
+    if projArea > 0:
+        srp_force = -SRPPressure * projArea * np.cos(theta) * ( (1-specCoeff) * sHat + 2 * ( (diffCoeff / 3) + specCoeff * np.cos(theta)) * normal_B )
+    else:
+        srp_force = np.zeros([3, ])
+
+    # Calculate the SRP torque contribution from the facet
+    srp_torque = np.cross(locationPntB_B, srp_force)
+
+    return srp_torque
+
+
+def TestfacetSRPDynamicEffector(show_plots):
+    """Call this routine directly to run the unit test."""
+    # Init test support variables
+    testFailCount = 0
+    testMessages = []
+
+    # Create the simulation task and process
+    simTaskName = "simTask"
+    simProcessName = "simProcess"
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess(simProcessName)
+    simulationTimeStep_Sec = 0.1
+    simulationTimeStep_NS = macros.sec2nano(simulationTimeStep_Sec)
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep_NS))
+
+    # Create the spacecraft object
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraft"
+
+    # Add the Earth and Sun as gravitational bodies
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    earth = gravFactory.createEarth()
+    sun = gravFactory.createSun()
+    earth.isCentralBody = True  # ensure this is the central gravitational body
+    earthIdx = 0
+    sunIdx = 1
+    earthStateMsg = messaging.SpicePlanetStateMsgPayload()
+    earthStateMsg.PositionVector = [0.0, -149598023 * 1000, 0.0]
+    earthStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    earthMsg = messaging.SpicePlanetStateMsg().write(earthStateMsg)
+    gravFactory.gravBodies['earth'].planetBodyInMsg.subscribeTo(earthMsg)
+    sunStateMsg = messaging.SpicePlanetStateMsgPayload()
+    sunStateMsg.PositionVector = [0.0, 0.0, 0.0]
+    sunStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    sunMsg = messaging.SpicePlanetStateMsg().write(sunStateMsg)
+    gravFactory.gravBodies['sun'].planetBodyInMsg.subscribeTo(sunMsg)
+
+    # Create an instance of the facetSRPEffector module to be tested
+    newSRP = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    newSRP.ModelTag = "FacetSRP"
+
+    # Connect the Sun's ephemeris message to the module
+    newSRP.sunInMsg.subscribeTo(sunMsg)
+
+    # Add the SRP dynamic effector to the spacecraft object
+    scObject.addDynamicEffector(newSRP)
+
+    # Define the spacecraft geometry for this test
+    try:
+        # Define the facet surface areas
+        area1 = 1.5*1.5  # [m^2]
+        area2 = np.pi*(0.5*7.5)*(0.5*7.5)  # [m^2]
+        facetAreas = [area1, area1, area1, area1, area1, area1, area2, area2, area2, area2]
+
+        # Define the facet normals in B frame components
+        facetNormal1 = np.array([1.0, 0.0, 0.0])
+        facetNormal2 = np.array([0.0, 1.0, 0.0])
+        facetNormal3 = np.array([-1.0, 0.0, 0.0])
+        facetNormal4 = np.array([0.0, -1.0, 0.0])
+        facetNormal5 = np.array([0.0, 0.0, 1.0])
+        facetNormal6 = np.array([0.0, 0.0, -1.0])
+        facetNormal7 = np.array([0.0, 1.0, 0.0])
+        facetNormal8 = np.array([0.0, -1.0, 0.0])
+        facetNormal9 = np.array([0.0, 1.0, 0.0])
+        facetNormal10 = np.array([0.0, -1.0, 0.0])
+        normals_B = [facetNormal1, facetNormal2, facetNormal3, facetNormal4, facetNormal5, facetNormal6, facetNormal7, facetNormal8, facetNormal9, facetNormal10]
+
+        # Define the facet center of pressure locations with respect to point B in B frame components
+        facetLoc1 = np.array([0.75, 0.0, 0.0])  # [m]
+        facetLoc2 = np.array([0.0, 0.75, 0.0])  # [m]
+        facetLoc3 = np.array([-0.75, 0.0, 0.0])  # [m]
+        facetLoc4 = np.array([0.0, -0.75, 0.0])  # [m]
+        facetLoc5 = np.array([0.0, 0.0, 0.75])  # [m]
+        facetLoc6 = np.array([0.0, 0.0, -0.75])  # [m]
+        facetLoc7 = np.array([4.5, 0.0, 0.75])  # [m]
+        facetLoc8 = np.array([4.5, 0.0, 0.75])  # [m]
+        facetLoc9 = np.array([-4.5, 0.0, 0.75])  # [m]
+        facetLoc10 = np.array([-4.5, 0.0, 0.75])  # [m]
+        locationsPntB_B = [facetLoc1, facetLoc2, facetLoc3, facetLoc4, facetLoc5, facetLoc6, facetLoc7, facetLoc8, facetLoc9, facetLoc10]
+
+        # Define the facet optical coefficients
+        specCoeff = np.array([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
+        diffCoeff = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
+
+        # Populate the scGeometry structure with the facet information
+        for i in range(len(facetAreas)):
+            newSRP.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i])
+    except:
+        testFailCount += 1
+        testMessages.append("ERROR: FacetDrag unit test failed while setting facet parameters.")
+        return testFailCount, testMessages
+
+    # Set up the spacecraft orbit
+    oe = orbitalMotion.ClassicElements()
+    r_eq = 6371*1000.0  # [m]
+    rN = np.array([r_eq+2000.0, -149598023 * 1000, 0.0])  # [m]
+    vN = np.array([0.0, 7.90854, 0.0])  # [m/s]
+    sig_BN = np.array([0.0, 0.0, 0.0])
+
+    # Initialize spacecraft states with the initialization variables
+    scObject.hub.r_CN_NInit = rN  # [m] r_CN_N
+    scObject.hub.v_CN_NInit = vN  # [m] v_CN_N
+    scObject.hub.sigma_BNInit = sig_BN
+
+    # Set up data logging
+    scPosDataLog = scObject.scStateOutMsg.recorder()
+    sunPosDataLog = gravFactory.gravBodies['sun'].planetBodyInMsg.recorder()
+
+    # Add the BSK objects to the simulation process
+    scSim.AddModelToTask(simTaskName, scObject)
+    scSim.AddModelToTask(simTaskName, newSRP)
+    scSim.AddModelToTask(simTaskName, scPosDataLog)
+    scSim.AddModelToTask(simTaskName, sunPosDataLog)
+
+    # Set the simulation time
+    simTimeSec = 10.0  # [s]
+    simulationTime = macros.sec2nano(simTimeSec)
+
+    # Initialize the simulation
+    scSim.InitializeSimulation()
+
+    # Add the data for logging
+    scSim.AddVariableForLogging(newSRP.ModelTag + ".forceExternal_B", simulationTimeStep_NS, 0, 2, 'double')
+    scSim.AddVariableForLogging(newSRP.ModelTag + ".torqueExternalPntB_B", simulationTimeStep_NS, 0, 2, 'double')
+
+    # Configure the simulation stop time and execute the simulation run
+    scSim.ConfigureStopTime(simulationTime)
+    scSim.ExecuteSimulation()
+
+    # Retrieve the logged data
+    timespan = scPosDataLog.times()
+    r_BN_N = scPosDataLog.r_BN_N
+    sigma_BN = scPosDataLog.sigma_BN
+    r_SN_N = sunPosDataLog.PositionVector
+    SRPDataForce_B = scSim.GetLogVariableData(newSRP.ModelTag + ".forceExternal_B")
+    SRPDataTorque_B = scSim.GetLogVariableData(newSRP.ModelTag + ".torqueExternalPntB_B")
+
+    # Store the logged data for plotting
+    srpForce_B_plotting = SRPDataForce_B
+    srpForce_B_plotting = np.delete(srpForce_B_plotting, 0, axis=1)
+    srpTorque_B_plotting = SRPDataTorque_B
+    srpTorque_B_plotting = np.delete(srpTorque_B_plotting, 0, axis=1)
+
+    # Plotting results
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * 1e-9, r_BN_N[:, 0], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_1$')
+    plt.plot(timespan * 1e-9, r_BN_N[:, 1], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_2$')
+    plt.plot(timespan * 1e-9, r_BN_N[:, 2], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_3$')
+    plt.xlabel(r'Time (s)')
+    plt.ylabel(r'${}^\mathcal{N} r_{\mathcal{B}/\mathcal{N}}$ (m)')
+    plt.legend()
+
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * 1e-9, srpForce_B_plotting[:, 0], label=r'$F \cdot \hat{b}_1$')
+    plt.plot(timespan * 1e-9, srpForce_B_plotting[:, 1], label=r'$F \cdot \hat{b}_2$')
+    plt.plot(timespan * 1e-9, srpForce_B_plotting[:, 2], label=r'$F \cdot \hat{b}_3$')
+    plt.xlabel(r'Time (s)')
+    plt.ylabel(r'${}^\mathcal{B} F_{SRP, B}$ (N)')
+    plt.legend()
+
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan * 1e-9, srpTorque_B_plotting[:, 0], label=r'$L \cdot \hat{b}_1$')
+    plt.plot(timespan * 1e-9, srpTorque_B_plotting[:, 1], label=r'$L \cdot \hat{b}_2$')
+    plt.plot(timespan * 1e-9, srpTorque_B_plotting[:, 2], label=r'$L \cdot \hat{b}_3$')
+    plt.xlabel(r'Time (s)')
+    plt.ylabel(r'${}^\mathcal{B} L_{SRP, B}$ (Nm)')
+    plt.legend()
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # Compare the retrieved data to the expected values computed in python
+    accuracy = 1e-15
+    forceTest1Val = np.zeros([3,])
+    forceTest2Val = np.zeros([3,])
+    torqueTest1Val = np.zeros([3, ])
+    torqueTest2Val = np.zeros([3, ])
+    index2 = int(0.5*simTimeSec / simulationTimeStep_Sec)
+
+    for i in range(len(facetAreas)):
+        forceTest1Val += checkFacetSRPForce(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], sigma_BN[1], r_BN_N[1], r_SN_N[1])
+        forceTest2Val += checkFacetSRPForce(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], sigma_BN[index2], r_BN_N[index2],
+                                       r_SN_N[index2])
+        torqueTest1Val += checkFacetSRPTorque(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i], sigma_BN[1],
+                                            r_BN_N[1], r_SN_N[1])
+        torqueTest2Val += checkFacetSRPTorque(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i],
+                                              locationsPntB_B[i], sigma_BN[index2],
+                                              r_BN_N[index2], r_SN_N[index2])
+    if not unitTestSupport.isArrayEqual(SRPDataForce_B[1, 1:4], forceTest1Val, 3, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
+            SRPDataForce_B[1, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
+            SRPDataForce_B[1, 1:] - forceTest1Val))
+        print(SRPDataForce_B[1, 1:])
+        print(forceTest1Val)
+
+    if not unitTestSupport.isArrayEqual(SRPDataForce_B[index2, 1:4], forceTest2Val, 3, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
+            SRPDataForce_B[index2, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
+            SRPDataForce_B[index2, 1:] - forceTest2Val))
+        print(SRPDataForce_B[index2, 1:])
+        print(forceTest2Val)
+
+    if not unitTestSupport.isArrayEqual(SRPDataTorque_B[1, 1:4], torqueTest1Val, 3, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
+            SRPDataTorque_B[1, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
+            SRPDataTorque_B[1, 1:] - torqueTest1Val))
+        print(SRPDataTorque_B[1, 1:])
+        print(torqueTest1Val)
+
+    if not unitTestSupport.isArrayEqual(SRPDataTorque_B[index2, 1:4], torqueTest2Val, 3, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
+            SRPDataTorque_B[index2, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
+            SRPDataTorque_B[index2, 1:] - torqueTest2Val))
+        print(SRPDataTorque_B[index2, 1:])
+        print(torqueTest2Val)
+
+    if testFailCount:
+        print(testMessages)
+    else:
+        print("PASSED")
+
+    return testFailCount, testMessages
+
+if __name__=="__main__":
+    # TestfacetSRPDynamicEffector
+    TestfacetSRPDynamicEffector(
+            True  # show plots
+           )

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -18,10 +18,14 @@
  */
 
 #include "facetSRPDynamicEffector.h"
+#include <cmath>
 
 /*! The constructor initializes the member variables to zero. */
 FacetSRPDynamicEffector::FacetSRPDynamicEffector()
 {
+    this->forceExternal_B.fill(0.0);
+    this->torqueExternalPntB_B.fill(0.0);
+    this->numFacets = 0;
 }
 
 /*! The destructor. */

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -66,6 +66,12 @@ void FacetSRPDynamicEffector::addFacet(double area,
                                        Eigen::Vector3d normal_B,
                                        Eigen::Vector3d locationPntB_B)
 {
+    this->scGeometry.facetAreas.push_back(area);
+    this->scGeometry.facetSpecCoeffs.push_back(specCoeff);
+    this->scGeometry.facetDiffCoeffs.push_back(diffCoeff);
+    this->scGeometry.facetNormals_B.push_back(normal_B);
+    this->scGeometry.facetLocationsPntB_B.push_back(locationPntB_B);
+    this->numFacets = this->numFacets + 1;
 }
 
 /*! This method is used to link the faceted SRP effector to the hub attitude and position,

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -39,6 +39,9 @@ FacetSRPDynamicEffector::~FacetSRPDynamicEffector()
 */
 void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos)
 {
+    if (!this->sunInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "FacetSRPDynamicEffector.sunInMsg was not linked.");
+    }
 }
 
 /*! The SRP dynamic effector does not write any output messages.

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -81,6 +81,8 @@ which are required for calculating SRP forces and torques.
 */
 void FacetSRPDynamicEffector::linkInStates(DynParamManager& states)
 {
+    this->hubSigma = states.getStateObject("hubSigma");
+    this->hubPosition = states.getStateObject("hubPosition");
 }
 
 /*! This method computes the body forces and torques for the SRP effector.

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -1,0 +1,88 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "facetSRPDynamicEffector.h"
+
+/*! The constructor initializes the member variables to zero. */
+FacetSRPDynamicEffector::FacetSRPDynamicEffector()
+{
+}
+
+/*! The destructor. */
+FacetSRPDynamicEffector::~FacetSRPDynamicEffector()
+{
+}
+
+/*! The reset member function. This method checks to ensure the input message is linked.
+ @return void
+ @param currentSimNanos [ns]  Time the method is called
+*/
+void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos)
+{
+}
+
+/*! The SRP dynamic effector does not write any output messages.
+ @return void
+ @param currentClock [ns] Time the method is called
+*/
+void FacetSRPDynamicEffector::writeOutputMessages(uint64_t currentClock)
+{
+}
+
+/*! This member function populates the spacecraft geometry structure with user-input facet information.
+ @return void
+ @param area  [m^2] Facet area
+ @param specCoeff  Facet spectral reflection optical coefficient
+ @param diffCoeff  Facet diffuse reflection optical coefficient
+ @param normal_B  Facet normal expressed in B frame components
+ @param locationPntB_B  [m] Facet location wrt point B in B frame components
+*/
+void FacetSRPDynamicEffector::addFacet(double area,
+                                       double specCoeff,
+                                       double diffCoeff,
+                                       Eigen::Vector3d normal_B,
+                                       Eigen::Vector3d locationPntB_B)
+{
+}
+
+/*! This method is used to link the faceted SRP effector to the hub attitude and position,
+which are required for calculating SRP forces and torques.
+ @return void
+ @param states  Dynamic parameter states
+*/
+void FacetSRPDynamicEffector::linkInStates(DynParamManager& states)
+{
+}
+
+/*! This method computes the body forces and torques for the SRP effector.
+ @return void
+ @param integTime  [s] Time the method is called
+ @param timeStep  [s] Simulation time step
+*/
+void FacetSRPDynamicEffector::computeForceTorque(double integTime, double timeStep)
+{
+}
+
+/*! This is the UpdateState() method
+ @return void
+ @param currentSimNanos [ns] Time the method is called
+*/
+void FacetSRPDynamicEffector::UpdateState(uint64_t currentSimNanos)
+{
+}

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -28,6 +28,7 @@
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
 class FacetSRPDynamicEffector: public SysModel, public DynamicEffector
@@ -43,6 +44,8 @@ public:
     void addFacet(double area, double specCoeff, double diffCoeff, Eigen::Vector3d normal_B, Eigen::Vector3d locationPntB_B);  //!< Method for adding facets to the spacecraft geometry structure
 
     ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;                                                                               //!< Sun spice ephemeris input message
+    StateData *hubPosition;                                                                                                         //!< [m] Hub inertial position vector
+    StateData *hubSigma;                                                                                                            //!< MRP attitude of the hub B frame with respect to the inertial frame
 
 private:
 };

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -1,0 +1,45 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#ifndef FACET_SRP_DYNAMIC_EFFECTOR_H
+#define FACET_SRP_DYNAMIC_EFFECTOR_H
+
+#include <Eigen/Dense>
+#include <vector>
+#include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+
+/*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
+class FacetSRPDynamicEffector: public SysModel, public DynamicEffector
+{
+public:                                                             
+    FacetSRPDynamicEffector();                                      //!< The module constructor
+    ~FacetSRPDynamicEffector();                                     //!< The module destructor
+    void linkInStates(DynParamManager& states);                     //!< Method for giving the effector access to the hub states
+    void computeForceTorque(double integTime, double timeStep);     //!< Method for computing the SRP force and torque about point B
+    void Reset(uint64_t currentSimNanos) override;                  //!< Reset method
+    void UpdateState(uint64_t currentSimNanos) override;            //!< Method for updating the effector states
+    void writeOutputMessages(uint64_t currentClock);                //!< Method for writing the output messages
+    void addFacet(double area, double specCoeff, double diffCoeff, Eigen::Vector3d normal_B, Eigen::Vector3d locationPntB_B);  //!< Method for adding facets to the spacecraft geometry structure
+
+private:
+};
+
+#endif 

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -29,6 +29,17 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 #include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/avsEigenMRP.h"
+
+/*! @brief Spacecraft Geometry Data */
+typedef struct {
+    std::vector<double> facetAreas;                                   //!< [m^2] Vector of facet areas
+    std::vector<double> facetSpecCoeffs;                              //!< Vector of facet spectral reflection optical coefficients
+    std::vector<double> facetDiffCoeffs;                              //!< Vector of facet diffuse reflection optical coefficients
+    std::vector<Eigen::Vector3d> facetNormals_B;                      //!< Vector of facet normals expressed in B frame components
+    std::vector<Eigen::Vector3d> facetLocationsPntB_B;                //!< [m] Vector of facet locations wrt point B in B frame components
+}FacetedSRPSpacecraftGeometryData;
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
 class FacetSRPDynamicEffector: public SysModel, public DynamicEffector
@@ -43,11 +54,14 @@ public:
     void writeOutputMessages(uint64_t currentClock);                //!< Method for writing the output messages
     void addFacet(double area, double specCoeff, double diffCoeff, Eigen::Vector3d normal_B, Eigen::Vector3d locationPntB_B);  //!< Method for adding facets to the spacecraft geometry structure
 
-    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;                                                                               //!< Sun spice ephemeris input message
-    StateData *hubPosition;                                                                                                         //!< [m] Hub inertial position vector
-    StateData *hubSigma;                                                                                                            //!< MRP attitude of the hub B frame with respect to the inertial frame
+    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;               //!< Sun spice ephemeris input message
+    uint64_t numFacets;                                             //!< Total number of spacecraft facets
+    Eigen::Vector3d r_SN_N;                                         //!< [m] Position vector of the Sun with respect to the inertial frame
+    StateData *hubPosition;                                         //!< [m] Hub inertial position vector
+    StateData *hubSigma;                                            //!< MRP attitude of the hub B frame with respect to the inertial frame
 
 private:
+    FacetedSRPSpacecraftGeometryData scGeometry;                    //!< Structure to hold the spacecraft facet data
 };
 
 #endif 

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/utilities/bskLogging.h"
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
 class FacetSRPDynamicEffector: public SysModel, public DynamicEffector

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -26,6 +26,8 @@
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
 class FacetSRPDynamicEffector: public SysModel, public DynamicEffector
@@ -39,6 +41,8 @@ public:
     void UpdateState(uint64_t currentSimNanos) override;            //!< Method for updating the effector states
     void writeOutputMessages(uint64_t currentClock);                //!< Method for writing the output messages
     void addFacet(double area, double specCoeff, double diffCoeff, Eigen::Vector3d normal_B, Eigen::Vector3d locationPntB_B);  //!< Method for adding facets to the spacecraft geometry structure
+
+    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;                                                                               //!< Sun spice ephemeris input message
 
 private:
 };

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
@@ -32,6 +32,7 @@ from Basilisk.architecture.swig_common_model import *
 
 // Instantiate templates used by example
 %include "sys_model.h"
+%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "facetSRPDynamicEffector.h"

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
@@ -1,0 +1,42 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+%module facetSRPDynamicEffector
+%{
+   #include "facetSRPDynamicEffector.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_eigen.i"
+%include "swig_conly_data.i"
+
+// Instantiate templates used by example
+%include "sys_model.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+%include "facetSRPDynamicEffector.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
@@ -36,6 +36,9 @@ from Basilisk.architecture.swig_common_model import *
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "facetSRPDynamicEffector.h"
 
+%include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
+struct SpicePlanetStateMsg_C;
+
 %pythoncode %{
 import sys
 protectAllClasses(sys.modules[__name__])

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.rst
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.rst
@@ -1,0 +1,188 @@
+Executive Summary
+-----------------
+This new dynamic effector module uses a static faceted spacecraft model to calculate the force and torque acting on a
+spacecraft due to solar radiation pressure (SRP). The force and torque acting on the spacecraft are defined with respect
+to the spacecraft body frame origin :math:`B`.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  
+The module msg connection is set by the user from python.  
+The msg type contains a link to the message structure definition, while the description 
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - sunInMsg
+      - :ref:`SpicePlanetStateMsgPayload`
+      - Input msg with the Sun state information
+
+Detailed Module Description
+---------------------------
+
+Mathematical Modeling
+^^^^^^^^^^^^^^^^^^^^^
+The spacecraft is represented as a collection of :math:`n` facets with negligible thickness. Each facet is characterized
+by an area :math:`A`, a vector normal to its surface :math:`\boldsymbol{\hat{n}}`, a position vector from the
+spacecraft body frame origin, point :math:`B` to the facet center of pressure, :math:`\boldsymbol{r}_{F/B}`, and three optical coefficients
+representing the interaction of impinging photons with the facet surface. The fraction of specularly reflected,
+diffusely scattered, and absorbed photons are represented using the coefficients :math:`\delta, \rho,` and
+:math:`\alpha`, respectively.
+
+A faceted force model is used to estimate the SRP force acting on the spacecraft:
+
+.. math::
+    \boldsymbol{F}_{\text{SRP}} = \sum_{i = 1}^{n} \boldsymbol{F}_{\text{SRP}_i} = -P(|\boldsymbol{r}_{\text{sc} / \odot }|) \sum_{i = 1}^{n} A_i \cos(\theta_i) \left [ (1 - \delta_i) \boldsymbol{\hat{s}} + 2 \left ( \frac{\rho_i}{3} + \delta_i \cos(\theta_i) \right ) \boldsymbol{\hat{n}}_{i}\right ]
+
+Note that all vector quantities are expressed in the spacecraft principal body-frame components for the SRP force
+calculation. :math:`\boldsymbol{\hat{s}}` is the unit direction vector pointing radially towards the Sun from the
+spacecraft body-frame origin. This vector is found by subtracting the current spacecraft inertial position from the
+Sun position given from the Spice input message:
+
+.. math::
+    {}^B \boldsymbol{\hat{s}} = [BN] ( {}^N \boldsymbol{r}_{\odot / N} - {}^N \boldsymbol{r}_{\text{sc} / N})
+
+Note that both the Sun and spacecraft inertial positions are given in inertial frame components. The current spacecraft
+attitude, :math:`\sigma_{\mathcal{B} / \mathcal{N}}` is used to find the current Direction Cosine Matrix (DCM) of the
+spacecraft body frame relative to the inertial frame, :math:`[BN]`.
+
+:math:`\theta` is defined as the incidence angle between each facet normal vector and the
+Sun-direction vector, and :math:`P(|\boldsymbol{r}_{\text{sc}/ \odot\ }|)` is the pressure acting on the spacecraft
+scaled by the spacecraft heliocentric distance.
+
+The total torque acting on the spacecraft about point :math:`B` due to SRP is calculated by summing the torque
+contributions over all :math:`n` facets:
+
+.. math::
+    \boldsymbol{L}_{\text{SRP},B} = \sum_{i = 1}^{n} \boldsymbol{L}_{{\text{SRP},B}_i} = \sum_{i = 1}^{n} \boldsymbol{r}_{F_i/B} \times \boldsymbol{F}_{\text{SRP}_i}
+
+Module Testing
+^^^^^^^^^^^^^^
+The unit test for this module ensures that the calculated Solar Radiation Pressure (SRP) force and torque acting
+on the spacecraft about the body-fixed point B is properly computed for a static spacecraft. The spacecraft
+geometry defined in this test consists of a cubic hub and two circular solar arrays. Six square facets represent
+the cubic hub and four circular facets describe the solar arrays. The SRP force and torque module values are
+checked with values computed in python both initially and at a time halfway through the simulation.
+
+The initial module-computed SRP force value ``SRPDataForce_B`` is checked with the value computed in
+python ``forceTest1Val``. The initial module-computed SRP torque value ``SRPDataTorque_B`` is also checked
+with the value computed in python ``torqueTest1Val``. Similarly, these values halfway through the simulation
+are checked to match.
+
+User Guide
+----------
+The user configures the spacecraft geometry as a collection of :math:`n` facets, each with an area :math:`A`,
+a vector normal to its surface :math:`\boldsymbol{\hat{n}}`, a position vector from the spacecraft center of mass to
+the facet center of pressure, :math:`\boldsymbol{r}_{F/c}`, and the three optical coefficients
+:math:`\delta, \rho,` and :math:`\alpha`, representing the fraction of specularly reflected, diffusely scattered,
+and absorbed photons, respectively.
+
+The following steps are needed to setup a faceted SRP dynamic effector in python using Basilisk.
+
+#. Import the facetSRPDynamicEffector class::
+
+    from Basilisk.simulation import facetSRPDynamicEffector
+
+#. Add the Earth and Sun as gravitational bodies to the simulation::
+
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    earth = gravFactory.createEarth()
+    sun = gravFactory.createSun()
+    earth.isCentralBody = True  # ensure this is the central gravitational body
+    earthIdx = 0
+    sunIdx = 1
+
+    earthStateMsg = messaging.SpicePlanetStateMsgPayload()
+    earthStateMsg.PositionVector = [0.0, -149598023 * 1000, 0.0]
+    earthStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    earthMsg = messaging.SpicePlanetStateMsg().write(earthStateMsg)
+    gravFactory.gravBodies['earth'].planetBodyInMsg.subscribeTo(earthMsg)
+
+    sunStateMsg = messaging.SpicePlanetStateMsgPayload()
+    sunStateMsg.PositionVector = [0.0, 0.0, 0.0]
+    sunStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    sunMsg = messaging.SpicePlanetStateMsg().write(sunStateMsg)
+    gravFactory.gravBodies['sun'].planetBodyInMsg.subscribeTo(sunMsg)
+
+#. Create an instantiation of the dynamic effector::
+
+    newSRP = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    newSRP.ModelTag = "FacetSRP"
+
+#. Define the spacecraft geometry of interest::
+
+    # Define the facet surface areas
+    area1 = 1.5*1.5  # [m]
+    area2 = np.pi*(0.5*7.5)*(0.5*7.5)  # [m]
+    facetAreas = [area1, area1, area1, area1, area1, area1, area2, area2, area2, area2]
+
+    # Define the facet normals in B frame components
+    facetNormal1 = np.array([1.0, 0.0, 0.0])
+    facetNormal2 = np.array([0.0, 1.0, 0.0])
+    facetNormal3 = np.array([-1.0, 0.0, 0.0])
+    facetNormal4 = np.array([0.0, -1.0, 0.0])
+    facetNormal5 = np.array([0.0, 0.0, 1.0])
+    facetNormal6 = np.array([0.0, 0.0, -1.0])
+    facetNormal7 = np.array([0.0, 1.0, 0.0])
+    facetNormal8 = np.array([0.0, -1.0, 0.0])
+    facetNormal9 = np.array([0.0, 1.0, 0.0])
+    facetNormal10 = np.array([0.0, -1.0, 0.0])
+    normals_B = [facetNormal1, facetNormal2, facetNormal3, facetNormal4, facetNormal5, facetNormal6, facetNormal7, facetNormal8, facetNormal9, facetNormal10]
+
+    # Define the facet center of pressure locations with respect to point B in B frame components
+    facetLoc1 = np.array([0.75, 0.0, 0.0])  # [m]
+    facetLoc2 = np.array([0.0, 0.75, 0.0])  # [m]
+    facetLoc3 = np.array([-0.75, 0.0, 0.0])  # [m]
+    facetLoc4 = np.array([0.0, -0.75, 0.0])  # [m]
+    facetLoc5 = np.array([0.0, 0.0, 0.75])  # [m]
+    facetLoc6 = np.array([0.0, 0.0, -0.75])  # [m]
+    facetLoc7 = np.array([4.5, 0.0, 0.75])  # [m]
+    facetLoc8 = np.array([4.5, 0.0, 0.75])  # [m]
+    facetLoc9 = np.array([-4.5, 0.0, 0.75])  # [m]
+    facetLoc10 = np.array([-4.5, 0.0, 0.75])  # [m]
+    locationsPntB_B = [facetLoc1, facetLoc2, facetLoc3, facetLoc4, facetLoc5, facetLoc6, facetLoc7, facetLoc8, facetLoc9, facetLoc10]
+
+    # Define the facet optical coefficients
+    specCoeff = np.array([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
+    diffCoeff = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
+
+#. Populate the scGeometry structure with the defined facet information::
+
+    for i in range(len(facetAreas)):
+        newSRP.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i])
+
+Note that for each added facet, the user is required to set the corresponding area, normal vector, location, and optical coefficients parameters in the scGeometry structure.
+
+#. Connect the Sun's ephemeris message to the SRP module::
+
+    newSRP.sunInMsg.subscribeTo(sunMsg)
+
+#. Add the SRP dynamic effector to the spacecraft::
+
+    scObject.addDynamicEffector(newSRP)
+
+   See :ref:`spacecraft` documentation on how to set up a spacecraft object.
+
+#. Set up the spacecraft orbit::
+
+    oe = orbitalMotion.ClassicElements()
+    r_eq = 6371*1000.0  # [m]
+    rN = np.array([r_eq+2000.0, -149598023 * 1000, 0.0])  # [m]
+    vN = np.array([0.0, 7.90854, 0.0])  # [m/s]
+    sig_BN = np.array([0.0, 0.0, 0.0])
+
+#. Initialize the spacecraft states with the initialization variables::
+
+    scObject.hub.r_CN_NInit = rN  # [m] r_CN_N
+    scObject.hub.v_CN_NInit = vN  # [m] v_CN_N
+    scObject.hub.sigma_BNInit = sig_BN
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, newSRP)
+


### PR DESCRIPTION
* **Tickets addressed:** #68 
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
This new dynamic effector module uses a static faceted spacecraft model to calculate the force and torque acting on a
spacecraft due to solar radiation pressure (SRP). The force and torque acting on the spacecraft are defined with respect
to the spacecraft body frame origin `B`.

## Verification
The unit test for this module ensures that the calculated Solar Radiation Pressure (SRP) force and torque acting
on the spacecraft about the body-fixed point B is properly computed for a static spacecraft. The spacecraft
geometry defined in this test consists of a cubic hub and two circular solar arrays. Six square facets represent
the cubic hub and four circular facets describe the solar arrays. The SRP force and torque module values are
checked with values computed in python both initially and at a time halfway through the simulation.

## Documentation
This is a new module. New documentation is provided to describe how the module works.

## Future work
This module will be expanded in the future to incorporate time-varying articulation of the spacecraft facets. 