### PR TITLE
Restrict Basilisk to build using conan <= 1.59.0

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
       - name: "Install wheel and conan package"
-        run: source .venv/bin/activate && pip3 install wheel conan pytest datashader holoviews pytest-xdist
+        run: source .venv/bin/activate && pip3 install wheel conan==1.59.0 pytest datashader holoviews pytest-xdist
       - name: "Build basilisk"
         run: source .venv/bin/activate && python3 conanfile.py
       - name: "Run Test"
@@ -99,7 +99,7 @@ jobs:
         shell: pwsh
         run: |
             venv\Scripts\activate
-            pip install wheel conan parse six pytest-xdist
+            pip install wheel conan==1.59.0 parse six pytest-xdist
       - name: "Add basilisk and cmake path to env path"
         shell: pwsh
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -69,6 +69,10 @@ class BasiliskConan(ConanFile):
         print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
         print("use version 1.40.1+ to work with the conan repo changes from 2021." + endColor)
         exit(0)
+    if conan_version > Version("1.59.0"):
+        print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
+        print("use version 1.40.1 to 1.59.0 to work with the conan repo changes." + endColor)
+        exit(0)
 
     # ensure latest pip is installed
     if is_running_virtual_env() or platform.system() == "Windows":

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -49,6 +49,7 @@ Version |release|
 - Created a :ref:`prescribedMotionStateEffector` dynamics module for appending rigid bodies with prescribed motion
   to the spacecraft hub.
 - Added :ref:`solarArrayReference` to compute the reference angle and angle rate for a rotating solar array.
+- Update python dependency documentation and check to not use ``conan`` version 2.0.0 for now
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/docs/source/bskPkgRequired.txt
+++ b/docs/source/bskPkgRequired.txt
@@ -4,4 +4,5 @@
 ``pytest``
 ``Pillow``
 ``conan>=1.40.1``
+``conan<=1.56.0``
 ``parse>=1.18.0``


### PR DESCRIPTION
* **Tickets addressed:** resolves #207
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
BSK is not yet compatible with conan 2.0.0.  Change BSK dependency to ensure earlier conan version is used for now.

## Verification
Did a clean build and configuration without issues.

## Documentation
update python package dependency information.

## Future work
Will need to update BSK to make use of conan 2.x in the future.