### PR TITLE
Feature/bsk 195 integration dyn objects

### DIFF
--- a/docs/source/Learn/bskPrinciples.rst
+++ b/docs/source/Learn/bskPrinciples.rst
@@ -18,5 +18,6 @@ by writing a python script.
    bskPrinciples/bskPrinciples-6
    bskPrinciples/bskPrinciples-7
    bskPrinciples/bskPrinciples-8
+   bskPrinciples/bskPrinciples-9
 
 

--- a/docs/source/Learn/bskPrinciples/bskPrinciples-9.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-9.rst
@@ -1,0 +1,41 @@
+.. _bskPrinciples-9:
+
+Advanced: Using ``DynamicObject`` Basilisk Modules
+==================================================
+Basilisk modules such as :ref:`spacecraft` and :ref:`spacecraftSystem` are members of
+the ``DynamicObject`` class.  This means they still have the regular Basilisk ``Reset()`` and
+``UpdateState()`` methods, but they also have a state machine and integrator build in as these
+modules have to integrate internal ordinate differential equations (ODEs).
+
+The ``DynamicObject`` class has the ability to integrate not just the ODEs of the one Basilisk module,
+but it is possible to synchronize the integration across multiple subclasses of ``DynamicObject``
+instances.  Consider an example where the integration of two spacecraft instances  ``scObject`` and ``scObject2``
+must be synchronized because effectors are used that create forces and torques onto both spacecraft.
+From python, this can be done elegantly using::
+
+    scObject.syncDynamicsIntegration(scObject2)
+
+This steps ties the integration of ``scObject2`` to the integration of ``scObject``.  Thus, even if
+``scObject`` is setup in a Basilisk task running 10Hz using the RK4 integrator, and ``scObject2`` is
+in a 1Hz task and specifies an RK2 integrator, the ODE integration of the primary object overrides
+the setup of the sync'd ``DynamicObjects``.  As a result both objects would be integrated using
+the RK4 integrator at 10Hz.  The ``UpdateState()`` method of ``scObjects2`` would still be called
+at 1Hz as this method is called at the task update period.
+
+.. note::
+
+    The ``syncDynamicsIntegration()`` method is not limited to syncing the ODE integration across
+    two ``DynamicObject`` instances.  Rather, the primary ``DynamicObject`` contains a standard
+    vector of points to sync'd ``DynamicObject`` instances.  Thus, the ODE integration of
+    an arbitrary number of ``DynamicObject`` integrations can be thus synchronized.
+
+The integration type is determined by the integrator assigned to the primary ``DynamicObject`` to
+which the other ``DynamicObject`` integrations is synchronized.  By default this is the ``RK4``
+integrator.  It doesn't matter what integrator is assigned to the secondary ``DynamicObject`` instances,
+the integrator of the primary object is used.
+
+Assigning an integrator to ``DynamicObject`` using ``setIntegrator()``,
+as discussed in :ref:`scenarioIntegrators`, clears
+out the vector of objects being integrated. Thus, if the integrator needs to be changed to
+one other than the default ``RK4``, then this must be done before the
+``syncDynamicsIntegration()`` method is called.

--- a/docs/source/Learn/makingModules.rst
+++ b/docs/source/Learn/makingModules.rst
@@ -31,5 +31,6 @@ The following pages cover the primary tasks required to make a Basilisk module. 
    makingModules/makingModules-4
    makingModules/makingDraftModule
    makingModules/makingModules-5
+   makingModules/advancedTopics
 
 

--- a/docs/source/Learn/makingModules/advancedTopics.rst
+++ b/docs/source/Learn/makingModules/advancedTopics.rst
@@ -1,0 +1,13 @@
+.. _advancedTopics:
+
+Advanced Topics
+===============
+This section covers advanced BSK module writing topics.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   advancedTopics/creatingDynObject
+
+

--- a/docs/source/Learn/makingModules/advancedTopics/creatingDynObject.rst
+++ b/docs/source/Learn/makingModules/advancedTopics/creatingDynObject.rst
@@ -1,0 +1,38 @@
+.. _creatingDynObject:
+
+Creating ``DynamicObject`` Basilisk Modules
+===========================================
+
+Basilisk modules that inherit from the class :ref:`dynamicObject` are still regular Basilisk modules
+that have the typical ``SelfInit()``, ``Reset()`` and ``UpdateState()`` methods.  However, they also contain
+a state engine called ``dynManager`` of the class ``DynParamManager``, as well as an integrator
+pointer called ``integrator`` of class ``StateVecIntegrator``.  :ref:`spacecraft` is an example of
+a Basilisk module that is also inheriting from the ``DynamicObject`` class.
+
+In the spacecraft ``UpdateState()`` method the ``DynamicObject::integrateState()`` method is called.
+This call integrates all the registered spacecraft states, as well as all the connect state
+and dynamic effectors, to the next time step using the connected integrator type.  See
+:ref:`scenarioIntegrators` for an example how how to set the integrator on a dynamic object.
+
+.. note::
+
+    Integrators connected to ``DynamicObject`` instances don't have to be the same.
+    It is possible to use an RK2 integrator on one spacecraft and the RK4 integrator on another.
+
+The ``initializeDynamics()`` virtual method must be defined in the ``DynamicObject`` subclass.
+It typically performs the required setup steps, including registering the ODE states that are
+to be integrated.
+
+The ``DynamicObject`` class contains two virtual methods ``preIntegration()`` and ``postIntegration()``.
+The ``DynamicObject`` subclass must define what steps are to be completed before the integration step,
+and what post-integrations must be completed.  For example, with :ref:`spacecraft` the pre-integration
+process determines the current time step to be integrated and stores some values used.  In the post-integration
+step the MRP spacecraft attitude states are checked to not have a norm larger than 1 and the conservative DV
+component is determined.
+
+Basilisk modules that are a subclass of ``DynamicObject`` are not restricted to mechanical integration
+scenarios as with the spacecraft example.  See the discussion in :ref:`bskPrinciples-9` on how multiple
+Basilisk modules that inherit from the ``DynamicObject`` class can be linked.  If linked,
+then the associated module ordinate differential equations (ODEs) are integrated
+simultaneously.
+

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -34,7 +34,10 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
-- text here
+- Created new way to define Python modules by inheriting from ``Basilisk.architecture.sysModel.SysModel``.
+  See :ref:`pyModules` for details.
+- Added the ability to integrate the ODE's of two or more Basilisk modules that are ``DynamicObject`` class
+  member at the same time.  See :ref:`bskPrinciples-9`
 
 Version 2.1.7 (March 24, 2023)
 ------------------------------
@@ -69,7 +72,7 @@ Version 2.1.7 (March 24, 2023)
 - Added :ref:`thrusterPlatformReference` to align the dual-gimballed thruster with the system's center of mass, or at an offset thereof to perform momentum dumping.
 - Improved reliability of opNav scenario communication between :ref:`vizInterface` and Vizard
 - provide support or Vizard 2.1.4 features
-- Created new way to define Python modules by inheriting from ``Basilisk.architecture.sysModel.SysModel``. See :ref:`pyModules` for details.
+
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -27,6 +27,10 @@ are taken from :ref:`scenarioAttitudeFeedbackRW`. The purpose of this script is 
 setup multiple satellites, and also show how to store the Basilisk simulation data to be able to visualize
 both satellite's motions within the :ref:`Vizard <vizard>` application.
 
+Note, this scenario also illustrates how to ensure that the differential equations of motion of
+the servicer and debris object are integrated at the same time.  This is not required in this scenario
+as there are no direct satellite-to-satellite dynamic interactions.
+
 The script is found in the folder ``basilisk/examples`` and executed by using::
 
       python3 scenarioFormationBasic.py
@@ -226,6 +230,9 @@ def run(show_plots):
           0., 0, 450.]
     scObject2.hub.mHub = 350.0  # kg
     scObject2.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I2)
+    # this next step is not required, just a demonstration how we can ensure that
+    # the Servicer and Debris differential equations are integrated simultaneously
+    scObject.syncDynamicsIntegration(scObject2)
 
     # make another debris object */
     scObject3 = spacecraft.Spacecraft()
@@ -237,9 +244,9 @@ def run(show_plots):
     scObject3.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I3)
 
     # add spacecraft object to the simulation process
-    scSim.AddModelToTask(simTaskName, scObject, None, 1)
-    scSim.AddModelToTask(simTaskName, scObject2, None, 2)
-    scSim.AddModelToTask(simTaskName, scObject3, None, 3)
+    scSim.AddModelToTask(simTaskName, scObject)
+    scSim.AddModelToTask(simTaskName, scObject2)
+    scSim.AddModelToTask(simTaskName, scObject3)
 
     # clear prior gravitational body and SPICE setup definitions
     gravFactory = simIncludeGravBody.gravBodyFactory()

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -52,6 +52,20 @@ in a 2:1 centered ellipse and a lead-follower configuration with the servicer re
 has a camera instrument attached that is pointing in the 3rd body axis direction.
 The servicer has a light attached to illuminate the debris object.
 
+By default, every :ref:`spacecraft` module instance will integrate its differential equations, and that of
+all the associated state and dynamics effectors, during the module ``Update()`` method.  Thus, the
+second spacecraft ODEs are integrated forward one time step after the first spacecraft, and so on.
+If you require
+both sets of spacecraft differential equations to be integrated at the same time, then the integration
+of the second spacecraft can be synchronized with the integration of the first spacecraft using::
+
+     scObject.syncDynamicsIntegration(scObject2)
+
+This is illustrated in this example script where the debris satellite integration is sync'd with that
+of the servicer satellite.  However, in this scenario this is not required as the ODEs of each spacecraft
+are independent of each other.  If an effector is used that is connected to both spacecraft, then this
+step will allow the effector force and torque evaluations to be properly applied to all sync'd objects.
+
 This simulation scripts illustrates how to use the :ref:`vizSupport` methods to record the simulation data such
 that it can be viewed in the Vizard visualization.
 

