### PR TITLE
Provide support for Vizard 2.1.4

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,13 +56,13 @@ Version |release|
 - Added two new unit tests to :ref:`spinningBodyOneDOFStateEffector`.
 - Updated :ref:`magneticFieldWMM` to use the latest WMM coefficient file and evaluation software
 - Added a :ref:`spinningBodyTwoDOFStateEffector` module that simulates a two-axis rotating rigid component.
-- Created :ref:`oneAxisSolarArrayPoint` to generate the reference attitude for a spacecraft that needs to point a body-fixed 
+- Created :ref:`oneAxisSolarArrayPoint` to generate the reference attitude for a spacecraft that needs to point a body-fixed
   axis along an inertial direction while ensuring maximum power generation on the solar arrays
 - Added a maximum power parameter ``maxPower`` to :ref:`reactionWheelStateEffector` for limiting supplied
   power, independent of the modules in simulation/power.
 - Added :ref:`thrusterPlatformReference` to align the dual-gimballed thruster with the system's center of mass, or at an offset thereof to perform momentum dumping.
 - Improved reliability of opNav scenario communication between :ref:`vizInterface` and Vizard
-
+- provide support or Vizard 2.1.4 features
 
 
 Version 2.1.6 (Jan. 21, 2023)

--- a/docs/source/Vizard/Vizard.rst
+++ b/docs/source/Vizard/Vizard.rst
@@ -24,7 +24,7 @@ About Vizard
 
     **License:** Freeware
 
-    **Status:** Version 2.1.3 (Released Jan. 20, 2023)
+    **Status:** Version 2.1.4 (Released March 24, 2023)
 
 The Vizard Unity-based Basilisk
 visualization is able to display in a three-dimensional view the

--- a/docs/source/Vizard/VizardReleaseNotes.rst
+++ b/docs/source/Vizard/VizardReleaseNotes.rst
@@ -15,10 +15,44 @@ Release Notes
     - visualize MSM charge values
     - load custom Unity generated spacecraft and celestial body models at run time
 
+
+**Version 2.1.4 (March 24, 2023)**
+
+- support for changing the true path trajectory line color allowing a path line with multiple
+  colors that can be used to indicate phases of interest in the trajectory
+- added support for reflection probes on Custom spacecraft models imported via Addressables,
+  Vizard will detect any reflection probes included on the model and configure them to display
+  correctly with Vizard’s internal settings
+- added ``parentSpacecraftName`` field to the ``VizMessage.proto`` spacecraft message definition which
+  will allow the creation of effectors using the spacecraft message template. Providing a spacecraft
+  name in that field will indicate that the message belongs to an effector of that parent spacecraft.
+- added Vizard support for effectors including:
+
+  - not showing orbit lines for effectors
+  - adding a coordinate system toggle for effectors
+  - adding subdropdowns to the GUI to indicate which bodies are effectors and to reduce clutter
+    in the main body dropdown
+  - added parent spacecraft name to effector name on any HUD or panel toggles to clarify effector parent
+
+- fixed bug in thruster and transceiver particle systems that did not correctly scale for small sats
+- fixed bug in hemisphere mesh generation (used by CSS and location range) that would result in
+  failure if the field of view was very small
+- fixed bug where GenericSensor HUD was not correctly illuminated by the HUDShell lighting
+- fixed bug where CSS would incorrectly turn on after exiting Sprite mode when they should have
+  stayed off due to current settings
+- fixed bug in orbitLine template that would sometimes throw an error when reference was accessed
+  before being set
+- migrated Vizard to Unity Editor 2020.3.45f1
+- removed auto creation of the two standard camera panels, now camera panels will only be generated
+  when requested by user in the GUI or in messages
+- added support for spacecraft where no spacecraft name was specified in Basilisk, user will see an
+  error message in the VizConsole Log panel and Vizard will automatically name the spacecraft and continue to run
+
+
 **Version 2.1.3 (Jan. 20, 2023)**
 
-- added support for Settings flag `ForceStartAtSpacecraftLocalView`. If this flag is set to 1, the main camera will stay in the spacecraft local view and has been improved to allow zooming out to very large distances from the camera target spacecraft. Vizard will remain locked in spacecraft local view unless a non-spacecraft camera target is selected.
-- added MultiSphere support to `VizMessage.proto` and support visualizing the MultiSpheres on a spacecraft.
+- added support for Settings flag ``ForceStartAtSpacecraftLocalView``. If this flag is set to 1, the main camera will stay in the spacecraft local view and has been improved to allow zooming out to very large distances from the camera target spacecraft. Vizard will remain locked in spacecraft local view unless a non-spacecraft camera target is selected.
+- added MultiSphere support to ``VizMessage.proto`` and support visualizing the MultiSpheres on a spacecraft.
 
 
 **Version 2.1.2 (Dec. 13, 2022)**

