### PR TITLE
Feature/zmq 4 5 0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -110,18 +110,6 @@ class BasiliskConan(ConanFile):
             except:
                 pass
 
-    try:
-        consoleReturn = str(subprocess.check_output(["conan", "remote", "list", "--raw"]))
-        conanRepos = ["bincrafters https://bincrafters.jfrog.io/artifactory/api/conan/public-conan"
-                      ]
-        for item in conanRepos:
-            if item not in consoleReturn:
-                print("Configuring: " + statusColor + item + endColor)
-                cmdString = ["conan", "remote", "add"] + item.split(" ")
-                subprocess.check_call(cmdString)
-    except:
-        print("conan: " + failColor + "Error configuring conan repo information." + endColor)
-
     print(statusColor + "Checking conan configuration:" + endColor + " Done")
 
     try:
@@ -193,7 +181,7 @@ class BasiliskConan(ConanFile):
         if self.options.vizInterface or self.options.opNav:
             self.requires.add("libsodium/1.0.18")
             self.requires.add("protobuf/3.17.1")
-            self.requires.add("cppzmq/4.3.0@bincrafters/stable")
+            self.requires.add("cppzmq/4.5.0")
 
     def configure(self):
         if self.options.clean:

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -38,6 +38,9 @@ Version |release|
   See :ref:`pyModules` for details.
 - Added the ability to integrate the ODE's of two or more Basilisk modules that are ``DynamicObject`` class
   member at the same time.  See :ref:`bskPrinciples-9`
+- updated ZMQ version to 4.5.0.  For 2-way communication with ``opNav`` modules talking to Vizard
+  then Vizard 2.1.5 or newer should be used.  This also removes the need for the legacy bincrafters code repo.
+  Delete ``~/.conan`` folder if you run into ``conan`` issues.
 
 Version 2.1.7 (March 24, 2023)
 ------------------------------


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Need to update the ZMQ library to 4.5.0.  The prior version is only available on bincrafters repo through ``conan`` which is now depreciated.  If doing two-way communication with Vizard, it is recommended to use Vizard 2.1.5 which also uses ZMQ 4.5.0.

## Verification
Deleted `.conan` and did a complete clean build, ran ``pytest`` and all tests pasted.

## Documentation
None

## Future work
None