### PR TITLE
Feature/286 sysmodel logger

### DIFF
--- a/docs/source/Learn/bskPrinciples.rst
+++ b/docs/source/Learn/bskPrinciples.rst
@@ -20,3 +20,4 @@ by writing a python script.
    bskPrinciples/bskPrinciples-8
    bskPrinciples/bskPrinciples-9
    bskPrinciples/bskPrinciples-10
+   bskPrinciples/bskPrinciples-11

--- a/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
@@ -1,0 +1,31 @@
+
+
+.. _bskPrinciples-11:
+
+.. warning:: 
+
+    This section refers to a deprecated way of logging variables. Refer to previous documentation pages for the updated way.
+
+Deprecated: Setting and Recording Module Variables
+==================================================
+
+The deprecated :ref:`SimulationBaseClass` method to record a module variable is::
+
+    scSim.AddVariableForLogging( variableString, recordingTime, indexStart==0, indexStop==0)
+
+Here ``variableString`` must be composed of the module tag string, a period and the variable name.
+The examples above illustrate how to apply this method for a C or C++ module variable.
+
+The ``recordingTime`` variable is the minimum time that must pass, in nano-seconds again, before the
+module variable is recorded.
+
+The optional integer arguments ``indexStart`` and ``indexStop`` are defaulted to zero, resulting in a
+single value being recorded.  As this example is also recording a 3-dimensional array ``dumVector``,
+it is recorded by setting the start and end index to 0 and 2 respectively.
+
+After executing the script, the recorded variables are retrieved in general using
+the :ref:`SimulationBaseClass` method::
+
+    scSim.GetLogVariableData(variableString)
+
+Here ``variableString`` is again composed of the ``ModelTag`` and variable name as before.  Note that the returned array has a first column that represents the time where the variable is recorded in nano-seconds.  Executing the script you should thus see the following output:

--- a/docs/source/Learn/makingModules/cppModules/cppModules-4.rst
+++ b/docs/source/Learn/makingModules/cppModules/cppModules-4.rst
@@ -19,7 +19,7 @@ The basic swig interface file looks like this:
     from Basilisk.architecture.swig_common_model import *
     %}
 
-    %include "sys_model.h"
+    %include "sys_model.i"
     %include "swig_conly_data.i"
 
     %include "someModule.h"

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -48,10 +48,17 @@ Version |release|
   removing the need for "Config" and "Wrap" objects. Updated all scenarios and test files for this new syntax.
   To convert prior script to use the new syntax, see :ref:`bskPrinciples-2` for the simple new
   syntaxt to add C-modules.
-- Modified :ref:`mrpFeedback` to enable the use of a modified control law, and added the integral control torque
+- Modified :ref:`mrpFeedback` to enable the use of a modified control law, and added the integral control torque 
   feedback output message.
 - Resolved a crash, induced by uninitialized memory, in the Camera module. The crash was first seen on Ubuntu 22 with
   gcc 9.5
+- Implemented new syntax for variable logging. See :ref:`bskPrinciples-6`.
+
+.. warning::
+
+    SWIG files (``.i``) for modules should include ``%include "sys_model.i"`` instead of ``%include "sys_model.h"``
+    to take advantage of the new module variable logging feature.
+
 
 Version 2.2.0 (June 28, 2023)
 -----------------------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -43,7 +43,7 @@ Version |release|
 - Corrected an error with :ref:`magnetometer` where the RNG seed was passed to the Gauss-Markov noise model within the
   constructor and could therefore not be modified after creating the object. Furthermore, the noise model is now only
   used if all three components of the standard deviation parameter are initialized to a positive value.
-- Removed fswAuto and associated documenation, as the tool was outdated.
+- Removed fswAuto and associated documentation, as the tool was outdated.
 - Changed how C modules are wrapped as C++ classes. This makes handling C modules the same as C++ modules,
   removing the need for "Config" and "Wrap" objects. Updated all scenarios and test files for this new syntax.
   To convert prior script to use the new syntax, see :ref:`bskPrinciples-2` for the simple new

--- a/docs/source/codeSamples/bsk-6.py
+++ b/docs/source/codeSamples/bsk-6.py
@@ -51,11 +51,11 @@ def run():
     mod2.dummy = 1
     mod2.dumVector = [1., 2., 3.]
 
-    # request these module variables to be recorded
-    scSim.AddVariableForLogging(mod1.ModelTag + ".dummy", macros.sec2nano(1.))
-    scSim.AddVariableForLogging(mod1.ModelTag + ".dumVector", macros.sec2nano(1.), 0, 2)
-    scSim.AddVariableForLogging(mod2.ModelTag + ".dummy", macros.sec2nano(1.))
-    scSim.AddVariableForLogging(mod2.ModelTag + ".dumVector", macros.sec2nano(1.), 0, 2)
+    # request these module variables to be recorded    
+    mod1Logger = mod1.logger("dummy", macros.sec2nano(1.))
+    scSim.AddModelToTask("dynamicsTask", mod1Logger)
+    mod2WrapLogger = mod2.logger(["dummy", "dumVector"], macros.sec2nano(1.))
+    scSim.AddModelToTask("dynamicsTask", mod2WrapLogger)
 
     #  initialize Simulation:
     scSim.InitializeSimulation()
@@ -64,17 +64,16 @@ def run():
     scSim.ConfigureStopTime(macros.sec2nano(1.0))
     scSim.ExecuteSimulation()
 
+    # Print when were the variables logged (the same for every logged variable)
+    print("Times: ", mod1Logger.times())
+
+    # Print values logged
     print("mod1.dummy:")
-    print(scSim.GetLogVariableData(mod1.ModelTag + ".dummy"))
-    print("mod1.dumVector:")
-    print(scSim.GetLogVariableData(mod1.ModelTag + ".dumVector"))
+    print(mod1Logger.dummy)
     print("mod2.dummy:")
-    print(scSim.GetLogVariableData(mod2.ModelTag + ".dummy"))
+    print(mod2WrapLogger.dummy)
     print("mod2.dumVector:")
-    print(scSim.GetLogVariableData(mod2.ModelTag + ".dumVector"))
-
-    return
-
+    print(mod2WrapLogger.dumVector)
 
 if __name__ == "__main__":
     run()

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavHeading.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavHeading.py
@@ -143,10 +143,10 @@ class scenario_OpNav(BSKScenario):
             self.rwLogs.append(DynModel.rwStateEffector.rwOutMsgs[item].recorder(samplingTime))
             self.masterSim.AddModelToTask(DynModel.taskName, self.rwLogs[item])
 
-        self.masterSim.AddVariableForLogging('headingUKF.bVec_B', samplingTime, 0, 2)
-
+        self.headingBVecLog = FswModel.headingUKF.logger("bVec_B")
         self.filtRec = FswModel.headingUKF.filtDataOutMsg.recorder(samplingTime)
         self.opNavFiltRec = FswModel.headingUKF.opnavDataOutMsg.recorder(samplingTime)
+        self.masterSim.AddModelToTask(DynModel.taskName, self.headingBVecLog)
         self.masterSim.AddModelToTask(DynModel.taskName, self.filtRec)
         self.masterSim.AddModelToTask(DynModel.taskName, self.opNavFiltRec)
 
@@ -167,7 +167,7 @@ class scenario_OpNav(BSKScenario):
         circleRadii = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
         validCircle = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
 
-        frame = self.masterSim.GetLogVariableData('headingUKF.bVec_B')
+        frame = unitTestSupport.addTimeColumn(self.headingBVecLog.times(), self.headingBVecLog.bVec_B) 
 
         numRW = 4
         dataRW = []

--- a/examples/scenarioDragDeorbit.py
+++ b/examples/scenarioDragDeorbit.py
@@ -250,9 +250,11 @@ def run(show_plots, initialAlt=250, deorbitAlt=100, model="exponential"):
     # Setup data logging before the simulation is initialized
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     dataAtmoLog = atmo.envOutMsgs[0].recorder(samplingTime)
+    forceLog = dragEffector.logger("forceExternal_B", samplingTime)
+
     scSim.AddModelToTask(simTaskName, dataRec)
     scSim.AddModelToTask(simTaskName, dataAtmoLog)