--- a/src/simulation/dynamics/Integrators/svIntegratorEuler.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorEuler.cpp
@@ -24,13 +24,10 @@
 
 svIntegratorEuler::svIntegratorEuler(DynamicObject* dyn) : StateVecIntegrator(dyn)
 {
-    
-    return;
 }
 
 svIntegratorEuler::~svIntegratorEuler()
 {
-    return;
 }
 
 /*!
@@ -41,23 +38,32 @@ svIntegratorEuler::~svIntegratorEuler()
  */
 void svIntegratorEuler::integrate(double currentTime, double timeStep)
 {
-	StateVector stateOut;
-	StateVector stateInit;
-	std::map<std::string, StateData>::iterator it;
-	std::map<std::string, StateData>::iterator itOut;
-	std::map<std::string, StateData>::iterator itInit;
-	stateOut = dynPtr->dynManager.getStateVector();
-	stateInit = dynPtr->dynManager.getStateVector();
-	dynPtr->equationsOfMotion(currentTime, timeStep);
-	for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-	{
-		itOut->second.setDerivative(it->second.getStateDeriv());
-		itOut->second.propagateState(timeStep);
-	}
+    std::vector<StateVector> stateOut;
+    std::vector<StateVector> stateInit;
+    std::map<std::string, StateData>::iterator it;
+    std::map<std::string, StateData>::iterator itOut;
+    std::map<std::string, StateData>::iterator itInit;
 
-	dynPtr->dynManager.updateStateVector(stateOut);	
+    for (auto dynPtr : this->dynPtrs) {
+        stateOut.push_back(dynPtr->dynManager.getStateVector());
+        stateInit.push_back(dynPtr->dynManager.getStateVector());
+        dynPtr->equationsOfMotion(currentTime, timeStep);
+    }
+    for (size_t i=0; i<dynPtrs.size(); i++) {
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(),
+             itOut = stateOut.at(i).stateMap.begin(),
+             itInit = stateInit.at(i).stateMap.begin();
+             it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end();
+             it++,
+             itOut++,
+             itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(timeStep);
+        }
+    }
 
-    return;
+    for (size_t i=0; i<dynPtrs.size(); i++) {
+        dynPtrs.at(i)->dynManager.updateStateVector(stateOut.at(i));
+    }
 }
-
-

--- a/src/simulation/dynamics/Integrators/svIntegratorEuler.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorEuler.cpp
@@ -44,7 +44,7 @@ void svIntegratorEuler::integrate(double currentTime, double timeStep)
     std::map<std::string, StateData>::iterator itOut;
     std::map<std::string, StateData>::iterator itInit;
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         stateOut.push_back(dynPtr->dynManager.getStateVector());
         stateInit.push_back(dynPtr->dynManager.getStateVector());
         dynPtr->equationsOfMotion(currentTime, timeStep);

--- a/src/simulation/dynamics/Integrators/svIntegratorRK2.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRK2.cpp
@@ -24,13 +24,10 @@
 
 svIntegratorRK2::svIntegratorRK2(DynamicObject* dyn) : StateVecIntegrator(dyn)
 {
-    
-    return;
 }
 
 svIntegratorRK2::~svIntegratorRK2()
 {
-    return;
 }
 
 /*<!
@@ -39,31 +36,50 @@ svIntegratorRK2::~svIntegratorRK2()
  */
 void svIntegratorRK2::integrate(double currentTime, double timeStep)
 {
-	StateVector stateOut;
-	StateVector stateInit;
-	std::map<std::string, StateData>::iterator it;
-	std::map<std::string, StateData>::iterator itOut;
-	std::map<std::string, StateData>::iterator itInit;
-	stateOut = dynPtr->dynManager.getStateVector();
-	stateInit = dynPtr->dynManager.getStateVector();
-    dynPtr->equationsOfMotion(currentTime, timeStep);
-    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-    {
-        itOut->second.setDerivative(it->second.getStateDeriv());
-        itOut->second.propagateState(timeStep / 2.0);
-        it->second.state = itInit->second.state + timeStep*it->second.stateDeriv;
+    std::vector<StateVector> stateOut;
+    std::vector<StateVector> stateInit;
+    std::map<std::string, StateData>::iterator it;
+    std::map<std::string, StateData>::iterator itOut;
+    std::map<std::string, StateData>::iterator itInit;
+
+    for (auto dynPtr : dynPtrs) {
+        stateOut.push_back(dynPtr->dynManager.getStateVector());
+        stateInit.push_back(dynPtr->dynManager.getStateVector());
+        dynPtr->equationsOfMotion(currentTime, timeStep);
+    }
+    for (size_t i=0; i<dynPtrs.size(); i++) {
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(),
+             itOut = stateOut.at(i).stateMap.begin(),
+             itInit = stateInit.at(i).stateMap.begin();
+             it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end();
+             it++,
+             itOut++,
+             itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(timeStep / 2.0);
+            it->second.state = itInit->second.state + timeStep*it->second.stateDeriv;
+        }
+    }
+    
+    for (auto dynPtr : dynPtrs) {
+        dynPtr->equationsOfMotion(currentTime + timeStep, timeStep);
+    }
+    for (size_t i=0; i<dynPtrs.size(); i++) {
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(),
+             itOut = stateOut.at(i).stateMap.begin(),
+             itInit = stateInit.at(i).stateMap.begin();
+             it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end();
+             it++,
+             itOut++,
+             itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(timeStep / 2.0);
+        }
     }
 
-    dynPtr->equationsOfMotion(currentTime + timeStep, timeStep);
-    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-    {
-        itOut->second.setDerivative(it->second.getStateDeriv());
-        itOut->second.propagateState(timeStep / 2.0);
+    for (size_t i=0; i<dynPtrs.size(); i++) {
+        dynPtrs.at(i)->dynManager.updateStateVector(stateOut.at(i));
     }
-
-	dynPtr->dynManager.updateStateVector(stateOut);	
-
-    return;
 }
-
-

--- a/src/simulation/dynamics/Integrators/svIntegratorRK2.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRK2.cpp
@@ -42,7 +42,7 @@ void svIntegratorRK2::integrate(double currentTime, double timeStep)
     std::map<std::string, StateData>::iterator itOut;
     std::map<std::string, StateData>::iterator itInit;
 
-    for (auto dynPtr : dynPtrs) {
+    for (const auto& dynPtr : dynPtrs) {
         stateOut.push_back(dynPtr->dynManager.getStateVector());
         stateInit.push_back(dynPtr->dynManager.getStateVector());
         dynPtr->equationsOfMotion(currentTime, timeStep);
@@ -62,7 +62,7 @@ void svIntegratorRK2::integrate(double currentTime, double timeStep)
         }
     }
     
