### PR TITLE
Feature/bsk 200 python modules

### DIFF
--- a/docs/source/Learn/makingModules/pyModules.rst
+++ b/docs/source/Learn/makingModules/pyModules.rst
@@ -1,12 +1,115 @@
+.. _pyModules:
+
 Making Python Modules
 =====================
 
-To learn how to program a Python module, see :ref:`scenarioAttitudePointingPy`.  The module is defined purely in a python script.  As such there is no header, definition or swig interface file.
+.. sidebar:: Source Code
 
-.. note::
+    The Python code shown below can be downloaded :download:`here </../../docs/source/codeSamples/making-pyModules.py>`.
 
-    Python modules run much slower than C or C++ modules.  They are very convenient when prototyping a module behavior, or having a simple task to perform that is not called very often.
+Python modules are a good alternative to C and C++ modules for quick prototyping.
+They are defined entirely in a Python script, which means that there is no need
+for a header (``.h``), definition (``.cpp``), or SWIG interface file (``.i``). However, they 
+are much slower than C or C++ modules, which will significantly slow down your simulation.
 
-.. warning::
+Python modules are implemented by subclassing ``SysModel`` from ``Basilisk.architecture.sysModel``. 
+Then, one can implement the ``__init__``,
+``Reset``, and ``UpdateState`` methods in the same way that one would
+implement these methods in C++. Remember to always call ``__init__`` of
+the parent class ``SysModel`` if you are implementing your own ``__init__``.
 
-    The python process(es) will always be executed after the regular C/C++ processes.
+The ``ModelTag`` value of these python BSK modules will be a unique positive number,
+same as with C/C++ BSK modules.
+
+All Python modules have a logger stored in ``bskLogger`` (although it will
+not be available until the module has been added to a simulation). Additionally,
+you may declare any other variables, methods, messages, etc. within your Python module.
+
+The script below expands on the code shown in :ref:`bskPrinciples-2` to include
+a Python module.
+
+.. literalinclude:: ../../codeSamples/making-pyModules.py
+   :language: python
+   :linenos:
+   :lines: 18-
+
+Running the above code prints:
+
+.. code-block::
+
+    (.venv) source/codeSamples % python making-pyModules.py
+    BSK_INFORMATION: Variable dummy set to 0.000000 in reset.
+    BSK_INFORMATION: Reset in TestPythonModule
+    BSK_INFORMATION: Variable dummy set to 0.000000 in reset.
+    BSK_INFORMATION: Variable dummy set to 0.000000 in reset.
+    InitializeSimulation() completed...
+    BSK_INFORMATION: C Module ID 3 ran Update at 0.000000s
+    BSK_INFORMATION: Python Module ID 4 ran Update at 0.0s
+    BSK_INFORMATION: C++ Module ID 2 ran Update at 0.000000s
+    BSK_INFORMATION: C Module ID 1 ran Update at 0.000000s
+    BSK_INFORMATION: C Module ID 3 ran Update at 5.000000s
+    BSK_INFORMATION: Python Module ID 4 ran Update at 5.0s
+    BSK_INFORMATION: C++ Module ID 2 ran Update at 5.000000s
+    BSK_INFORMATION: C Module ID 1 ran Update at 5.000000s
+    Recorded mod2.dataOutMsg.dataVector:  [[2. 1. 0.]
+    [5. 2. 0.]]
+
+Note how the Python module made use of ``bskLogger``, the ``Reset``
+and ``UpdateState`` were called, how the priority of the Python
+module was respected, and how messaging happened between a C++
+and Python module.
+
+The scenario :ref:`scenarioAttitudePointingPy` further shows how to define Python modules.
+
+Deprecated way of creating Python modules
+-----------------------------------------
+.. warning:: 
+
+    This section discusses the deprecated way of setting up Python modules
+    in Basilisk versions earlier than 2.2.
+    Users should refer to the previous section when setting up new simulation
+    scripts using Python modules.
+
+Apart from the way to shown above, there exist an older way to create 
+Python modules which has now been deprecated. This section briefly
+discusses this older method, its disadvantages, and how to update to the
+new system. Note that this deprecated method is pending for removal;
+users are advised to update to the new system.
+
+Before the new system, Python modules had to be added to separate
+Python processes, which could not have C/C++ modules. Moreover, this
+Python processes always had to have a lower priority than C++/C
+processes, which effectively meant that all Python modules would run
+after the C++/C modules. This severely limited users' control of the
+execution order of their simulation.
+
+Moreover, the syntax for creating these modules was slightly different
+than for C++ modules:
+
+- The class inherited from ``PythonModelClass`` instead of ``SysModel``
+- The ``ModelTag`` had to be passed to the constructor of the class
+- One had to overload ``reset`` and ``updateState``, instead of ``Reset`` and ``UpdateState``
+
+In order to update python simulation scripts that use the deprecated system to the
+new system, one needs to:
+
+- Replace ``CreateNewPythonProcess`` by ``CreateNewProcess``, as the new Python modules
+  can be added to regular processes.
+- Make the Python module class inherit from ``SysModel``, and not from ``PythonModelClass``
+  Note that you must import ``SysModel`` from ``Basilisk.architecture.sysModel``.
+- Instead of passing the module tag and priority in the constructor, set the tag by
+  setting the ``ModuleTag`` attribute (similar to C++ modules), and set the priority on the ``addTask`` method.
+- Rename ``selfInit``, ``reset``, and ``updateState`` to ``SelftInit``, ``Reset``, and ``UpdateState``.
+
+With this depreciated manner of creating a python Basilisk module the ``ModelTag`` value
+is an unique negative number, while the C/C++ modules had unique positive numbers.
+This means that updating your simulation script
+might change the ID of your modules compared to previous versions.
+
+It is possible that you may not even need a separate process
+for your Python modules, so consider adding the Python modules directly
+to other existing processes, always with a lower priority if you want
+to retain the older behaviour.
+
+The scenario :ref:`scenarioAttitudePointingPyDEPRECATED` shows both the 
+deprecated way of creating a Python module.

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -69,7 +69,7 @@ Version 2.1.7 (March 24, 2023)
 - Added :ref:`thrusterPlatformReference` to align the dual-gimballed thruster with the system's center of mass, or at an offset thereof to perform momentum dumping.
 - Improved reliability of opNav scenario communication between :ref:`vizInterface` and Vizard
 - provide support or Vizard 2.1.4 features