-    scSim.AddVariableForLogging('DragEff.forceExternal_B', samplingTime, StartIndex=0, StopIndex=2)
+    scSim.AddModelToTask(simTaskName, forceLog)
 
     # Event to terminate the simulation
     scSim.createNewEvent("Deorbited", simulationTimeStep, True,
@@ -282,7 +284,7 @@ def run(show_plots, initialAlt=250, deorbitAlt=100, model="exponential"):
     # retrieve the logged data
     posData = dataRec.r_BN_N
     velData = dataRec.v_BN_N
-    dragForce = scSim.GetLogVariableData('DragEff.forceExternal_B')
+    dragForce = forceLog.forceExternal_B
     denseData = dataAtmoLog.neutralDensity
 
     figureList = plotOrbits(dataRec.times(), posData, velData, dragForce, denseData, oe, mu, planet, model)
@@ -348,7 +350,7 @@ def plotOrbits(timeAxis, posData, velData, dragForce, denseData, oe, mu, planet,
 
     # draw drag as a function of time
     fig, ax = register_fig(4)
-    plt.semilogy(timeAxis * macros.NANO2HOUR, np.linalg.norm(dragForce[:, 1:], 2, 1))
+    plt.semilogy(timeAxis * macros.NANO2HOUR, np.linalg.norm(dragForce, 2, 1))
     plt.xlabel('$t$ [hr]')
     plt.ylabel('$|F_drag|$ [N]')
 

--- a/src/architecture/_GeneralModuleFiles/py_sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/py_sys_model.i
@@ -1,0 +1,37 @@
+
+%module(directors="1") sysModel
+%{
+   #include "sys_model.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+%include "architecture/utilities/bskLogging.h"
+
+%feature("director") SysModel;
+%feature("pythonappend") SysModel::SysModel %{
+    self.__super_init_called__ = True%}
+%rename("_SysModel") SysModel;
+%include "sys_model.i"
+
+%pythoncode %{
+class SuperInitChecker(type):
+
+    def __call__(cls, *a, **kw):
+        rv = super(SuperInitChecker, cls).__call__(*a, **kw)
+        if not getattr(rv, "__super_init_called__", False):
+            error_msg = (
+               "Need to call parent __init__ in SysModel subclasses:\n"
+               f"class {cls.__name__}(sysModel.SysModel):\n"
+               "    def __init__(...):\n"
+               "        super().__init__()"
+            )
+            raise SyntaxError(error_msg)
+        return rv
+
+class SysModel(_SysModel, metaclass=SuperInitChecker):
+    bskLogger: BSKLogger = None
+%}

--- a/src/architecture/_GeneralModuleFiles/swig_c_wrap.i
+++ b/src/architecture/_GeneralModuleFiles/swig_c_wrap.i
@@ -26,8 +26,7 @@
 %}
 %include <std_string.i>
 
-%include "architecture/_GeneralModuleFiles/sys_model.h"
-%include "swig_conly_data.i"
+%include "sys_model.i"
 
 %inline %{
 

--- a/src/architecture/_GeneralModuleFiles/sys_model.cpp
+++ b/src/architecture/_GeneralModuleFiles/sys_model.cpp
@@ -21,39 +21,11 @@
 #include "architecture/utilities/moduleIdGenerator/moduleIdGenerator.h"
 
 SysModel::SysModel()
-{
-    this->ModelTag = "";
-    this->RNGSeed = 0x1badcad1;
-    this->moduleID = ModuleIdGenerator::GetInstance()->checkoutModuleID();
-}
+    : moduleID(ModuleIdGenerator::GetInstance()->checkoutModuleID())
+{}
 
 SysModel::SysModel(const SysModel &obj)
-{
-    this->ModelTag = obj.ModelTag;
-    this->RNGSeed = obj.RNGSeed;
-    this->moduleID = ModuleIdGenerator::GetInstance()->checkoutModuleID();
-}
-
-SysModel::~SysModel()
-{
-}
-
-void SysModel :: SelfInit()
-{
-    return;
-}
-
-void SysModel :: IntegratedInit()
-{
-    return;
-}
-
-void SysModel :: UpdateState(uint64_t CurrentSimNanos)
-{
-    return;
-}
-
-void SysModel::Reset(uint64_t CurrentSimNanos)
-{
-	return;
-}
+    : ModelTag{obj.ModelTag},
+    RNGSeed{obj.RNGSeed},
+    moduleID{ModuleIdGenerator::GetInstance()->checkoutModuleID()}
+{}

--- a/src/architecture/_GeneralModuleFiles/sys_model.h
+++ b/src/architecture/_GeneralModuleFiles/sys_model.h
@@ -27,22 +27,46 @@
 /*! @brief Simulation System Model Class */
 class SysModel
 {
-    
 public:
     SysModel();
-    SysModel(const SysModel &obj);  //!< constructor definition
-    virtual ~SysModel();
-    virtual void SelfInit();  //!< -- initialize the module, create messages
-    virtual void IntegratedInit();  //!< -- ???
-    virtual void UpdateState(uint64_t CurrentSimNanos);  //!< -- What the module does each time step
-    virtual void Reset(uint64_t CurrentSimNanos);  //!< -- Reset module to specified time
-    
+    SysModel(const SysModel &obj);
+
+    virtual ~SysModel(){};
+
+    /** Initializes the module, create messages */
+    virtual void SelfInit(){};
+
+    /** ??? */
+    virtual void IntegratedInit(){};
+
+    /** Reads incoming messages, performs module actions, writes output messages */
+    virtual void UpdateState(uint64_t CurrentSimNanos){};
+
+    /** Called at simulation initialization, resets module to specified time */
+    virtual void Reset(uint64_t CurrentSimNanos){};
+
 public:
-    std::string ModelTag;  //!< -- name for the algorithm to base off of
-    uint64_t CallCounts=0;  //!< -- Counts on the model being called
-    uint32_t RNGSeed;  //!< -- Giving everyone a random seed for ease of MC
-    int64_t moduleID;  //!< -- Module ID for this module  (handed out by module_id_generator)
+    std::string ModelTag = "";     //!< -- name for the algorithm to base off of
+    uint64_t CallCounts = 0;       //!< -- Counts on the model being called
+    uint32_t RNGSeed = 0x1badcad1; //!< -- Giving everyone a random seed for ease of MC
+    int64_t moduleID;              //!< -- Module ID for this module  (handed out by module_id_generator)
 };
 
+// The following code helps users who defined their own module classes
+// to transition to using the SWIG file for sys_model instead of the header file.
+// After a period of 12 months from 2023/09/15, this message can be removed.
+#ifdef SWIG
+%extend SysModel
+{
+    %pythoncode %{
+        def logger(self, *args, **kwargs):
+            raise TypeError(
+                f"The 'logger' function is not supported for this type ('{type(self).__qualname__}'). "
+                "To fix this, update the SWIG file for this module. Change "
+                """'%include "sys_model.h"' to '%include "sys_model.i"'"""
+            )
+    %}
+}
+#endif
 
 #endif /* _SYS_MODEL_H_ */

--- a/src/architecture/alg_contain/alg_contain.i
+++ b/src/architecture/alg_contain/alg_contain.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 
 %feature("copyctor");
-%include "sys_model.h"
+%include "sys_model.i"
 %include "alg_contain.h"
 
 %pythoncode %{

--- a/src/fswAlgorithms/attDetermination/CSSEst/_UnitTest/test_cssWlsEstUnitTest.py
+++ b/src/fswAlgorithms/attDetermination/CSSEst/_UnitTest/test_cssWlsEstUnitTest.py
@@ -216,9 +216,10 @@ def cssWlsEstTestFunction(show_plots):
     # Log the output message as well as the internal numACtiveCss variables
     navData = CSSWlsEstFSW.navStateOutMsg.recorder()
     filterData = CSSWlsEstFSW.cssWLSFiltResOutMsg.recorder()
+    numActiveData = CSSWlsEstFSW.logger("numActiveCss")
     unitTestSim.AddModelToTask(unitTaskName, navData)
     unitTestSim.AddModelToTask(unitTaskName, filterData)
-    unitTestSim.AddVariableForLogging("CSSWlsEst.numActiveCss", int(1E8))
+    unitTestSim.AddModelToTask(unitTaskName, numActiveData)
 
     # connect the messages
     CSSWlsEstFSW.cssDataInMsg.subscribeTo(cssDataInMsg)
@@ -259,7 +260,7 @@ def cssWlsEstTestFunction(show_plots):
         # Pull logged data out into workspace for analysis
         sHatEst = navData.vehSunPntBdy
 
-        numActive = unitTestSim.GetLogVariableData("CSSWlsEst.numActiveCss")
+        numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss) 
         sHatEstUse = sHatEst[logLengthPrev:, :]  # Only data for this subtest
         numActiveUse = numActive[logLengthPrev + 1:, :]  # Only data for this subtest
 
@@ -296,7 +297,7 @@ def cssWlsEstTestFunction(show_plots):
     unitTestSim.ExecuteSimulation()
     stepCount += 1
     sHatEst = navData.vehSunPntBdy
-    numActive = unitTestSim.GetLogVariableData("CSSWlsEst.numActiveCss")
+    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
     sHatEstUse = sHatEst[logLengthPrev:, :]
     numActiveUse = numActive[logLengthPrev + 1:, :]
     logLengthPrev = sHatEst.shape[0]
@@ -320,7 +321,7 @@ def cssWlsEstTestFunction(show_plots):
     unitTestSim.ConfigureStopTime(int((stepCount + 1) * 1E9))
     unitTestSim.ExecuteSimulation()
     stepCount += 1
-    numActive = unitTestSim.GetLogVariableData("CSSWlsEst.numActiveCss")
+    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
     numActiveUse = numActive[logLengthPrev + 1:, :]
     sHatEst = navData.vehSunPntBdy
     sHatEstUse = sHatEst[logLengthPrev + 1:, :]
@@ -341,7 +342,7 @@ def cssWlsEstTestFunction(show_plots):
 
     unitTestSim.ConfigureStopTime(int((stepCount + 1) * 1E9))
     unitTestSim.ExecuteSimulation()
-    numActive = unitTestSim.GetLogVariableData("CSSWlsEst.numActiveCss")
+    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
     numActiveUse = numActive[logLengthPrev:, :]
     logLengthPrev = numActive.shape[0]
     testFailCount += checkNumActiveAccuracy(cssDataMsg, numActiveUse,
@@ -350,7 +351,7 @@ def cssWlsEstTestFunction(show_plots):
     # Format data for plotting
     truthData = numpy.array(truthData)
     sHatEst = navData.vehSunPntBdy
-    numActive = unitTestSim.GetLogVariableData("CSSWlsEst.numActiveCss")
+    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
 
 
     #

--- a/src/fswAlgorithms/attDetermination/InertialUKF/_UnitTest/test_inertialKF.py
+++ b/src/fswAlgorithms/attDetermination/InertialUKF/_UnitTest/test_inertialKF.py
@@ -163,7 +163,9 @@ def filterMethods():
 
     module.STDatasStruct.STMessages = STList
     module.STDatasStruct.numST = len(STList)
-    unitTestSim.AddVariableForLogging('inertialUKF.stSensorOrder', testProcessRate, 0, 3, 'double')
+
+    inertialUKFLog = module.logger("stSensorOrder")
+    unitTestSim.AddModelToTask(unitTaskName, inertialUKFLog)
 
     # create ST input messages
     st1InMsg = messaging.STAttMsg().write(st1)
@@ -189,7 +191,7 @@ def filterMethods():
     unitTestSim.ConfigureStopTime(1E9)
     unitTestSim.ExecuteSimulation()
 
-    stOrdered = unitTestSim.GetLogVariableData('inertialUKF.stSensorOrder')
+    stOrdered = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.stSensorOrder)
     if numpy.linalg.norm(numpy.array(stOrdered[0]) - numpy.array([0., 2, 1, 0, 0])) > accuracy:
         testFailCount += 1
         testMessages.append("ST order test failed")
@@ -256,8 +258,8 @@ def stateUpdateInertialAttitude(show_plots):
 #    stateTarget = testVector.tolist()
 #    stateTarget.extend([0.0, 0.0, 0.0])
 #    module.state = [0.7, 0.7, 0.0]
-    unitTestSim.AddVariableForLogging('InertialUKF.covar', testProcessRate*10, 0, 35, 'double')
-    unitTestSim.AddVariableForLogging('InertialUKF.state', testProcessRate*10, 0, 5, 'double')
+    inertialUKFLog = module.logger(["covar", "state"], testProcessRate*10)
+    unitTestSim.AddModelToTask(unitTaskName, inertialUKFLog)
 
     # make input messages but don't write to them
     rwSpeedInMsg = messaging.RWSpeedMsg()
@@ -283,8 +285,8 @@ def stateUpdateInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i+1)*0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSim.GetLogVariableData('InertialUKF.covar')
-    stateLog = unitTestSim.GetLogVariableData('InertialUKF.state')
+    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     accuracy = 1.0E-5
     unitTestSupport.writeTeXSnippet("toleranceValue11", str(accuracy), path)
     for i in range(3):
@@ -315,8 +317,8 @@ def stateUpdateInertialAttitude(show_plots):
         unitTestSim.ExecuteSimulation()
 
 
-    covarLog = unitTestSim.GetLogVariableData('InertialUKF.covar')
-    stateLog = unitTestSim.GetLogVariableData('InertialUKF.state')
+    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     for i in range(3):
         if(covarLog[-1, i*6+1+i] > covarLog[0, i*6+1+i]):
             testFailCount += 1
@@ -393,8 +395,7 @@ def statePropInertialAttitude(show_plots):
     vcInMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
 
-    unitTestSim.AddVariableForLogging('InertialUKF.covar', testProcessRate*10, 0, 35)
-    unitTestSim.AddVariableForLogging('InertialUKF.state', testProcessRate*10, 0, 5)
+    inertialUKFLog = module.logger(["covar", "state"], testProcessRate*10)
 
     # make input messages but don't write to them
     rwSpeedInMsg = messaging.RWSpeedMsg()
@@ -416,8 +417,8 @@ def statePropInertialAttitude(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(8000.0))
     unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSim.GetLogVariableData('InertialUKF.covar')
-    stateLog = unitTestSim.GetLogVariableData('InertialUKF.state')
+    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
 
     accuracy = 1.0E-10
     unitTestSupport.writeTeXSnippet("toleranceValue22", str(accuracy), path)
@@ -506,8 +507,8 @@ def stateUpdateRWInertialAttitude(show_plots):
     #    stateTarget = testVector.tolist()
     #    stateTarget.extend([0.0, 0.0, 0.0])
     #    module.state = [0.7, 0.7, 0.0]
-    unitTestSim.AddVariableForLogging('InertialUKF.covar', testProcessRate * 10, 0, 35, 'double')
-    unitTestSim.AddVariableForLogging('InertialUKF.state', testProcessRate * 10, 0, 5, 'double')
+    inertialUKFLog = module.logger(["covar", "state"], testProcessRate*10)
+    unitTestSim.AddModelToTask(unitTaskName, inertialUKFLog)
 
     # make input messages but don't write to them
     gyroInMsg = messaging.AccDataMsg()
@@ -536,8 +537,10 @@ def stateUpdateRWInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + 1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSim.GetLogVariableData('InertialUKF.covar')
-    stateLog = unitTestSim.GetLogVariableData('InertialUKF.state')
+    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
+    print(inertialUKFLog.covar, covarLog)
+
     accuracy = 1.0E-5
     unitTestSupport.writeTeXSnippet("toleranceValue33", str(accuracy), path)
     for i in range(3):
@@ -565,8 +568,8 @@ def stateUpdateRWInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + 20000 + 1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSim.GetLogVariableData('InertialUKF.covar')
-    stateLog = unitTestSim.GetLogVariableData('InertialUKF.state')
+    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     for i in range(3):
         if (covarLog[-1, i * 6 + 1 + i] > covarLog[0, i * 6 + 1 + i]):
             testFailCount += 1
@@ -671,9 +674,7 @@ def statePropRateInertialAttitude(show_plots):
 
     stateInit = [0.0, 0.0, 0.0, math.pi/18.0, 0.0, 0.0]
     module.stateInit = stateInit
-    unitTestSim.AddVariableForLogging('InertialUKF.covar', testProcessRate*10, 0, 35)
-    unitTestSim.AddVariableForLogging('InertialUKF.sigma_BNOut', testProcessRate*10, 0, 2)
-    unitTestSim.AddVariableForLogging('InertialUKF.omega_BN_BOut', testProcessRate*10, 0, 2)
+    inertialUKFLog = module.logger(["covar", "sigma_BNOut", "omega_BN_BOut"], testProcessRate*10)
 
     stMessage1 = messaging.STAttMsgPayload()
     stMessage1.MRP_BdyInrtl = [0., 0., 0.]
@@ -704,9 +705,9 @@ def statePropRateInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i+1)*0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSim.GetLogVariableData('InertialUKF.covar')
-    sigmaLog = unitTestSim.GetLogVariableData('InertialUKF.sigma_BNOut')
-    omegaLog = unitTestSim.GetLogVariableData('InertialUKF.omega_BN_BOut')
+    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    sigmaLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.sigma_BNOut)
+    omegaLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.omega_BN_BOut)
     accuracy = 1.0E-3
     unitTestSupport.writeTeXSnippet("toleranceValue44", str(accuracy), path)
     for i in range(3):

--- a/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.i
+++ b/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/constrainedAttitudeManeuver.i
@@ -26,7 +26,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 %include "std_string.i"
 %include "swig_conly_data.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "constrainedAttitudeManeuver.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/fswAlgorithms/attGuidance/waypointReference/waypointReference.i
