### PR TITLE
Feature/fix viz interface com

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -190,6 +190,7 @@ class BasiliskConan(ConanFile):
             self.requires.add("pcre/8.45")
             self.requires.add("opencv/4.1.2")
             self.requires.add("zlib/1.2.13")
+            self.requires.add("xz_utils/5.4.0")
 
         if self.options.vizInterface or self.options.opNav:
             self.requires.add("libsodium/1.0.18")

--- a/conanfile.py
+++ b/conanfile.py
@@ -83,7 +83,6 @@ class BasiliskConan(ConanFile):
     print(cmakeCmdString)
     os.system(cmakeCmdString)
 
-
     for opt, value in bskModuleOptionsBool.items():
         options.update({opt: [True, False]})
         default_options.update({opt: value})
@@ -112,6 +111,18 @@ class BasiliskConan(ConanFile):
 
             except:
                 pass
+
+    try:
+        consoleReturn = str(subprocess.check_output(["conan", "remote", "list", "--raw"]))
+        conanRepos = ["bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan"
+                      ]
+        for item in conanRepos:
+            if item not in consoleReturn:
+                print("Configuring: " + statusColor + item + endColor)
+                cmdString = ["conan", "remote", "add"] + item.split(" ")
+                subprocess.check_call(cmdString)
+    except:
+        print("conan: " + failColor + "Error configuring conan repo information." + endColor)
 
     print(statusColor + "Checking conan configuration:" + endColor + " Done")
 
@@ -183,7 +194,7 @@ class BasiliskConan(ConanFile):
         if self.options.vizInterface or self.options.opNav:
             self.requires.add("libsodium/1.0.18")
             self.requires.add("protobuf/3.17.1")
-            self.requires.add("cppzmq/4.5.0")
+            self.requires.add("cppzmq/4.3.0@bincrafters/stable")
 
     def configure(self):
         if self.options.clean:

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,7 +10,11 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
-- text here
+- The streaming between ``vizInterface`` and Vizard was not reliable because of a ZMQ compatibility
+  issue between the two code bases.  BSK is reverting to using ZMQ 4.3.0 for now to avoid this issue.
+- Building Basilisk with ``opNav`` mode was no longer working as a conan package dependency issue came up.
+  This has been corrected in the new version by specifying ``xz_utils/5.4.0`` in ``conanfile.py``.  Note
+  that building with ``opNav`` now also appears to require ``conan==1.59.0``.  
 
 
 Version 2.1.6

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -61,6 +61,8 @@ Version |release|
 - Added a maximum power parameter ``maxPower`` to :ref:`reactionWheelStateEffector` for limiting supplied
   power, independent of the modules in simulation/power.
 - Added :ref:`thrusterPlatformReference` to align the dual-gimballed thruster with the system's center of mass, or at an offset thereof to perform momentum dumping.
+- Improved reliability of opNav scenario communication between :ref:`vizInterface` and Vizard
+
 
 
 Version 2.1.6 (Jan. 21, 2023)


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The two-way communication between the Basilisk ``opNav`` scenarios and Vizard has become unreliable and hangs occasionally.  It was an issue between different versions of ZMQ being used in Vizard and BSK.  Doing testing is it apparent that the `opNav` based build is failing because of a compatibility issue with `conan` packages.

## Verification
Did a complete clean build of Basilisk and conan folder and ran an opNav scenario a dozen times.  No more issues now.

## Documentation
Added the issue to the known issues document.

## Future work
We should upgrade Vizard in the future to use a newer version of ZMQ.