-
+- Created new way to define Python modules by inheriting from ``Basilisk.architecture.sysModel.SysModel``. See :ref:`pyModules` for details.
 
 Version 2.1.6 (Jan. 21, 2023)
 -----------------------------

--- a/docs/source/codeSamples/making-pyModules.py
+++ b/docs/source/codeSamples/making-pyModules.py
@@ -1,0 +1,117 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.moduleTemplates import cModuleTemplate
+from Basilisk.moduleTemplates import cppModuleTemplate
+from Basilisk.architecture import sysModel
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging
+
+import numpy as np
+
+def run():
+    """
+    Illustration of adding Basilisk Python modules to a task
+    """
+
+    #  Create a sim module as an empty container
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    #  create the simulation process
+    dynProcess = scSim.CreateNewProcess("dynamicsProcess")
+
+    # create the dynamics task and specify the integration update time
+    dynProcess.addTask(scSim.CreateNewTask("dynamicsTask", macros.sec2nano(5.)))
+
+    # create copies of the Basilisk modules
+    mod1 = cModuleTemplate.cModuleTemplateConfig()
+    mod1Wrap = scSim.setModelDataWrap(mod1)
+    mod1Wrap.ModelTag = "cModule1"
+    scSim.AddModelToTask("dynamicsTask", mod1Wrap, mod1, 0)
+
+    mod2 = cppModuleTemplate.CppModuleTemplate()
+    mod2.ModelTag = "cppModule2"
+    scSim.AddModelToTask("dynamicsTask", mod2, None, 5)
+
+    mod3 = cModuleTemplate.cModuleTemplateConfig()
+    mod3Wrap = scSim.setModelDataWrap(mod3)
+    mod3Wrap.ModelTag = "cModule3"
+    scSim.AddModelToTask("dynamicsTask", mod3Wrap, mod3, 15)
+
+    # The following is a Python module, which has a higher priority
+    # then some of the C++/C modules. Observe in the script output
+    # how the Python module is called in the order that respects
+    # its priority with respect to the rest of the modules.
+    mod4 = TestPythonModule()
+    mod4.ModelTag = "pythonModule4"
+    scSim.AddModelToTask("dynamicsTask", mod4, None, 10)
+
+    mod2.dataInMsg.subscribeTo(mod4.dataOutMsg)
+    mod4.dataInMsg.subscribeTo(mod3.dataOutMsg)
+
+    # Set up recording
+    mod2MsgRecorder = mod2.dataOutMsg.recorder()
+    scSim.AddModelToTask("dynamicsTask", mod2MsgRecorder)
+
+    #  initialize Simulation:
+    scSim.InitializeSimulation()
+    print("InitializeSimulation() completed...")
+
+    #   configure a simulation stop time and execute the simulation run
+    scSim.ConfigureStopTime(macros.sec2nano(5.0))
+    scSim.ExecuteSimulation()
+
+    print("Recorded mod2.dataOutMsg.dataVector: ", mod2MsgRecorder.dataVector)
+
+    return
+
+class TestPythonModule(sysModel.SysModel):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    def Reset(self, CurrentSimNanos):
+        # Ensure that self.dataInMsg is linked
+        if not self.dataInMsg.isLinked():
+            self.bskLogger.bskLog(bskLogging.BSK_ERROR, "TestPythonModule.dataInMsg is not linked.")
+
+        # Initialiazing self.dataOutMsg
+        payload = self.dataOutMsg.zeroMsgPayload
+        payload.dataVector = np.array([0,0,0])
+        self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
+
+        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, "Reset in TestPythonModule")
+
+    def UpdateState(self, CurrentSimNanos):
+        # Read input message
+        inPayload = self.dataInMsg()
+        inputVector = inPayload.dataVector
+
+        # Set output message
+        payload = self.dataOutMsg.zeroMsgPayload
+        payload.dataVector = self.dataOutMsg.read().dataVector + np.array([0,1,0]) + inputVector
+        self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
+
+        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, f"Python Module ID {self.moduleID} ran Update at {CurrentSimNanos*1e-9}s")
+
+if __name__ == "__main__":
+    run()

