### PR TITLE
Refactor/bsk 244 definitions and tolerance refactor

### DIFF
--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
@@ -248,6 +248,11 @@ def oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, 
                 "bodyAxisInput = {}, inertialAxisInput = {} and priorityFlag = {}".format(
                     bodyAxisInput, inertialAxisInput, alignmentPriority))
 
+    if testFailCount:
+        print(testMessages)
+    else:
+        print("Unit Test Passed")
+
     return [testFailCount, ''.join(testMessages)]
 
 

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
@@ -64,9 +64,10 @@ def computeGamma(alpha, delta):
 
     return gamma
 
-# The 'ang' array spans the interval from 0 to pi. 0 and pi are excluded because 
-# the code is less accurate around those points; it still provides accurate results at 1e-6
-ang = np.linspace(0, np.pi, 5, endpoint=True)
+
+# The 'ang' array spans the interval from 0 to pi.  pi is excluded because
+# the code is less accurate around this point;
+ang = np.linspace(0, np.pi, 5, endpoint=False)
 ang = list(ang)
 
 @pytest.mark.parametrize("alpha", ang)
@@ -74,7 +75,7 @@ ang = list(ang)
 @pytest.mark.parametrize("bodyAxisInput", [0,1])
 @pytest.mark.parametrize("inertialAxisInput", [0,1,2])
 @pytest.mark.parametrize("alignmentPriority", [0,1])
