### PR TITLE
fix RST documentation warning

### DIFF
--- a/examples/_default.rst
+++ b/examples/_default.rst
@@ -322,7 +322,8 @@ Advanced Simulation Options
 
    Setting Type of Integrator <scenarioIntegrators>
    Using a Variable Time Step Integrator <scenarioVariableTimeStepIntegrators>
-   Using a Python BSK Module <scenarioAttitudePointingPy>
+   Using a Python BSK Module Inherited from SysModel Class <scenarioAttitudePointingPy>
+   Using a Python BSK Module (depreciated)  <scenarioAttitudePointingPyDEPRECATED>
    Changing the bskLog Verbosity from Python <scenarioBskLog>
 
 Multi-Threading Basilisk Simulations


### PR DESCRIPTION

* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We need to include both the current scenario on making a BSK module in python, and the depreciated scenario, in the examples index.  Currently building BSK documentation yields a warning due to an unlined python file.

## Verification
Did a clean documentation build.

## Documentation
N/A

## Future work
None