### PR TITLE
Increase range of allowed conan versions

### DIFF
--- a/docs/source/bskPkgRequired.txt
+++ b/docs/source/bskPkgRequired.txt
@@ -3,6 +3,5 @@
 ``matplotlib``
 ``pytest``
 ``Pillow``
-``conan>=1.40.1``
-``conan<=1.56.0``
+``conan>=1.40.1, <=1.59.0``
 ``parse>=1.18.0``


### PR DESCRIPTION
* **Tickets addressed:** resolves #252 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR increases the allowable range of conan versions. The maximum conan version in bskPkgRequired.txt is adjusted to match the maximum forced by the conanfile.py. While the current version max of 1.56.0 doesn't impact the default build config, it does impact the selection of package dependency versions when the build has toggled opNav==True. 

## Verification
Suffice that the CI runs, no further verification is needed.

## Documentation
NA

## Future work
None