+++ b/src/fswAlgorithms/attGuidance/waypointReference/waypointReference.i
@@ -26,7 +26,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 %include "std_string.i"
 %include "swig_conly_data.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "waypointReference.h"
 
 %include "architecture/msgPayloadDefC/AttRefMsgPayload.h"

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot2DOF/_UnitTest/test_prescribedRot2DOF.py
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot2DOF/_UnitTest/test_prescribedRot2DOF.py
@@ -142,8 +142,8 @@ def PrescribedRot2DOFTestFunction(show_plots, thetaInit, thetaRef1a, thetaRef2a,
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
     # Set up module variable data recording
-    unitTestSim.AddVariableForLogging(prescribedRot2DOFObj.ModelTag + ".phi", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(prescribedRot2DOFObj.ModelTag + ".phiAccum", testProcessRate, 0, 0, 'double')
+    prescribedRot2DOFObjLog = prescribedRot2DOFObj.logger(["phi", "phiAccum"])
+    unitTestSim.AddModelToTask(unitTaskName, prescribedRot2DOFObjLog)
 
     # Initialize the simulation
     unitTestSim.InitializeSimulation()
@@ -218,10 +218,8 @@ def PrescribedRot2DOFTestFunction(show_plots, thetaInit, thetaRef1a, thetaRef2a,
     sigma_FM = dataLog.sigma_FM
 
     # Extract the logged module variables
-    phi = unitTestSim.GetLogVariableData(prescribedRot2DOFObj.ModelTag + ".phi")
-    phi = np.delete(phi, 0, axis=1)
-    phiAccum = unitTestSim.GetLogVariableData(prescribedRot2DOFObj.ModelTag + ".phiAccum")
-    phiAccum = np.delete(phiAccum, 0, axis=1)
+    phi = prescribedRot2DOFObjLog.phi
+    phiAccum = prescribedRot2DOFObjLog.phiAccum
 
     # Store the final angular velocity of the spinning body
     thetaDot_Final = np.linalg.norm(omega_FM_F[-1, :])

--- a/src/fswAlgorithms/formationFlying/formationBarycenter/formationBarycenter.i
+++ b/src/fswAlgorithms/formationFlying/formationBarycenter/formationBarycenter.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "formationBarycenter.h"
 
 %include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
@@ -42,4 +42,3 @@ struct NavTransMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/_UnitTest/test_spacecraftReconfig.py
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/_UnitTest/test_spacecraftReconfig.py
@@ -141,8 +141,9 @@ def spacecraftReconfigTestFunction(show_plots, useRefAttitude, accuracy):
 
     # Setup logging on the test spacecraftReconfig output message so that we get all the writes to it
     dataLog = module.attRefOutMsg.recorder()
+    moduleLog = module.logger("resetPeriod")
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
-    unitTestSim.AddVariableForLogging(module.ModelTag + ".resetPeriod", testProcessRate)
+    unitTestSim.AddModelToTask(unitTaskName, moduleLog)
 
     # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
@@ -158,7 +159,7 @@ def spacecraftReconfigTestFunction(show_plots, useRefAttitude, accuracy):
 
     # This pulls the actual data log from the simulation run.
     attOutput = dataLog.sigma_RN
-    resetPeriod = unitTestSim.GetLogVariableData(module.ModelTag + ".resetPeriod")
+    resetPeriod = unitTestSupport.addTimeColumn(moduleLog.times(), moduleLog.resetPeriod)
     # set the filtered output truth states
     if useRefAttitude:
         trueVector = [[1.0,0.0,0.0]]

--- a/src/fswAlgorithms/imageProcessing/centerRadiusCNN/centerRadiusCNN.i
+++ b/src/fswAlgorithms/imageProcessing/centerRadiusCNN/centerRadiusCNN.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "stdint.i"
 %include "std_string.i"
 %include "swig_conly_data.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "centerRadiusCNN.h"
 
 %include "architecture/msgPayloadDefC/OpNavCirclesMsgPayload.h"
@@ -39,4 +39,3 @@ struct CameraImageMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/imageProcessing/houghCircles/houghCircles.i
+++ b/src/fswAlgorithms/imageProcessing/houghCircles/houghCircles.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "stdint.i"
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "swig_conly_data.i"
 
 %include "houghCircles.h"
@@ -42,4 +42,3 @@ struct CameraImageMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/imageProcessing/limbFinding/limbFinding.i
+++ b/src/fswAlgorithms/imageProcessing/limbFinding/limbFinding.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "stdint.i"
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "swig_conly_data.i"
 
 %include "limbFinding.h"
@@ -41,4 +41,3 @@ struct OpNavLimbMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.i
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.i
@@ -29,7 +29,7 @@
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "smallBodyWaypointFeedback.h"
 
 %include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
@@ -45,4 +45,3 @@ struct CmdForceBodyMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.i
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.i
@@ -29,7 +29,7 @@
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "smallBodyNavEKF.h"
 
 %include "architecture/msgPayloadDefC/NavTransMsgPayload.h"
@@ -47,4 +47,3 @@ struct CmdForceBodyMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.i
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.i
@@ -29,7 +29,7 @@
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "smallBodyNavUKF.h"
 
 %include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
@@ -43,4 +43,3 @@ struct SmallBodyNavUKFMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplate.py
+++ b/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplate.py
@@ -113,7 +113,8 @@ def fswModuleTestFunction(show_plots):
     dataLog = module.dataOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
     variableName = "dummy"                              # name the module variable to be logged
-    unitTestSim.AddVariableForLogging(module.ModelTag + "." + variableName, testProcessRate)
+    moduleLog = module.logger(variableName)
+    unitTestSim.AddModelToTask(unitTaskName, moduleLog)
 
     # connect the message interfaces
     module.dataInMsg.subscribeTo(inputMsg)
@@ -141,7 +142,7 @@ def fswModuleTestFunction(show_plots):
 
     # This pulls the actual data log from the simulation run.
     # Note that range(3) will provide [0, 1, 2]  Those are the elements you get from the vector (all of them)
-    variableState = unitTestSim.GetLogVariableData(module.ModelTag + "." + variableName)
+    variableState = unitTestSupport.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
 
     # set the filtered output truth states
     trueVector = [

--- a/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplateParametrized.py
+++ b/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplateParametrized.py
@@ -160,7 +160,8 @@ def fswModuleTestFunction(show_plots, param1, param2, accuracy):
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
     variableName = "dummy"                              # name the module variable to be logged
-    unitTestSim.AddVariableForLogging(module.ModelTag + "." + variableName, testProcessRate)
+    moduleLog = module.logger(variableName)
+    unitTestSim.AddModelToTask(unitTaskName, moduleLog)
 
     # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
@@ -184,7 +185,7 @@ def fswModuleTestFunction(show_plots, param1, param2, accuracy):
 
     # This pulls the BSK module internal varialbe log from the simulation run.
     # Note, this should only be done for debugging as it is a slow process
-    variableState = unitTestSim.GetLogVariableData(module.ModelTag + "." + variableName)
+    variableState = unitTestSupport.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
 
     # set the filtered output truth states
     trueVector = []

--- a/src/moduleTemplates/cppModuleTemplate/_UnitTest/test_cppModuleTemplateParametrized.py
+++ b/src/moduleTemplates/cppModuleTemplate/_UnitTest/test_cppModuleTemplateParametrized.py
@@ -160,7 +160,8 @@ def cppModuleTestFunction(show_plots, param1, param2, accuracy):
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
     variableName = "dummy"                              # name the module variable to be logged
-    unitTestSim.AddVariableForLogging(module.ModelTag + "." + variableName, testProcessRate)
+    moduleLog = module.logger(variableName)
+    unitTestSim.AddModelToTask(unitTaskName, moduleLog)
 
     # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
@@ -184,7 +185,7 @@ def cppModuleTestFunction(show_plots, param1, param2, accuracy):
 
     # This pulls the BSK module internal varialbe log from the simulation run.
     # Note, this should only be done for debugging as it is a slow process
-    variableState = unitTestSim.GetLogVariableData(module.ModelTag + "." + variableName)
+    variableState = unitTestSupport.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
 
     # set the filtered output truth states
     trueVector = []

--- a/src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.i
+++ b/src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "cppModuleTemplate.h"
 
 %include "architecture/msgPayloadDefC/CModuleTemplateMsgPayload.h"

--- a/src/simulation/deviceInterface/encoder/encoder.i
+++ b/src/simulation/deviceInterface/encoder/encoder.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "architecture/utilities/simDefinitions.h"
 %include "architecture/utilities/macroDefinitions.h"
 %include "encoder.h"

--- a/src/simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.i
+++ b/src/simulation/deviceInterface/hingedBodyLinearProfiler/hingedBodyLinearProfiler.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "hingedBodyLinearProfiler.h"
 
 %include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
@@ -38,4 +38,3 @@ struct HingedRigidBodyMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.i
+++ b/src/simulation/deviceInterface/motorVoltageInterface/motorVoltageInterface.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "motorVoltageInterface.h"
 
 %include "architecture/msgPayloadDefC/ArrayMotorVoltageMsgPayload.h"

--- a/src/simulation/deviceInterface/tempMeasurement/tempMeasurement.i
+++ b/src/simulation/deviceInterface/tempMeasurement/tempMeasurement.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "tempMeasurement.h"
 
 %include "architecture/msgPayloadDefC/TemperatureMsgPayload.h"
@@ -38,4 +38,3 @@ struct TemperatureMsgPayload_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/_UnitTest/test_bore_ang_calc.py
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/_UnitTest/test_bore_ang_calc.py
@@ -140,9 +140,11 @@ def bore_ang_calc_func(testFixture, show_plots, boresightLoc, eulerLoc):
     dataLog = BACObject.angOutMsg.recorder()
     TotalSim.AddModelToTask(unitTaskName, dataLog)
 
+    BACObjectLog = BACObject.logger("boreVec_Po")
+    TotalSim.AddModelToTask(unitTaskName, BACObjectLog)
+
     # Execute simulation
     TotalSim.InitializeSimulation()
-    TotalSim.AddVariableForLogging(BACObject.ModelTag + ".boreVec_Po", 1, 0, 2, "double")
     TotalSim.ExecuteSimulation()
     ###################################################################################################################
     #
@@ -150,7 +152,7 @@ def bore_ang_calc_func(testFixture, show_plots, boresightLoc, eulerLoc):
 
     simMiss = dataLog.missAngle
     simAz = dataLog.azimuth
-    simBoreVecPt = TotalSim.GetLogVariableData(BACObject.ModelTag + ".boreVec_Po")
+    simBoreVecPt = BACObjectLog.boreVec_Po
 
     # Truth values
     dcm_BN = RigidBodyKinematics.MRP2C(stateMessage.sigma_BN)
@@ -193,7 +195,7 @@ def bore_ang_calc_func(testFixture, show_plots, boresightLoc, eulerLoc):
     # Set tolersnce
     AllowTolerance = 1E-10
     boreVecPoint_final = [numpy.ndarray.tolist(boreVecPoint_1)]
-    simBoreVecPt_final = [numpy.delete([simBoreVecPt[0]],0)]
+    simBoreVecPt_final = [simBoreVecPt[0]]
 
     testFailCount, testMessages = unitTestSupport.compareArray(boreVecPoint_final, simBoreVecPt_final,
                                                                AllowTolerance,

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.i
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/boreAngCalc.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "boreAngCalc.h"
 
 %include "architecture/msgPayloadDefC/BoreAngleMsgPayload.h"
@@ -45,4 +45,3 @@ struct SCStatesMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.i
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "architecture/utilities/orbitalMotion.h"
 %include "orbElemConvert.h"
 

--- a/src/simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.i
+++ b/src/simulation/dynamics/ExtPulsedTorque/ExtPulsedTorque.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "stdint.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "ExtPulsedTorque.h"
 

--- a/src/simulation/dynamics/ExtPulsedTorque/_UnitTest/test_extPulsedTorque.py
+++ b/src/simulation/dynamics/ExtPulsedTorque/_UnitTest/test_extPulsedTorque.py
@@ -80,36 +80,31 @@ def run(show_plots, offCount):
     scSim.AddModelToTask(unitTaskName, testObject)
 
     #
+    #   Setup data logging
+    #
+    testObjectLog = testObject.logger("torqueExternalPntB_B")
+    scSim.AddModelToTask(unitTaskName, testObjectLog)
+
+    #
     #   initialize the simulation
     #
     scSim.InitializeSimulation()
 
     #
-    #   Setup data logging
+    #   run the simulation
     #
     DT = 0.1
     testProcessRate = macros.sec2nano(DT)
-    variableTorque = "torqueExternalPntB_B"       # name the module variable to be logged
-    scSim.AddVariableForLogging (testObject.ModelTag + "." + variableTorque, testProcessRate, 0, 2, 'double')
-
-    #
-    #   run the simulation
-    #
     for tStop in range(1, 11):
         scSim.ConfigureStopTime(macros.sec2nano(tStop*DT))
         scSim.ExecuteSimulation()
         testObject.computeForceTorque(scSim.TotalSim.CurrentNanos, testProcessRate)
         scSim.TotalSim.SingleStepProcesses()
-        scSim.RecordLogVars()
 
     # log the data
-    dataTorque = scSim.GetLogVariableData(testObject.ModelTag+"."+variableTorque)
+    dataTorque = testObjectLog.torqueExternalPntB_B[1:,:]
 
     np.set_printoptions(precision=16)
-
-    # Remove time zero from list
-    dataTorque = dataTorque[1:len(dataTorque),:]
-    dataTorque = np.delete(dataTorque, 0, axis=1)  # remove time column
 
     #
     #   set true position information

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -138,11 +138,10 @@ def massDepletionTest(show_plots, thrusterType):
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]
     scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]
 
-    unitTestSim.InitializeSimulation()
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     posRef = scObject.dynManager.getStateObject("hubPosition")
     sigmaRef = scObject.dynManager.getStateObject("hubSigma")
@@ -150,9 +149,9 @@ def massDepletionTest(show_plots, thrusterType):
     stopTime = 60.0 * 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
 
     thrust = thrLog.thrustForce_B
     thrustPercentage = thrLog.thrustFactor
@@ -305,11 +304,10 @@ def axisChangeHelper(r_BcB_B):
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]
     scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]
 
-    unitTestSim.InitializeSimulation()
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     posRef = scObject.dynManager.getStateObject("hubPosition")
     sigmaRef = scObject.dynManager.getStateObject("hubSigma")
@@ -317,9 +315,9 @@ def axisChangeHelper(r_BcB_B):
     stopTime = 60.0 * 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
 
     dataPos = posRef.getState()
     dataSigma = sigmaRef.getState()

--- a/src/simulation/dynamics/FuelTank/fuelTank.i
+++ b/src/simulation/dynamics/FuelTank/fuelTank.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.i
+++ b/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.i
@@ -32,7 +32,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 
 // Instantiate templates used by example
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/HingedRigidBodies/_UnitTest/test_hingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/HingedRigidBodies/_UnitTest/test_hingedRigidBodyStateEffector.py
@@ -34,6 +34,7 @@ import matplotlib.pyplot as plt
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import hingedRigidBodyStateEffector
 from Basilisk.utilities import macros
+from Basilisk.utilities import pythonVariableLogger
 from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import extForceTorque
 from Basilisk.simulation import spacecraftSystem
@@ -142,16 +143,21 @@ def hingedRigidBodyGravity(show_plots):
     datLog = scObject.primaryCentralSpacecraft.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, datLog)
 