--- a/src/architecture/_GeneralModuleFiles/sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/sys_model.i
@@ -1,0 +1,37 @@
+
+%module(directors="1") sysModel
+%{
+   #include "sys_model.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "architecture/utilities/bskLogging.h"
+
+%feature("director") SysModel;
+%feature("pythonappend") SysModel::SysModel %{
+    self.__super_init_called__ = True%}
+%rename("_SysModel") SysModel;
+%include "sys_model.h"
+
+%pythoncode %{
+class SuperInitChecker(type):
+
+    def __call__(cls, *a, **kw):
+        rv = super(SuperInitChecker, cls).__call__(*a, **kw)
+        if not getattr(rv, "__super_init_called__", False):
+            error_msg = (
+               "Need to call parent __init__ in SysModel subclasses:\n"
+               f"class {cls.__name__}(sysModel.SysModel):\n"
+               "    def __init__(...):\n"
+               "        super().__init__()"
+            )
+            raise SyntaxError(error_msg)
+        return rv
+
+class SysModel(_SysModel, metaclass=SuperInitChecker):
+    bskLogger: BSKLogger = None
+%}

--- a/src/architecture/system_model/_UnitTest/test_PySysModel.py
+++ b/src/architecture/system_model/_UnitTest/test_PySysModel.py
@@ -1,0 +1,105 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.moduleTemplates import cModuleTemplate
+from Basilisk.moduleTemplates import cppModuleTemplate
+from Basilisk.architecture import sysModel
+from Basilisk.architecture import bskLogging
+from Basilisk.architecture import messaging
+
+import numpy as np
+
+def test_PySysModel():
+    testResults, testMessage = 0, []
+
+    #  Create a sim module as an empty container
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    #  create the simulation process
+    dynProcess = scSim.CreateNewProcess("dynamicsProcess")
+
+    # create the dynamics task and specify the integration update time
+    dynProcess.addTask(scSim.CreateNewTask("dynamicsTask", macros.sec2nano(5.)))
+
+    # create copies of the Basilisk modules
+    mod1 = cModuleTemplate.cModuleTemplateConfig()
+    mod1Wrap = scSim.setModelDataWrap(mod1)
+    mod1Wrap.ModelTag = "cModule1"
+
+    mod2 = cppModuleTemplate.CppModuleTemplate()
+    mod2.ModelTag = "cppModule2"
+
+    mod3 = cModuleTemplate.cModuleTemplateConfig()
+    mod3Wrap = scSim.setModelDataWrap(mod3)
+    mod3Wrap.ModelTag = "cModule3"
+
+    mod4 = PythonModule()
+    mod4.ModelTag = "pythonModule4"
+
+    mod2.dataInMsg.subscribeTo(mod4.dataOutMsg)
+
+    scSim.AddModelToTask("dynamicsTask", mod1Wrap, mod1, 0)
+    scSim.AddModelToTask("dynamicsTask", mod2, None, 5)
+    scSim.AddModelToTask("dynamicsTask", mod3Wrap, mod3, 15)
+    scSim.AddModelToTask("dynamicsTask", mod4, None, 10)
+
+    # Set up recording
+    mod2MsgRecorder = mod2.dataOutMsg.recorder()
+    scSim.AddModelToTask("dynamicsTask", mod2MsgRecorder)
+
+    # initialize Simulation:
+    scSim.InitializeSimulation()
+
+    # configure a simulation stop time and execute the simulation run
+    scSim.ConfigureStopTime(macros.sec2nano(5.0))
+    scSim.ExecuteSimulation()
+
+    if mod4.CallCounts != 2:
+        testResults += 1
+        testMessage.append("TestPythonModule::UpdateState was not called")
+
+    if mod2MsgRecorder.dataVector[1,1] == 0:
+        testResults += 1
+        testMessage.append("Message from TestPythonModule was not connected to message in mod2")
+    elif mod2MsgRecorder.dataVector[1,1] == 1:
+        testResults += 1
+        testMessage.append("TestPythonModule does not run before mod2 despite having greater priority")
+
+    assert testResults < 1, testMessage
+
+class PythonModule(sysModel.SysModel):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    def Reset(self, CurrentSimNanos):
+        payload = self.dataOutMsg.zeroMsgPayload
+        payload.dataVector = np.array([0,0,0])
+        self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
+        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, "Reset in TestPythonModule")
+
+    def UpdateState(self, CurrentSimNanos):
+        payload = self.dataOutMsg.zeroMsgPayload
+        payload.dataVector = self.dataOutMsg.read().dataVector + np.array([0,1,0])
+        self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
+        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, f"Python Module ID {self.moduleID} ran Update at {CurrentSimNanos*1e-9}s")
+
+if __name__ == "__main__":
+    test_PySysModel()

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -3,4 +3,5 @@
 markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.
