### PR TITLE
Refactor/bsk 237 documentation refactor

### DIFF
--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
@@ -108,7 +108,8 @@ def test_oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisIn
     :math:`{}^\mathcal{B}\hat{h}_1` and the solar array axis drive :math:`{}^\mathcal{B}\hat{a}_1`.
     The angle :math:`\gamma` is computed from the output reference attitude and compared with the results of a 
     python function that computes the correct output based on the geometry of the problem. For a description of how
-    such correct result is obtained, see `Calaon et al. <http://hanspeterschaub.info/Papers/Calaon2023.pdf>`__.
+    such correct result is obtained, see R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft
+    with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
 
     **General Documentation Comments**
 

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
@@ -74,7 +74,7 @@ ang = list(ang)
 @pytest.mark.parametrize("bodyAxisInput", [0,1])
 @pytest.mark.parametrize("inertialAxisInput", [0,1,2])
 @pytest.mark.parametrize("alignmentPriority", [0,1])
-@pytest.mark.parametrize("accuracy", [1e-10])
+@pytest.mark.parametrize("accuracy", [1e-9])
 
 def test_oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, inertialAxisInput, alignmentPriority, accuracy):
     r"""
@@ -261,5 +261,5 @@ if __name__ == "__main__":
                  0,           # flagB
                  1,           # flagN
                  0,           # priorityFlag
-                 1e-10         # accuracy
+                 1e-9         # accuracy
                )

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
@@ -56,7 +56,7 @@ void Reset_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint
     if (BodyHeadingMsg_C_isLinked(&configData->bodyHeadingInMsg)) {
         configData->bodyAxisInput = inputBodyHeadingMsg;
     }
-    else if (v3Norm(configData->h1Hat_B) > EPS) {
+    else if (v3Norm(configData->h1Hat_B) > ONE_AXIS_SA_EPS) {
             configData->bodyAxisInput = inputBodyHeadingParameter;
     }
     else {
@@ -79,7 +79,7 @@ void Reset_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint
         }
     }
     else {
-        if (v3Norm(configData->hHat_N) > EPS) {
+        if (v3Norm(configData->hHat_N) > ONE_AXIS_SA_EPS) {
             configData->inertialAxisInput = inputInertialHeadingParameter;
         }
         else {
@@ -141,7 +141,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
 
     /*! get the second body frame direction */
     double a2Hat_B[3];
-    if (v3Norm(configData->a2Hat_B) > EPS) {
+    if (v3Norm(configData->a2Hat_B) > ONE_AXIS_SA_EPS) {
         v3Normalize(configData->a2Hat_B, a2Hat_B);
     }
     else {
@@ -170,7 +170,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
     double sigma_RN[3];
     C2MRP(RN, sigma_RN);
 
-    if (v3Norm(configData->h2Hat_B) > EPS) {
+    if (v3Norm(configData->h2Hat_B) > ONE_AXIS_SA_EPS) {
         // compute second reference frame
         computeFinalRotation(configData->alignmentPriority, BN, rHat_SB_B, configData->h2Hat_B, hReqHat_B, a1Hat_B, a2Hat_B, RN);
         
@@ -181,7 +181,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
 
         double dotP_1 = v3Dot(rHat_SB_R1, a2Hat_B);
         double dotP_2 = v3Dot(rHat_SB_R2, a2Hat_B);
-        if (dotP_2 > dotP_1 && fabs(dotP_2 - dotP_1) > EPS) {
+        if (dotP_2 > dotP_1 && fabs(dotP_2 - dotP_1) > ONE_AXIS_SA_EPS) {
             // if second reference frame gives a better result, save this as reference MRP set
             C2MRP(RN, sigma_RN);
         }
@@ -266,11 +266,11 @@ void computeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3
     double e_phi[3];
     v3Cross(hRefHat_B, hReqHat_B, e_phi);
     // If phi = PI, e_phi can be any vector perpendicular to hRefHat_B
-    if (fabs(phi-MPI) < EPS) {
+    if (fabs(phi-MPI) < ONE_AXIS_SA_EPS) {
         phi = MPI;
         v3Perpendicular(hRefHat_B, e_phi);
     }
-    else if (fabs(phi) < EPS) {
+    else if (fabs(phi) < ONE_AXIS_SA_EPS) {
         phi = 0;
     }
     // normalize e_phi
@@ -304,8 +304,8 @@ void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1H
 
     /*! compute exact solution or best solution depending on Delta */
     double t, t1, t2, y, y1, y2, psi;
-    if (fabs(A) < EPS) {
-        if (fabs(B) < EPS) {
+    if (fabs(A) < ONE_AXIS_SA_EPS) {
+        if (fabs(B) < ONE_AXIS_SA_EPS) {
             // zero-th order equation has no solution 
             // the solution of the minimum problem is psi = MPI
             psi = MPI;
@@ -320,7 +320,7 @@ void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1H
         if (Delta < 0) {
             // second order equation has no solution 
             // the solution of the minimum problem is found
-            if (fabs(B) < EPS) {
+            if (fabs(B) < ONE_AXIS_SA_EPS) {
                 t = 0.0;
             }
             else {
@@ -350,10 +350,10 @@ void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1H
 
             // choose between t1 and t2 according to a2Hat
             t = t1;            
-            if (fabs(v3Dot(hRefHat_B, a2Hat_B)-1) > EPS) {
+            if (fabs(v3Dot(hRefHat_B, a2Hat_B)-1) > ONE_AXIS_SA_EPS) {
                 y1 = (E*t1*t1 + F*t1 + G) / (1 + t1*t1);
                 y2 = (E*t2*t2 + F*t2 + G) / (1 + t2*t2);
-                if (y2 - y1 > EPS) {
+                if (y2 - y1 > ONE_AXIS_SA_EPS) {
                     t = t2;
                 }
             }
@@ -380,7 +380,7 @@ void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHa
     else {
         double sTheta = v3Dot(rHat_SB_R2, a1Hat_B);
         double theta = asin( fmin( fmax( fabs(sTheta), -1 ), 1 ) );
-        if (fabs(theta) < EPS) {
+        if (fabs(theta) < ONE_AXIS_SA_EPS) {
             // if Sun direction and solar array drive are already perpendicular, third rotation is null
             for (int i = 0; i < 3; i++) {
             PRV_theta[i] = 0;
@@ -389,7 +389,7 @@ void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHa
         else {
             // if Sun direction and solar array drive are not perpendicular, project solar array drive a1Hat_B onto perpendicular plane (aPHat_B) and compute third rotation
             double e_theta[3], aPHat_B[3];
-            if (fabs(fabs(theta)-MPI/2) > EPS) {
+            if (fabs(fabs(theta)-MPI/2) > ONE_AXIS_SA_EPS) {
                 for (int i = 0; i < 3; i++) {
                     aPHat_B[i] = (a1Hat_B[i] - sTheta * rHat_SB_R2[i]) / (1 - sTheta * sTheta);
                 }
@@ -398,7 +398,7 @@ void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHa
             else {
                 // rotate about the axis that minimizes variation in hRefHat_B direction
                 v3Cross(rHat_SB_R2, hRefHat_B, aPHat_B);
-                if (v3Norm(aPHat_B) < EPS) {
+                if (v3Norm(aPHat_B) < ONE_AXIS_SA_EPS) {
                     v3Perpendicular(rHat_SB_R2, aPHat_B);
                 }
                 v3Cross(a1Hat_B, aPHat_B, e_theta);

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -29,7 +29,7 @@
 #include "cMsgCInterface/EphemerisMsg_C.h"
 #include "cMsgCInterface/NavAttMsg_C.h"
 
-#define EPS 1e-12
+#define ONE_AXIS_SA_EPS 1e-12                    //!< accuracy to check if a variable is zero
 
 typedef enum alignmentPriority{
     prioritizeAxisAlignment = 0,

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.rst
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.rst
@@ -36,7 +36,7 @@ provides information on what this message is used for.
 
 Detailed Module Description
 ---------------------------
-A detailed mathematical derivation of the equations applied by this module can be found in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints," In preparation for Journal of Spacecraft and Rockets.
+A detailed mathematical derivation of the equations applied by this module can be found in R. Calaon, C. Allard and H. Schaub, "Attitude Reference Generation for Spacecraft with Rotating Solar Arrays and Pointing Constraints", in preparation for Journal of Spacecraft and Rockets.
 The input parameter ``alignmentPriority`` allows to choose whether the first or the second constraint is strictly enforced. When ``alignmentPriority = 0``, the body heading :math:`{}^\mathcal{B}\hat{h}` and the inertial heading :math:`{}^\mathcal{N}\hat{h}_\text{ref}` match exactly, while the incidence angle on the solar arrays is as close to optimal as possible. On the contrary, when ``alignmentPriority = 1``, the solar array drive :math:`{}^\mathcal{B}\hat{a}_1` is perpendicular to the Sun direction, to ensure maximum power generation, while the body heading and the inertial heading are as close to parallel as possible.
 
 Attention must be paid to how these pieces of input information is provided:

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
@@ -124,7 +124,7 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
     double thetaC = atan2(sinThetaC, cosThetaC);      // clip theta current between 0 and 2*pi
 
     /*! compute reference angle and store in buffer msg */
-    if (v3Norm(a2Hat_R) < EPS) {
+    if (v3Norm(a2Hat_R) < SA_REF_EPS) {
         // if norm(a2Hat_R) = 0, reference coincides with current angle
         hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta;
     }

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.h
@@ -26,7 +26,7 @@
 #include "cMsgCInterface/AttRefMsg_C.h"
 #include "cMsgCInterface/HingedRigidBodyMsg_C.h"
 
-#define EPS 1e-6                    //!< accuracy to check if a variable is zero
+#define SA_REF_EPS 1e-12                    //!< accuracy to check if a variable is zero
 
 enum attitudeFrame{
     referenceFrame = 0,


### PR DESCRIPTION
* **Tickets addressed:** bsk-237
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Commit 1 reduces the accuracy on the output of the oneAxisSolarArray point Unit Test, to circumvent the failures in the server build of the module.

This branch resolves the documentation build issues related to the multiple instantiation of the same variable across different modules. This issue is fixed by renaming the variable with a different name in each module, to avoid conflict. This is done in commits 2 and 3.

A fix in the oneAxisSolarArrayPoint module is implemented to remove a broken link. This is done in commit 4.

## Documentation
Documentation does not cause build errors anymore.

## Future work
No future work