+    # Add energy and momentum variables to log
+    panel1Log = unitTestSim.panel1.logger("forceOnBody_B")
+    panel2Log = unitTestSim.panel2.logger("forceOnBody_B")
+    scLog = pythonVariableLogger.PythonVariableLogger({
+        "totOrbEnergy": lambda _: scObject.primaryCentralSpacecraft.totOrbEnergy,
+        "totOrbAngMomPntN_N": lambda _: scObject.primaryCentralSpacecraft.totOrbAngMomPntN_N,
+        "totRotAngMomPntC_N": lambda _: scObject.primaryCentralSpacecraft.totRotAngMomPntC_N,
+        "totRotEnergy": lambda _: scObject.primaryCentralSpacecraft.totRotEnergy,
+    })
+    unitTestSim.AddModelToTask(unitTaskName, panel1Log)
+    unitTestSim.AddModelToTask(unitTaskName, panel2Log)
+    unitTestSim.AddModelToTask(unitTaskName, scLog)
+
     # Initialize the simulation
     unitTestSim.InitializeSimulation()
-
-    # Add energy and momentum variables to log
-    unitTestSim.AddVariableForLogging(unitTestSim.panel1.ModelTag + ".forceOnBody_B", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(unitTestSim.panel2.ModelTag + ".forceOnBody_B", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotEnergy", testProcessRate, 0, 0, 'double')
 
     stopTime = 2.5
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
@@ -159,12 +165,12 @@ def hingedRigidBodyGravity(show_plots):
 
     sigmaOut = datLog.sigma_BN
 
-    forcePanel1 = unitTestSim.GetLogVariableData(unitTestSim.panel1.ModelTag + ".forceOnBody_B")
-    forcePanel2 = unitTestSim.GetLogVariableData(unitTestSim.panel2.ModelTag + ".forceOnBody_B")
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotEnergy")
+    forcePanel1 = unitTestSupport.addTimeColumn(panel1Log.times(), panel1Log.forceOnBody_B)
+    forcePanel2 = unitTestSupport.addTimeColumn(panel2Log.times(), panel2Log.forceOnBody_B)
+    orbEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbEnergy)
+    orbAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotEnergy)
 
     dataSigma = [sigmaOut[-1]]
 
@@ -356,12 +362,15 @@ def hingedRigidBodyNoGravity(show_plots):
     dataLog = scObject.primaryCentralSpacecraft.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
     
-    unitTestSim.InitializeSimulation()
+    scLog = pythonVariableLogger.PythonVariableLogger({
+        "totOrbEnergy": lambda _: scObject.primaryCentralSpacecraft.totOrbEnergy,
+        "totOrbAngMomPntN_N": lambda _: scObject.primaryCentralSpacecraft.totOrbAngMomPntN_N,
+        "totRotAngMomPntC_N": lambda _: scObject.primaryCentralSpacecraft.totRotAngMomPntC_N,
+        "totRotEnergy": lambda _: scObject.primaryCentralSpacecraft.totRotEnergy,
+    })
+    unitTestSim.AddModelToTask(unitTaskName, scLog)
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     stopTime = 2.5
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
@@ -371,10 +380,10 @@ def hingedRigidBodyNoGravity(show_plots):
     rOut_BN_N = dataLog.r_BN_N
     vOut_CN_N = dataLog.v_CN_N
 
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotEnergy")
+    orbEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbEnergy)
+    orbAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotEnergy)
 
     # Get the last sigma and position
     dataSigma = [sigmaOut[-1]]
@@ -584,11 +593,14 @@ def hingedRigidBodyNoGravityDamping(show_plots):
     dataLog = scObject.primaryCentralSpacecraft.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    unitTestSim.InitializeSimulation()
+    scLog = pythonVariableLogger.PythonVariableLogger({
+        "totOrbEnergy": lambda _: scObject.primaryCentralSpacecraft.totOrbEnergy,
+        "totOrbAngMomPntN_N": lambda _: scObject.primaryCentralSpacecraft.totOrbAngMomPntN_N,
+        "totRotAngMomPntC_N": lambda _: scObject.primaryCentralSpacecraft.totRotAngMomPntC_N,
+    })
+    unitTestSim.AddModelToTask(unitTaskName, scLog)
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
+    unitTestSim.InitializeSimulation()
 
     stopTime = 2.5
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
@@ -596,9 +608,9 @@ def hingedRigidBodyNoGravityDamping(show_plots):
 
     vOut_CN_N = dataLog.v_CN_N
 
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N")
+    orbEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbEnergy)
+    orbAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
 
     initialOrbAngMom_N = [[orbAngMom_N[0,1], orbAngMom_N[0,2], orbAngMom_N[0,3]]]
 
@@ -776,17 +788,20 @@ def hingedRigidBodyThetaSS(show_plots):
     unitTestSim.AddModelToTask(unitTaskName, unitTestSim.panel1)
     unitTestSim.AddModelToTask(unitTaskName, unitTestSim.panel2)
 
-    unitTestSim.InitializeSimulation()
+    stateLog = pythonVariableLogger.PythonVariableLogger({
+        "theta1": lambda _: scObject.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState(),
+        "theta2": lambda _: scObject.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState(),
+    })
+    unitTestSim.AddModelToTask(unitTaskName, stateLog)
 
-    unitTestSim.AddVariableForLogging("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState()", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState()", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     stopTime = 60.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    theta1Out = unitTestSim.GetLogVariableData("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState()")
-    theta2Out = unitTestSim.GetLogVariableData("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState()")
+    theta1Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta1)
+    theta2Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta2)
 
     # Developing the lagrangian result
     # Define initial values
@@ -969,10 +984,13 @@ def hingedRigidBodyFrequencyAmp(show_plots):
     dataLog = scObject.primaryCentralSpacecraft.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    unitTestSim.InitializeSimulation()
+    stateLog = pythonVariableLogger.PythonVariableLogger({
+        "theta1": lambda _: scObject.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState(),
+        "theta2": lambda _: scObject.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState(),
+    })
+    unitTestSim.AddModelToTask(unitTaskName, stateLog)
 
-    unitTestSim.AddVariableForLogging("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState()", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState()", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     stopTime = 58
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime/2))
@@ -988,8 +1006,8 @@ def hingedRigidBodyFrequencyAmp(show_plots):
     sigmaOut_BN = dataLog.sigma_BN
     thetaOut = 4.0*numpy.arctan(sigmaOut_BN[:,2])
 
-    theta1Out = unitTestSim.GetLogVariableData("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState()")
-    theta2Out = unitTestSim.GetLogVariableData("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState()")
+    theta1Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta1)
+    theta2Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta2)
 
     # Developing the lagrangian result
     # Define initial values
@@ -1267,14 +1285,15 @@ def hingedRigidBodyMotorTorque(show_plots, useScPlus):
     unitTestSim.AddModelToTask(unitTaskName, dataPanel1Log)
     unitTestSim.AddModelToTask(unitTaskName, dataPanel2Log)
 
+    if useScPlus:
+        scLog = scObject.logger("totRotAngMomPntC_N")
+    else:
+        scLog = pythonVariableLogger.PythonVariableLogger({
+            "totRotAngMomPntC_N": lambda _: scObject.primaryCentralSpacecraft.totRotAngMomPntC_N
+        })
+    unitTestSim.AddModelToTask(unitTaskName, scLog)
+
     unitTestSim.InitializeSimulation()
-
-    variableLogTag = scObject.ModelTag
-    if not useScPlus:
-        variableLogTag += ".primaryCentralSpacecraft"
-
-    unitTestSim.AddVariableForLogging(variableLogTag + ".totRotAngMomPntC_N",
-                                      testProcessRate, 0, 2, 'double')
 
     stopTime = 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
@@ -1295,8 +1314,7 @@ def hingedRigidBodyMotorTorque(show_plots, useScPlus):
     sB2N = dataPanel2Log.sigma_BN[0]
     oB2N = dataPanel2Log.omega_BN_B[0]
 
-    rotAngMom_N = unitTestSim.GetLogVariableData(
-        variableLogTag + ".totRotAngMomPntC_N")
+    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
 
     # Get the last sigma and position
     dataPos = [rOut_CN_N[-1]]
@@ -1495,10 +1513,13 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     dataLog = scObject.primaryCentralSpacecraft.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
-    unitTestSim.InitializeSimulation()
+    stateLog = pythonVariableLogger.PythonVariableLogger({
+        "theta1": lambda _: scObject.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState(),
+        "theta2": lambda _: scObject.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState(),
+    })
+    unitTestSim.AddModelToTask(unitTaskName, stateLog)
 
-    unitTestSim.AddVariableForLogging("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState()", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState()", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     # Define times that the new forces will be applies
     force1OffTime = 5.0
@@ -1529,8 +1550,8 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    theta1Out = unitTestSim.GetLogVariableData("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta1').getState()")
-    theta2Out = unitTestSim.GetLogVariableData("spacecraftBody.dynManager.getStateObject('spacecrafthingedRigidBodyTheta2').getState()")
+    theta1Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta1)
+    theta2Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta2)
 
     rOut_BN_N = dataLog.r_BN_N
     sigmaOut_BN = dataLog.sigma_BN

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/Integrators/svIntegrators.i
+++ b/src/simulation/dynamics/Integrators/svIntegrators.i
@@ -52,8 +52,7 @@ _rk_adaptive_base_classes = {}
     }
 }
 
-%include "sys_model.h"
-%include "../_GeneralModuleFiles/dynamicObject.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/stateVecIntegrator.h"
 
 %include "../_GeneralModuleFiles/svIntegratorRungeKutta.h"

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.i
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.i
@@ -32,7 +32,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "stdint.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/fuelSlosh.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.i
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
@@ -47,4 +47,3 @@ struct MTBMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "stdint.i"
 
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
+++ b/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
@@ -143,18 +143,12 @@ def unitRadiationPressure(show_plots, modelType, eclipseOn):
     srpDynEffector.sunEphmInMsg.subscribeTo(sunMsg)
     srpDynEffector2.sunEphmInMsg.subscribeTo(sunMsg)
 