-    for (auto dynPtr : dynPtrs) {
+    for (const auto& dynPtr : dynPtrs) {
         dynPtr->equationsOfMotion(currentTime + timeStep, timeStep);
     }
     for (size_t i=0; i<dynPtrs.size(); i++) {

--- a/src/simulation/dynamics/Integrators/svIntegratorRKF45.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRKF45.cpp
@@ -90,7 +90,7 @@ void svIntegratorRKF45::integrate(double currentTime, double timeStep)
     std::map<std::string, StateData>::iterator itkMatrix;
     std::map<std::string, StateData>::iterator itError;
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         stateOut.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
         stateInit.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
         errorMatrix.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables

--- a/src/simulation/dynamics/Integrators/svIntegratorRKF45.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRKF45.cpp
@@ -88,18 +88,22 @@ svIntegratorRKF45::~svIntegratorRKF45()
  */
 void svIntegratorRKF45::integrate(double currentTime, double timeStep)
 {
-	StateVector stateOut;  // output state vector
-	StateVector stateInit;  // initial state vector
-    StateVector errorMatrix;  // error state vector
-    std::vector<StateVector> kMatrix;  // matrix of k coefficients
+    std::vector<StateVector> stateOut;
+    std::vector<StateVector> stateInit;
+    std::vector<StateVector> errorMatrix;  // error state vector
+    std::vector<std::vector<StateVector>> kMatrix;  // matrix of k coefficients
 	std::map<std::string, StateData>::iterator it;
 	std::map<std::string, StateData>::iterator itOut;
 	std::map<std::string, StateData>::iterator itInit;
     std::map<std::string, StateData>::iterator itkMatrix;
     std::map<std::string, StateData>::iterator itError;
-	stateOut = dynPtr->dynManager.getStateVector();  // copy current state variables
-	stateInit = dynPtr->dynManager.getStateVector();  // copy current state variables
-    errorMatrix = dynPtr->dynManager.getStateVector();  // copy current state variables
+
+    for (auto dynPtr : this->dynPtrs) {
+        stateOut.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
+        stateInit.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
+        errorMatrix.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
+    }
+    kMatrix.resize(this->dynPtrs.size());
     double h = timeStep;  // updated variable time step that depends on the relative error and the relative tolerance
     double t = currentTime;  // integration time
     double hInt = timeStep;  // time step used for the current integration loop
@@ -121,70 +125,87 @@ void svIntegratorRKF45::integrate(double currentTime, double timeStep)
             // Reset the time step for integration
             hInt = h;
 
-            // Reset the k matrix
-            kMatrix.clear();
+            // loop over all the dynamic object elements
+            for (int c = 0; c < this->dynPtrs.size(); c++) {
+                // Reset the k matrix
+                kMatrix.at(c).clear();
 
-            // Compute the equations of motion for t
-            dynPtr->equationsOfMotion(t, hInt);
-
-            // Reset the ouput and error vectors
-            for (itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(), itError = errorMatrix.stateMap.begin(); itOut != stateOut.stateMap.end(); itOut++, itInit++, itError++)
-            {
-                itOut->second.state = itInit->second.state;
-                itError->second.state.setZero();
+                // Compute the equations of motion for t
+                dynPtrs.at(c)->equationsOfMotion(t, hInt);
+            }
+            for (int c = 0; c < this->dynPtrs.size(); c++) {
+                // Reset the ouput and error vectors
+                for (itOut = stateOut.at(c).stateMap.begin(),
+                     itInit = stateInit.at(c).stateMap.begin(),
+                     itError = errorMatrix.at(c).stateMap.begin();
+                     itOut != stateOut.at(c).stateMap.end();
+                     itOut++,
+                     itInit++,
+                     itError++)
+                {
+                    itOut->second.state = itInit->second.state;
+                    itError->second.state.setZero();
+                }
             }
 
             // Loop through all 6 coefficients (k1 through k6)
             for (uint64_t i = 0; i < 6; i++)
             {
-                // Initialize the state iterators. The state variables are defined in a dictionary and are pulled and populated one by one
-                for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itInit++)
-                {
-                    it->second.state = itInit->second.state;
-                }
-
-                // Loop through the B matrix coefficients that define the point of integration
-                for (uint64_t j = 0; j < i; j++)
-                {
-                    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = kMatrix[j].stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++)
+                for (int c = 0; c < this->dynPtrs.size(); c++) {
+                    // Initialize the state iterators. The state variables are defined in a dictionary and are pulled and populated one by one
+                    for (it = dynPtrs.at(c)->dynManager.stateContainer.stateMap.begin(), itInit = stateInit.at(c).stateMap.begin(); it != dynPtrs.at(c)->dynManager.stateContainer.stateMap.end(); it++, itInit++)
                     {
-                        it->second.state = it->second.state + hInt * betaMatrix[i][j] * itOut->second.stateDeriv;
+                        it->second.state = itInit->second.state;
+                    }
+
+                    // Loop through the B matrix coefficients that define the point of integration
+                    for (uint64_t j = 0; j < i; j++)
+                    {
+                        for (it = dynPtrs.at(c)->dynManager.stateContainer.stateMap.begin(), itOut = kMatrix.at(c)[j].stateMap.begin(); it != dynPtrs.at(c)->dynManager.stateContainer.stateMap.end(); it++, itOut++)
+                        {
+                            it->second.state = it->second.state + hInt * betaMatrix[i][j] * itOut->second.stateDeriv;
+                        }
                     }
                 }
+                for (int c = 0; c < this->dynPtrs.size(); c++) {
 
-                // Integrate with the appropriate time step using the A matrix coefficients
-                dynPtr->equationsOfMotion(t + hInt * alphaMatrix[i], hInt);
+                    // Integrate with the appropriate time step using the A matrix coefficients
+                    dynPtrs.at(c)->equationsOfMotion(t + hInt * alphaMatrix[i], hInt);
 
-                // Save the current k coefficient
-                kMatrix.push_back(dynPtr->dynManager.getStateVector());
-
-                // Update the state at the end of the current integration step
-                for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++)
-                {
-                    itOut->second.state += hInt * chMatrix[i] * it->second.stateDeriv;
+                    // Save the current k coefficient
+                    kMatrix.at(c).push_back(dynPtrs.at(c)->dynManager.getStateVector());
                 }
+                for (int c = 0; c < this->dynPtrs.size(); c++) {
+                    // Update the state at the end of the current integration step
+                    for (it = dynPtrs.at(c)->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.at(c).stateMap.begin(); it != dynPtrs.at(c)->dynManager.stateContainer.stateMap.end(); it++, itOut++)
+                    {
+                        itOut->second.state += hInt * chMatrix[i] * it->second.stateDeriv;
+                    }
 
-                // Update the current error vector
-                for (itkMatrix = kMatrix[i].stateMap.begin(), itError = errorMatrix.stateMap.begin(); itkMatrix != kMatrix[i].stateMap.end(); itkMatrix++, itError++)
-                {
-                    // Update the error vector with the appropriate coefficients
-                    itError->second.state += hInt * ctMatrix[i] * itkMatrix->second.stateDeriv;
+                    // Update the current error vector
+                    for (itkMatrix = kMatrix.at(c)[i].stateMap.begin(), itError = errorMatrix.at(c).stateMap.begin(); itkMatrix != kMatrix.at(c)[i].stateMap.end(); itkMatrix++, itError++)
+                    {
+                        // Update the error vector with the appropriate coefficients
+                        itError->second.state += hInt * ctMatrix[i] * itkMatrix->second.stateDeriv;
+                    }
                 }
             }
 
-            // Calculate the relative error. The error is calculated using the norm of each state variable
-            for (it = stateOut.stateMap.begin(), itError = errorMatrix.stateMap.begin(); it != stateOut.stateMap.end(); it++, itError++)
-            {
-                // Check if the norm is smaller than the absolute tolerance. If it is, calculate the error relative to the absolute tolerance instead
-                if (it->second.state.norm() < this->absTol)
-                    relError = itError->second.state.norm() / this->absTol;
-                else {
-                    relError = itError->second.state.norm() / it->second.state.norm();
-                }
-                
-                // Save the maximum relative error to use on the time step refinement
-                if (maxRelError < relError) {
-                    maxRelError = relError;
+            for (int c = 0; c < this->dynPtrs.size(); c++) {
+                // Calculate the relative error. The error is calculated using the norm of each state variable
+                for (it = stateOut.at(c).stateMap.begin(), itError = errorMatrix.at(c).stateMap.begin(); it != stateOut.at(c).stateMap.end(); it++, itError++)
+                {
+                    // Check if the norm is smaller than the absolute tolerance. If it is, calculate the error relative to the absolute tolerance instead
+                    if (it->second.state.norm() < this->absTol)
+                        relError = itError->second.state.norm() / this->absTol;
+                    else {
+                        relError = itError->second.state.norm() / it->second.state.norm();
+                    }
+
+                    // Save the maximum relative error to use on the time step refinement
+                    if (maxRelError < relError) {
+                        maxRelError = relError;
+                    }
                 }
             }
 
@@ -192,12 +213,13 @@ void svIntegratorRKF45::integrate(double currentTime, double timeStep)
             h *= scaleFactor * pow(this->relTol / maxRelError, 0.2);
         }
 
-        // Update the entire state vector after integration
-        dynPtr->dynManager.updateStateVector(stateOut);
+        for (int c = 0; c < this->dynPtrs.size(); c++) {
+            // Update the entire state vector after integration
+            dynPtrs.at(c)->dynManager.updateStateVector(stateOut.at(c));
 
-        // Update the initial state
-        stateInit = dynPtr->dynManager.getStateVector();
-
+            // Update the initial state
+            stateInit.at(c) = dynPtrs.at(c)->dynManager.getStateVector();
+        }
         // Update the time
         t += hInt;
 

--- a/src/simulation/dynamics/Integrators/svIntegratorRKF45.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRKF45.cpp
@@ -20,13 +20,8 @@
 
 #include "svIntegratorRKF45.h"
 #include "../_GeneralModuleFiles/dynamicObject.h"
-#include <stdio.h>
-#include <iostream>
-#include <Eigen/Dense>
 #include <vector>
 
-using namespace Eigen;
-using namespace std;
 
 svIntegratorRKF45::svIntegratorRKF45(DynamicObject* dyn) : StateVecIntegrator(dyn)
 {
@@ -73,13 +68,10 @@ svIntegratorRKF45::svIntegratorRKF45(DynamicObject* dyn) : StateVecIntegrator(dy
     // Set the default values for absolute and relative tolerance
     this->absTol = 1e-8;
     this->relTol = 1e-4;
-    
-    return;
 }
 
 svIntegratorRKF45::~svIntegratorRKF45()
 {
-    return;
 }
 
 /*<!
@@ -228,6 +220,4 @@ void svIntegratorRKF45::integrate(double currentTime, double timeStep)
             h = currentTime + timeStep - t;
         }
     }
-    
-    return;
 }

--- a/src/simulation/dynamics/Integrators/svIntegratorRKF78.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRKF78.cpp
@@ -135,7 +135,7 @@ void svIntegratorRKF78::integrate(double currentTime, double timeStep)
     std::map<std::string, StateData>::iterator itkMatrix;
     std::map<std::string, StateData>::iterator itError;
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         stateOut.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
         stateInit.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
         errorMatrix.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables

--- a/src/simulation/dynamics/Integrators/svIntegratorRKF78.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRKF78.cpp
@@ -20,7 +20,7 @@
 
 #include "svIntegratorRKF78.h"
 #include "../_GeneralModuleFiles/dynamicObject.h"
-#include <stdio.h>
+
 
 svIntegratorRKF78::svIntegratorRKF78(DynamicObject* dyn) : StateVecIntegrator(dyn)
 {
@@ -114,12 +114,10 @@ svIntegratorRKF78::svIntegratorRKF78(DynamicObject* dyn) : StateVecIntegrator(dy
     this->absTol = 1e-8;
     this->relTol = 1e-4;
     
-    return;
 }
 
 svIntegratorRKF78::~svIntegratorRKF78()
 {
-    return;
 }
 
 
@@ -128,18 +126,22 @@ svIntegratorRKF78::~svIntegratorRKF78()
  */
 void svIntegratorRKF78::integrate(double currentTime, double timeStep)
 {
-    StateVector stateOut;  // output state vector
-    StateVector stateInit;  // initial state vector
-    StateVector errorMatrix;  // error state vector
-    std::vector<StateVector> kMatrix;  // matrix of k coefficients
+    std::vector<StateVector> stateOut;
+    std::vector<StateVector> stateInit;
+    std::vector<StateVector> errorMatrix;  // error state vector
+    std::vector<std::vector<StateVector>> kMatrix;  // matrix of k coefficients
     std::map<std::string, StateData>::iterator it;
     std::map<std::string, StateData>::iterator itOut;
     std::map<std::string, StateData>::iterator itInit;
     std::map<std::string, StateData>::iterator itkMatrix;
     std::map<std::string, StateData>::iterator itError;
-    stateOut = dynPtr->dynManager.getStateVector();  // copy current state variables
-    stateInit = dynPtr->dynManager.getStateVector();  // copy current state variables
-    errorMatrix = dynPtr->dynManager.getStateVector();  // copy current state variables
+
+    for (auto dynPtr : this->dynPtrs) {
+        stateOut.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
+        stateInit.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
+        errorMatrix.push_back(dynPtr->dynManager.getStateVector());  // copy current state variables
+    }
+    kMatrix.resize(this->dynPtrs.size());
     double h = timeStep;  // updated variable time step that depends on the relative error and the relative tolerance
     double t = currentTime;  // integration time
     double hInt = timeStep;  // time step used for the current integration loop
@@ -161,70 +163,87 @@ void svIntegratorRKF78::integrate(double currentTime, double timeStep)
             // Reset the time step for integration
             hInt = h;
 
-            // Reset the k matrix
-            kMatrix.clear();
+            // loop over all the dynamic object elements
+            for (int c = 0; c < this->dynPtrs.size(); c++) {
+                // Reset the k matrix
+                kMatrix.at(c).clear();
 
-            // Compute the equations of motion for t
-            dynPtr->equationsOfMotion(t, hInt);
-
-            // Reset the ouput and error vectors
-            for (itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(), itError = errorMatrix.stateMap.begin(); itOut != stateOut.stateMap.end(); itOut++, itInit++, itError++)
-            {
-                itOut->second.state = itInit->second.state;
-                itError->second.state.setZero();
+                // Compute the equations of motion for t
+                dynPtrs.at(c)->equationsOfMotion(t, hInt);
+            }
+            for (int c = 0; c < this->dynPtrs.size(); c++) {
+                // Reset the ouput and error vectors
+                for (itOut = stateOut.at(c).stateMap.begin(),
+                     itInit = stateInit.at(c).stateMap.begin(),
+                     itError = errorMatrix.at(c).stateMap.begin();
+                     itOut != stateOut.at(c).stateMap.end();
+                     itOut++,
+                     itInit++,
+                     itError++)
+                {
+                    itOut->second.state = itInit->second.state;
+                    itError->second.state.setZero();
+                }
             }
 
             // Loop through all 13 coefficients (k1 through k13)
             for (uint64_t i = 0; i < 13; i++)
             {
-                // Initialize the state iterators. The state variables are defined in a dictionary and are pulled and populated one by one
-                for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itInit++)
-                {
-                    it->second.state = itInit->second.state;
-                }
-
-                // Loop through the B matrix coefficients that define the point of integration
-                for (uint64_t j = 0; j < i; j++)
-                {
-                    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = kMatrix[j].stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++)
+                for (int c = 0; c < this->dynPtrs.size(); c++) {
+                    // Initialize the state iterators. The state variables are defined in a dictionary and are pulled and populated one by one
+                    for (it = dynPtrs.at(c)->dynManager.stateContainer.stateMap.begin(), itInit = stateInit.at(c).stateMap.begin(); it != dynPtrs.at(c)->dynManager.stateContainer.stateMap.end(); it++, itInit++)
                     {
-                        it->second.state = it->second.state + hInt * betaMatrix[i][j] * itOut->second.stateDeriv;
+                        it->second.state = itInit->second.state;
+                    }
+
+                    // Loop through the B matrix coefficients that define the point of integration
+                    for (uint64_t j = 0; j < i; j++)
+                    {
+                        for (it = dynPtrs.at(c)->dynManager.stateContainer.stateMap.begin(), itOut = kMatrix.at(c)[j].stateMap.begin(); it != dynPtrs.at(c)->dynManager.stateContainer.stateMap.end(); it++, itOut++)
+                        {
+                            it->second.state = it->second.state + hInt * betaMatrix[i][j] * itOut->second.stateDeriv;
+                        }
                     }
                 }
+                for (int c = 0; c < this->dynPtrs.size(); c++) {
 
-                // Integrate with the appropriate time step using the A matrix coefficients
-                dynPtr->equationsOfMotion(t + hInt * alphaMatrix[i], hInt);
+                    // Integrate with the appropriate time step using the A matrix coefficients
+                    dynPtrs.at(c)->equationsOfMotion(t + hInt * alphaMatrix[i], hInt);
 
-                // Save the current k coefficient
-                kMatrix.push_back(dynPtr->dynManager.getStateVector());
-
-                // Update the state at the end of the current integration step
-                for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++)
-                {
-                    itOut->second.state += hInt * chMatrix[i] * it->second.stateDeriv;
+                    // Save the current k coefficient
+                    kMatrix.at(c).push_back(dynPtrs.at(c)->dynManager.getStateVector());
                 }
+                for (int c = 0; c < this->dynPtrs.size(); c++) {
+                    // Update the state at the end of the current integration step
+                    for (it = dynPtrs.at(c)->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.at(c).stateMap.begin(); it != dynPtrs.at(c)->dynManager.stateContainer.stateMap.end(); it++, itOut++)
+                    {
+                        itOut->second.state += hInt * chMatrix[i] * it->second.stateDeriv;
+                    }
 
-                // Update the current error vector
-                for (itkMatrix = kMatrix[i].stateMap.begin(), itError = errorMatrix.stateMap.begin(); itkMatrix != kMatrix[i].stateMap.end(); itkMatrix++, itError++)
-                {
-                    // Update the error vector with the appropriate coefficients
-                    itError->second.state += hInt * ctMatrix[i] * itkMatrix->second.stateDeriv;
+                    // Update the current error vector
+                    for (itkMatrix = kMatrix.at(c)[i].stateMap.begin(), itError = errorMatrix.at(c).stateMap.begin(); itkMatrix != kMatrix.at(c)[i].stateMap.end(); itkMatrix++, itError++)
+                    {
+                        // Update the error vector with the appropriate coefficients
+                        itError->second.state += hInt * ctMatrix[i] * itkMatrix->second.stateDeriv;
+                    }
                 }
             }
 
-            // Calculate the relative error. The error is calculated using the norm of each state variable
-            for (it = stateOut.stateMap.begin(), itError = errorMatrix.stateMap.begin(); it != stateOut.stateMap.end(); it++, itError++)
-            {
-                // Check if the norm is smaller than the absolute tolerance. If it is, calculate the error relative to the absolute tolerance instead
-                if (it->second.state.norm() < this->absTol)
-                    relError = itError->second.state.norm() / this->absTol;
-                else {
-                    relError = itError->second.state.norm() / it->second.state.norm();
-                }
+            for (int c = 0; c < this->dynPtrs.size(); c++) {
+                // Calculate the relative error. The error is calculated using the norm of each state variable
+                for (it = stateOut.at(c).stateMap.begin(), itError = errorMatrix.at(c).stateMap.begin(); it != stateOut.at(c).stateMap.end(); it++, itError++)
+                {
+                    // Check if the norm is smaller than the absolute tolerance. If it is, calculate the error relative to the absolute tolerance instead
+                    if (it->second.state.norm() < this->absTol)
+                        relError = itError->second.state.norm() / this->absTol;
+                    else {
+                        relError = itError->second.state.norm() / it->second.state.norm();
+                    }
 
-                // Save the maximum relative error to use on the time step refinement
-                if (maxRelError < relError) {
-                    maxRelError = relError;
+                    // Save the maximum relative error to use on the time step refinement
+                    if (maxRelError < relError) {
+                        maxRelError = relError;
+                    }
                 }
             }
 
@@ -232,12 +251,13 @@ void svIntegratorRKF78::integrate(double currentTime, double timeStep)
             h *= scaleFactor * pow(this->relTol / maxRelError, 0.2);
         }
 
-        // Update the entire state vector after integration
-        dynPtr->dynManager.updateStateVector(stateOut);
+        for (int c = 0; c < this->dynPtrs.size(); c++) {
+            // Update the entire state vector after integration
+            dynPtrs.at(c)->dynManager.updateStateVector(stateOut.at(c));
 
-        // Update the initial state
-        stateInit = dynPtr->dynManager.getStateVector();
-
+            // Update the initial state
+            stateInit.at(c) = dynPtrs.at(c)->dynManager.getStateVector();
+        }
         // Update the time
         t += hInt;
 

--- a/src/simulation/dynamics/Integrators/svIntegratorRKF78.cpp
+++ b/src/simulation/dynamics/Integrators/svIntegratorRKF78.cpp
@@ -113,7 +113,6 @@ svIntegratorRKF78::svIntegratorRKF78(DynamicObject* dyn) : StateVecIntegrator(dy
     // Set the default values for absolute and relative tolerance
     this->absTol = 1e-8;
     this->relTol = 1e-4;
-    
 }
 
 svIntegratorRKF78::~svIntegratorRKF78()
@@ -266,6 +265,4 @@ void svIntegratorRKF78::integrate(double currentTime, double timeStep)
             h = currentTime + timeStep - t;
         }
     }
-
-    return;
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -62,3 +62,23 @@ void DynamicObject::syncDynamicsIntegration(DynamicObject *dynPtr)
     this->integrator->dynPtrs.push_back(dynPtr);
     dynPtr->isDynamicsSynced = true;
 }
+
+/*! This method is used to prepare the dynamic object to be integrate, integrate the states forward in time, and
+    finally perform the post-integration steps */
+void DynamicObject::integrateState(double integrateToThisTime)
+{
+    if (!this->isDynamicsSynced) {
+
+        int i;      // dynamic Object counter
+        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+            this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
+        }
+
+        this->integrator->integrate(this->timeBefore, this->localTimeStep);
+
+        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+            this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
+        }
+    }
+}
+

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -53,3 +53,12 @@ void DynamicObject::setIntegrator(StateVecIntegrator *newIntegrator)
 
     return;
 }
+
+
+/*! This method is used to connect the integration of another DynamicObject
+    to the integration of this spacecraft module */
+void DynamicObject::syncDynamicsIntegration(DynamicObject *dynPtr)
+{
+    this->integrator->dynPtrs.push_back(dynPtr);
+    dynPtr->isDynamicsSynced = true;
+}

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -70,13 +70,13 @@ void DynamicObject::integrateState(double integrateToThisTime)
 {
     if (this->isDynamicsSynced) return;
 
-    for (auto dynPtr : this->integrator->dynPtrs) {
+    for (const auto& dynPtr : this->integrator->dynPtrs) {
         dynPtr->preIntegration(integrateToThisTime);
     }
 
     this->integrator->integrate(this->timeBefore, this->timeStep);
 
-    for (auto dynPtr : this->integrator->dynPtrs) {
+    for (const auto& dynPtr : this->integrator->dynPtrs) {
         dynPtr->postIntegration(integrateToThisTime);
     }
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -56,7 +56,7 @@ void DynamicObject::setIntegrator(StateVecIntegrator *newIntegrator)
 
 
 /*! This method is used to connect the integration of another DynamicObject
-    to the integration of this spacecraft module */
+    to the integration of this DynamicObject */
 void DynamicObject::syncDynamicsIntegration(DynamicObject *dynPtr)
 {
     this->integrator->dynPtrs.push_back(dynPtr);
@@ -64,21 +64,19 @@ void DynamicObject::syncDynamicsIntegration(DynamicObject *dynPtr)
 }
 
 /*! This method is used to prepare the dynamic object to be integrate, integrate the states forward in time, and
-    finally perform the post-integration steps */
+    finally perform the post-integration steps.  This is only done if the DynamicObject integration is
+    not sync'd to another DynamicObject */
 void DynamicObject::integrateState(double integrateToThisTime)
 {
-    if (!this->isDynamicsSynced) {
+    if (this->isDynamicsSynced) return;
 
-        int i;      // dynamic Object counter
-        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-            this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
-        }
+    for (auto dynPtr : this->integrator->dynPtrs) {
+        dynPtr->preIntegration(integrateToThisTime);
+    }
 
-        this->integrator->integrate(this->timeBefore, this->localTimeStep);
+    this->integrator->integrate(this->timeBefore, this->timeStep);
 
-        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-            this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
-        }
+    for (auto dynPtr : this->integrator->dynPtrs) {
+        dynPtr->postIntegration(integrateToThisTime);
     }
 }
-

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -47,6 +47,7 @@ public:
     void setIntegrator(StateVecIntegrator *newIntegrator);  //!< -- Sets a new integrator
     virtual void preIntegration(double callTime) = 0;       //!< -- method to perform pre-integration steps
     virtual void postIntegration(double callTime) = 0;      //!< -- method to perform post-integration steps
+    bool isDynamicsSynced = false;                    //!< flag indicating that another spacecraft object is controlling the integration
 };
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -45,6 +45,8 @@ public:
     virtual void equationsOfMotion(double t, double timeStep) = 0;     //!< -- This is computing F = Xdot(X,t)
     virtual void integrateState(double t) = 0;        //!< -- This method steps the state forward in time
     void setIntegrator(StateVecIntegrator *newIntegrator);  //!< -- Sets a new integrator
+    virtual void preIntegration(double callTime) = 0;       //!< -- method to perform pre-integration steps
+    virtual void postIntegration(double callTime) = 0;      //!< -- method to perform post-integration steps
 };
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -47,6 +47,7 @@ public:
     void setIntegrator(StateVecIntegrator *newIntegrator);  //!< -- Sets a new integrator
     virtual void preIntegration(double callTime) = 0;       //!< -- method to perform pre-integration steps
     virtual void postIntegration(double callTime) = 0;      //!< -- method to perform post-integration steps
+    void syncDynamicsIntegration(DynamicObject *dynPtr);    //!< add another DynamicObject to be intregated simultaneously
     bool isDynamicsSynced = false;                    //!< flag indicating that another spacecraft object is controlling the integration
 };
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -43,12 +43,15 @@ public:
     virtual void computeEnergyMomentum(double t);     //!< -- Method to compute energy and momentum of the system
     virtual void UpdateState(uint64_t callTime) = 0;  //!< -- This hooks the dyn-object into Basilisk architecture
     virtual void equationsOfMotion(double t, double timeStep) = 0;     //!< -- This is computing F = Xdot(X,t)
-    virtual void integrateState(double t) = 0;        //!< -- This method steps the state forward in time
+    void integrateState(double t);                    //!< -- This method steps the state forward in time
     void setIntegrator(StateVecIntegrator *newIntegrator);  //!< -- Sets a new integrator
     virtual void preIntegration(double callTime) = 0;       //!< -- method to perform pre-integration steps
     virtual void postIntegration(double callTime) = 0;      //!< -- method to perform post-integration steps
     void syncDynamicsIntegration(DynamicObject *dynPtr);    //!< add another DynamicObject to be intregated simultaneously
     bool isDynamicsSynced = false;                    //!< flag indicating that another spacecraft object is controlling the integration
+    double localTimeStep;                             //!< [s] integration time step
+    double timeBefore;                                //!< [s] prior time value
+
 };
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -49,7 +49,7 @@ public:
     virtual void postIntegration(double callTime) = 0;      //!< -- method to perform post-integration steps
     void syncDynamicsIntegration(DynamicObject *dynPtr);    //!< add another DynamicObject to be intregated simultaneously
     bool isDynamicsSynced = false;                    //!< flag indicating that another spacecraft object is controlling the integration
-    double localTimeStep;                             //!< [s] integration time step
+    double timeStep;                                  //!< [s] integration time step
     double timeBefore;                                //!< [s] prior time value
 
 };

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.cpp
@@ -23,7 +23,7 @@
 /*! @brief Constructor */
 StateVecIntegrator::StateVecIntegrator(DynamicObject* dyn)
 {
-    this->dynPtr = dyn;
+    this->dynPtrs.push_back(dyn);
     
     return;
 }