-@pytest.mark.parametrize("accuracy", [1e-9])
+@pytest.mark.parametrize("accuracy", [1e-12])
 
 def test_oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, inertialAxisInput, alignmentPriority, accuracy):
     r"""

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
@@ -159,7 +159,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
 
     /*! compute the total rotation DCM */
     double RN[3][3];
-    computeFinalRotation(configData->alignmentPriority, BN, rHat_SB_B, hRefHat_B, hReqHat_B, a1Hat_B, a2Hat_B, RN);
+    oasapComputeFinalRotation(configData->alignmentPriority, BN, rHat_SB_B, hRefHat_B, hReqHat_B, a1Hat_B, a2Hat_B, RN);
 
     /*! compute the relative rotation DCM and Sun direction in relative frame */
     double RB[3][3];
@@ -173,7 +173,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
 
     if (v3Norm(configData->h2Hat_B) > epsilon) {
         // compute second reference frame
-        computeFinalRotation(configData->alignmentPriority, BN, rHat_SB_B, configData->h2Hat_B, hReqHat_B, a1Hat_B, a2Hat_B, RN);
+        oasapComputeFinalRotation(configData->alignmentPriority, BN, rHat_SB_B, configData->h2Hat_B, hReqHat_B, a1Hat_B, a2Hat_B, RN);
         
         // compute the relative rotation DCM and Sun direction in relative frame
         m33MultM33t(RN, BN, RB);
@@ -260,7 +260,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
 }
 
 /*! This helper function computes the first rotation that aligns the body heading with the inertial heading */
-void computeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3])
+void oasapComputeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3])
 {
     /*! compute principal rotation angle (phi) and vector (e_phi) for the first rotation */
     double phi = acos( fmin( fmax( v3Dot(hRefHat_B, hReqHat_B), -1 ), 1 ) );
@@ -284,7 +284,7 @@ void computeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3
 }
 
 /*! This helper function computes the second rotation that achieves the best incidence on the solar arrays maintaining the heading alignment */
-void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3])
+void oasapComputeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3])
 {
     /*! define second rotation vector to coincide with the thrust direction in B coordinates */
     double e_psi[3];
@@ -369,7 +369,7 @@ void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1H
 }
 
 /*! This helper function computes the third rotation that breaks the heading alignment if needed, to achieve maximum incidence on solar arrays */
-void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3])
+void oasapComputeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3])
 {
     double PRV_theta[3];
 
@@ -414,11 +414,11 @@ void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHa
 }
 
 /*! This helper function computes the final rotation as a product of the first three DCMs */
-void computeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3])
+void oasapComputeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3])
 {
     /*! compute the first rotation DCM */
     double R1B[3][3];
-    computeFirstRotation(hRefHat_B, hReqHat_B, R1B);
+    oasapComputeFirstRotation(hRefHat_B, hReqHat_B, R1B);
 
     /*! compute Sun direction vector in R1 frame coordinates */
     double rHat_SB_R1[3];
@@ -426,7 +426,7 @@ void computeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB
 
     /*! compute the second rotation DCM */
     double R2R1[3][3];
-    computeSecondRotation(hRefHat_B, rHat_SB_R1, a1Hat_B, a2Hat_B, R2R1);
+    oasapComputeSecondRotation(hRefHat_B, rHat_SB_R1, a1Hat_B, a2Hat_B, R2R1);
 
     /* compute Sun direction in R2 frame components */
     double rHat_SB_R2[3];
@@ -434,7 +434,7 @@ void computeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB
 
     /*! compute the third rotation DCM */
     double R3R2[3][3];
-    computeThirdRotation(alignmentPriority, hRefHat_B, rHat_SB_R2, a1Hat_B, R3R2);
+    oasapComputeThirdRotation(alignmentPriority, hRefHat_B, rHat_SB_R2, a1Hat_B, R3R2);
 
     /*! compute reference frames w.r.t inertial frame */
     double R1N[3][3], R2N[3][3];

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -29,7 +29,6 @@
 #include "cMsgCInterface/EphemerisMsg_C.h"
 #include "cMsgCInterface/NavAttMsg_C.h"
 
-#define ONE_AXIS_SA_EPS 1e-12                    //!< accuracy to check if a variable is zero
 
 typedef enum alignmentPriority{
     prioritizeAxisAlignment = 0,

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.h
@@ -86,10 +86,10 @@ extern "C" {
     void Reset_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID);
     void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uint64_t callTime, int64_t moduleID);
 
-    void computeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3]);
-    void computeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3]);
-    void computeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3]);
-    void computeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
+    void oasapComputeFirstRotation(double hRefHat_B[3], double hReqHat_B[3], double R1B[3][3]);
+    void oasapComputeSecondRotation(double hRefHat_B[3], double rHat_SB_R1[3], double a1Hat_B[3], double a2Hat_B[3], double R2R1[3][3]);
+    void oasapComputeThirdRotation(int alignmentPriority, double hRefHat_B[3], double rHat_SB_R2[3], double a1Hat_B[3], double R3R2[3][3]);
+    void oasapComputeFinalRotation(int alignmentPriority, double BN[3][3], double rHat_SB_B[3], double hRefHat_B[3], double hReqHat_B[3], double a1Hat_B[3], double a2Hat_B[3], double RN[3][3]);
 
 #ifdef __cplusplus
 }

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
@@ -22,13 +22,12 @@
 #include "string.h"
 #include <math.h>
 
-
-/* Support files.  Be sure to use the absolute path relative to Basilisk directory. */
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/macroDefinitions.h"
 
+const double epsilon = 1e-12;                           // module tolerance for zero
 
 /*! This method initializes the output messages for this module.
  @return void
@@ -124,7 +123,7 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
     double thetaC = atan2(sinThetaC, cosThetaC);      // clip theta current between 0 and 2*pi
 
     /*! compute reference angle and store in buffer msg */
-    if (v3Norm(a2Hat_R) < SA_REF_EPS) {
+    if (v3Norm(a2Hat_R) < epsilon) {
         // if norm(a2Hat_R) = 0, reference coincides with current angle
         hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta;
     }

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.h
@@ -26,7 +26,6 @@
 #include "cMsgCInterface/AttRefMsg_C.h"
 #include "cMsgCInterface/HingedRigidBodyMsg_C.h"
 
-#define SA_REF_EPS 1e-12                    //!< accuracy to check if a variable is zero
 
 enum attitudeFrame{
     referenceFrame = 0,

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -94,7 +94,7 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
     v3Add(configData->r_FM_F, configData->r_TF_F, r_TM_F);   // position of T w.r.t. M in F-frame coordinates
     
     double FM[3][3];
-    computeFinalRotation(r_CM_M, r_TM_F, configData->T_F, FM);
+    tprComputeFinalRotation(r_CM_M, r_TM_F, configData->T_F, FM);
 
     /*! compute net RW momentum */
     double vec3[3], hs_B[3], hs_M[3];
@@ -115,7 +115,7 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
     /*! recompute thrust direction and FM matrix based on offset */
     double r_CMd_M[3];
     v3Add(r_CM_M, d_M, r_CMd_M);
-    computeFinalRotation(r_CMd_M, r_TM_F, configData->T_F, FM);
+    tprComputeFinalRotation(r_CMd_M, r_TM_F, configData->T_F, FM);
 
     /*! extract theta1 and theta2 angles */
     hingedRigidBodyRef1Out.theta = atan2(FM[1][2], FM[1][1]);
@@ -151,7 +151,7 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
     CmdTorqueBodyMsg_C_write(&thrusterTorqueOut, &configData->thrusterTorqueOutMsg, moduleID, callTime);
 }
 
-void computeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3])
+void tprComputeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3])
 {
     // compute principal rotation angle phi
     double phi = acos( fmin( fmax( v3Dot(THat_F, rHat_CM_F), -1 ), 1 ) );
@@ -190,7 +190,7 @@ void computeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3
     PRV2C(PRV_phi, F1M);
 }
 
-void computeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3], double THat_F[3], double F2F1[3][3])
+void tprComputeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3], double THat_F[3], double F2F1[3][3])
 {
     // define offset vector aVec
     double aVec[3];
@@ -231,7 +231,7 @@ void computeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3],
     PRV2C(PRV_psi, F2F1);
 }
 
-void computeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3])
+void tprComputeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3])
 {
     double e1 = e_theta[0];  
     double e2 = e_theta[1];  
@@ -301,7 +301,7 @@ void computeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3]
     PRV2C(PRV_theta, F3F2);
 }
 
-void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], double FM[3][3])
+void tprComputeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], double FM[3][3])
 {
     /*! define unit vectors of CM direction in M coordinates and thrust direction in F coordinates */
     double rHat_CM_M[3];
@@ -313,7 +313,7 @@ void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], dou
 
     /*! compute first rotation to make T_F parallel to r_CM */
     double F1M[3][3];
-    computeFirstRotation(THat_F, rHat_CM_F, F1M);
+    tprComputeFirstRotation(THat_F, rHat_CM_F, F1M);
 
     /*! rotate r_CM_F */
     double r_CM_F[3];
@@ -325,7 +325,7 @@ void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], dou
 
     /*! compute second rotation to zero the offset between T_F and r_CT_F */
     double F2F1[3][3];
-    computeSecondRotation(r_CM_F, r_TM_F, r_CT_F, THat_F, F2F1);
+    tprComputeSecondRotation(r_CM_F, r_TM_F, r_CT_F, THat_F, F2F1);
 
     /*! define intermediate platform rotation F2M */
     double F2M[3][3];
@@ -336,7 +336,7 @@ void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], dou
     m33MultV3(F2M, r_CM_M, e_theta);
     v3Normalize(e_theta, e_theta);
     double F3F2[3][3];
-    computeThirdRotation(e_theta, F2M, F3F2);
+    tprComputeThirdRotation(e_theta, F2M, F3F2);
 
     /*! define final platform rotation FM */
     m33MultM33(F3F2, F2M, FM);

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -72,10 +72,10 @@ extern "C" {
     void Reset_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
     void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configData, uint64_t callTime, int64_t moduleID);
 
-    void computeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3]);
-    void computeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3], double T_F_hat[3], double FF1[3][3]);
-    void computeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3]);
-    void computeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], double FM[3][3]);
+    void tprComputeFirstRotation(double THat_F[3], double rHat_CM_F[3], double F1M[3][3]);
+    void tprComputeSecondRotation(double r_CM_F[3], double r_TM_F[3], double r_CT_F[3], double T_F_hat[3], double FF1[3][3]);
+    void tprComputeThirdRotation(double e_theta[3], double F2M[3][3], double F3F2[3][3]);
+    void tprComputeFinalRotation(double r_CM_M[3], double r_TM_F[3], double T_F[3], double FM[3][3]);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* **Tickets addressed:** bsk-244
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This branch changes the way that tolerance variables ''epsilon'' are defined in modules solarArrayReference and oneAxisSolarArrayPoint. This is done in commits 1 and 2. Later, this branch changes the definition of some functions in thrusterPlatformReference and oneAxisSolarArrayPoint, which were causing .rst build issues. This is done in commits 3 and 4. Commit 5 removes pi from the range of tested values for oneAxisSolarArrayPoint due to a loss in precision, and pushes the precision on the other test cases to 1e-12. Commit 6 has the unit test print the test results.