-    unitTestSim.AddVariableForLogging(srpDynEffector.ModelTag + ".forceExternal_B",
-                                      simulationTime, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(srpDynEffector.ModelTag + ".forceExternal_N",
-                                      simulationTime, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(srpDynEffector.ModelTag + ".torqueExternalPntB_B",
-                                      simulationTime, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(srpDynEffector2.ModelTag + ".forceExternal_B",
-                                      simulationTime, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(srpDynEffector2.ModelTag + ".forceExternal_N",
-                                      simulationTime, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(srpDynEffector2.ModelTag + ".torqueExternalPntB_B",
-                                      simulationTime, 0, 2, 'double')
+    srpDynEffectorLog = [
+        effector.logger(["forceExternal_B", "forceExternal_N", "torqueExternalPntB_B"])
+        for effector in [srpDynEffector, srpDynEffector2]
+    ]
+    for effLog in srpDynEffectorLog:
+        unitTestSim.AddModelToTask(testTaskName, effLog)
 
     unitTestSim.InitializeSimulation()
 
@@ -164,15 +158,14 @@ def unitRadiationPressure(show_plots, modelType, eclipseOn):
     srpDynEffector.computeForceTorque(unitTestSim.TotalSim.CurrentNanos, testTaskRate)
     srpDynEffector2.computeForceTorque(unitTestSim.TotalSim.CurrentNanos, testTaskRate)
     unitTestSim.TotalSim.SingleStepProcesses()
-    unitTestSim.RecordLogVars()
 
-    srpDataForce_B = unitTestSim.GetLogVariableData(srpDynEffector.ModelTag + ".forceExternal_B")
-    srpDataForce_N = unitTestSim.GetLogVariableData(srpDynEffector.ModelTag + ".forceExternal_N")
-    srpTorqueData = unitTestSim.GetLogVariableData(srpDynEffector.ModelTag + ".torqueExternalPntB_B")
+    srpDataForce_B = unitTestSupport.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].forceExternal_B)
+    srpDataForce_N = unitTestSupport.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].forceExternal_N)
+    srpTorqueData = unitTestSupport.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].torqueExternalPntB_B)
 
-    srp2DataForce_B = unitTestSim.GetLogVariableData(srpDynEffector2.ModelTag + ".forceExternal_B")
-    srp2DataForce_N = unitTestSim.GetLogVariableData(srpDynEffector2.ModelTag + ".forceExternal_N")
-    srp2TorqueData = unitTestSim.GetLogVariableData(srpDynEffector2.ModelTag + ".torqueExternalPntB_B")
+    srp2DataForce_B = unitTestSupport.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].forceExternal_B)
+    srp2DataForce_N = unitTestSupport.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].forceExternal_N)
+    srp2TorqueData = unitTestSupport.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].torqueExternalPntB_B)
 
     errTol = 1E-12
     if modelType == "cannonball":

--- a/src/simulation/dynamics/RadiationPressure/radiationPressure.i
+++ b/src/simulation/dynamics/RadiationPressure/radiationPressure.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "radiationPressure.h"
 
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
@@ -97,6 +97,16 @@ def executeSimRun(simContainer, thrusterSet, simRate, totalTime):
             simContainer.TotalSim.CurrentNanos * macros.NANO2SEC + simRate * macros.NANO2SEC)
 
 
+def fixMDotData(mDotData):
+    """This test was written before a bug in variable logging was fixed.
+    
+    This bug made it so consecutive logged zeros would get removed, which
+    is why we need to remove all zero rows at the beginning of mDotData
+    but one.
+    """
+    firstNonZeroRow = np.nonzero(mDotData[:,1])[0][0]
+    return np.row_stack([[0,0], mDotData[firstNonZeroRow:, :]])
+
 # uncomment this line if this test has an expected failure, adjust message as needed
 # @pytest.mark.xfail(True)
 
@@ -197,9 +207,8 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
     thrDurationTime=duration*1./macros.NANO2SEC # Parametrized thrust duration
 
     #Configure a single thruster firing, create a message for it
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.forceExternal_B', testRate, 0, 2)
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.torqueExternalPntB_B', testRate, 0, 2)
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.mDotTotal', testRate, 0, 0)
+    thrusterSetLog = thrusterSet.logger(["forceExternal_B", "torqueExternalPntB_B", "mDotTotal"])
+    TotalSim.AddModelToTask(unitTaskName, thrusterSetLog)
 
     ThrustMessage = messaging.THRArrayOnTimeCmdMsgPayload()
     if thrustNumber==1:
@@ -228,9 +237,10 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
         executeSimRun(TotalSim, thrusterSet, testRate, int(thrDurationTime+sparetime))
 
         # Gather the Force and Torque results
-        thrForce = TotalSim.GetLogVariableData('ACSThrusterDynamics.forceExternal_B')
-        thrTorque = TotalSim.GetLogVariableData('ACSThrusterDynamics.torqueExternalPntB_B')
-        mDotData = TotalSim.GetLogVariableData('ACSThrusterDynamics.mDotTotal')
+        thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+        thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+        mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+        mDotData = fixMDotData(mDotData)
 
         # Auto Generate LaTex Figures
         format = r"width=0.8\textwidth"
@@ -386,9 +396,10 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
                 executeSimRun(TotalSim, thrusterSet, testRate, int(thrDurationTime+sparetime))
 
                 # Extract log variables and plot the results
-                thrForce = TotalSim.GetLogVariableData('ACSThrusterDynamics.forceExternal_B')
-                thrTorque = TotalSim.GetLogVariableData('ACSThrusterDynamics.torqueExternalPntB_B')
-                mDotData = TotalSim.GetLogVariableData('ACSThrusterDynamics.mDotTotal')
+                thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+                thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+                mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+                mDotData = fixMDotData(mDotData)
 
                 snippetName = "Snippet" + "Ramp_" + str(rampsteps) +"steps_" + str(int(duration)) + "s"+  "_Cutoff" + cutoff + "_Rate" + str(
                     int(1. / (testRate * macros.NANO2SEC))) + "_Cutoff" + cutoff
@@ -501,9 +512,10 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
                 executeSimRun(TotalSim, thrusterSet, testRate, int(COrestart * 1.0 / macros.NANO2SEC + sparetime))
 
                 # Extract log variables and plot the results
-                thrForce = TotalSim.GetLogVariableData('ACSThrusterDynamics.forceExternal_B')
-                thrTorque = TotalSim.GetLogVariableData('ACSThrusterDynamics.torqueExternalPntB_B')
-                mDotData = TotalSim.GetLogVariableData('ACSThrusterDynamics.mDotTotal')
+                thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+                thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+                mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+                mDotData = fixMDotData(mDotData)
 
                 PlotName = "Ramp_" + str(rampsteps) + "steps_Cutoff" + cutoff +"_" + str(int(duration)) + "s"+"_testRate" + str(
                 int(1. / (testRate * macros.NANO2SEC)))
@@ -605,9 +617,10 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber , duration  ,  lon
             executeSimRun(TotalSim, thrusterSet, testRate, int(RDlength * 1.0 / macros.NANO2SEC + sparetime))
 
             # Extract log variables and plot the results
-            thrForce = TotalSim.GetLogVariableData('ACSThrusterDynamics.forceExternal_B')
-            thrTorque = TotalSim.GetLogVariableData('ACSThrusterDynamics.torqueExternalPntB_B')
-            mDotData = TotalSim.GetLogVariableData('ACSThrusterDynamics.mDotTotal')
+            thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+            thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+            mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+            mDotData = fixMDotData(mDotData)
 
             PlotName = "Ramp_" + str(rampsteps) + "steps_Cutoff" + cutoff + "rampDown" + rampDown+"_testRate" + str(
                 int(1. / (testRate * macros.NANO2SEC)))

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_dynamics_attached_body.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_dynamics_attached_body.py
@@ -159,8 +159,8 @@ def unitThrusters(show_plots, long_angle, lat_angle, location, rate):
     testDurationTime = 2.0
 
     # Log variables of interest
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.forceExternal_B', testRate, 0, 2)
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.torqueExternalPntB_B', testRate, 0, 2)
+    thrusterSetLog = thrusterSet.logger(["forceExternal_B", "torqueExternalPntB_B"])
+    TotalSim.AddModelToTask(unitTaskName2, thrusterSetLog)
 
     # Initialize the simulation
     TotalSim.InitializeSimulation()
@@ -180,8 +180,8 @@ def unitThrusters(show_plots, long_angle, lat_angle, location, rate):
     TotalSim.ExecuteSimulation()
 
     # Gather the Force, Torque and Mass Rate results
-    thrForce = TotalSim.GetLogVariableData('ACSThrusterDynamics.forceExternal_B')
-    thrTorque = TotalSim.GetLogVariableData('ACSThrusterDynamics.torqueExternalPntB_B')
+    thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+    thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
 
     # Generate the truth data (force, torque and mass rate)
     expectedThrustData = np.zeros([3, np.shape(thrForce)[0]])

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
@@ -37,7 +37,7 @@ namespace std {
     %template(ThrusterConfigVector) vector<THRSimConfig>;
 }
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
@@ -252,9 +252,8 @@ def unitThrusters(testFixture, show_plots, thrustNumber, initialConditions, dura
     thrDurationTime = macros.sec2nano(2.0)
 
     # Log variables of interest
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.forceOnBody_B', testRate, 0, 2)
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.torqueOnBodyPntB_B', testRate, 0, 2)
-    TotalSim.AddVariableForLogging('ACSThrusterDynamics.mDotTotal', testRate, 0, 0)
+    thrusterSetLog = thrusterSet.logger(["forceOnBody_B", "torqueOnBodyPntB_B", "mDotTotal"])
+    TotalSim.AddModelToTask(unitTaskName2, thrusterSetLog)
 
     #  Configure a single thruster firing, create a message for it
     ThrustMessage = messaging.THRArrayOnTimeCmdMsgPayload()
@@ -285,9 +284,9 @@ def unitThrusters(testFixture, show_plots, thrustNumber, initialConditions, dura
         plt.show()
 
     # Gather the Force, Torque and Mass Rate results
-    thrForce = TotalSim.GetLogVariableData('ACSThrusterDynamics.forceOnBody_B')
-    thrTorque = TotalSim.GetLogVariableData('ACSThrusterDynamics.torqueOnBodyPntB_B')
-    mDot = TotalSim.GetLogVariableData('ACSThrusterDynamics.mDotTotal')
+    thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceOnBody_B)
+    thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueOnBodyPntB_B)
+    mDot = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
 
     # Save the time vector
     timeSec = dataRec.times() * macros.NANO2SEC

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.i
@@ -33,7 +33,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "std_vector.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/VSCMGs/_UnitTest/test_VSCMGStateEffector_integrated.py
+++ b/src/simulation/dynamics/VSCMGs/_UnitTest/test_VSCMGStateEffector_integrated.py
@@ -244,10 +244,8 @@ def VSCMGIntegratedTest(show_plots,useFlag,testCase):
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
     unitTestSim.AddModelToTask(unitTaskName, speedLog)
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totOrbEnergy", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
     unitTestSim.ConfigureStopTime(macros.sec2nano(duration))
 
@@ -258,10 +256,10 @@ def VSCMGIntegratedTest(show_plots,useFlag,testCase):
 
     unitTestSim.ExecuteSimulation()
 
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     wheelSpeeds = speedLog.wheelSpeeds
     gimbalAngles = speedLog.gimbalAngles

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.i
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/stateData.h"
 %include "../_GeneralModuleFiles/stateEffector.h"
 %include "../_GeneralModuleFiles/dynamicEffector.h"

--- a/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
+++ b/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
@@ -224,7 +224,9 @@ def run(show_plots, orbitCase, planetCase):
     scSim.AddModelToTask(simTaskName, dataLog)
     scSim.AddModelToTask(simTaskName, dataNewAtmoLog)
 
-    scSim.AddVariableForLogging('DragEff.forceExternal_B', samplingTime, StartIndex=0, StopIndex=2)
+    dragEffectorLog = dragEffector.logger("forceExternal_B", samplingTime)
+    scSim.AddModelToTask(simTaskName, dragEffectorLog)
+
     #
     #   initialize Spacecraft States with initialization variables
     #
@@ -248,7 +250,7 @@ def run(show_plots, orbitCase, planetCase):
     posData = dataLog.r_BN_N
     velData = dataLog.v_BN_N
     attData = dataLog.sigma_BN
-    dragForce = scSim.GetLogVariableData('DragEff.forceExternal_B')
+    dragForce = dragEffectorLog.forceExternal_B
     densData = dataNewAtmoLog.neutralDensity
     np.set_printoptions(precision=16)
 
@@ -267,15 +269,15 @@ def run(show_plots, orbitCase, planetCase):
         # print "Density data:", densData[ind,1]
         refDragForce[ind] = cannonballDragComp(dragCoeff,densData[ind],projArea,velData[ind], attData[ind])
         # print "Reference drag data:", refDragForce[ind,:]
-        # print "Drag Data:", dragForce[ind,1:]
+        # print "Drag Data:", dragForce[ind,:]
         # print ""
         # check a vector values
     for ind in range(1,endInd-1):
-        if not unitTestSupport.isArrayEqual(dragForce[ind,1:4], refDragForce[ind],3,accuracy):
+        if not unitTestSupport.isArrayEqual(dragForce[ind,:], refDragForce[ind],3,accuracy):
             testFailCount += 1
             testMessages.append(
                 "FAILED:  DragEffector failed force unit test with a value difference of "
-                + str(np.linalg.norm(dragForce[ind,1:4]-refDragForce[ind])))
+                + str(np.linalg.norm(dragForce[ind,:]-refDragForce[ind])))
 
     #
     #   plot the results