@@ -31,6 +31,6 @@ StateVecIntegrator::StateVecIntegrator(DynamicObject* dyn)
 /*! @brief Destructor */
 StateVecIntegrator::~StateVecIntegrator(void)
 {
-    this->dynPtr = nullptr;
+    this->dynPtrs.clear();
     return;
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.cpp
@@ -24,13 +24,10 @@
 StateVecIntegrator::StateVecIntegrator(DynamicObject* dyn)
 {
     this->dynPtrs.push_back(dyn);
-    
-    return;
 }
 
 /*! @brief Destructor */
 StateVecIntegrator::~StateVecIntegrator(void)
 {
     this->dynPtrs.clear();
-    return;
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.h
@@ -35,8 +35,6 @@ public:
     virtual void integrate(double currentTime, double timeStep) = 0; //!< class method
     std::vector<DynamicObject*> dynPtrs; //!< This is an object that contains the method equationsOfMotion(), also known as the F function.
 
-protected:
-    DynamicObject* dynPtr; //!< This is an object that contains the method equationsOfMotion(), also known as the F function.
 };
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateVecIntegrator.h
@@ -21,6 +21,7 @@
 #ifndef stateVecIntegrator_h
 #define stateVecIntegrator_h
 
+#include <vector>
 
 class DynamicObject;
 
@@ -32,7 +33,8 @@ public:
     StateVecIntegrator(DynamicObject* dynIn);
     virtual ~StateVecIntegrator(void);
     virtual void integrate(double currentTime, double timeStep) = 0; //!< class method
-    
+    std::vector<DynamicObject*> dynPtrs; //!< This is an object that contains the method equationsOfMotion(), also known as the F function.
+
 protected:
     DynamicObject* dynPtr; //!< This is an object that contains the method equationsOfMotion(), also known as the F function.
 };

