### PR TITLE
Feature/bsk 180 thruster platform reference

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -60,6 +60,7 @@ Version |release|
   axis along an inertial direction while ensuring maximum power generation on the solar arrays
 - Added a maximum power parameter ``maxPower`` to :ref:`reactionWheelStateEffector` for limiting supplied
   power, independent of the modules in simulation/power.
+- Added :ref:`thrusterPlatformReference` to align the dual-gimballed thruster with the system's center of mass, or at an offset thereof to perform momentum dumping.
 
 
 Version 2.1.6 (Jan. 21, 2023)

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/_UnitTest/test_thrusterPlatformReference.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/_UnitTest/test_thrusterPlatformReference.py
@@ -1,0 +1,248 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        thrusterPlatformReference
+#   Author:             Riccardo Calaon
+#   Creation Date:      February 15, 2023
+#
+
+import pytest
+import os, inspect, random
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+
+# Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport 
+from Basilisk.fswAlgorithms import thrusterPlatformReference
+from Basilisk.utilities import macros
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging
+
+
+# Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
+# @pytest.mark.skipif(conditionstring)
+# Uncomment this line if this test has an expected failure, adjust message as needed.
+# @pytest.mark.xfail(conditionstring)
+# Provide a unique test method name, starting with 'test_'.
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.  Note that the order in that you add the parametrize method
+# matters for the documentation in that it impacts the order in which the test arguments are shown.
+# The first parametrize arguments are shown last in the pytest argument list
+@pytest.mark.parametrize("seed", list(np.linspace(1,10,10)))
+@pytest.mark.parametrize("delta_CM", [0.1, 0.2, 0.3])
+@pytest.mark.parametrize("K", [0,1,5,10])
+@pytest.mark.parametrize("accuracy", [1e-10])
+
+# update "module" in this function name to reflect the module name
+def test_platformRotation(show_plots, delta_CM, K, seed, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the correctness of the tip and tilt reference angles computed by 
+    :ref:`thrusterPlatformReference`. The correctness of the output is determined based on whether the thruster 
+    is aligned with the system's center of mass, when the momentum dumping control gain :math:`\kappa = 0`.
+    Moreover, the other module output messages, ``bodyHeadingOutMsg`` and ``thrusterTorqueOutMsg`` are checked
+    versus equivalent python code.
+
+    **Test Parameters**
+
+    This test randomizes the position of the center of mass and runs the test 10 times for any other combination
+    of test parameters. 
+
+    Args:
+        delta_CM (m): magnitude of the center of mass shift, whose direction is generated randomly
+        K (Hz): proportional gain of the momentum dumping control law
+        seed (-): seed is varied to randomly change the shift in the center of mass
+        accuracy (float): accuracy within which results are considered to match the truth values.
+
+    **Description of Variables Being Tested**
+
+    For :math:`\kappa = 0`, the correctness of the result is assessed based on the norm of the
+    cross product between the thrust direction vector :math:`{}^\mathcal{F}\boldsymbol{t}` and the relative position
+    of the center of mass with respect to the thruster application point :math:`T`. For :math:`\kappa \neq 0` this 
+    test is not performed, as the thruster is not aligned with the center of mass.
+
+    The python code also computes equivalently the thrust direction in body frame coordinates :math:`{}^\mathcal{B}\boldsymbol{t}`
+    and the net torque on the system :math:`{}^\mathcal{B}\boldsymbol{L}`, and compares them to the respective output
+    messages for all values of :math:`\kappa = 0` tested.
+
+    **General Documentation Comments**
+
+    The offset vectors provided as input parameters ensure that a solution exists, such that the Unit Test can correctly
+    assess the alignment of the thruster. This is, in general, not guaranteed.
+    """
+    # each test method requires a single assert method to be called
+    [testResults, testMessage] = platformRotationTestFunction(show_plots, delta_CM, K, seed, accuracy)
+    assert testResults < 1, testMessage
+
+
+def platformRotationTestFunction(show_plots, delta_CM, K, seed, accuracy):
+
+    random.seed(seed)
+
+    sigma_MB = np.array([0., 0., 0.])
+    r_BM_M = np.array([0.0, 0.1, 1.4])
+    r_FM_F = np.array([0.0, 0.0, -0.1])
+    r_TF_F = np.array([-0.01, 0.03, 0.02])
+    T_F    = np.array([1.0, 1.0, 10.0])
+
+    r_CB_B = np.array([0,0,0]) + np.random.rand(3)
+    r_CB_B = r_CB_B / np.linalg.norm(r_CB_B) * delta_CM
+
+    testFailCount = 0                        # zero unit test result counter
+    testMessages = []                        # create empty array to store test log messages
+    unitTaskName = "unitTask"                # arbitrary name (don't change)
+    unitProcessName = "TestProcess"          # arbitrary name (don't change)
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    platformConfig = thrusterPlatformReference.ThrusterPlatformReferenceConfig()
+    platformWrap = unitTestSim.setModelDataWrap(platformConfig)
+    platformWrap.ModelTag = "platformReference"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, platformWrap, platformConfig)
+
+    # Initialize the test module configuration data
+    platformConfig.sigma_MB = sigma_MB
+    platformConfig.r_BM_M = r_BM_M
+    platformConfig.r_FM_F = r_FM_F
+    platformConfig.r_TF_F = r_TF_F
+    platformConfig.T_F    = T_F
+    platformConfig.K      = K
+
+    # Create input vehicle configuration msg
+    inputVehConfigMsgData = messaging.VehicleConfigMsgPayload()
+    inputVehConfigMsgData.CoM_B = r_CB_B
+    inputVehConfigMsg = messaging.VehicleConfigMsg().write(inputVehConfigMsgData)
+    platformConfig.vehConfigInMsg.subscribeTo(inputVehConfigMsg)
+
+    # Create input RW configuration msg
+    inputRWConfigMsgData = messaging.RWArrayConfigMsgPayload()
+    inputRWConfigMsgData.GsMatrix_B = [1,0,0,0,1,0,0,0,1]
+    inputRWConfigMsgData.JsList = [0.01, 0.01, 0.01]
+    inputRWConfigMsgData.numRW = 3
+    inputRWConfigMsgData.uMax = [0.001, 0.001, 0.001]
+    inputRWConfigMsg = messaging.RWArrayConfigMsg().write(inputRWConfigMsgData)
+    platformConfig.rwConfigDataInMsg.subscribeTo(inputRWConfigMsg)
+
+    # Create input RW speeds msg
+    inputRWSpeedsMsgData = messaging.RWSpeedMsgPayload()
+    inputRWSpeedsMsgData.wheelSpeeds = [100, 100, 100]
+    inputRWSpeedsMsg = messaging.RWSpeedMsg().write(inputRWSpeedsMsgData)
+    platformConfig.rwSpeedsInMsg.subscribeTo(inputRWSpeedsMsg)
+
+    # Setup logging on the test module output messages so that we get all the writes to it
+    ref1Log = platformConfig.hingedRigidBodyRef1OutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, ref1Log)
+    ref2Log = platformConfig.hingedRigidBodyRef2OutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, ref2Log)
+    bodyHeadingLog = platformConfig.bodyHeadingOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, bodyHeadingLog)
+    thrusterTorqueLog = platformConfig.thrusterTorqueOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, thrusterTorqueLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time.
+    # NOTE: the total simulation time may be longer than this value. The
+    # simulation is stopped at the next logging event on or after the
+    # simulation end time.
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))        # seconds to stop simulation
+
+    # Begin the simulation time run set above
+    unitTestSim.ExecuteSimulation()
+
+    theta1 = ref1Log.theta[0]
+    theta2 = ref2Log.theta[0]
+
+    FM = [[np.cos(theta2),  np.sin(theta1)*np.sin(theta2), -np.cos(theta1)*np.sin(theta2)],
+          [       0      ,          np.cos(theta1)       ,         np.sin(theta1)        ],
+          [np.sin(theta2), -np.sin(theta1)*np.cos(theta2),  np.cos(theta1)*np.cos(theta2)]]
+
+    MB = rbk.MRP2C(sigma_MB)
+
+    r_CB_M = np.matmul(MB, r_CB_B)
+    r_CM_M = r_CB_M + r_BM_M
+    r_CM_F = np.matmul(FM, r_CM_M)
+    r_CT_F = r_CM_F - r_FM_F - r_TF_F
+
+    offset = np.linalg.norm(np.cross(r_CT_F,T_F) / np.linalg.norm(np.array(r_CT_F)) / np.linalg.norm(np.array(T_F)))
+
+    # check if the CM offset is zero if control gain K is also 0
+    if K == 0:
+        if not unitTestSupport.isDoubleEqual(offset, 0.0, accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + platformWrap.ModelTag + "thrusterPlatformReference module failed unit test on zero offset \n")
+
+    T_B_hat_sim = bodyHeadingLog.rHat_XB_B[0]               # simulation result
+    FB = np.matmul(FM, MB)
+    T_B = np.matmul(FB.transpose(), T_F)
+    T_B_hat = T_B / np.linalg.norm(T_B)                     # truth value
+
+    # compare the module results to the python computation for body-frame thruster direction
+    if not unitTestSupport.isVectorEqual(T_B_hat_sim, T_B_hat, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + platformWrap.ModelTag + "thrusterPlatformReference module failed unit test on body frame thruster direction \n")
+
+    L_B_sim = thrusterTorqueLog.torqueRequestBody[0]        # simulation result
+    L_F = np.cross(r_CT_F, T_F)
+    L_B = np.matmul(FB.transpose(),L_F)
+
+    # compare the module results to the python computation for body-frame cmd torque
+    if not unitTestSupport.isVectorEqual(L_B_sim, L_B, accuracy):
+        testFailCount += 1
+        testMessages.append("FAILED: " + platformWrap.ModelTag + "thrusterPlatformReference module failed unit test on thruster torque \n")
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    return [testFailCount, ''.join(testMessages)]
+
+
+#
+# This statement below ensures that the unitTestScript can be run as a
+# stand-along python script
+#
+if __name__ == "__main__":
+    test_platformRotation(
+                 False,                   # show_plots
+                 0.1,                     # delta_CM
+                 0,                       # k
+                 np.random.rand(1)[0],    # seed
+                 1e-10                    # accuracy
+               )

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -73,5 +73,271 @@ void Reset_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData
 */
 void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
 {
+    /*! - Create and assign message buffers */
+    VehicleConfigMsgPayload    vehConfigMsgIn = VehicleConfigMsg_C_read(&configData->vehConfigInMsg);
+    RWSpeedMsgPayload          rwSpeedMsgIn = RWSpeedMsg_C_read(&configData->rwSpeedsInMsg);
+    HingedRigidBodyMsgPayload  hingedRigidBodyRef1Out = HingedRigidBodyMsg_C_zeroMsgPayload();
+    HingedRigidBodyMsgPayload  hingedRigidBodyRef2Out = HingedRigidBodyMsg_C_zeroMsgPayload();
+    BodyHeadingMsgPayload      bodyHeadingOut = BodyHeadingMsg_C_zeroMsgPayload();
+    CmdTorqueBodyMsgPayload    thrusterTorqueOut = CmdTorqueBodyMsg_C_zeroMsgPayload();
 
+    /*! compute CM position w.r.t. M frame origin, in M coordinates */
+    double MB[3][3];
+    MRP2C(configData->sigma_MB, MB);                         // B to M DCM
+    double r_CB_B[3];
+    v3Copy(vehConfigMsgIn.CoM_B, r_CB_B);                    // position of C w.r.t. B in B-frame coordinates
+    double r_CB_M[3];
+    m33MultV3(MB, r_CB_B, r_CB_M);                           // position of C w.r.t. B in M-frame coordinates
+    double r_CM_M[3];
+    v3Add(r_CB_M, configData->r_BM_M, r_CM_M);               // position of C w.r.t. M in M-frame coordinates
+    double r_TM_F[3];
+    v3Add(configData->r_FM_F, configData->r_TF_F, r_TM_F);   // position of T w.r.t. M in F-frame coordinates
+    
+    double FM[3][3];
+    computeFinalRotation(r_CM_M, r_TM_F, configData->T_F, FM);
+
+    /*! compute net RW momentum */
+    double vec3[3], hs_B[3], hs_M[3];
+    v3SetZero(hs_B);
+    for (int i=0; i<configData->rwConfigParams.numRW; i++) {
+        v3Scale(configData->rwConfigParams.JsList[i]*rwSpeedMsgIn.wheelSpeeds[i], &configData->rwConfigParams.GsMatrix_B[i*3], vec3);
+        v3Add(hs_B, vec3, hs_B);
+    }
+    m33tMultV3(MB, hs_B, hs_M);
+
+    /*! compute offset vector */
+    double T_M[3];
+    m33tMultV3(FM, configData->T_F, T_M);
+    double d_M[3];
+    v3Cross(T_M, hs_M, d_M);
+    v3Scale(-configData->K/v3Dot(T_M, T_M), d_M, d_M);
+
+    /*! recompute thrust direction and FM matrix based on offset */
+    double r_CMd_M[3];
+    v3Add(r_CM_M, d_M, r_CMd_M);
+    computeFinalRotation(r_CMd_M, r_TM_F, configData->T_F, FM);
+
+    /*! extract theta1 and theta2 angles */
+    hingedRigidBodyRef1Out.theta = atan2(FM[1][2], FM[1][1]);
+    hingedRigidBodyRef1Out.thetaDot = 0;
+    hingedRigidBodyRef2Out.theta = atan2(FM[2][0], FM[0][0]);
+    hingedRigidBodyRef2Out.thetaDot = 0;
+
+    /*! write output spinning body messages */
+    HingedRigidBodyMsg_C_write(&hingedRigidBodyRef1Out, &configData->hingedRigidBodyRef1OutMsg, moduleID, callTime);
+    HingedRigidBodyMsg_C_write(&hingedRigidBodyRef2Out, &configData->hingedRigidBodyRef2OutMsg, moduleID, callTime);
+
+    /*! define mapping between final platform frame and body frame FB */
+    double FB[3][3];
+    m33MultM33(FM, MB, FB);
+
+    /*! compute thruster direction in body frame coordinates */
+    m33tMultV3(FB, configData->T_F, bodyHeadingOut.rHat_XB_B);
+    v3Normalize(bodyHeadingOut.rHat_XB_B, bodyHeadingOut.rHat_XB_B);
+
+    /* write output body heading message */
+    BodyHeadingMsg_C_write(&bodyHeadingOut, &configData->bodyHeadingOutMsg, moduleID, callTime);
+
+    /* compute thruster torque on the system in body frame coordinates */
+    double r_CM_F[3];
+    m33MultV3(FM, r_CM_M, r_CM_F);
+    double r_TC_F[3];
+    v3Subtract(r_TM_F, r_CM_F, r_TC_F);
+    double Torque_F[3];
+    v3Cross(configData->T_F, r_TC_F, Torque_F);    // compute the opposite of torque to compensate with the RWs
+    m33tMultV3(FB, Torque_F, thrusterTorqueOut.torqueRequestBody);
+
+    /* write output commanded torque message */
+    CmdTorqueBodyMsg_C_write(&thrusterTorqueOut, &configData->thrusterTorqueOutMsg, moduleID, callTime);
+}
+
+void computeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3])
+{
+    // compute principal rotation angle phi
+    double phi = acos( fmin( fmax( v3Dot(THat_F, rHat_CM_F), -1 ), 1 ) );
+
+    // compute principal rotation vector e_phi
+    double e_phi[3];
+    v3Cross(THat_F, rHat_CM_F, e_phi);
+    // If phi = PI, e_phi can be any vector perpendicular to F_current_B
+    if (fabs(phi-MPI) < epsilon) {
+        phi = MPI;
+        if (fabs(THat_F[0]) > epsilon) {
+            e_phi[0] = -(THat_F[1]+THat_F[2]) / THat_F[0];
+            e_phi[1] = 1;
+            e_phi[2] = 1;
+        }
+        else if (fabs(THat_F[1]) > epsilon) {
+            e_phi[0] = 1;
+            e_phi[1] = -(THat_F[0]+THat_F[2]) / THat_F[1];
+            e_phi[2] = 1;
+        }
+        else {
+            e_phi[0] = 1;
+            e_phi[1] = 1;
+            e_phi[2] = -(THat_F[0]+THat_F[1]) / THat_F[2];
+        }
+    }
+    else if (fabs(phi) < epsilon) {
+        phi = 0;
+    }
+    // normalize e_phi
+    v3Normalize(e_phi, e_phi);
+
+    // compute intermediate rotation F1M
+    double PRV_phi[3];
+    v3Scale(phi, e_phi, PRV_phi);
+    PRV2C(PRV_phi, F1M);
+}
+
+void computeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3], double THat_F[3], double F2F1[3][3])
+{
+    // define offset vector aVec
+    double aVec[3];
+    v3Copy(r_TM_F, aVec);
+    double a = v3Norm(aVec);
+
+    // define offset vector aVec
+    double bVec[3];
+    v3Copy(r_CM_F, bVec);
+    double b = v3Norm(bVec);
+    
+    double c1 = v3Norm(r_CT_F);
+
+    double psi;
+    if (fabs(a) < epsilon) {
+        // if offset a = 0, second rotation is null
+        psi = 0;
+    }
+    else {
+        double beta = acos( -fmin( fmax( v3Dot(aVec, THat_F) / a, -1 ), 1 ) );
+        double nu = acos( -fmin( fmax( v3Dot(aVec, r_CT_F) / (a*c1), -1 ), 1 ) );
+
+        double c2 = a*cos(beta) + sqrt(b*b - a*a*sin(beta)*sin(beta));
+
+        double cosGamma1 = (a*a + b*b - c1*c1) / (2*a*b);
+        double cosGamma2 = (a*a + b*b - c2*c2) / (2*a*b);
+
+        psi = asin( fmin( fmax( (c1*sin(nu)*cosGamma2 - c2*sin(beta)*cosGamma1)/b, -1 ), 1 ) );
+    }
+    
+    double e_psi[3];
+    v3Cross(THat_F, r_CT_F, e_psi);
+    v3Normalize(e_psi, e_psi);
+
+    // compute intermediate rotation F2F1
+    double PRV_psi[3];
+    v3Scale(psi, e_psi, PRV_psi);
+    PRV2C(PRV_psi, F2F1);
+}
+
+void computeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3])
+{
+    double e1 = e_theta[0];  
+    double e2 = e_theta[1];  
+    double e3 = e_theta[2];
+
+    double A = 2 * (F2M[1][0]*e2*e2 + F2M[0][0]*e1*e2 + F2M[2][0]*e2*e3) - F2M[1][0];
+    double B = 2 * (F2M[2][0]*e1 - F2M[0][0]*e3);
+    double C = F2M[1][0];
+    double Delta = B*B - 4*A*C;
+
+    /* compute exact solution or best solution depending on Delta */
+    double t, t1, t2, y, y1, y2, theta;
+    if (fabs(A) < epsilon) {
+        if (fabs(B) < epsilon) {
+            // zero-th order equation has no solution 
+            // the solution of the minimum problem is theta = MPI
+            theta = MPI;
+        }
+        else {
+            // first order equation
+            t = - C / B;
+            theta = 2*atan(t);
+        }
+    }
+    else {
+        if (Delta < 0) {
+            // second order equation has no solution 
+            // the solution of the minimum problem is found
+            if (fabs(B) < epsilon) {
+                t = 0.0;
+            }
+            else {
+                double q = (A-C) / B;
+                t1 = (q + sqrt(q*q + 1));
+                t2 = (q - sqrt(q*q + 1));
+                y1 = (A*t1*t1 + B*t1 + C) / (1 + t1*t1);
+                y2 = (A*t2*t2 + B*t2 + C) / (1 + t2*t2);
+
+                // choose which returns a smaller fcn value between t1 and t2
+                t = t1;
+                if (fabs(y2) < fabs(y1)) {
+                    t = t2;
+                }
+            }
+            theta = 2*atan(t);
+            y = (A*t*t + B*t + C) / (1 + t*t);
+            // check if the absolute fcn minimum is for theta = MPI
+            if (fabs(A) < fabs(y)) {
+                theta = MPI;
+            }
+        }
+        else {
+            t1 = (-B + sqrt(Delta)) / (2*A);
+            t2 = (-B - sqrt(Delta)) / (2*A);
+            t = t1;
+            if (fabs(t2) < fabs(t1)) {
+                t = t2;
+            }
+
+            theta = 2*atan(t);
+        }
+    }
+
+    // compute intermediate rotation F3F2
+    double PRV_theta[3];
+    v3Scale(theta, e_theta, PRV_theta);
+    PRV2C(PRV_theta, F3F2);
+}
+
+void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], double FM[3][3])
+{
+    /*! define unit vectors of CM direction in M coordinates and thrust direction in F coordinates */
+    double rHat_CM_M[3];
+    v3Normalize(r_CM_M, rHat_CM_M);
+    double THat_F[3];
+    v3Normalize(T_F, THat_F);
+    double rHat_CM_F[3];
+    v3Copy(rHat_CM_M, rHat_CM_F);        // assume zero initial rotation between F and M
+
+    /*! compute first rotation to make T_F parallel to r_CM */
+    double F1M[3][3];
+    computeFirstRotation(THat_F, rHat_CM_F, F1M);
+
+    /*! rotate r_CM_F */
+    double r_CM_F[3];
+    m33MultV3(F1M, r_CM_M, r_CM_F);
+
+    /*! compute position of CM w.r.t. thrust application point T */
+    double r_CT_F[3];
+    v3Subtract(r_CM_F, r_TM_F, r_CT_F);
+
+    /*! compute second rotation to zero the offset between T_F and r_CT_F */
+    double F2F1[3][3];
+    computeSecondRotation(r_CM_F, r_TM_F, r_CT_F, THat_F, F2F1);
+
+    /*! define intermediate platform rotation F2M */
+    double F2M[3][3];
+    m33MultM33(F2F1, F1M, F2M);
+
+    /*! compute third rotation to make the frame compliant with the platform constraint */
+    double e_theta[3];
+    m33MultV3(F2M, r_CM_M, e_theta);
+    v3Normalize(e_theta, e_theta);
+    double F3F2[3][3];
+    computeThirdRotation(e_theta, F2M, F3F2);
+
+    /*! define final platform rotation FM */
+    m33MultM33(F3F2, F2M, FM);
 }

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -1,0 +1,66 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "thrusterPlatformReference.h"
+#include "string.h"
+#include <math.h>
+
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/astroConstants.h"
+
+const double epsilon = 1e-12;                           // module tolerance for zero
+
+/*! This method initializes the output messages for this module.
+ @return void
+ @param configData The configuration data associated with this module
+ @param moduleID The module identifier
+ */
+void SelfInit_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, int64_t moduleID)
+{
+    HingedRigidBodyMsg_C_init(&configData->hingedRigidBodyRef1OutMsg);
+    HingedRigidBodyMsg_C_init(&configData->hingedRigidBodyRef2OutMsg);
+    BodyHeadingMsg_C_init(&configData->bodyHeadingOutMsg);
+    CmdTorqueBodyMsg_C_init(&configData->thrusterTorqueOutMsg);
+}
+
+
+/*! This method performs a complete reset of the module.  Local module variables that retain
+ time varying states between function calls are reset to their default values.
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime [ns] time the method is called
+ @param moduleID The module identifier
+*/
+void Reset_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}
+
+
+/*! This method updates the platformAngles message based on the updated information about the system center of mass
+ @return void
+ @param configData The configuration data associated with the module
+ @param callTime The clock time at which the function was called (nanoseconds)
+ @param moduleID The module identifier
+*/
+void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
+{
+
+}

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -50,7 +50,18 @@ void SelfInit_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configD
 */
 void Reset_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID)
 {
+    if (!VehicleConfigMsg_C_isLinked(&configData->vehConfigInMsg)) {
+        _bskLog(configData->bskLogger, BSK_ERROR, " thrusterPlatformReference.vehConfigInMsg wasn't connected.");
+    }
+    if (RWArrayConfigMsg_C_isLinked(&configData->rwConfigDataInMsg) && RWSpeedMsg_C_isLinked(&configData->rwSpeedsInMsg)) {
+        configData->momentumDumping = Yes;
 
+        /*! - read in the RW configuration message */
+        configData->rwConfigParams = RWArrayConfigMsg_C_read(&configData->rwConfigDataInMsg);
+    }
+    else {
+        configData->momentumDumping = No;
+    }
 }
 
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -72,6 +72,11 @@ extern "C" {
     void Reset_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
     void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
 
+    void computeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3]);
+    void computeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3], double T_F_hat[3], double FF1[3][3]);
+    void computeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3]);
+    void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], double FM[3][3]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -1,0 +1,80 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _THRUSTER_PLATFORM_REFERENCE_
+#define _THRUSTER_PLATFORM_REFERENCE_
+
+#include <stdint.h>
+#include "architecture/utilities/bskLogging.h"
+#include "cMsgCInterface/VehicleConfigMsg_C.h"
+#include "cMsgCInterface/RWArrayConfigMsg_C.h"
+#include "cMsgCInterface/RWSpeedMsg_C.h"
+#include "cMsgCInterface/CmdTorqueBodyMsg_C.h"
+#include "cMsgCInterface/HingedRigidBodyMsg_C.h"
+#include "cMsgCInterface/BodyHeadingMsg_C.h"
+
+
+enum momentumDumping{
+    Yes = 0,
+    No  = 1
+};
+
+/*! @brief Top level structure for the sub-module routines. */
+typedef struct {
+
+    /* declare these user-defined quantities */
+    double sigma_MB[3];                                   //!< orientation of the M frame w.r.t. the B frame
+    double r_BM_M[3];                                     //!< position of B frame origin w.r.t. M frame origin, in M frame coordinates
+    double r_FM_F[3];                                     //!< position of F frame origin w.r.t. M frame origin, in F frame coordinates
+    double r_TF_F[3];                                     //!< position of the thrust application point w.r.t. F frame origin, in F frame coordinates
+    double T_F[3];                                        //!< thrust vector in F frame coordinates
+
+    double K;                                             //!< momentum dumping time constant [1/s]
+
+    /* declare variables for internal module calculations */
+    RWArrayConfigMsgPayload   rwConfigParams;             //!< struct to store message containing RW config parameters in body B frame
+    int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
+
+    /* declare module IO interfaces */
+    VehicleConfigMsg_C        vehConfigInMsg;             //!< input msg vehicle configuration msg (needed for CM location)
+    RWSpeedMsg_C              rwSpeedsInMsg;              //!< input reaction wheel speeds message
+    RWArrayConfigMsg_C        rwConfigDataInMsg;          //!< input RWA configuration message
+    HingedRigidBodyMsg_C      hingedRigidBodyRef1OutMsg;  //!< output msg containing theta1 reference and thetaDot1 reference
+    HingedRigidBodyMsg_C      hingedRigidBodyRef2OutMsg;  //!< output msg containing theta2 reference and thetaDot2 reference
+    BodyHeadingMsg_C          bodyHeadingOutMsg;          //!< output msg containing the thrust heading in body frame coordinates
+    CmdTorqueBodyMsg_C        thrusterTorqueOutMsg;       //!< output msg containing the opposite of the thruster torque to be compensated by RW's
+
+    BSKLogger *bskLogger;                                 //!< BSK Logging
+
+}ThrusterPlatformReferenceConfig;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void SelfInit_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, int64_t moduleID);
+    void Reset_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
+    void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.i
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.i
@@ -1,0 +1,50 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module thrusterPlatformReference
+%{
+   #include "thrusterPlatformReference.h"
+%}
+
+%include "swig_conly_data.i"
+%constant void SelfInit_thrusterPlatformReference(void*, uint64_t);
+%ignore SelfInit_thrusterPlatformReference;
+%constant void Reset_thrusterPlatformReference(void*, uint64_t, uint64_t);
+%ignore Reset_thrusterPlatformReference;
+%constant void Update_thrusterPlatformReference(void*, uint64_t, uint64_t);
+%ignore Update_thrusterPlatformReference;
+
+%include "thrusterPlatformReference.h"
+
+%include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+struct VehicleConfigMsg_C;
+%include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
+struct RWArrayConfigMsg_C;
+%include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
+struct RWSpeedMsg_C;
+%include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
+struct CmdTorqueBodyMsg_C;
+%include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
+struct HingedRigidBodyMsg_C;
+%include "architecture/msgPayloadDefC/BodyHeadingMsgPayload.h"
+struct BodyHeadingMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.rst
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.rst
@@ -1,0 +1,109 @@
+Executive Summary
+-----------------
+This module computes a reference orientation for a dual-gimballed platform connected to the main hub. The platform can only perform a tip-and-tilt type of rotation, and therefore one degree of freedom is blocked. A thruster is mounted on the platform, whose direction is known in platform-frame coordinates. The goal of this module is to compute a reference orientation for the platform which can align the thruster direction with the system's center of mass, to zero the net torque produced by the thruster on the spacecraft. Alternatively, this module can offset the thrust direction with respect to the center of mass to produce a net torque that dumps the momentum accumulated on the reaction wheels.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages.  The module msg variable name is set by the
+user from python.  The msg type contains a link to the message structure definition, while the description
+provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - vehConfigInMsg
+      - :ref:`VehicleConfigMsgPayload`
+      - Input vehicle configuration message containing the position of the center of mass of the system.
+    * - rwConfigDataInMsg
+      - :ref:`RWArrayConfigMsgPayload`
+      - Input message containing the number of reaction wheels, relative inertias and orientations with respect to the body frame.
+    * - rwSpeedsInMsg
+      - :ref:`RWSpeedMsgPayload`
+      - Input message containing the relative speeds of the reaction wheels with respect to the hub.
+    * - hingedRigidBodyRef1OutMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - Output message containing the reference angle and angle rate for the tip angle.
+    * - hingedRigidBodyRef2OutMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - Output message containing the reference angle and angle rate for the tilt angle.
+    * - bodyHeadingOutMsg
+      - :ref:`BodyHeadingMsgPayload`
+      - Output message containing the unit direction vector of the thruster in body-frame coordinates.
+    * - thrusterTorqueOutMsg
+      - :ref:`CmdTorqueBodyMsgPayload`
+      - Output message containing the opposite of the net torque produced by the thruster on the system.
+
+
+Detailed Module Description
+---------------------------
+A detailed mathematical derivation of the equations implemented in this module can be found in `R. Calaon, L. Kiner, C. Allard and H. Schaub, "Momentum Management of a Spacecraft equipped with a Dual-Gimballed Electric Thruster"  <http://hanspeterschaub.info/Papers/Calaon2023a.pdf>`__.
+
+This module computes a direction cosine matrix :math:`[\mathcal{FM}]` that describes the rotation between the platform frame :math:`\mathcal{F}` and the mount frame :math:`\mathcal{M}`. To be compliant with the constraint in the motion of the platform, i.e. the dual gimbal, such frame must have a zero in the element (2,1). When such condition is met, the reference angles computed from the D.C.M. allow to align the thruster through the system's center of mass. The input parameters for this module allow to specify offsets between the origin :math:`M` of the hub-fixed mount frame :math:`\mathcal{M}` and the origin :math:`F` of the platform-fixed frame :math:`\mathcal{F}`, the application point of the thruster force in the :math:`\mathcal{F}` frame, and the direction, in :math:`\mathcal{F}`-frame coordinates, of the thrust vector.
+
+When the optional input messages ``rwConfigDataInMsg`` and ``rwSpeedsInMsg`` the user can specify an input parameter ``K``, which is the proportional gain of a control gain that computes an offset with respect to the center of mass: this allows for the thruster to apply a torque on the system that dumps the momentum accumulated on the wheels. Such control law has the expression:
+
+.. math:: 
+    \boldsymbol{d} = \frac{\kappa}{t^2} (\boldsymbol{t} \times \boldsymbol{H}_w)
+
+where :math:`\boldsymbol{H}_w` is the momentum on the wheels.
+
+
+Module Assumptions and Limitations
+----------------------------------
+As pointed out in the paper referenced above, it is not always guaranteed that a direction cosine matrix exists, that can satisfy both the pointing requirement on the thrust direction and the kinematic constraint on the dual-gimballed platform. When a solution does not exist, a minimum problem is solved to compute the closest constraint-incompliant D.C.M. The tip and tilt referemce angles :math:`\nu_{1R}` and :math:`\nu_{2R}` are extracted from the final D.C.M. according to:
+
+.. math::
+    \begin{align}
+        \nu_{1R} &= \arctan \left( \frac{f_{23}}{f_{22}} \right) & 
+        \nu_{2R} &= \arctan \left( \frac{f_{31}}{f_{11}} \right)
+    \end{align}
+
+without checking whether the D.C.M. :math:`[\mathcal{FM}]` is constraint compliant. As a result, the angles :math:`\nu_{1R}` and :math:`\nu_{2R}` produce a constraint compliant reference, which however might not align the thruster with the desired point in the hub.
+
+
+User Guide
+----------
+The required module configuration is::
+
+    platformConfig = thrusterPlatformReference.ThrusterPlatformReferenceConfig()
+    platformWrap = unitTestSim.setModelDataWrap(platformConfig)
+    platformWrap.ModelTag = "platformReference"
+    platformConfig.sigma_MB = sigma_MB
+    platformConfig.r_BM_M = r_BM_M
+    platformConfig.r_FM_F = r_FM_F
+    platformConfig.r_TF_F = r_TF_F
+    platformConfig.T_F    = T_F
+    platformConfig.K      = K
+    scSim.AddModelToTaskAddModelToTask(simTaskName, platformWrap, platformConfig)
+ 	
+The module is configurable with the following parameters:
+
+.. list-table:: Module Parameters
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Parameter
+      - Default
+      - Description
+    * - ``sigma_MB``
+      - [0, 0, 0]
+      - relative rotation between body-fixed frames :math:`\mathcal{M}` and :math:`\mathcal{B}`
+    * - ``r_BM_M``
+      - [0, 0, 0]
+      - relative position of point :math:`B` with respect to point :math:`M`, in :math:`\mathcal{M}`-frame coordinates
+    * - ``r_FM_F``
+      - [0, 0, 0]
+      - relative position of point :math:`F` with respect to point :math:`M`, in :math:`\mathcal{F}`-frame coordinates
+    * - ``r_TF_F``
+      - [0, 0, 0]
+      - relative position of point :math:`T` with respect to point :math:`F`, in :math:`\mathcal{F}`-frame coordinates
+    * - ``T_F``
+      - [0, 0, 0]
+      - thrust vector in :math:`\mathcal{F}`-frame coordinates
+    * - ``K``
+      - 0
+      - proportional gain of the momentum dumping control loop


### PR DESCRIPTION
* **Tickets addressed:** bsk-180
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This module computes reference tip-and-tilt angles for a dual-gimballed platform connected to the spacecraft hub, on which a thruster is mounted. The reference angles computed make the platform rotation compliant with the dual-gimbal motion constraint. This module allows to align the thrust vector, which moves with the platform, to the system center of mass, or to set it at an offset in order to produce a net torque on the system that can dump the momentum accumulated on the reaction wheels. Commit 1 initializes the module functions. Commit 2 checks which input msgs are connected. In Commit 3, reference angles, thrust direction and net torque are computed and output messages are written. Commits 4 and 5 contain documentation and unit test, respectively.

## Verification
A Unit Test is provided. This test checks that, when no momentum dumping is performed, the thrust direction computed is aligned with the system's center of mass. Moreover, thrust direction in body-frame components and net torque in body-frame components outputted by the module are checked versus equivalent values computed in python.

## Documentation
This is a new module. New documentation is provided to describe how the module works. 

## Future work
No future work is foreseen at the moment.
