### PR TITLE
Feature/276 change integrator after sync

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-9.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-9.rst
@@ -33,9 +33,3 @@ The integration type is determined by the integrator assigned to the primary ``D
 which the other ``DynamicObject`` integrations is synchronized.  By default this is the ``RK4``
 integrator.  It doesn't matter what integrator is assigned to the secondary ``DynamicObject`` instances,
 the integrator of the primary object is used.
-
-Assigning an integrator to ``DynamicObject`` using ``setIntegrator()``,
-as discussed in :ref:`scenarioIntegrators`, clears
-out the vector of objects being integrated. Thus, if the integrator needs to be changed to
-one other than the default ``RK4``, then this must be done before the
-``syncDynamicsIntegration()`` method is called.

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -109,7 +109,7 @@ import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError,
                                     rwMotorTorque, hillPoint)
-from Basilisk.simulation import reactionWheelStateEffector, simpleNav, spacecraft
+from Basilisk.simulation import reactionWheelStateEffector, simpleNav, spacecraft, svIntegrators
 from Basilisk.utilities import (SimulationBaseClass, macros,
                                 orbitalMotion, simIncludeGravBody,
                                 simIncludeRW, unitTestSupport, vizSupport)
@@ -247,6 +247,13 @@ def run(show_plots):
     # this next step is not required, just a demonstration how we can ensure that
     # the Servicer and Debris differential equations are integrated simultaneously
     scObject.syncDynamicsIntegration(scObject2)
+
+    # Likewise, the following step is not required, as the default integrator
+    # is already RK4. However, this illustrates that you can change the integrator
+    # of the primary after calling sync, but not of the secondary!
+    integratorObject = svIntegrators.svIntegratorRK4(scObject)
+    scObject.setIntegrator(integratorObject)
+    # scObject2.setIntegrator(integratorObject) # <- Will raise an error!
 
     # make another debris object */
     scObject3 = spacecraft.Spacecraft()

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -19,39 +19,39 @@
 
 #include "dynamicObject.h"
 
-/*! This is the constructor, just setting the variables to zero */
-DynamicObject::DynamicObject()
-{
-    return;
-}
-
-/*! This is the destructor, nothing to report here */
-DynamicObject::~DynamicObject()
-{
-    return;
-}
-
-/*! This method initializes the stateEffectors and dynamicEffectors and links the necessarry components together */
-void DynamicObject::initializeDynamics()
-{
-    return;
-}
-
-/*! This method allows a dynamicObject to compute energy and momentum. Great for sim validation purposes */
-void DynamicObject::computeEnergyMomentum(double t)
-{
-    return;
-}
-
 /*! This method changes the integrator in use (Default integrator: RK4) */
 void DynamicObject::setIntegrator(StateVecIntegrator *newIntegrator)
 {
-    if (newIntegrator != nullptr) {
-        delete integrator;
-        integrator = newIntegrator;
+    if (this->isDynamicsSynced)
+    {
+        bskLogger.bskLog(BSK_WARNING, 
+            "You cannot set the integrator of a DynamicObject with synced integration. "
+            "If you want to change the integrator, change the integrator of the primary DynamicObject.");
+        return;
     }
 
-    return;
+    if (!newIntegrator)
+    {
+        bskLogger.bskLog(BSK_ERROR, "New integrator cannot be a null pointer");
+        return;
+    }
+    
+    if (newIntegrator->dynPtrs.at(0) != this)
+    {
+        bskLogger.bskLog(BSK_ERROR, "New integrator must have been created using this DynamicObject");
+        return;
+    }
+
+    // If there was already an integrator set, then whatever dynPtrs that the
+    // original integrator had take priority over the dynPtrs of newIntegrator
+    if (this->integrator)
+    {
+        newIntegrator->dynPtrs = std::move(this->integrator->dynPtrs);
+    }
+
+    delete this->integrator;
+
+    this->integrator = newIntegrator;
 }
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -37,10 +37,9 @@ public:
     BSKLogger bskLogger;                      //!< -- BSK Logging
 
 public:
-    DynamicObject();                                  //!< -- Constructor
-    virtual ~DynamicObject();                         //!< -- Destructor
-    virtual void initializeDynamics();                //!< -- Initializes the dynamics and variables
-    virtual void computeEnergyMomentum(double t);     //!< -- Method to compute energy and momentum of the system
+    virtual ~DynamicObject() = default;               //!< -- Destructor
+    virtual void initializeDynamics() {};             //!< -- Initializes the dynamics and variables
+    virtual void computeEnergyMomentum(double t) {};  //!< -- Method to compute energy and momentum of the system
     virtual void UpdateState(uint64_t callTime) = 0;  //!< -- This hooks the dyn-object into Basilisk architecture
     virtual void equationsOfMotion(double t, double timeStep) = 0;     //!< -- This is computing F = Xdot(X,t)
     void integrateState(double t);                    //!< -- This method steps the state forward in time


### PR DESCRIPTION
* **Tickets addressed:** #276
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The dynPtrs of the current integrator override the dynPtrs of the newly set integrator.

## Verification
An existing scenario was altered so that the integrator is set after the dynamics are sync. Propagation of both objects happened as one would expect.

## Documentation
Some documentation that warned against changing the integrator after syncing has been removed