--- a/docs/source/Vizard/VizardReleaseNotes.rst
+++ b/docs/source/Vizard/VizardReleaseNotes.rst
@@ -8,12 +8,11 @@ Release Notes
 .. sidebar:: In Progress Features
 
     - general GUI enhancements
-    - articulating CAD models
     - Add the rate gyro visualization
     - Alternate camera view points relative to non-spacecraft locations (lunar landing site, etc.)
     - Add magnetic torque bar visualization
-    - visualize MSM charge values
-    - load custom Unity generated spacecraft and celestial body models at run time
+    - Add range to target information
+    - Visualize aerobraking maneuvers
 
 
 **Version 2.1.4 (March 24, 2023)**

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -1547,8 +1547,25 @@ spacecraft::
 The argument None is used to specify the Vizard default shape to be used.
 
 Similarly, to set the actual or true trajectory color, use the keyword ``trueOrbitColorList`` with the same behavior
-as ``oscOrbitColorList``.
+as ``oscOrbitColorList``.  Note that if the color is set through this variable it remains the same
+throughout the simulation.  By reading in the line color through an input message it is possible
+to change the color of the local true orbit line segment to a new color.  This is useful to denote
+during what parts of the orbit an ion engine is active, or we are in sun pointing mode, etc.  To connect
+a color message of type :ref:`ColorMsgPayload`, you use the argument ``trueOrbitColorInMsgList``
+and provide it the color message.  This could be the output of a BSK module, or a stand alone message.
+Here is sample code using a stand-alone message::
 
+    colorMsgContent = messaging.ColorMsgPayload()
+    colorMsgContent.colorRGBA = vizSupport.toRGBA255("Yellow")
+    colorMsg = messaging.ColorMsg().write(colorMsgContent)
+
+    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
+                                              , trueOrbitColorInMsgList=colorMsg.addSubscriber()
+                                              , saveFile=__file__
+                                              )
+
+See :ref:`scenarioHelioTransSpice` for an example where the true trajectory line color is
+changed during the simulation.
 
 
 Adding Ellipsoid Objects to a Spacecraft Location

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -805,6 +805,18 @@ one entry per spacecraft.  If a spacecraft has no RW devices, then add ``None`` 
 If custom RW state output messages are used, then the ``scData.rwInMsgs`` can be specified directly.  This case
 is employed in the test script :ref:`test_dataFileToViz`.
 
+Specifying CSS Information
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+To include a cluster clusters of CSS sensors to the spacecraft,
+call ``vizSupport.enableUnityVisualization()`` with the additional argument::
+
+    cssList=[cssDeviceList]
+
+Here ``cssDeviceList`` is a list of :ref:`CoarseSunSensor` objects.  The length of ``cssDeviceList``
+must match the number of spacecraft being modeled.  If a spacecraft has no CSS devices, then use
+the ``None`` label.  See :ref:`scenarioCSS` for an example of CSS devices being visualized in Vizard.
+
+
 Specifying Thruster Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The simplest method to include the clusters of thrusters of a one more spacecraft in the Vizard data file is to

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -1631,37 +1631,26 @@ example would be :ref:`hingedRigidBodyStateEffector` where a rigid body is hinge
 These effectors output a spacecraft state message containing its inertial position and orientation
 information.  This allows Vizard to show this rigid body as a separate spacecraft object.
 
-.. note::
+To show these time-varying body components such as :ref:`hingedRigidBodyStateEffector`,
+:ref:`spinningBodyOneDOFStateEffector` or :ref:`dualHingedRigidBodyStateEffector` , the BSK modules can be
+added to the ``enableUnityVisualization`` spacecraft list.  The parent spacecraft object
+should be listed first, followed by the spacecraft effector objects as a list of
+the effector name and effector state output message.  Let ``panel1`` and ``panel2``
+be instances of :ref:`hingedRigidBodyStateEffector` which are attached to spacecraft ``scObject``,
+all three components can be visualized using::
 
-    Currently the support for time varying spacecraft components is limited.  Their body-relative
-    position and orientation can be shown, but each component is treated as an independent spacecraft
-    object.  Thus, for example, if the orbit lines are shown, each body component has its own orbit
-    line drawn. Moreover, each body component will have its own axis shown when ``View/All Spacecraft CS``
-    option is selected.
-
-To show these time-varying body components, the argument ``bodyList`` is provided to ``enableUnityVisualization``::
-
-    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, [scObject, scObject2]
+    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, [scObject
+                                                                    , [panel1.ModelTag, panel1.hingedRigidBodyConfigLogOutMsg]
+                                                                    , [panel2.ModelTag, panel2.hingedRigidBodyConfigLogOutMsg]
+                                                                   ]
                                               , saveFile=fileName