-
+filterwarnings =
+    ignore:BSK Deprecation:DeprecationWarning

--- a/src/tests/test_scenarioAttitudePointingPyDEPRECATED.py
+++ b/src/tests/test_scenarioAttitudePointingPyDEPRECATED.py
@@ -1,0 +1,72 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+# Basilisk Scenario Script and Integrated Test
+#
+# Purpose:  integrated test of a script that uses a Python BSK module
+# Author:   Hanspeter Schaub
+# Creation Date:  Jan. 16, 2021
+#
+#
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import unitTestSupport
+
+# Get current file path
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+sys.path.append(path + '/../../examples')
+import scenarioAttitudePointingPyDEPRECATED
+
+
+# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
+# @pytest.mark.skipif(conditionstring)
+# uncomment this line if this test has an expected failure, adjust message as needed
+# @pytest.mark.xfail(True)
+
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+#   of the multiple test runs for this test.
+@pytest.mark.scenarioTest
+def test_bskAttitudePointingPD(show_plots):
+    """This function is called by the py.test environment."""
+    # each test method requires a single assert method to be called
+    # provide a unique test method name, starting with test_
+
+    testFailCount = 0  # zero unit test result counter
+    testMessages = []  # create empty array to store test log messages
+
+    try:
+        figureList = scenarioAttitudePointingPyDEPRECATED.run(show_plots)
+        # save the figures to the Doxygen scenario images folder
+        for pltName, plt in list(figureList.items()):
+            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+
+    except OSError as err:
+        testFailCount += 1
+        testMessages.append("scenarioAttitudePointingPyDEPRECATED  test are failed.")
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    assert testFailCount < 1, testMessages

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -24,6 +24,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -374,6 +375,15 @@ class SimBaseClass:
         :param priority (int): Priority that determines when the model gets updated. (Higher number = Higher priority)
         :return: simulationArchTypes.PythonProcessClass object
         """
+        warnings.warn(
+            "BSK Deprecation: "
+            "PythonProcess and Python modules that inherit from "
+            "simulationArchTypes.PythonModelClass are deprecated. "
+            "See examples/scenarioAttitudePointingPy for details.",
+            category=DeprecationWarning,
+            stacklevel=2
+        )
+
         proc = simulationArchTypes.PythonProcessClass(procName, priority)
         i=0;
         for procLoc in self.pyProcList:


### PR DESCRIPTION
* **Tickets addressed:** #200, #209
* **Review:** By file
* **Merge strategy:** Merge (no squash)

## Description
A SWIG file was created for `sys_model.i` so that the type is available for subclassing on the Python layer. The "director" feature was used so that polymorphism is two-directional: not only can Python objects call C++ methods, but C++ calls can be redirected to Python implementations. This means that one simply needs to overload the ´Reset´ and ´UpdateState´ methods in the Python layer and C++ will call the overloaded methods.

## Verification
An automatic test was added, which checks that the ´Reset´ and ´UpdateState´ Python methods are called, that they are called in the appropriate order (respecting priority), and that messages can be linked as expected.

## Documentation
`scenarioAttitudePointingPy` was updated to reflect the new Python module architecture. `/Learn/makingModules/pyModules.rst` was also updated to remove a warning that no longer applies with the new system.

## Future work
- Python versions of `DynamicEffector` and `StateEffector`.
- Using the new Python modules to allow variable logging in a similar style to message recorders (prototype works).