--- a/src/simulation/dynamics/dragEffector/dragDynamicEffector.i
+++ b/src/simulation/dynamics/dragEffector/dragDynamicEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 // Instantiate templates used by example
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "std_vector.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/extForceTorque/_UnitTest/test_extForceTorque.py
+++ b/src/simulation/dynamics/extForceTorque/_UnitTest/test_extForceTorque.py
@@ -107,22 +107,16 @@ def unitDynamicsModesTestFunction(show_plots, torqueInput, forceNInput, forceBIn
     scSim.AddModelToTask(unitTaskName, extFTObject)
 
     #
+    #   Setup data logging
+    #
+    extFTObjectLog = extFTObject.logger(["forceExternal_N", "forceExternal_B", "torqueExternalPntB_B"])
+    scSim.AddModelToTask(unitTaskName, extFTObjectLog)
+
+    #
     #   initialize the simulation
     #
     scSim.InitializeSimulation()
     scSim.ConfigureStopTime(macros.sec2nano(0.001))
-
-
-    #
-    #   Setup data logging
-    #
-    testProcessRate = macros.sec2nano(0.1)
-    variableForceN = "forceExternal_N"            # name the module variable to be logged
-    scSim.AddVariableForLogging (extFTObject.ModelTag + "." + variableForceN, testProcessRate, 0, 2, 'double')
-    variableForceB = "forceExternal_B"            # name the module variable to be logged
-    scSim.AddVariableForLogging (extFTObject.ModelTag + "." + variableForceB, testProcessRate, 0, 2, 'double')
-    variableTorque = "torqueExternalPntB_B"       # name the module variable to be logged
-    scSim.AddVariableForLogging (extFTObject.ModelTag + "." + variableTorque, testProcessRate, 0, 2, 'double')
 
     #
     #   run the simulation
@@ -131,20 +125,13 @@ def unitDynamicsModesTestFunction(show_plots, torqueInput, forceNInput, forceBIn
 
     extFTObject.computeForceTorque(scSim.TotalSim.CurrentNanos, macros.sec2nano(0.1))
     scSim.TotalSim.SingleStepProcesses()
-    scSim.RecordLogVars()
-
 
     # log the data
-    dataForceN = (scSim.GetLogVariableData(extFTObject.ModelTag+"."+variableForceN))[-1]
-    dataForceB = (scSim.GetLogVariableData(extFTObject.ModelTag+"."+variableForceB))[-1]
-    dataTorque = (scSim.GetLogVariableData(extFTObject.ModelTag+"."+variableTorque))[-1]
+    dataForceN = [extFTObjectLog.forceExternal_N[-1]]
+    dataForceB = [extFTObjectLog.forceExternal_B[-1]]
+    dataTorque = [extFTObjectLog.torqueExternalPntB_B[-1]]
 
     np.set_printoptions(precision=16)
-
-    # Remove time zero from list
-    dataForceN = [dataForceN[1:len(dataForceN)]]
-    dataForceB = [dataForceB[1:len(dataForceB)]]
-    dataTorque = [dataTorque[1:len(dataTorque)]]
 
     #
     #   set true position information

--- a/src/simulation/dynamics/extForceTorque/extForceTorque.i
+++ b/src/simulation/dynamics/extForceTorque/extForceTorque.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 
 %include "extForceTorque.h"

--- a/src/simulation/dynamics/facetDragEffector/_UnitTest/test_unitFacetDrag.py
+++ b/src/simulation/dynamics/facetDragEffector/_UnitTest/test_unitFacetDrag.py
@@ -176,16 +176,13 @@ def TestDragCalculation():
     scSim.AddModelToTask(simTaskName, dataLog)
     atmoLog = newAtmo.envOutMsgs[0].recorder()
     scSim.AddModelToTask(simTaskName, atmoLog)
+    newDragLog = newDrag.logger(["forceExternal_B", "torqueExternalPntB_B"])
+    scSim.AddModelToTask(simTaskName, newDragLog)
 
     #
     #   initialize Simulation
     #
     scSim.InitializeSimulation()
-
-    scSim.AddVariableForLogging(newDrag.ModelTag + ".forceExternal_B",
-                                      simulationTimeStep, 0, 2, 'double')
-    scSim.AddVariableForLogging(newDrag.ModelTag + ".torqueExternalPntB_B",
-                                      simulationTimeStep, 0, 2, 'double')
 
     #   configure a simulation stop time and execute the simulation run
     #
@@ -193,8 +190,8 @@ def TestDragCalculation():
     scSim.ExecuteSimulation()
 
     #   Retrieve logged data
-    dragDataForce_B = scSim.GetLogVariableData(newDrag.ModelTag + ".forceExternal_B")
-    dragTorqueData = scSim.GetLogVariableData(newDrag.ModelTag + ".torqueExternalPntB_B")
+    dragDataForce_B = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.forceExternal_B)
+    dragTorqueData = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.torqueExternalPntB_B)
     posData = dataLog.r_BN_N
     velData = dataLog.v_BN_N
     attData = dataLog.sigma_BN
@@ -331,16 +328,13 @@ def TestShadowCalculation():
     scSim.AddModelToTask(simTaskName, dataLog)
     atmoLog = newAtmo.envOutMsgs[0].recorder()
     scSim.AddModelToTask(simTaskName, atmoLog)
+    newDragLog = newDrag.logger(["forceExternal_B", "torqueExternalPntB_B"])
+    scSim.AddModelToTask(simTaskName, newDragLog)
 
     #
     #   initialize Simulation
     #
     scSim.InitializeSimulation()
-
-    scSim.AddVariableForLogging(newDrag.ModelTag + ".forceExternal_B",
-                                simulationTimeStep, 0, 2, 'double')
-    scSim.AddVariableForLogging(newDrag.ModelTag + ".torqueExternalPntB_B",
-                                simulationTimeStep, 0, 2, 'double')
 
     #   configure a simulation stop time and execute the simulation run
     #
@@ -348,9 +342,8 @@ def TestShadowCalculation():
     scSim.ExecuteSimulation()
 
     #   Retrieve logged data
-    #dragDataForce_B = scSim.GetLogVariableData(newDrag.ModelTag + ".forceExternal_B")
-    dragDataForce_B = scSim.GetLogVariableData(newDrag.ModelTag + ".forceExternal_B")
-    dragTorqueData = scSim.GetLogVariableData(newDrag.ModelTag + ".torqueExternalPntB_B")
+    dragDataForce_B = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.forceExternal_B)
+    dragTorqueData = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.torqueExternalPntB_B)
     posData = dataLog.r_BN_N
     velData = dataLog.v_BN_N
     attData = dataLog.sigma_BN

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.i
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 
 // Instantiate templates used by example
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
@@ -287,12 +287,12 @@ def TestfacetSRPDynamicEffector(show_plots):
     simTimeSec = 10.0  # [s]
     simulationTime = macros.sec2nano(simTimeSec)
 
+    # Add the data for logging
+    newSRPLog = newSRP.logger(["forceExternal_B", "torqueExternalPntB_B"])
+    scSim.AddModelToTask(simTaskName, newSRPLog)
+
     # Initialize the simulation
     scSim.InitializeSimulation()
-
-    # Add the data for logging
-    scSim.AddVariableForLogging(newSRP.ModelTag + ".forceExternal_B", simulationTimeStep_NS, 0, 2, 'double')
-    scSim.AddVariableForLogging(newSRP.ModelTag + ".torqueExternalPntB_B", simulationTimeStep_NS, 0, 2, 'double')
 
     # Configure the simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime)
@@ -303,8 +303,8 @@ def TestfacetSRPDynamicEffector(show_plots):
     r_BN_N = scPosDataLog.r_BN_N
     sigma_BN = scPosDataLog.sigma_BN
     r_SN_N = sunPosDataLog.PositionVector
-    SRPDataForce_B = scSim.GetLogVariableData(newSRP.ModelTag + ".forceExternal_B")
-    SRPDataTorque_B = scSim.GetLogVariableData(newSRP.ModelTag + ".torqueExternalPntB_B")
+    SRPDataForce_B = unitTestSupport.addTimeColumn(newSRPLog.times(), newSRPLog.forceExternal_B)
+    SRPDataTorque_B = unitTestSupport.addTimeColumn(newSRPLog.times(), newSRPLog.torqueExternalPntB_B)
 
     # Store the logged data for plotting
     srpForce_B_plotting = SRPDataForce_B

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 
 // Instantiate templates used by example
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/gravityEffector/gravityEffector.i
+++ b/src/simulation/dynamics/gravityEffector/gravityEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
-%include "sys_model.h"
+%include "sys_model.i"
 #pragma SWIG nowarn=362
 %include "simulation/dynamics/_GeneralModuleFiles/gravityEffector.h"
 
@@ -51,4 +51,3 @@ protectAllClasses(sys.modules[__name__])
 %}
 
 %pythoncode "gravCoeffOps.py"
-

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.i
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "hingedRigidBodyMotor.h"
 
 %include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
@@ -40,4 +40,3 @@ struct ArrayMotorTorqueMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/dynamics/msmForceTorque/msmForceTorque.i
+++ b/src/simulation/dynamics/msmForceTorque/msmForceTorque.i
@@ -30,7 +30,7 @@
 %include "std_vector.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "msmForceTorque.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