-                                              , bodyList=[ None, panelList ]
                                               )
 
-The ``bodyList`` is a list of dictionary lists where the dictionary key is the component name, and the
-dictionary item is the  message containing the component inertial states.  The length of ``bodyList``
-must match the length of the list of spacecraft objects.  Information must be provided for each
-spacecraft. If a spacecraft has no time varying components then provide the argument ``None``.
-
-For example, assume a simulation has 2 spacecraft where the second spacecraft contains two time varying
-panels.  This could be visualized using::
-
-    scBodyList = {}
-    scBodyList[panel1.ModelTag] = panel1.hingedRigidBodyConfigLogOutMsg
-    scBodyList[panel2.ModelTag] = panel2.hingedRigidBodyConfigLogOutMsg
-
-    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, [scObject1, scObject2]
-                                              , bodyList=[None, scBodyList]
-                                              , saveFile=__file__
-                                              )
+Each effector is treated like a Vizard spacecraft object.  This means it is possible to add CSS,
+lights etc. to the panel objects as you do with the primary spacecraft.
+Note that the device list length must match that of the rigid body objects being
+sent to Vizard.  In the above example, this means Vizard is seeing 3 objects and the ``lightList``, for
+example, would need to contain three entrees.
 
 By default each component will be given the default ``bsk-Sat`` shape.  It is recommended that a
 custom model is assigned to each component.  See the scenario :ref:`scenarioDeployingPanel` for

--- a/examples/scenarioDeployingPanel.py
+++ b/examples/scenarioDeployingPanel.py
@@ -281,12 +281,11 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, pwr1Log)
     scSim.AddModelToTask(simTaskName, pwr2Log)
 
-    scBodyList = {}
-    scBodyList[panel1.ModelTag] = panel1.hingedRigidBodyConfigLogOutMsg
-    scBodyList[panel2.ModelTag] = panel2.hingedRigidBodyConfigLogOutMsg
-
-    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
-                                              , bodyList=[scBodyList]
+    viz = vizSupport.enableUnityVisualization(scSim, simTaskName,
+                                              [scObject
+                                                  , [panel1.ModelTag, panel1.hingedRigidBodyConfigLogOutMsg]
+                                                  , [panel2.ModelTag, panel2.hingedRigidBodyConfigLogOutMsg]
+                                               ]
                                               # , saveFile=__file__
                                               )
 

--- a/examples/scenarioHelioTransSpice.py
+++ b/examples/scenarioHelioTransSpice.py
@@ -75,18 +75,20 @@ The following image illustrates the expected visualization of this simulation sc
 
 import inspect
 import os
