### PR TITLE
fix documentation errors

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.rst
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.rst
@@ -1,7 +1,8 @@
 Executive Summary
 -----------------
 
-This module implements a simple Proportional-Integral-Derivative (PID) control law to provide the commanded torque to a :ref:`spinningBodyStateEffector`.
+This module implements a simple Proportional-Integral-Derivative (PID) control law to provide the commanded
+torque to a :ref:`spinningBodyOneDOFStateEffector`.
 
 
 Message Connection Descriptions
@@ -37,7 +38,7 @@ overdamped, or critically damped) depends on the choice of gains provided as inp
 Detailed Module Description
 ---------------------------
 For this module to operate, the user needs to provide control gains ``K``, ``P`` and ``I``. Let's define :math:`\theta_R` and :math:`\dot{\theta}_R` the reference angle and angle rate contained in the
-``hingedRigidBodyRefInMsg``, and :math:`\theta` and :math:`\dot{\theta}` the current solar array angle and angle rate contained in the ``hingedRigidBodyInMsg``, which is provided as an output of the :ref:`spinningBodyStateEffector`. The control torque is obtained as follows:
+``hingedRigidBodyRefInMsg``, and :math:`\theta` and :math:`\dot{\theta}` the current solar array angle and angle rate contained in the ``hingedRigidBodyInMsg``, which is provided as an output of the :ref:`spinningBodyOneDOFStateEffector`. The control torque is obtained as follows:
 
 .. math::
     T = K (\theta_R - \theta) + P (\dot{\theta}_R - \dot{\theta}) + I \int_0^t (\theta_R - \theta) \text{d}\tau.

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.rst
@@ -58,7 +58,7 @@ how to run it, as well as testing.
 
 .. note::
 
-    In contrast to :ref:`spinningBodyStateEffector`, this module assumes:
+    In contrast to :ref:`spinningBodyOneDOFStateEffector`, this module assumes:
 
     - rigid body inertia matrix is diagonal as seen in the hinged body :math:`\cal S` frame
     - the center of mass lies on the :math:`\hat{\bf s}_1` axis

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
@@ -50,13 +50,13 @@ User Guide
 ----------
 This section is to outline the steps needed to setup a Spinning Body State Effector in Python using Basilisk.
 
-#. Import the spinningBodyStateEffector class::
+#. Import the spinningBodyOneDOFStateEffector class::
 
-    from Basilisk.simulation import spinningBodyStateEffector
+    from Basilisk.simulation import spinningBodyOneDOFStateEffector
 
 #. Create an instantiation of a Spinning body::
 
-    spinningBody = spinningBodyStateEffector.SpinningBodyStateEffector()
+    spinningBody = spinningBodyOneDOFStateEffector.SpinningBodyOneDOFStateEffector()
 
 #. Define all physical parameters for a Spinning Body. For example::
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
With the refactor of spinningBodiesEffector the RST documentation label `spinningBodyStateEffector` was not always updated to `spinningBodyOneDOFStateEffector`

## Verification
Documentation build clean again with no warnings and errors.

## Documentation
None

## Future work
None