@@ -50,4 +50,3 @@ struct CmdForceInertialMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -208,10 +208,8 @@ def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posI
         scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
 
         # Add energy and momentum variables to log
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
+        scObjectLog = scObject.logger(["totOrbEnergy", "totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
+        unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
         # Add other states to log
         scStateData = scObject.scStateOutMsg.recorder()
@@ -232,10 +230,10 @@ def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posI
         unitTestSim.ExecuteSimulation()
 
         # Extract the logged data
-        orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
-        orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-        rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
-        rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
+        orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+        orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+        rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+        rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
         omega_BN_B = scStateData.omega_BN_B
         r_BN_N = scStateData.r_BN_N
         sigma_BN = scStateData.sigma_BN
@@ -446,10 +444,8 @@ def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posI
         scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
 
         # Add energy and momentum variables to log
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
-        unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
+        scObjectLog = scObject.logger(["totOrbEnergy", "totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
+        unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
         # Add other states to log
         scStateData = scObject.scStateOutMsg.recorder()
@@ -470,10 +466,10 @@ def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posI
         unitTestSim.ExecuteSimulation()
 
         # Extract the logged data
-        orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
-        orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-        rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
-        rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
+        orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+        orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+        rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+        rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
         r_BN_N = scStateData.r_BN_N
         sigma_BN = scStateData.sigma_BN
         omega_BN_B = scStateData.omega_BN_B

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
@@ -227,12 +227,11 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
             unitTestSim.AddModelToTask(unitTaskName, rw1DataLog)
         scObject.hub.r_CN_NInit = [[0.0], [0.0], [0.0]]
         scObject.hub.v_CN_NInit = [[0.0], [0.0], [0.0]]
-    unitTestSim.InitializeSimulation()
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totOrbEnergy", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
+
+    unitTestSim.InitializeSimulation()
 
     stopTime = 1.0
     if testCase == 'BOE':
@@ -254,10 +253,10 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     posData = scDataLog.r_BN_N
     sigmaData = scDataLog.sigma_BN

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraft.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraft.py
@@ -109,6 +109,9 @@ def SCTranslation(show_plots):
     scObject.hub.r_CN_NInit = [[-4020338.690396649],	[7490566.741852513],	[5248299.211589362]]
     scObject.hub.v_CN_NInit = [[-5199.77710904224],	[-3436.681645356935],	[1041.576797498721]]
 
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totOrbEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
+
     unitTestSim.InitializeSimulation()
     accuracy = 1e-3
     if not unitTestSupport.isArrayEqual(scObject.scStateOutMsg.read().r_BN_N,
@@ -123,14 +126,11 @@ def SCTranslation(show_plots):
         testMessages.append("FAILED: SCHub Translation test failed init pos msg unit test")
 
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-
     stopTime = 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     plt.close("all")
     plt.figure()
@@ -246,20 +246,19 @@ def SCTransAndRotation(show_plots):
     scObject.hub.sigma_BNInit = [[0.0], [0.0], [0.0]]
     scObject.hub.omega_BN_BInit = [[0.5], [-0.4], [0.7]]
 
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totOrbEnergy", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
+
     unitTestSim.InitializeSimulation()
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
 
     stopTime = 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     r_BN_NOutput = dataLog.r_BN_N
     sigma_BNOutput = dataLog.sigma_BN
@@ -437,17 +436,17 @@ def SCRotation(show_plots):
     sigmaCalc = RigidBodyKinematics.C2MRP(dcm_BN)
     scObject.hub.sigma_BNInit = [[sigmaCalc[0]], [sigmaCalc[1]], [sigmaCalc[2]]]
 
-    unitTestSim.InitializeSimulation()
+    scObjectLog = scObject.logger(["totRotAngMomPntC_N", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
+    unitTestSim.InitializeSimulation()
 
     stopTime = 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
     rotAngMomMag = numpy.zeros(len(rotAngMom_N))
     for i in range(0,len(rotAngMom_N)):
         rotAngMomMag[i] = numpy.linalg.norm(numpy.asarray(rotAngMom_N[i,1:4]))

--- a/src/simulation/dynamics/spacecraft/spacecraft.i
+++ b/src/simulation/dynamics/spacecraft/spacecraft.i
@@ -35,7 +35,7 @@ namespace std {
     %template(GravBodyVector) vector<GravBodyData *>;
 }
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"

--- a/src/simulation/dynamics/spacecraftSystem/_UnitTest/test_multiSpacecraft.py
+++ b/src/simulation/dynamics/spacecraftSystem/_UnitTest/test_multiSpacecraft.py
@@ -30,6 +30,7 @@ from Basilisk.utilities import unitTestSupport  # general support file with comm
 import matplotlib.pyplot as plt
 from Basilisk.simulation import spacecraftSystem
 from Basilisk.utilities import macros
+from Basilisk.utilities import pythonVariableLogger
 from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import hingedRigidBodyStateEffector
 
@@ -182,20 +183,24 @@ def SCConnected(show_plots):
     dataLog = scSystem.primaryCentralSpacecraft.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
+    scLog = pythonVariableLogger.PythonVariableLogger({
+        "totOrbEnergy": lambda _: scSystem.primaryCentralSpacecraft.totOrbEnergy,
+        "totOrbAngMomPntN_N": lambda _: scSystem.primaryCentralSpacecraft.totOrbAngMomPntN_N,
+        "totRotAngMomPntC_N": lambda _: scSystem.primaryCentralSpacecraft.totRotAngMomPntC_N,
+        "totRotEnergy": lambda _: scSystem.primaryCentralSpacecraft.totRotEnergy,
+    })
+    unitTestSim.AddModelToTask(unitTaskName, scLog)
+
     unitTestSim.InitializeSimulation()
-    unitTestSim.AddVariableForLogging(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totRotEnergy", testProcessRate, 0, 0, 'double')
 
     stopTime = 1.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    orbEnergy = unitTestSim.GetLogVariableData(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scSystem.ModelTag + ".primaryCentralSpacecraft" + ".totRotEnergy")
+    orbEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbEnergy)
+    orbAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotEnergy)
 
     r_BN_NOutput = dataLog.r_BN_N
     sigma_BNOutput = dataLog.sigma_BN

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.i
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.i
@@ -36,7 +36,7 @@ namespace std {
     %template(GravBodyVector) vector<GravBodyData *>;
 }
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/stateData.h"
 %include "../_GeneralModuleFiles/dynParamManager.h"
 %include "../_GeneralModuleFiles/dynamicObject.h"

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.i
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.i
@@ -32,7 +32,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/fuelSlosh.h"
 %include "../_GeneralModuleFiles/stateData.h"
 %include "../_GeneralModuleFiles/stateEffector.h"

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
@@ -153,14 +153,12 @@ def spinningBody(show_plots, cmdTorque, lock):
     datLog = scObject.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, datLog)
 
+    # Add energy and momentum variables to log
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totOrbEnergy", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
+    
     # Initialize the simulation
     unitTestSim.InitializeSimulation()
-
-    # Add energy and momentum variables to log
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
 
     # Add states to log
     thetaData = spinningBody.spinningBodyOutMsg.recorder()
@@ -172,10 +170,10 @@ def spinningBody(show_plots, cmdTorque, lock):
     unitTestSim.ExecuteSimulation()
 
     # Extract the logged variables
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
     theta = thetaData.theta
     thetaDot = thetaData.thetaDot
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
@@ -172,14 +172,12 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
     datLog = scObject.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, datLog)
 
+    # Add energy and momentum variables to log
+    scObjectLog = scObject.logger(["totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totOrbEnergy", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
+    
     # Initialize the simulation
     unitTestSim.InitializeSimulation()
-
-    # Add energy and momentum variables to log
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbEnergy", testProcessRate, 0, 0, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totOrbAngMomPntN_N", testProcessRate, 0, 2, 'double')
-    unitTestSim.AddVariableForLogging(scObject.ModelTag + ".totRotAngMomPntC_N", testProcessRate, 0, 2, 'double')
 
     # Add states to log
     theta1Data = spinningBody.spinningBodyOutMsgs[0].recorder()
@@ -193,10 +191,10 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
     unitTestSim.ExecuteSimulation()
 
     # Extract the logged variables
-    orbEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbEnergy")
-    orbAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totOrbAngMomPntN_N")
-    rotAngMom_N = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotAngMomPntC_N")
-    rotEnergy = unitTestSim.GetLogVariableData(scObject.ModelTag + ".totRotEnergy")
+    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
     theta1 = theta1Data.theta
     theta1Dot = theta1Data.thetaDot
     theta2 = theta2Data.theta

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.i
@@ -32,7 +32,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"

--- a/src/simulation/environment/ExponentialAtmosphere/exponentialAtmosphere.i
+++ b/src/simulation/environment/ExponentialAtmosphere/exponentialAtmosphere.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 %include "std_string.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/environment/_GeneralModuleFiles/atmosphereBase.h"
 %include "exponentialAtmosphere.h"
 

--- a/src/simulation/environment/MsisAtmosphere/msisAtmosphere.i
+++ b/src/simulation/environment/MsisAtmosphere/msisAtmosphere.i
@@ -27,7 +27,7 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "swig_eigen.i"
 %include "std_vector.i"
 %include "swig_conly_data.i"

--- a/src/simulation/environment/TabularAtmosphere/tabularAtmosphere.i
+++ b/src/simulation/environment/TabularAtmosphere/tabularAtmosphere.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 %include "std_string.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/environment/_GeneralModuleFiles/atmosphereBase.h"
 %include "tabularAtmosphere.h"
 

--- a/src/simulation/environment/albedo/albedo.i
+++ b/src/simulation/environment/albedo/albedo.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "albedo.h"
 
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"

--- a/src/simulation/environment/dentonFluxModel/dentonFluxModel.i
+++ b/src/simulation/environment/dentonFluxModel/dentonFluxModel.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "dentonFluxModel.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
@@ -42,4 +42,3 @@ struct PlasmaFluxMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/environment/eclipse/eclipse.i
+++ b/src/simulation/environment/eclipse/eclipse.i
@@ -26,7 +26,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "eclipse.h"
 %include "swig_conly_data.i"
 %include "std_vector.i"

--- a/src/simulation/environment/ephemerisConverter/ephemerisConverter.i
+++ b/src/simulation/environment/ephemerisConverter/ephemerisConverter.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "std_vector.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "ephemerisConverter.h"
 
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"

--- a/src/simulation/environment/groundLocation/groundLocation.i
+++ b/src/simulation/environment/groundLocation/groundLocation.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "groundLocation.h"
 %include "std_vector.i"
 

--- a/src/simulation/environment/groundMapping/groundMapping.i
+++ b/src/simulation/environment/groundMapping/groundMapping.i
@@ -29,7 +29,7 @@
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 %include "std_vector.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "groundMapping.h"
 
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
@@ -45,4 +45,3 @@ struct GroundStateMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/environment/magneticFieldCenteredDipole/magneticFieldCenteredDipole.i
+++ b/src/simulation/environment/magneticFieldCenteredDipole/magneticFieldCenteredDipole.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "std_vector.i"
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/environment/_GeneralModuleFiles/magneticFieldBase.h"
 %include "magneticFieldCenteredDipole.h"
 

--- a/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.i
+++ b/src/simulation/environment/magneticFieldWMM/magneticFieldWMM.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "std_vector.i"
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/environment/_GeneralModuleFiles/magneticFieldBase.h"
 %include "magneticFieldWMM.h"
 

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.i
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.i
@@ -33,7 +33,7 @@ namespace std {
     %template(classicElementVector) vector<ClassicElementsMsgPayload>;
 }
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "planetEphemeris.h"
 %include "architecture/utilities/orbitalMotion.h"
 %include "architecture/msgPayloadDefC/ClassicElementsMsgPayload.h"

--- a/src/simulation/environment/solarFlux/solarFlux.i
+++ b/src/simulation/environment/solarFlux/solarFlux.i
@@ -26,7 +26,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "solarFlux.h"
 %include "swig_conly_data.i"
 

--- a/src/simulation/environment/spacecraftLocation/spacecraftLocation.i
+++ b/src/simulation/environment/spacecraftLocation/spacecraftLocation.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "std_vector.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "spacecraftLocation.h"
 
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
@@ -192,20 +192,19 @@ def unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos
         # epoch message over-rules any info set in this variable.
         SpiceObject.UTCCalInit = "1990 February 10, 00:00:00.0 TDB"
 
+    spiceObjectLog = SpiceObject.logger(["GPSSeconds", "J2000Current", "julianDateCurrent", "GPSWeek"])
+    TotalSim.AddModelToTask(unitTaskName, spiceObjectLog)
+
     # Configure simulation
     TotalSim.ConfigureStopTime(int(60.0 * 1E9))
-    TotalSim.AddVariableForLogging('SpiceInterfaceData.GPSSeconds')
-    TotalSim.AddVariableForLogging('SpiceInterfaceData.J2000Current')
-    TotalSim.AddVariableForLogging('SpiceInterfaceData.julianDateCurrent')
-    TotalSim.AddVariableForLogging('SpiceInterfaceData.GPSWeek')
 
     # Execute simulation
     TotalSim.InitializeSimulation()
     TotalSim.ExecuteSimulation()
 
     # Get the logged variables (GPS seconds, Julian Date)
-    DataGPSSec = TotalSim.GetLogVariableData('SpiceInterfaceData.GPSSeconds')
-    DataJD = TotalSim.GetLogVariableData('SpiceInterfaceData.julianDateCurrent')
+    DataGPSSec = unitTestSupport.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.GPSSeconds)
+    DataJD = unitTestSupport.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.julianDateCurrent)
 
     # Get parametrized date from DatePlot
     year = "".join(("20", DatePlot[6:8]))

--- a/src/simulation/environment/spiceInterface/spiceInterface.i
+++ b/src/simulation/environment/spiceInterface/spiceInterface.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "std_vector.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 
 %include "spiceInterface.h"
 

--- a/src/simulation/navigation/planetHeading/planetHeading.i
+++ b/src/simulation/navigation/planetHeading/planetHeading.i
@@ -26,7 +26,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "planetHeading.h"
 %include "swig_conly_data.i"
 

--- a/src/simulation/navigation/planetNav/planetNav.i
+++ b/src/simulation/navigation/planetNav/planetNav.i
@@ -29,7 +29,7 @@
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "planetNav.h"
 
 %include "architecture/msgPayloadDefC/EphemerisMsgPayload.h"
@@ -39,4 +39,3 @@ struct ephemerisMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/navigation/simpleNav/simpleNav.i
+++ b/src/simulation/navigation/simpleNav/simpleNav.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simpleNav.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.i
+++ b/src/simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 %include "std_vector.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "mappingInstrument.h"
 
 %include "architecture/msgPayloadDefC/AccessMsgPayload.h"
@@ -39,4 +39,3 @@ struct AccessMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/onboardDataHandling/instrument/simpleInstrument/simpleInstrument.i
+++ b/src/simulation/onboardDataHandling/instrument/simpleInstrument/simpleInstrument.i
@@ -26,7 +26,7 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../../_GeneralModuleFiles/dataNodeBase.h"
 %include "simpleInstrument.h"
 %include "swig_conly_data.i"

--- a/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.i
+++ b/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.i
@@ -24,7 +24,7 @@
 
 %include "swig_common_model.i"
 %include "carrays.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/dataNodeBase.h"
 %include "spaceToGroundTransmitter.h"
 

--- a/src/simulation/onboardDataHandling/storageUnit/partitionedStorageUnit.i
+++ b/src/simulation/onboardDataHandling/storageUnit/partitionedStorageUnit.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 %include "carrays.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "std_vector.i"
 %include "cstring.i"
 

--- a/src/simulation/onboardDataHandling/storageUnit/simpleStorageUnit.i
+++ b/src/simulation/onboardDataHandling/storageUnit/simpleStorageUnit.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 %include "std_vector.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "stdint.i"
 
 %include "simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.h"

--- a/src/simulation/onboardDataHandling/transmitter/simpleTransmitter.i
+++ b/src/simulation/onboardDataHandling/transmitter/simpleTransmitter.i
@@ -27,7 +27,7 @@
 %include "std_string.i"
 %include "carrays.i"
 %include "std_vector.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "stdint.i"
 
 %include "simulation/onboardDataHandling/_GeneralModuleFiles/dataNodeBase.h"

--- a/src/simulation/power/ReactionWheelPower/ReactionWheelPower.i
+++ b/src/simulation/power/ReactionWheelPower/ReactionWheelPower.i
@@ -30,7 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "stdint.i"
 %include "std_string.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simulation/power/_GeneralModuleFiles/powerNodeBase.h"
 %include "ReactionWheelPower.h"
 

--- a/src/simulation/power/simpleBattery/simpleBattery.i
+++ b/src/simulation/power/simpleBattery/simpleBattery.i
@@ -50,7 +50,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/powerStorageBase.h"
 %include "simpleBattery.h"
 %include "swig_conly_data.i"

--- a/src/simulation/power/simplePowerMonitor/simplePowerMonitor.i
+++ b/src/simulation/power/simplePowerMonitor/simplePowerMonitor.i
@@ -48,7 +48,7 @@ from Basilisk.architecture.swig_common_model import *
 %}
 %include "std_string.i"
 %include "swig_eigen.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/powerStorageBase.h"
 %include "simplePowerMonitor.h"
 %include "swig_conly_data.i"

--- a/src/simulation/power/simplePowerSink/simplePowerSink.i
+++ b/src/simulation/power/simplePowerSink/simplePowerSink.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/powerNodeBase.h"
 %include "simplePowerSink.h"
 %include "swig_conly_data.i"

--- a/src/simulation/power/simpleSolarPanel/simpleSolarPanel.i
+++ b/src/simulation/power/simpleSolarPanel/simpleSolarPanel.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "../_GeneralModuleFiles/powerNodeBase.h"
 %include "simpleSolarPanel.h"
 

--- a/src/simulation/sensors/camera/camera.i
+++ b/src/simulation/sensors/camera/camera.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "stdint.i"
 %include "std_string.i"
 %include "std_vector.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "camera.h"
 
 %include "architecture/msgPayloadDefC/CameraImageMsgPayload.h"
@@ -41,4 +41,3 @@ struct CameraConfigMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.i
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.i
@@ -26,7 +26,7 @@
 %include "std_vector.i"
 %include "std_string.i"
 
-%include "architecture/_GeneralModuleFiles/sys_model.h"
+%include "sys_model.i"
 %include "coarseSunSensor.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.i
+++ b/src/simulation/sensors/hingedRigidBodyMotorSensor/hingedRigidBodyMotorSensor.i
@@ -28,7 +28,7 @@
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "hingedRigidBodyMotorSensor.h"
 
 %include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
@@ -38,4 +38,3 @@ struct HingedRigidBodyMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/sensors/imuSensor/imuSensor.i
+++ b/src/simulation/sensors/imuSensor/imuSensor.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "std_string.i"
 %include "swig_eigen.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "imuSensor.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/sensors/magnetometer/magnetometer.i
+++ b/src/simulation/sensors/magnetometer/magnetometer.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "magnetometer.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/sensors/simpleMassProps/simpleMassProps.i
+++ b/src/simulation/sensors/simpleMassProps/simpleMassProps.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simpleMassProps.h"
 
 %include "architecture/msgPayloadDefC/SCMassPropsMsgPayload.h"

--- a/src/simulation/sensors/simpleVoltEstimator/simpleVoltEstimator.i
+++ b/src/simulation/sensors/simpleVoltEstimator/simpleVoltEstimator.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simpleVoltEstimator.h"
 
 %include "architecture/msgPayloadDefC/VoltMsgPayload.h"

--- a/src/simulation/sensors/starTracker/starTracker.i
+++ b/src/simulation/sensors/starTracker/starTracker.i
@@ -29,7 +29,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 %include "stdint.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "starTracker.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/simSynch/simSynch.i
+++ b/src/simulation/simSynch/simSynch.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "std_string.i"
 %include "stdint.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "simSynch.h"
 
 %include "architecture/msgPayloadDefC/SynchClockMsgPayload.h"

--- a/src/simulation/thermal/motorThermal/motorThermal.i
+++ b/src/simulation/thermal/motorThermal/motorThermal.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "motorThermal.h"
 
 %include "architecture/msgPayloadDefC/TemperatureMsgPayload.h"

--- a/src/simulation/thermal/sensorThermal/sensorThermal.i
+++ b/src/simulation/thermal/sensorThermal/sensorThermal.i
@@ -31,7 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "sensorThermal.h"
 
 %include "architecture/msgPayloadDefC/TemperatureMsgPayload.h"

--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.i
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.i
@@ -26,7 +26,7 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "swig_conly_data.i"
 %include "std_string.i"
-%include "sys_model.h"
+%include "sys_model.i"
 %include "std_vector.i"
 
 
@@ -59,4 +59,3 @@ namespace std {
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/simulation/vizard/vizInterface/vizInterface.i
+++ b/src/simulation/vizard/vizInterface/vizInterface.i
@@ -28,7 +28,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
 
-%include "sys_model.h"
+%include "sys_model.i"
 %include "std_vector.i"
 
 // Instantiate templates used by example
@@ -77,4 +77,3 @@ struct EpochMsg_C;
 import sys
 protectAllClasses(sys.modules[__name__])
 %}
-

--- a/src/tests/test_scenarioFuelSlosh.py
+++ b/src/tests/test_scenarioFuelSlosh.py
@@ -46,36 +46,23 @@ def test_scenarioFuelSlosh(show_plots, damping_parameter, timeStep):
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty array to store test log messages
 
-    rhoj1Out, rhoj2Out, rhoj3Out, figureList = \
-        scenarioFuelSlosh.run(show_plots, damping_parameter, timeStep)
+    time, rhojOuts, figureList = scenarioFuelSlosh.run(
+        show_plots, damping_parameter, timeStep)
 
     if damping_parameter != 0:
-
-        zita1 = damping_parameter / (2 * np.sqrt(1500.0 * 1.0))
-        omegan1 = np.sqrt(1.0 / 1500.0)
-        settling_time1 = -1.0 / (zita1 * omegan1) * np.log(0.05 * np.sqrt(1 - zita1**2))
-        index_settling_time1 = np.argmax(rhoj1Out[:, 0] * 1e-9 > settling_time1)
-
-        zita2 = damping_parameter / (2 * np.sqrt(1400.0 * 1.0))
-        omegan2 = np.sqrt(1.0 / 1400.0)
-        settling_time2 = -1.0 / (zita2 * omegan2) * np.log(0.05 * np.sqrt(1 - zita2**2))
-        index_settling_time2 = np.argmax(rhoj2Out[:, 0] * 1e-9 > settling_time2)
-
-        zita3 = damping_parameter / (2 * np.sqrt(1300.0 * 1.0))
-        omegan3 = np.sqrt(1.0 / 1300.0)
-        settling_time3 = -1.0 / (zita3 * omegan3) * np.log(0.05 * np.sqrt(1 - zita3**2))
-        index_settling_time3 = np.argmax(rhoj3Out[:, 0] * 1e-9 > settling_time3)
-
         accuracy = 0.05
-        if abs(rhoj1Out[index_settling_time1, 1] - rhoj1Out[-1, 1]) > accuracy:
-            testFailCount = testFailCount + 1
-            testMessages = [testMessages, "Particle 1 settling time does not match second order systems theories"]
-        if abs(rhoj2Out[index_settling_time2, 1] - rhoj2Out[-1, 1]) > accuracy:
-            testFailCount = testFailCount + 1
-            testMessages = [testMessages, "Particle 1 settling time does not match second order systems theories"]
-        if abs(rhoj3Out[index_settling_time3, 1] - rhoj3Out[-1, 1]) > accuracy:
-            testFailCount = testFailCount + 1
-            testMessages = [testMessages, "Particle 1 settling time does not match second order systems theories"]
+        mass = (1500, 1400, 1300)
+
+        for i in range(3):
+            zita = damping_parameter / (2 * np.sqrt(mass[i] * 1.0))
+            omegan = np.sqrt(1.0 / mass[i])
+            settling_time = -1.0 / (zita * omegan) * np.log(0.05 * np.sqrt(1 - zita**2))
+            index_settling_time = np.argmax(time > settling_time)
+
+            if abs(rhojOuts[i][index_settling_time] - rhojOuts[i][-1]) > accuracy:
+                testFailCount = testFailCount + 1
+                testMessages = [testMessages, f"Particle {i+1} settling time does "
+                                "not match second order systems theories"]
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):

--- a/src/utilities/makeDraftModule.py
+++ b/src/utilities/makeDraftModule.py
@@ -413,7 +413,7 @@ class moduleGenerator:
         swigFile += '%include "std_string.i"\n'
         swigFile += '%include "swig_conly_data.i"\n'
         swigFile += '\n'
-        swigFile += '%include "sys_model.h"\n'
+        swigFile += '%include "sys_model.i"\n'
         swigFile += '%include "' + name + '.h"\n'
         swigFile += '\n'
         includedMsgs = []

--- a/src/utilities/pythonVariableLogger.py
+++ b/src/utilities/pythonVariableLogger.py
@@ -1,0 +1,88 @@
+from typing import Callable, Any, Sequence, Union, Dict
+
+import numpy as np
+
+from Basilisk.architecture import sysModel
+
+LoggingFunction = Callable[[int], Any]
+
+class PythonVariableLogger(sysModel.SysModel):
+    """This a Python Module that will call one or multiple functions
+    and store their results. After the simulation is over, these
+    values can be retrieved.
+
+    This object is built with a dictionary of functions, and the
+    results can be retrieved from the object using the keys of
+    this dictionary::
+
+        log = VariableLogger({
+            "a": lambda CurrentSimNanos: CurrentSimNanos**2,
+            "b": lambda CurrentSimNanos: CurrentSimNanos**3,
+        })
+
+        # Run simulation
+
+        times        = log.times()
+        timesSquared = log.a
+        timesCubed   = log.b
+    """
+
+    def __init__(
+        self, 
+        logging_functions: Dict[str, LoggingFunction], 
+        min_log_period: int = 0
+    ) -> None:
+        """Initializer.
+
+        Args:
+            logging_functions (Dict[str, LoggingFunction]): A dictionary where the
+                keys are the names of variables to store, and the values are functions
+                called to retrieve these variables. These functions must accept a single
+                input, an integer with the time in nanoseconds when the function is 
+                called.
+            min_log_period (int, optional): The minimum interval between data recordings
+                Defaults to 0.
+        """
+        super().__init__()
+
+        self.logging_functions = logging_functions
+
+        self.min_log_period = min_log_period
+        self._next_update_time = 0
+        self.clear()
+
+    def clear(self):
+        """Called to clear the internal data storages"""
+        self._times = []
+        self._variables = {name: [] for name in self.logging_functions}
+
+    def times(self):
+        """Retrieve the times when the data was logged"""
+        return np.array(self._times)
+    
+    def Reset(self, CurrentSimNanos):
+        self.clear()
+        return super().Reset(CurrentSimNanos)
+    
+    def UpdateState(self, CurrentSimNanos):
+        if CurrentSimNanos >= self._next_update_time:
+            self._times.append(CurrentSimNanos)
+            for variable_name, logging_function in self.logging_functions.items():
+                try:
+                    val = logging_function(CurrentSimNanos)
+                except Exception as ex:
+                    self.bskLogger.bskLog(sysModel.BSK_ERROR, 
+                                        f"Error while logging '{variable_name}'"
+                                        f" in logger '{self.ModelTag}': {ex}")
+                    val = None
+                val = np.array(val).squeeze()
+                self._variables[variable_name].append(val)
+
+            self._next_update_time += self.min_log_period
+        return super().UpdateState(CurrentSimNanos)
+    
+    def __getattr__(self, __name: str) -> Any:
+        if __name in self._variables:
+            return np.array(self._variables[__name])
+        raise AttributeError(f"Logger is not logging '{__name}'. "
+                             f"Must be one of: {', '.join(self._variables)}")


### PR DESCRIPTION
* **Tickets addressed:** Closes #286
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Variable logging was implemented through a `SysModel`, which is added to a task similarly to message recorders. For usage, see documentation bskPrinciples 6.

The new `SysModel` logger take arbitrary lambdas as callback functions for logging, which are given in a dictionary. However, for recording simple module attributes, the utility function `logger` has been added to every module, which takes as input a string or list of strings and produces a logger that will record the given attributes:
```
moduleLogger = module.logger(["dummy", "dumVector"], macros.sec2nano(1.))
scSim.AddModelToTask("dynamicsTask", moduleLogger)
```
is equivalent to:
```
moduleLogger = pythonVariableLogger.PythonVariableLogger(
        {
            "dummy": lambda _: module.dummy,
            "dumVector": lambda _: module.dumVector,
        }, 
        macros.sec2nano(1.)
    )
scSim.AddModelToTask("dynamicsTask", moduleLogger)
```

The `logger` method is added to `SysModel` through a new swig file that all module swig files now include. An error is raised for scripts that try to access `logger` for modules that do not use the swig file (i.e. they use `%include sys_model.h` instead of `%include sys_model.i`).

The following methods are now deprecated:
- `AddVariableForLogging`
- `GetLogVariableData`
- `RecordLogVars`

However, they still work as expected. This was accomplished by having these functions call the new logging functionality internally, which means that the old logging has been completely removed from the code. 

## Verification
All scenarios and tests that used the old syntax have been updated to the new syntax, and all are passing. On a personal note, updating these has been a pain as it is difficult to script the conversion reliably.

## Documentation
`bskPrinciples-6` was updated to reflect the new way of logging variables. **Note that the associated video is now outdated.** Scenarios have also been updated to use the new syntax.