-
 from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.simulation import gravityEffector
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import simIncludeGravBody
+from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import vizSupport
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
-
-from Basilisk.simulation import spacecraft, gravityEffector
-from Basilisk.utilities import SimulationBaseClass, macros, simIncludeGravBody, unitTestSupport
-from Basilisk.architecture import messaging
-from Basilisk.utilities import vizSupport
 
 def run():
     """

--- a/examples/scenarioHelioTransSpice.py
+++ b/examples/scenarioHelioTransSpice.py
@@ -160,8 +160,13 @@ def run():
 
     # Configure Vizard settings
     if vizSupport.vizFound:
+        colorMsgContent = messaging.ColorMsgPayload()
+        colorMsgContent.colorRGBA = vizSupport.toRGBA255("Yellow")
+        colorMsg = messaging.ColorMsg().write(colorMsgContent)
+
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
                                                   , oscOrbitColorList=[vizSupport.toRGBA255("Magenta")]
+                                                  , trueOrbitColorInMsgList=colorMsg.addSubscriber()
                                                   # , saveFile=__file__
                                                   )
         viz.epochInMsg.subscribeTo(gravFactory.epochMsg)
@@ -175,6 +180,13 @@ def run():
     # Initialize and execute simulation
     scSim.InitializeSimulation()
     day = 60 * 60 * 24  # sec
+    simulationTime = macros.sec2nano(0.5 * 365 * day)
+    scSim.ConfigureStopTime(simulationTime)
+    scSim.ExecuteSimulation()
+
+    # change true orbit line color
+    colorMsgContent.colorRGBA = vizSupport.toRGBA255("Cyan")
+    colorMsg.write(colorMsgContent)
     simulationTime = macros.sec2nano(4.5 * 365 * day)
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/src/architecture/msgPayloadDefC/ColorMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/ColorMsgPayload.h
@@ -1,0 +1,32 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef _COLOR_MESSAGE_H
+#define _COLOR_MESSAGE_H
+
+
+
+/*! @brief Structure used to define RGBA color */
+typedef struct {
+    int colorRGBA[4]; //!< [-] 0-255 Color values in RGBA format
+}ColorMsgPayload;
+
+
+
+#endif

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.h
@@ -51,6 +51,7 @@ typedef struct {
 class StateEffector {
 public:
     std::string nameOfSpacecraftAttachedTo="";//!< class variable
+    std::string parentSpacecraftName="";   //!< -- name of the spacecraft the state effector is attached to
     EffectorMassProps effProps;            //!< -- stateEffectors instantiation of effector mass props
     Eigen::VectorXd stateDerivContribution; //!< -- stateEffector contribution to another stateEffector to prevent double-counting
     Eigen::Vector3d forceOnBody_B;         //!< [N] Force that the state effector applies to the s/c

--- a/src/simulation/dynamics/dualHingedRigidBodies/_UnitTest/test_dualhingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/dualHingedRigidBodies/_UnitTest/test_dualhingedRigidBodyStateEffector.py
@@ -78,7 +78,7 @@ def dualHingedRigidBodyTest(show_plots, useFlag, testCase):
     unitTestSim.panel2 = dualHingedRigidBodyStateEffector.DualHingedRigidBodyStateEffector()
 
     # Define Variable for panel 1
-    unitTestSim.panel2.ModelTag = "panel1"
+    unitTestSim.panel1.ModelTag = "panel1"
     unitTestSim.panel1.mass1 = 50.0
     unitTestSim.panel1.IPntS1_S1 = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]
     unitTestSim.panel1.d1 = 0.75

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.rst
@@ -30,7 +30,7 @@ provides information on what this message is used for.
     * - dualHingedRigidBodyOutMsgs
       - :ref:`HingedRigidBodyMsgPayload`
       - vector of output message containing the panel 1 and 2 hinge state angle and angle rate
-    * - dualHingedRigidBodyConfigLogOutMsg
+    * - dualHingedRigidBodyConfigLogOutMsgs
       - :ref:`SCStatesMsgPayload`
       - vector of output messages containing the panel 1 and 2 inertial position and attitude states
 

--- a/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
+++ b/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
@@ -301,6 +301,7 @@ VizSpacecraftData
 //@endcond
 {
     std::string spacecraftName = "bsk-Sat";                     //!< [-] Name of the spacecraft.
+    std::string parentSpacecraftName = "";                      //!< [-] Name of parent spacecraft object for multi-body spacecraft
     ReadFunctor<SCStatesMsgPayload> scStateInMsg;               //!< [-] msg of incoming spacecraft data
     MsgCurrStatus scStateInMsgStatus;                           //!< [-] (Private) status of the incoming spacecraft  data message
     SCStatesMsgPayload scStateMsgBuffer;                          //!< [-] (Private) s/c state message data

--- a/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
+++ b/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
@@ -18,6 +18,7 @@
 #include "architecture/msgPayloadDefCpp/DataStorageStatusMsgPayload.h"
 #include "architecture/msgPayloadDefC/PowerStorageStatusMsgPayload.h"
 #include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"
+#include "architecture/msgPayloadDefC/ColorMsgPayload.h"
 
 #include "architecture/msgPayloadDefCpp/CSSConfigLogMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
@@ -333,6 +334,7 @@ VizSpacecraftData
     std::string logoTexture = "";                               //!< (Optional) Path to image texture to be used to customize built-in spacecraft models
     std::vector<int> oscOrbitLineColor;                         //!< (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
     std::vector<int>  trueTrajectoryLineColor;                  //!< (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
+    ReadFunctor<ColorMsgPayload> trueTrajectoryLineColorInMsg;  //!< (Optional) Messages specifying true trajectory orbit line RGBA colors.  If connected, this replaces the values set in trueTrajectoryLineColor
     MultiSphereInfo msmInfo;                                    //!< (Optional) MSM configuration information
     std::vector<Ellipsoid *> ellipsoidList;                     //!< (Optional) ellipsoid about the spacecraft location
 }VizSpacecraftData;

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -271,6 +271,18 @@ void VizInterface::ReadBSKMessages()
         }
         }
 
+        /* read in true trajectory line color if connected */
+        if (scIt->trueTrajectoryLineColorInMsg.isLinked()) {
+            if (scIt->trueTrajectoryLineColorInMsg.isWritten()) {
+                ColorMsgPayload colorMsg;
+                colorMsg = scIt->trueTrajectoryLineColorInMsg();
+                scIt->trueTrajectoryLineColor.clear();
+                for (int i=0; i<4; i++) {
+                    scIt->trueTrajectoryLineColor.push_back(colorMsg.colorRGBA[i]);
+                }
+            }
+        }
+
         /* read in generic sensor cmd value */
         {
             for (size_t idx=0;idx< (size_t) scIt->genericSensorList.size(); idx++) {

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -740,6 +740,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
         if (scIt->scStateInMsg.isLinked() && scIt->scStateInMsgStatus.dataFresh){
             vizProtobufferMessage::VizMessage::Spacecraft* scp = message->add_spacecraft();
             scp->set_spacecraftname(scIt->spacecraftName);
+            scp->set_parentspacecraftname(scIt->parentSpacecraftName);
             for (int i=0; i<3; i++){
                 scp->add_position(scIt->scStateMsgBuffer.r_BN_N[i]);
                 scp->add_velocity(scIt->scStateMsgBuffer.v_BN_N[i]);

--- a/src/utilities/vizProtobuffer/vizMessage.proto
+++ b/src/utilities/vizProtobuffer/vizMessage.proto
@@ -47,7 +47,7 @@ message VizMessage{
     message Spacecraft{
         //FIELDS 1-4 EVERY TIMESTEP,
         //FIELDS 5-8, 10-12, 17-18 EVERY TIMESTEP IF THESE COMPONENTS ARE PRESENT IN SIM
-        //FIELDS 9, 13, 16 NEED ONLY BE SENT IN FIRST MESSAGE
+        //FIELDS 9, 13, 16, 19 NEED ONLY BE SENT IN FIRST MESSAGE
         //FIELDS 14-15 OPTIONAL FIELDS THAT CAN BE UPDATED EVERY TIMESTEP IF DESIRED, BUT NEED NEVER BE INCLUDED
         string spacecraftName = 1;
         repeated double position = 2;  //SCStatesMsg.r_BN_N
@@ -68,6 +68,7 @@ message VizMessage{
         string logoTexture = 16; //Path to image texture to be used to customize built-in spacecraft models
         repeated MultiSphere multiSpheres = 17; // (Optional) Multi-Sphere-Model (MSM) charging model information
         repeated Ellipsoid ellipsoids = 18; //(Optional) Ellipsoid Heads Up Displays
+        string parentSpacecraftName = 19; // Name of the main spacecraft body that this spacecraft object should be considered a component of. Required if this spacecraft object is a subcomponent of a larger craft (i.e. deployable solar panel)
 }
 
     message ReactionWheel{ //ONLY REQUIRED IF RW HUD/PANEL DESIRED

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -1101,9 +1101,6 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         list of MSM configuration messages
     ellipsoidList:
         list of lists of ``Ellipsoid`` structures.  The outer list length must match ``scList``.
-    bodyList:
-        list of lists containing time-varying spacecraft components (panels, etc.) The outer list length
-        must match ``scList``.
 
     Returns
     -------
@@ -1125,7 +1122,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         ['saveFile', 'opNavMode', 'rwEffectorList', 'thrEffectorList', 'thrColors', 'liveStream', 'cssList',
          'genericSensorList', 'transceiverList', 'genericStorageList', 'lightList', 'spriteList',
          'modelDictionaryKeyList', 'oscOrbitColorList', 'trueOrbitColorList', 'logoTextureList',
-         'msmInfoList', 'ellipsoidList', 'bodyList'],
+         'msmInfoList', 'ellipsoidList'],
         kwargs)
 
     # setup the Vizard interface module
@@ -1306,14 +1303,6 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         if len(msmInfoList) != scListLength:
             print('ERROR: vizSupport: msmInfoList should have the same length as the '
                   'number of spacecraft')
-            exit(1)
-
-    bodyScList = False
-    if 'bodyList' in kwargs:
-        bodyScList = kwargs['bodyList']
-        if len(bodyScList) != scListLength:
-            print('ERROR: vizSupport: bodyScList should have the same length as the '
-                  'number of spacecraft and contain lists of generic sensors')
             exit(1)
 
     # loop over all spacecraft to associated states and msg information

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -17,26 +17,22 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-
-#
-#   Unit Test Support Script
-#
-import os
-
 import numpy as np
+import os
 from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.simulation import spacecraft
 from Basilisk.utilities import unitTestSupport
 from matplotlib import colors
 from matplotlib.colors import is_color_like
-
-bskPath = __path__[0]
-from Basilisk.architecture import messaging
 
 try:
     from Basilisk.simulation import vizInterface
     vizFound = True
 except ImportError:
     vizFound = False
+
+bskPath = __path__[0]
 
 firstSpacecraftName = ''
 
@@ -1140,6 +1136,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     # ensure the spacecraft object list is a list
     if not isinstance(scList, list):
         scList = [scList]
+    scListLength = len(scList)
 
     firstSpacecraftName = scList[0].ModelTag
 
@@ -1149,7 +1146,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         rwEffectorScList = kwargs['rwEffectorList']
         if not isinstance(rwEffectorScList, list):
             rwEffectorScList = [rwEffectorScList]
-        if len(rwEffectorScList) != len(scList):
+        if len(rwEffectorScList) != scListLength:
             print('ERROR: vizSupport: rwEffectorList should have the same length as the number of spacecraft')
             exit(1)
 
@@ -1158,7 +1155,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         thrEffectorScList = kwargs['thrEffectorList']
         if not isinstance(thrEffectorScList, list):
             thrEffectorScList = [[thrEffectorScList]]
-        if len(thrEffectorScList) != len(scList):
+        if len(thrEffectorScList) != scListLength:
             print('ERROR: vizSupport: thrEffectorList should have the same length as the number of spacecraft')
             exit(1)
     thrColorsScList = False
@@ -1171,7 +1168,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
                     colorCheck = False
             if colorCheck:
                 thrColorsScList = [[thrColorsScList]]
-        if len(thrColorsScList) != len(scList):
+        if len(thrColorsScList) != scListLength:
             print('ERROR: vizSupport: thrColors should have the same length as the number of spacecraft')
             exit(1)
 
@@ -1180,7 +1177,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         cssScList = kwargs['cssList']
         if not isinstance(cssScList, list):
             cssScList = [[cssScList]]
-        if len(cssScList) != len(scList):
+        if len(cssScList) != scListLength:
             print('ERROR: vizSupport: cssList should have the same length as the number '
                   'of spacecraft and contain lists of CSSs')
             exit(1)
@@ -1190,7 +1187,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         gsScList = kwargs['genericSensorList']
         if not isinstance(gsScList, list):
             gsScList = [[gsScList]]
-        if len(gsScList) != len(scList):
+        if len(gsScList) != scListLength:
             print('ERROR: vizSupport: genericSensorList should have the same length as the '
                   'number of spacecraft and contain lists of generic sensors')
             exit(1)
@@ -1200,7 +1197,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         elScList = kwargs['ellipsoidList']
         if not isinstance(elScList, list):
             elScList = [[elScList]]
-        if len(elScList) != len(scList):
+        if len(elScList) != scListLength:
             print('ERROR: vizSupport: ellipsoidList should have the same length as the '
                   'number of spacecraft and contain lists of generic sensors')
             exit(1)
@@ -1210,7 +1207,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         liScList = kwargs['lightList']
         if not isinstance(liScList, list):
             liScList = [[liScList]]
-        if len(liScList) != len(scList):
+        if len(liScList) != scListLength:
             print('ERROR: vizSupport: lightList should have the same length as the '
                   'number of spacecraft and contain lists of light devices')
             exit(1)
@@ -1220,7 +1217,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         gsdScList = kwargs['genericStorageList']
         if not isinstance(gsdScList, list):
             gsdScList = [[gsdScList]]
-        if len(gsdScList) != len(scList):
+        if len(gsdScList) != scListLength:
             print('ERROR: vizSupport: genericStorageList should have the same length as the '
                   'number of spacecraft and contain lists of generic sensors')
             exit(1)
@@ -1230,7 +1227,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         tcScList = kwargs['transceiverList']
         if not isinstance(tcScList, list):
             tcScList = [[tcScList]]
-        if len(tcScList) != len(scList):
+        if len(tcScList) != scListLength:
             print('ERROR: vizSupport: tcScList should have the same length as the '
                   'number of spacecraft and contain lists of transceivers')
             exit(1)
@@ -1240,7 +1237,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         spriteScList = kwargs['spriteList']
         if not isinstance(spriteScList, list):
             spriteScList = [spriteScList]
-        if len(spriteScList) != len(scList):
+        if len(spriteScList) != scListLength:
             print('ERROR: vizSupport: spriteScList should have the same length as the '
                   'number of spacecraft and contain lists of transceivers')
             exit(1)
@@ -1250,7 +1247,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         modelDictionaryKeyList = kwargs['modelDictionaryKeyList']
         if not isinstance(modelDictionaryKeyList, list):
             modelDictionaryKeyList = [modelDictionaryKeyList]
-        if len(modelDictionaryKeyList) != len(scList):
+        if len(modelDictionaryKeyList) != scListLength:
             print('ERROR: vizSupport: modelDictionaryKeyList should have the same length as the '
                   'number of spacecraft and contain lists of transceivers')
             exit(1)
@@ -1260,7 +1257,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         logoTextureList = kwargs['logoTextureList']
         if not isinstance(logoTextureList, list):
             logoTextureList = [logoTextureList]
-        if len(logoTextureList) != len(scList):
+        if len(logoTextureList) != scListLength:
             print('ERROR: vizSupport: logoTextureList should have the same length as the '
                   'number of spacecraft and contain lists of transceivers')
             exit(1)
@@ -1268,7 +1265,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     oscOrbitColorList = False
     if 'oscOrbitColorList' in kwargs:
         oscOrbitColorList = kwargs['oscOrbitColorList']
-        if len(oscOrbitColorList) != len(scList):
+        if len(oscOrbitColorList) != scListLength:
             print('ERROR: vizSupport: oscOrbitColorList should have the same length as the '
                   'number of spacecraft and contain lists of transceivers')
             exit(1)
@@ -1286,7 +1283,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     trueOrbitColorList = False
     if 'trueOrbitColorList' in kwargs:
         trueOrbitColorList = kwargs['trueOrbitColorList']
-        if len(trueOrbitColorList) != len(scList):
+        if len(trueOrbitColorList) != scListLength:
             print('ERROR: vizSupport: trueOrbitColorList should have the same length as the '
                   'number of spacecraft and contain lists of transceivers')
             exit(1)
@@ -1306,7 +1303,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         msmInfoList = kwargs['msmInfoList']
         if not isinstance(msmInfoList, list):
             msmInfoList = [msmInfoList]
-        if len(msmInfoList) != len(scList):
+        if len(msmInfoList) != scListLength:
             print('ERROR: vizSupport: msmInfoList should have the same length as the '
                   'number of spacecraft')
             exit(1)
@@ -1314,7 +1311,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     bodyScList = False
     if 'bodyList' in kwargs:
         bodyScList = kwargs['bodyList']
-        if len(bodyScList) != len(scList):
+        if len(bodyScList) != scListLength:
             print('ERROR: vizSupport: bodyScList should have the same length as the '
                   'number of spacecraft and contain lists of generic sensors')
             exit(1)
@@ -1325,32 +1322,42 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     spiceMsgList = []
     vizMessenger.scData.clear()
     c = 0
+    spacecraftParentName = ""
+
     for sc in scList:
         # create spacecraft information container
         scData = vizInterface.VizSpacecraftData()
 
-        # set spacecraft name
-        scData.spacecraftName = sc.ModelTag
-
         # link to spacecraft state message
-        scData.scStateInMsg.subscribeTo(sc.scStateOutMsg)
+        if isinstance(sc, type(spacecraft.Spacecraft())):
+            # set spacecraft name
+            scData.spacecraftName = sc.ModelTag
+            spacecraftParentName = sc.ModelTag
+            scData.scStateInMsg.subscribeTo(sc.scStateOutMsg)
 
-        # link to celestial bodies information
-        for gravBody in sc.gravField.gravBodies:
-            # check if the celestial object has already been added
-            if gravBody.planetName not in planetNameList:
-                planetNameList.append(gravBody.planetName)
-                planetInfo = vizInterface.GravBodyInfo()
-                if gravBody.displayName == "":
-                    planetInfo.bodyName = gravBody.planetName
-                else:
-                    planetInfo.bodyName = gravBody.displayName
-                planetInfo.mu = gravBody.mu
-                planetInfo.radEquator = gravBody.radEquator
-                planetInfo.radiusRatio = gravBody.radiusRatio
-                planetInfo.modelDictionaryKey = gravBody.modelDictionaryKey
-                planetInfoList.append(planetInfo)
-                spiceMsgList.append(gravBody.planetBodyInMsg)
+            # link to celestial bodies information
+            for gravBody in sc.gravField.gravBodies:
+                # check if the celestial object has already been added
+                if gravBody.planetName not in planetNameList:
+                    planetNameList.append(gravBody.planetName)
+                    planetInfo = vizInterface.GravBodyInfo()
+                    if gravBody.displayName == "":
+                        planetInfo.bodyName = gravBody.planetName
+                    else:
+                        planetInfo.bodyName = gravBody.displayName
+                    planetInfo.mu = gravBody.mu
+                    planetInfo.radEquator = gravBody.radEquator
+                    planetInfo.radiusRatio = gravBody.radiusRatio
+                    planetInfo.modelDictionaryKey = gravBody.modelDictionaryKey
+                    planetInfoList.append(planetInfo)
+                    spiceMsgList.append(gravBody.planetBodyInMsg)
+        else:
+            # the scList object is an effector belonging to the parent spacecraft
+            scData.parentSpacecraftName = spacecraftParentName
+            ModelTag = sc[0]
+            effStateOutMsg = sc[1]
+            scData.spacecraftName = ModelTag
+            scData.scStateInMsg.subscribeTo(effStateOutMsg)
 
         # process RW effectors
         if rwEffectorScList:
@@ -1460,21 +1467,16 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
             if trueOrbitColorList[c] is not None:
                 scData.trueTrajectoryLineColor = vizInterface.IntVector(trueOrbitColorList[c])
 
+        if trueOrbitColorInMsgList:
+            if trueOrbitColorInMsgList[c] is not None:
+                scData.trueTrajectoryLineColorInMsg = trueOrbitColorInMsgList[c]
+
         # process MSM information
         if msmInfoList:
             if msmInfoList[c] is not None:  # MSM have been added to this spacecraft
                 scData.msmInfo = msmInfoList[c]
 
         vizMessenger.scData.push_back(scData)
-
-        # process spacecraft ellipsoids
-        if bodyScList:
-            if bodyScList[c] is not None:  # extra body(ies) have been added to this spacecraft
-                for tag, msg in bodyScList[c].items():
-                    bodyData = vizInterface.VizSpacecraftData()
-                    bodyData.spacecraftName = tag
-                    bodyData.scStateInMsg.subscribeTo(msg)
-                    vizMessenger.scData.push_back(bodyData)
 
         c += 1
 

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -1099,6 +1099,9 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     trueOrbitColorList:
         list of spacecraft true or actual orbit colors.  Can be 4 RGBA integer value (0-255), a color string, or
         ``None`` if default values should be used.  The array must be of the length of the spacecraft list
+    trueOrbitColorInMsgList:
+        list of color messages to read and provide the true orbit color at each time step.  This overwrites
+        the values set with trueOrbitColorList.
     msmInfoList:
         list of MSM configuration messages
     ellipsoidList:
@@ -1124,7 +1127,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
         ['saveFile', 'opNavMode', 'rwEffectorList', 'thrEffectorList', 'thrColors', 'liveStream', 'cssList',
          'genericSensorList', 'transceiverList', 'genericStorageList', 'lightList', 'spriteList',
          'modelDictionaryKeyList', 'oscOrbitColorList', 'trueOrbitColorList', 'logoTextureList',
-         'msmInfoList', 'ellipsoidList'],
+         'msmInfoList', 'ellipsoidList', 'trueOrbitColorInMsgList'],
         kwargs)
 
     # setup the Vizard interface module
@@ -1304,6 +1307,16 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
             msmInfoList = [msmInfoList]
         if len(msmInfoList) != scListLength:
             print('ERROR: vizSupport: msmInfoList should have the same length as the '
+                  'number of spacecraft')
+            exit(1)
+
+    trueOrbitColorInMsgList = False
+    if 'trueOrbitColorInMsgList' in kwargs:
+        trueOrbitColorInMsgList = kwargs['trueOrbitColorInMsgList']
+        if not isinstance(trueOrbitColorInMsgList, list):
+            trueOrbitColorInMsgList = [trueOrbitColorInMsgList]
+        if len(trueOrbitColorInMsgList) != scListLength:
+            print('ERROR: vizSupport: trueOrbitColorInMsgList should have the same length as the '
                   'number of spacecraft')
             exit(1)
 

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -37,6 +37,7 @@ bskPath = __path__[0]
 firstSpacecraftName = ''
 
 def toRGBA255(color, alpha=None):
+    answer = [0, 0, 0, 0]
     if isinstance(color, str):
         # convert color name to 4D array of values with 0-255
         if is_color_like(color):
@@ -124,6 +125,7 @@ def addLocation(viz, **kwargs):
         print("ERROR: parentBodyName argument must be provided to addLocation")
         exit(1)
 
+    r_GP_P = [0, 0, 0]
     if 'r_GP_P' in kwargs:
         r_GP_P = kwargs['r_GP_P']
         if not isinstance(r_GP_P, list):


### PR DESCRIPTION
* **Tickets addressed:** #160
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Vizard 2.1.4 has the following primary new features:
- ability to change the actual trajectory line color through an input message
- ability to group the spacecraft sub-components (hinged body, prescribed motion effector, etc.) with parent spacecraft
  

## Verification
Scenarios were updated to use the new features and the performance in Vizard was visually verified.

## Documentation
Updated the Vizard documentation to explain how to use these features.  

## Future work
The way sub-components are shown in Vizard lists is still verbose.  We have ideas how to make this more compact in the future to better handle large number of satellites.  