### PR TITLE
Disable unused opencv build flags

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -175,6 +175,11 @@ class BasiliskConan(ConanFile):
         if self.options.opNav:
             self.requires.add("pcre/8.45")
             self.requires.add("opencv/4.1.2")
+            self.options['opencv'].with_ffmpeg = False  # video frame encoding lib
+            self.options['opencv'].with_ade = False  # graph manipulations framework
+            self.options['opencv'].with_tiff = False  # generate image in TIFF format
+            self.options['opencv'].with_openexr = False  # generate image in EXR format
+            self.options['opencv'].with_quirc = False  # QR code lib
             self.requires.add("zlib/1.2.13")
             self.requires.add("xz_utils/5.4.0")
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -42,6 +42,10 @@ Version |release|
   then Vizard 2.1.5 or newer should be used.  This also removes the need for the legacy bincrafters code repo.
   Delete ``~/.conan`` folder if you run into ``conan`` issues.
 - The Basilisk project C++ version is advanced from C++11 to C++17
+- Disabled the following build options in the conan included OpenCV dependency; with_ffmpeg video frame encoding lib,
+  with_ade graph manipulations framework, with_tiff generate image in TIFF format, with_openexr generate image in EXR
+  format, with_quirc QR code lib. Users that have Basilisk control the build of these modules through the External
+  Modules CMake integration will need to manual toggle these OpenCV build options.
 
 Version 2.1.7 (March 24, 2023)
 ------------------------------


### PR DESCRIPTION
* **Tickets addressed:** #289 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
There are a number of OpenCV features that are not used and unlikely to be used by any module. Disabling these build flags will reduce the time spent building. The primary goal of this is to speed up CI turn around times. This would reduce time spent by the CI processes given they must build the conan dependencies each time.

The initial build duration can be reduced by about 30 secs (from ~3:30 to ~3) by disabling all unused OpenCV features. My machine is an M1 Max, so this reduction maybe longer or shorter on other hardware. Of course this gain will only be realized when opnav build flag is toggled on for CI builds. 

## Verification

## Documentation
None needed

## Future work
None