--- a/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.cpp
@@ -35,47 +35,59 @@ svIntegratorRK4::~svIntegratorRK4()
 
 void svIntegratorRK4::integrate(double currentTime, double timeStep)
 {
-    StateVector stateOut;
-    StateVector stateInit;
+    std::vector<StateVector> stateOut;
+    std::vector<StateVector> stateInit;
     std::map<std::string, StateData>::iterator it;
     std::map<std::string, StateData>::iterator itOut;
     std::map<std::string, StateData>::iterator itInit;
-    stateOut = dynPtr->dynManager.getStateVector();
-    stateInit = dynPtr->dynManager.getStateVector();
-    dynPtr->equationsOfMotion(currentTime, timeStep);
-    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-    {
-        itOut->second.setDerivative(it->second.getStateDeriv());
-        itOut->second.propagateState(timeStep / 6.0);
-        it->second.state = itInit->second.state + 0.5*timeStep*it->second.stateDeriv;
+    int i;              // dynamic object loop counter
+
+    for (i=0; i<dynPtrs.size(); i++) {
+        stateOut.push_back(dynPtrs[i]->dynManager.getStateVector());
+        stateInit.push_back(dynPtrs[i]->dynManager.getStateVector());
+        dynPtrs[i]->equationsOfMotion(currentTime, timeStep);
+        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(timeStep / 6.0);
+            it->second.state = itInit->second.state + 0.5*timeStep*it->second.stateDeriv;
+        }
     }
 
-    dynPtr->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
-    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-    {
-        itOut->second.setDerivative(it->second.getStateDeriv());
-        itOut->second.propagateState(2.0*timeStep / 6.0);
-        it->second.state = itInit->second.state + 0.5*timeStep*it->second.stateDeriv;
+    for (i=0; i<dynPtrs.size(); i++) {
+        dynPtrs[i]->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
+        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(2.0*timeStep / 6.0);
+            it->second.state = itInit->second.state + 0.5*timeStep*it->second.stateDeriv;
+        }
     }
 
-    dynPtr->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
-    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-    {
-        itOut->second.setDerivative(it->second.getStateDeriv());
-        itOut->second.propagateState(2.0*timeStep / 6.0);
-        it->second.state = itInit->second.state + timeStep*it->second.stateDeriv;
+    for (i=0; i<dynPtrs.size(); i++) {
+        dynPtrs[i]->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
+        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(2.0*timeStep / 6.0);
+            it->second.state = itInit->second.state + timeStep*it->second.stateDeriv;
 
+        }
     }
 
-    dynPtr->equationsOfMotion(currentTime + timeStep, timeStep);
-    for (it = dynPtr->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.stateMap.begin(), itInit = stateInit.stateMap.begin(); it != dynPtr->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
-    {
-        itOut->second.setDerivative(it->second.getStateDeriv());
-        itOut->second.propagateState(timeStep / 6.0);
+    for (i=0; i<dynPtrs.size(); i++) {
+        dynPtrs[i]->equationsOfMotion(currentTime + timeStep, timeStep);
+        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        {
+            itOut->second.setDerivative(it->second.getStateDeriv());
+            itOut->second.propagateState(timeStep / 6.0);
 
+        }
     }
 
-    dynPtr->dynManager.updateStateVector(stateOut);	
+    for (i=0; i<dynPtrs.size(); i++) {
+        dynPtrs[i]->dynManager.updateStateVector(stateOut[i]);
+    }
 
     return;
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.cpp
@@ -24,13 +24,12 @@
 
 svIntegratorRK4::svIntegratorRK4(DynamicObject* dyn) : StateVecIntegrator(dyn)
 {
-    
-    return;
+
 }
 
 svIntegratorRK4::~svIntegratorRK4()
 {
-    return;
+
 }
 
 void svIntegratorRK4::integrate(double currentTime, double timeStep)
@@ -40,13 +39,15 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
     std::map<std::string, StateData>::iterator it;
     std::map<std::string, StateData>::iterator itOut;
     std::map<std::string, StateData>::iterator itInit;
-    int i;              // dynamic object loop counter
+    size_t i;              // dynamic object loop counter
 
+    for (auto dynPtr : this->dynPtrs) {
+        stateOut.push_back(dynPtr->dynManager.getStateVector());
+        stateInit.push_back(dynPtr->dynManager.getStateVector());
+        dynPtr->equationsOfMotion(currentTime, timeStep);
+    }
     for (i=0; i<dynPtrs.size(); i++) {
-        stateOut.push_back(dynPtrs[i]->dynManager.getStateVector());
-        stateInit.push_back(dynPtrs[i]->dynManager.getStateVector());
-        dynPtrs[i]->equationsOfMotion(currentTime, timeStep);
-        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.at(i).stateMap.begin(), itInit = stateInit.at(i).stateMap.begin(); it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
         {
             itOut->second.setDerivative(it->second.getStateDeriv());
             itOut->second.propagateState(timeStep / 6.0);
@@ -54,9 +55,11 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
         }
     }
 
+    for (auto dynPtr : this->dynPtrs) {
+        dynPtr->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
+    }
     for (i=0; i<dynPtrs.size(); i++) {
-        dynPtrs[i]->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
-        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.at(i).stateMap.begin(), itInit = stateInit.at(i).stateMap.begin(); it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
         {
             itOut->second.setDerivative(it->second.getStateDeriv());
             itOut->second.propagateState(2.0*timeStep / 6.0);
@@ -64,9 +67,11 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
         }
     }
 
+    for (auto dynPtr : this->dynPtrs) {
+        dynPtr->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
+    }
     for (i=0; i<dynPtrs.size(); i++) {
-        dynPtrs[i]->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
-        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.at(i).stateMap.begin(), itInit = stateInit.at(i).stateMap.begin(); it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
         {
             itOut->second.setDerivative(it->second.getStateDeriv());
             itOut->second.propagateState(2.0*timeStep / 6.0);
@@ -75,9 +80,11 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
         }
     }
 
+    for (auto dynPtr : this->dynPtrs) {
+        dynPtr->equationsOfMotion(currentTime + timeStep, timeStep);
+    }
     for (i=0; i<dynPtrs.size(); i++) {
-        dynPtrs[i]->equationsOfMotion(currentTime + timeStep, timeStep);
-        for (it = dynPtrs[i]->dynManager.stateContainer.stateMap.begin(), itOut = stateOut[i].stateMap.begin(), itInit = stateInit[i].stateMap.begin(); it != dynPtrs[i]->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
+        for (it = dynPtrs.at(i)->dynManager.stateContainer.stateMap.begin(), itOut = stateOut.at(i).stateMap.begin(), itInit = stateInit.at(i).stateMap.begin(); it != dynPtrs.at(i)->dynManager.stateContainer.stateMap.end(); it++, itOut++, itInit++)
         {
             itOut->second.setDerivative(it->second.getStateDeriv());
             itOut->second.propagateState(timeStep / 6.0);
@@ -86,7 +93,7 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
     }
 
     for (i=0; i<dynPtrs.size(); i++) {
-        dynPtrs[i]->dynManager.updateStateVector(stateOut[i]);
+        dynPtrs.at(i)->dynManager.updateStateVector(stateOut.at(i));
     }
 
     return;

--- a/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.cpp
@@ -41,7 +41,7 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
     std::map<std::string, StateData>::iterator itInit;
     size_t i;              // dynamic object loop counter
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         stateOut.push_back(dynPtr->dynManager.getStateVector());
         stateInit.push_back(dynPtr->dynManager.getStateVector());
         dynPtr->equationsOfMotion(currentTime, timeStep);
@@ -55,7 +55,7 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
         }
     }
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         dynPtr->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
     }
     for (i=0; i<dynPtrs.size(); i++) {
@@ -67,7 +67,7 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
         }
     }
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         dynPtr->equationsOfMotion(currentTime + timeStep * 0.5, timeStep);
     }
     for (i=0; i<dynPtrs.size(); i++) {
@@ -80,7 +80,7 @@ void svIntegratorRK4::integrate(double currentTime, double timeStep)
         }
     }
 
-    for (auto dynPtr : this->dynPtrs) {
+    for (const auto& dynPtr : this->dynPtrs) {
         dynPtr->equationsOfMotion(currentTime + timeStep, timeStep);
     }
     for (i=0; i<dynPtrs.size(); i++) {

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -460,12 +460,17 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
  calculate the accumulated deltaV */
 void Spacecraft::integrateState(double integrateToThisTime)
 {
+    int i;      // dynamic Object counter
 
-    this->preIntegration(integrateToThisTime);
+    for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+        this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
+    }
 
     this->integrator->integrate(this->timeBefore, this->localTimeStep);
-    
-    this->postIntegration(integrateToThisTime);
+
+    for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+        this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
+    }
 
 }
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -35,7 +35,6 @@ Spacecraft::Spacecraft()
     this->currTimeStep = 0.0;
     this->timePrevious = 0.0;
     this->simTimePrevious = 0;
-    this->numOutMsgBuffers = 2;
     this->dvAccum_CN_B.setZero();
     this->dvAccum_BN_B.setZero();
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -456,25 +456,6 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     return;
 }
 
-/*! This method is used to integrate the state forward in time, switch MRPs, calculate energy and momentum, and
- calculate the accumulated deltaV */
-void Spacecraft::integrateState(double integrateToThisTime)
-{
-    if (!this->isDynamicsSynced) {
-
-        int i;      // dynamic Object counter
-        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-            this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
-        }
-
-        this->integrator->integrate(this->timeBefore, this->localTimeStep);
-
-        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-            this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
-        }
-    }
-}
-
 /*! Prepare for integration process
  @param integrateToThisTime Time to integrate to
  */

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -460,18 +460,19 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
  calculate the accumulated deltaV */
 void Spacecraft::integrateState(double integrateToThisTime)
 {
-    int i;      // dynamic Object counter
+    if (!this->isDynamicsSynced) {
 
-    for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-        this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
+        int i;      // dynamic Object counter
+        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+            this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
+        }
+
+        this->integrator->integrate(this->timeBefore, this->localTimeStep);
+
+        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+            this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
+        }
     }
-
-    this->integrator->integrate(this->timeBefore, this->localTimeStep);
-
-    for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-        this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
-    }
-
 }
 
 /*! Prepare for integration process

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -45,7 +45,6 @@
 class Spacecraft : public DynamicObject{
 public:
     uint64_t simTimePrevious;            //!< -- Previous simulation time
-    uint64_t numOutMsgBuffers;           //!< -- Number of output message buffers for I/O
     std::string sysTimePropertyName;     //!< -- Name of the system time property
     ReadFunctor<AttRefMsgPayload> attRefInMsg; //!< -- (optional) reference attitude input message name
     ReadFunctor<TransRefMsgPayload> transRefInMsg; //!< -- (optional) reference translation input message name

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -90,6 +90,8 @@ public:
     void integrateState(double time);       //!< -- This method steps the state forward one step in time
     void addStateEffector(StateEffector *newSateEffector);  //!< -- Attaches a stateEffector to the system
     void addDynamicEffector(DynamicEffector *newDynamicEffector);  //!< -- Attaches a dynamicEffector
+    void preIntegration(double callTime);       //!< -- method to perform pre-integration steps
+    void postIntegration(double callTime);      //!< -- method to perform post-integration steps
 
 private:
     StateData *hubR_N;                          //!< -- State data accesss to inertial position for the hub
@@ -111,6 +113,10 @@ private:
     Eigen::MatrixXd *ISCPntBPrime_B;     //!< [kg m^2/s] Body time derivative of ISCPntB_B
     Eigen::MatrixXd *g_N;                //!< [m/s^2] Gravitational acceleration in N frame components
     Eigen::MatrixXd *sysTime;            //!< [s] System time
+
+    double localTimeStep;                //!< [s] integration time step
+    double timeBefore;                   //!< [s] prior time value
+    Eigen::Vector3d oldOmega_BN_B;       //!< [r/s] prior angular rate of B wrt N in the Body frame
 
 private:
     void readOptionalRefMsg();                  //!< -- Read the optional attitude or translational reference input message and set the reference states

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -86,11 +86,10 @@ public:
     void UpdateState(uint64_t CurrentSimNanos);  //!< -- Runtime hook back into Basilisk arch
     void linkInStates(DynParamManager& statesIn);  //!< Method to get access to the hub's states
     void equationsOfMotion(double integTimeSeconds, double timeStep);    //!< -- This method computes the equations of motion for the whole system
-    void integrateState(double time);       //!< -- This method steps the state forward one step in time
     void addStateEffector(StateEffector *newSateEffector);  //!< -- Attaches a stateEffector to the system
     void addDynamicEffector(DynamicEffector *newDynamicEffector);  //!< -- Attaches a dynamicEffector
-    void preIntegration(double callTime);       //!< -- method to perform pre-integration steps
-    void postIntegration(double callTime);      //!< -- method to perform post-integration steps
+    void preIntegration(double callTime) final;       //!< -- method to perform pre-integration steps
+    void postIntegration(double callTime) final;      //!< -- method to perform post-integration steps
 
 private:
     StateData *hubR_N;                          //!< -- State data accesss to inertial position for the hub
@@ -113,8 +112,6 @@ private:
     Eigen::MatrixXd *g_N;                //!< [m/s^2] Gravitational acceleration in N frame components
     Eigen::MatrixXd *sysTime;            //!< [s] System time
 
-    double localTimeStep;                //!< [s] integration time step
-    double timeBefore;                   //!< [s] prior time value
     Eigen::Vector3d oldOmega_BN_B;       //!< [r/s] prior angular rate of B wrt N in the Body frame
 
 private:

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -1216,7 +1216,7 @@ void SpacecraftSystem::computeEnergyMomentumSystem(double time)
 void SpacecraftSystem::preIntegration(double integrateToThisTime) {
 
     // - Find the time step
-    this->localTimeStep = integrateToThisTime - this->timePrevious;
+    this->timeStep = integrateToThisTime - this->timePrevious;
 
     this->findPriorStateInformation(this->primaryCentralSpacecraft);
 
@@ -1228,7 +1228,7 @@ void SpacecraftSystem::preIntegration(double integrateToThisTime) {
     }
 
     // - Integrate the state from the last time (timeBefore) to the integrateToThisTime
-    this->timeBefore = integrateToThisTime - this->localTimeStep;
+    this->timeBefore = integrateToThisTime - this->timeStep;
 
 }
 
@@ -1296,12 +1296,12 @@ void SpacecraftSystem::postIntegration(double integrateToThisTime) {
         this->updateSpacecraftMassProps(integrateToThisTime, (*(*spacecraftUnConnectedIt)));
     }
 
-    this->calculateDeltaVandAcceleration(this->primaryCentralSpacecraft, this->localTimeStep);
+    this->calculateDeltaVandAcceleration(this->primaryCentralSpacecraft, this->timeStep);
 
     // - Call for the rest of the spacecraft
     for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
     {
-        this->calculateDeltaVandAcceleration((*(*spacecraftUnConnectedIt)), this->localTimeStep);
+        this->calculateDeltaVandAcceleration((*(*spacecraftUnConnectedIt)), this->timeStep);
     }
 
     // - Compute Energy and Momentum

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -919,25 +919,6 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
     return;
 }
 
-/*! This method is used to integrate the state forward in time, switch MRPs, calculate energy and momentum, and 
- calculate the accumulated deltaV */
-void SpacecraftSystem::integrateState(double integrateToThisTime)
-{
-    if (!this->isDynamicsSynced) {
-
-        int i;      // dynamic Object counter
-        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-            this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
-        }
-
-        this->integrator->integrate(this->timeBefore, this->localTimeStep);
-
-        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
-            this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
-        }
-    }
-}
-
 void SpacecraftSystem::findPriorStateInformation(SpacecraftUnit &spacecraft)
 {
     // - Find v_CN_N before integration for accumulated DV

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -923,91 +923,19 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
  calculate the accumulated deltaV */
 void SpacecraftSystem::integrateState(double integrateToThisTime)
 {
-    // - Find the time step
-    double localTimeStep = integrateToThisTime - timePrevious;
+    if (!this->isDynamicsSynced) {
 
-    this->findPriorStateInformation(this->primaryCentralSpacecraft);
+        int i;      // dynamic Object counter
+        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+            this->integrator->dynPtrs.at(i)->preIntegration(integrateToThisTime);
+        }
 
-    // - Call this for all of the unconnected spacecraft
-    std::vector<SpacecraftUnit*>::iterator spacecraftUnConnectedIt;
-    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
-    {
-        this->findPriorStateInformation((*(*spacecraftUnConnectedIt)));
-    }
+        this->integrator->integrate(this->timeBefore, this->localTimeStep);
 
-    // - Integrate the state from the last time (timeBefore) to the integrateToThisTime
-    double timeBefore = integrateToThisTime - localTimeStep;
-    this->integrator->integrate(timeBefore, localTimeStep);
-    this->timePrevious = integrateToThisTime;     // - copy the current time into previous time for next integrate state call
-
-    // - Calculate the states of the attached spacecraft from the primary spacecraft
-    this->determineAttachedSCStates();
-
-    // - Call hubs modify states to allow for switching of MRPs
-    this->primaryCentralSpacecraft.hub.modifyStates(integrateToThisTime);
-
-    // - Just in case the MRPs of the attached hubs need to be switched
-    std::vector<SpacecraftUnit*>::iterator spacecraftConnectedIt;
-    for(spacecraftConnectedIt = this->spacecraftDockedToPrimary.begin(); spacecraftConnectedIt != this->spacecraftDockedToPrimary.end(); spacecraftConnectedIt++)
-    {
-        (*spacecraftConnectedIt)->hub.modifyStates(integrateToThisTime);
-    }
-
-    // - Just in case the MRPs of the attached hubs need to be switched
-    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
-    {
-        (*spacecraftUnConnectedIt)->hub.modifyStates(integrateToThisTime);
-    }
-
-    // - Loop over stateEffectors to call modifyStates
-    std::vector<StateEffector*>::iterator it;
-    for(it = this->primaryCentralSpacecraft.states.begin(); it != this->primaryCentralSpacecraft.states.end(); it++)
-    {
-        // - Call energy and momentum calulations for stateEffectors
-        (*it)->modifyStates(integrateToThisTime);
-    }
-
-    // - Call this for all of the connected spacecraft
-    for(spacecraftConnectedIt = this->spacecraftDockedToPrimary.begin(); spacecraftConnectedIt != this->spacecraftDockedToPrimary.end(); spacecraftConnectedIt++)
-    {
-        for(it = (*spacecraftConnectedIt)->states.begin(); it != (*spacecraftConnectedIt)->states.end(); it++)
-        {
-            // - Call energy and momentum calulations for stateEffectors
-            (*it)->modifyStates(integrateToThisTime);
+        for (i = 0; i < this->integrator->dynPtrs.size(); i++) {
+            this->integrator->dynPtrs.at(i)->postIntegration(integrateToThisTime);
         }
     }
-
-    // - Call this for all of the unconnected spacecraft
-    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
-    {
-        for(it = (*spacecraftUnConnectedIt)->states.begin(); it != (*spacecraftUnConnectedIt)->states.end(); it++)
-        {
-            // - Call energy and momentum calulations for stateEffectors
-            (*it)->modifyStates(integrateToThisTime);
-        }
-    }
-
-    // - Call mass properties to get current info on the mass props of the spacecraft
-    this->updateSystemMassProps(integrateToThisTime);
-
-    // - Call mass props for all the rest of the spacecraft
-    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
-    {
-        this->updateSpacecraftMassProps(integrateToThisTime, (*(*spacecraftUnConnectedIt)));
-    }
-
-    this->calculateDeltaVandAcceleration(this->primaryCentralSpacecraft, localTimeStep);
-
-    // - Call for the rest of the spacecraft
-    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
-    {
-        this->calculateDeltaVandAcceleration((*(*spacecraftUnConnectedIt)), localTimeStep);
-    }
-
-    // - Compute Energy and Momentum
-    this->computeEnergyMomentum(integrateToThisTime);
-
-    return;
 }
 
 void SpacecraftSystem::findPriorStateInformation(SpacecraftUnit &spacecraft)
@@ -1300,3 +1228,103 @@ void SpacecraftSystem::computeEnergyMomentumSystem(double time)
     
     return;
 }
+
+/*! Prepare for integration process, not currently implemented in SpacecraftSystem
+ @param integrateToThisTime Time to integrate to
+ */
+void SpacecraftSystem::preIntegration(double integrateToThisTime) {
+
+    // - Find the time step
+    this->localTimeStep = integrateToThisTime - this->timePrevious;
+
+    this->findPriorStateInformation(this->primaryCentralSpacecraft);
+
+    // - Call this for all of the unconnected spacecraft
+    std::vector<SpacecraftUnit*>::iterator spacecraftUnConnectedIt;
+    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
+    {
+        this->findPriorStateInformation((*(*spacecraftUnConnectedIt)));
+    }
+
+    // - Integrate the state from the last time (timeBefore) to the integrateToThisTime
+    this->timeBefore = integrateToThisTime - this->localTimeStep;
+
+}
+
+/*! Perform post-integration steps, not currently implemented in SpacecraftSystem
+ @param integrateToThisTime Time to integrate to
+ */
+void SpacecraftSystem::postIntegration(double integrateToThisTime) {
+    std::vector<SpacecraftUnit*>::iterator spacecraftUnConnectedIt;
+
+    this->timePrevious = integrateToThisTime;     // - copy the current time into previous time for next integrate state call
+
+    // - Calculate the states of the attached spacecraft from the primary spacecraft
+    this->determineAttachedSCStates();
+
+    // - Call hubs modify states to allow for switching of MRPs
+    this->primaryCentralSpacecraft.hub.modifyStates(integrateToThisTime);
+
+    // - Just in case the MRPs of the attached hubs need to be switched
+    std::vector<SpacecraftUnit*>::iterator spacecraftConnectedIt;
+    for(spacecraftConnectedIt = this->spacecraftDockedToPrimary.begin(); spacecraftConnectedIt != this->spacecraftDockedToPrimary.end(); spacecraftConnectedIt++)
+    {
+        (*spacecraftConnectedIt)->hub.modifyStates(integrateToThisTime);
+    }
+
+    // - Just in case the MRPs of the unattached hubs need to be switched
+    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
+    {
+        (*spacecraftUnConnectedIt)->hub.modifyStates(integrateToThisTime);
+    }
+
+    // - Loop over stateEffectors to call modifyStates
+    std::vector<StateEffector*>::iterator it;
+    for(it = this->primaryCentralSpacecraft.states.begin(); it != this->primaryCentralSpacecraft.states.end(); it++)
+    {
+        // - Call energy and momentum calulations for stateEffectors
+        (*it)->modifyStates(integrateToThisTime);
+    }
+
+    // - Call this for all of the connected spacecraft
+    for(spacecraftConnectedIt = this->spacecraftDockedToPrimary.begin(); spacecraftConnectedIt != this->spacecraftDockedToPrimary.end(); spacecraftConnectedIt++)
+    {
+        for(it = (*spacecraftConnectedIt)->states.begin(); it != (*spacecraftConnectedIt)->states.end(); it++)
+        {
+            // - Call energy and momentum calulations for stateEffectors
+            (*it)->modifyStates(integrateToThisTime);
+        }
+    }
+
+    // - Call this for all of the unconnected spacecraft
+    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
+    {
+        for(it = (*spacecraftUnConnectedIt)->states.begin(); it != (*spacecraftUnConnectedIt)->states.end(); it++)
+        {
+            // - Call energy and momentum calulations for stateEffectors
+            (*it)->modifyStates(integrateToThisTime);
+        }
+    }
+
+    // - Call mass properties to get current info on the mass props of the spacecraft
+    this->updateSystemMassProps(integrateToThisTime);
+
+    // - Call mass props for all the rest of the spacecraft
+    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
+    {
+        this->updateSpacecraftMassProps(integrateToThisTime, (*(*spacecraftUnConnectedIt)));
+    }
+
+    this->calculateDeltaVandAcceleration(this->primaryCentralSpacecraft, this->localTimeStep);
+
+    // - Call for the rest of the spacecraft
+    for(spacecraftUnConnectedIt = this->unDockedSpacecraft.begin(); spacecraftUnConnectedIt != this->unDockedSpacecraft.end(); spacecraftUnConnectedIt++)
+    {
+        this->calculateDeltaVandAcceleration((*(*spacecraftUnConnectedIt)), this->localTimeStep);
+    }
+
+    // - Compute Energy and Momentum
+    this->computeEnergyMomentum(integrateToThisTime);
+
+}
+

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
@@ -154,6 +154,8 @@ public:
     std::vector<SpacecraftUnit*> unDockedSpacecraft; //!< -- vector of spacecraft currently detached from all other spacecraft
     int numberOfSCAttachedToPrimary;          //!< class variable 
     BSKLogger bskLogger;                      //!< -- BSK Logging
+    double localTimeStep;                //!< [s] integration time step
+    double timeBefore;                   //!< [s] prior time value
 
 public:
     SpacecraftSystem();                    //!< -- Constructor
@@ -177,6 +179,8 @@ public:
     void attachSpacecraftToPrimary(SpacecraftUnit *newSpacecraft, std::string dockingPortNameOfNewSpacecraft, std::string dockingToPortName);  //!< -- Attaches a spacecraft to the primary spacecraft chain
     void addSpacecraftUndocked(SpacecraftUnit *newSpacecraft);  //!< -- Attaches a spacecraft to the primary spacecraft chain
     void determineAttachedSCStates();  //!< class method
+    void preIntegration(double callTime);  //!< -- pre-integration steps
+    void postIntegration(double callTime);  //!< -- post-integration steps
 
 private:
     Eigen::MatrixXd *sysTime;            //!< [s] System time

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
@@ -154,8 +154,6 @@ public:
     std::vector<SpacecraftUnit*> unDockedSpacecraft; //!< -- vector of spacecraft currently detached from all other spacecraft
     int numberOfSCAttachedToPrimary;          //!< class variable 
     BSKLogger bskLogger;                      //!< -- BSK Logging
-    double localTimeStep;                //!< [s] integration time step
-    double timeBefore;                   //!< [s] prior time value
 
 public:
     SpacecraftSystem();                    //!< -- Constructor
@@ -175,12 +173,11 @@ public:
     void equationsOfMotionSystem(double integTimeSeconds, double timeStep);    //!< -- This method computes the equations of motion for the whole system
     void findPriorStateInformation(SpacecraftUnit& spacecraft);  //!< class method
     void calculateDeltaVandAcceleration(SpacecraftUnit& spacecraft, double localTimeStep); //!< class method
-    void integrateState(double time);       //!< -- This method steps the state forward one step in time
     void attachSpacecraftToPrimary(SpacecraftUnit *newSpacecraft, std::string dockingPortNameOfNewSpacecraft, std::string dockingToPortName);  //!< -- Attaches a spacecraft to the primary spacecraft chain
     void addSpacecraftUndocked(SpacecraftUnit *newSpacecraft);  //!< -- Attaches a spacecraft to the primary spacecraft chain
     void determineAttachedSCStates();  //!< class method
-    void preIntegration(double callTime);  //!< -- pre-integration steps
-    void postIntegration(double callTime);  //!< -- post-integration steps
+    void preIntegration(double callTime) final;  //!< -- pre-integration steps
+    void postIntegration(double callTime) final;  //!< -- post-integration steps
 
 private:
     Eigen::MatrixXd *sysTime;            //!< [s] System time


### PR DESCRIPTION
* **Tickets addressed:** #195
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Current the ODEs in a `DynamicsObject` are integrated per Basilisk module.  This prevents the 
 ODEs of 2 spacecraft from being integrated at the same time if they are coupled.  Currently no
effector couples the dynamics, but effectors being develop will require the ODEs of 2 or more `DynamicObject` modules to be integrated at the same time.

This branch updates the `DynamicObject` class to have not just a pointer to a single object to integrate, but a vector of objects.  This will allow any BSK modules of type `DynamicObject` to be integrated at the same time.

## Verification
The current Unit tests all still pass.  The new logic was validated visually by several dynamics researchers, but we don't have have effectors that couple the full dynamics.

## Documentation
Added new documentation on creating and using `DynamicObject` members.  Updated a scenario to
couple two regular spacecraft ODEs and illustrate how to do this.

## Future work
These integrators should be checked again once we have effectors that couple the dynamics. We also need to add a new integrator unit test that verifies spacecraft coupling.
