### PR TITLE
SmallBodyNavEKF Improvements

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -46,6 +46,8 @@ Version |release|
   with_ade graph manipulations framework, with_tiff generate image in TIFF format, with_openexr generate image in EXR
   format, with_quirc QR code lib. Users that have Basilisk control the build of these modules through the External
   Modules CMake integration will need to manual toggle these OpenCV build options.
+- Updated :ref:`SmallBodyNavEKF` with several bug fixes. Removed spacecraft attitude estimation component.
+
 
 Version 2.1.7 (March 24, 2023)
 ------------------------------

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -26,12 +26,9 @@ Bennu is used. However, any small body could be selected as long as the appropri
 In this scenario, :ref:`simpleNav` and :ref:`planetEphemeris` provide measurements to the EKF in the form of :ref:`navTransMsgPayload`,
 :ref:`navAttMsgPayload`, and :ref:`ephemerisMsgPayload` input messages. The EKF takes in these measurements at each timestep
 and updates the state estimate, outputting this state estimate in its own standalone message, a :ref:`smallBodyNavMsgPayload`,
-as well as navigation output messages - :ref:`navTransMsgPayload`, :ref:`navAttMsgPayload`, and :ref:`ephemerisMsgPayload`.
+as well as navigation output messages - :ref:`navTransMsgPayload` and :ref:`ephemerisMsgPayload`.
 
-Furthermore, an :ref:`mrpFeedback` module is also created to demonstrate using the filter output as
-an input into an attitude control algorithm.
-
-.. note:: This module is only meant to provide a somewhat representative autonomous small body proximity operations navigation solution for attitude control modules or POMDP solvers. Therefore, realistic measurement modules do not exist to support this module, and not every source of uncertainty in the problem is an estimated parameter.
+.. note:: This module is only meant to provide a somewhat representative autonomous small body proximity operations navigation solution for POMDP solvers. Therefore, realistic measurement modules do not exist to support this module, and not every source of uncertainty in the problem is an estimated parameter.
 
 .. attention::
 
@@ -54,7 +51,8 @@ Likewise, the relative velocity estimate and the estimation error and covariance
 .. image:: /_images/Scenarios/scenarioSmallBodyNav4.svg
    :align: center
 
-In the next four plots, the attitude and rate estimates of both the spacecraft and small body with respect to the inertial frame are displayed.
+In the next four plots, the attitude and rate estimates and error plots of the small body frame with respect to the
+ inertial frame are displayed.
 
 .. image:: /_images/Scenarios/scenarioSmallBodyNav5.svg
    :align: center
@@ -94,9 +92,11 @@ from Basilisk.fswAlgorithms import hillPoint
 from Basilisk.fswAlgorithms import mrpFeedback
 from Basilisk.fswAlgorithms import rwMotorTorque
 from Basilisk.fswAlgorithms import smallBodyNavEKF
+from Basilisk.fswAlgorithms import smallBodyWaypointFeedback
 from Basilisk.simulation import ephemerisConverter
 from Basilisk.simulation import planetEphemeris
 from Basilisk.simulation import planetNav
+from Basilisk.simulation import extForceTorque
 from Basilisk.simulation import radiationPressure
 from Basilisk.simulation import reactionWheelStateEffector
 from Basilisk.simulation import simpleNav
@@ -118,16 +118,16 @@ fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 
 # Plotting functions
-def plot_position(time, r_BO_O_truth, r_BO_O_est, r_BO_O_meas):
+def plot_position(time, meas_time, r_BO_O_truth, r_BO_O_est, r_BO_O_meas):
     """Plot the relative position result."""
     #plt.gcf()
     fig, ax = plt.subplots(3, sharex=True, figsize=(12,6))
     fig.add_subplot(111, frameon=False)
     plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
 
-    ax[0].plot(time, r_BO_O_meas[:, 0], 'k*', label='measurement', markersize=1)
-    ax[1].plot(time, r_BO_O_meas[:, 1], 'k*', markersize=1)
-    ax[2].plot(time, r_BO_O_meas[:, 2], 'k*', markersize=1)
+    ax[0].plot(meas_time, r_BO_O_meas[:, 0], 'k*', label='measurement', markersize=1)
+    ax[1].plot(meas_time, r_BO_O_meas[:, 1], 'k*', markersize=1)
+    ax[2].plot(meas_time, r_BO_O_meas[:, 2], 'k*', markersize=1)
 
     ax[0].plot(time, r_BO_O_truth[:, 0], label='${}^Or_{BO_{1}}$')
     ax[1].plot(time, r_BO_O_truth[:, 1], label='${}^Or_{BO_{2}}$')
@@ -149,16 +149,16 @@ def plot_position(time, r_BO_O_truth, r_BO_O_est, r_BO_O_meas):
     return
 
 
-def plot_velocity(time, v_BO_O_truth, v_BO_O_est, v_BO_O_meas):
+def plot_velocity(time, meas_time, v_BO_O_truth, v_BO_O_est, v_BO_O_meas):
     """Plot the relative velocity result."""
     plt.gcf()
     fig, ax = plt.subplots(3, sharex=True, figsize=(12,6))
     fig.add_subplot(111, frameon=False)
     plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
 
-    ax[0].plot(time, v_BO_O_meas[:, 0], 'k*', label='measurement', markersize=1)
-    ax[1].plot(time, v_BO_O_meas[:, 1], 'k*', markersize=1)
-    ax[2].plot(time, v_BO_O_meas[:, 2], 'k*', markersize=1)
+    ax[0].plot(meas_time, v_BO_O_meas[:, 0], 'k*', label='measurement', markersize=1)
+    ax[1].plot(meas_time, v_BO_O_meas[:, 1], 'k*', markersize=1)
+    ax[2].plot(meas_time, v_BO_O_meas[:, 2], 'k*', markersize=1)
 
     ax[0].plot(time, v_BO_O_truth[:, 0], label='truth')
     ax[1].plot(time, v_BO_O_truth[:, 1])
@@ -203,9 +203,9 @@ def plot_pos_error(time, r_err, P):
     plt.xlabel('Time [sec]')
     plt.title('Position Error and Covariance')
 
-    ax[0].set_ylabel('${}^Or_{BO_1}$ [m]')
-    ax[1].set_ylabel('${}^Or_{BO_2}}$ [m]')
-    ax[2].set_ylabel('${}^Or_{BO_3}$ [m]')
+    ax[0].set_ylabel('${}^Or_{BO_1}$ Error [m]')
+    ax[1].set_ylabel('${}^Or_{BO_2}}$ Error [m]')
+    ax[2].set_ylabel('${}^Or_{BO_3}$ Error [m]')
 
     ax[0].legend()
 
@@ -235,24 +235,24 @@ def plot_vel_error(time, v_err, P):
     plt.xlabel('Time [sec]')
     plt.title('Velocity Error and Covariance')
 
-    ax[0].set_ylabel('${}^Ov_{BO_1}$ [m/s]')
-    ax[1].set_ylabel('${}^Ov_{BO_2}}$ [m/s]')
-    ax[2].set_ylabel('${}^Ov_{BO_3}$ [m/s]')
+    ax[0].set_ylabel('${}^Ov_{BO_1}$ Error [m/s]')
+    ax[1].set_ylabel('${}^Ov_{BO_2}}$ Error [m/s]')
+    ax[2].set_ylabel('${}^Ov_{BO_3}$ Error [m/s]')
 
     ax[0].legend()
 
     return
 
 
-def plot_sc_att(time, sigma_BN_truth, sigma_BN_est, sigma_BN_meas):
+def plot_sc_att(time, meas_time, sigma_BN_truth, sigma_BN_est, sigma_BN_meas):
     plt.gcf()
     fig, ax = plt.subplots(3, sharex=True, sharey=True, figsize=(12,6))
     fig.add_subplot(111, frameon=False)
     plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
 
-    ax[0].plot(time, sigma_BN_meas[:, 0], 'k*', label='measurement', markersize=1)
-    ax[1].plot(time, sigma_BN_meas[:, 1], 'k*', markersize=1)
-    ax[2].plot(time, sigma_BN_meas[:, 2], 'k*', markersize=1)
+    ax[0].plot(meas_time, sigma_BN_meas[:, 0], 'k*', label='measurement', markersize=1)
+    ax[1].plot(meas_time, sigma_BN_meas[:, 1], 'k*', markersize=1)
+    ax[2].plot(meas_time, sigma_BN_meas[:, 2], 'k*', markersize=1)
 
     ax[0].plot(time, sigma_BN_truth[:, 0], label='truth')
     ax[1].plot(time, sigma_BN_truth[:, 1])
@@ -273,15 +273,15 @@ def plot_sc_att(time, sigma_BN_truth, sigma_BN_est, sigma_BN_meas):
     return
 
 
-def plot_sc_rate(time, omega_BN_B_truth, omega_BN_B_est, omega_BN_B_meas):
+def plot_sc_rate(time, meas_time, omega_BN_B_truth, omega_BN_B_est, omega_BN_B_meas):
     plt.gcf()
     fig, ax = plt.subplots(3, sharex=True, sharey=True, figsize=(12,6))
     fig.add_subplot(111, frameon=False)
     plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
 
-    ax[0].plot(time, omega_BN_B_meas[:, 0], 'k*', label='measurement', markersize=1)
-    ax[1].plot(time, omega_BN_B_meas[:, 1], 'k*', markersize=1)
-    ax[2].plot(time, omega_BN_B_meas[:, 2], 'k*', markersize=1)
+    ax[0].plot(meas_time, omega_BN_B_meas[:, 0], 'k*', label='measurement', markersize=1)
+    ax[1].plot(meas_time, omega_BN_B_meas[:, 1], 'k*', markersize=1)
+    ax[2].plot(meas_time, omega_BN_B_meas[:, 2], 'k*', markersize=1)
 
     ax[0].plot(time, omega_BN_B_truth[:, 0], label='truth')
     ax[1].plot(time, omega_BN_B_truth[:, 1])
@@ -302,15 +302,15 @@ def plot_sc_rate(time, omega_BN_B_truth, omega_BN_B_est, omega_BN_B_meas):
     return
 
 
-def plot_ast_att(time, sigma_AN_truth, sigma_AN_est, sigma_AN_meas):
+def plot_ast_att(time, meas_time, sigma_AN_truth, sigma_AN_est, sigma_AN_meas):
     plt.gcf()
     fig, ax = plt.subplots(3, sharex=True, sharey=True, figsize=(12,6))
     fig.add_subplot(111, frameon=False)
     plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
 
-    ax[0].plot(time, sigma_AN_meas[:, 0], 'k*', label='measurement', markersize=1)
-    ax[1].plot(time, sigma_AN_meas[:, 1], 'k*', markersize=1)
-    ax[2].plot(time, sigma_AN_meas[:, 2], 'k*', markersize=1)
+    ax[0].plot(meas_time, sigma_AN_meas[:, 0], 'k*', label='measurement', markersize=1)
+    ax[1].plot(meas_time, sigma_AN_meas[:, 1], 'k*', markersize=1)
+    ax[2].plot(meas_time, sigma_AN_meas[:, 2], 'k*', markersize=1)
 
     ax[0].plot(time, sigma_AN_truth[:, 0], label='truth')
     ax[1].plot(time, sigma_AN_truth[:, 1])
@@ -331,15 +331,15 @@ def plot_ast_att(time, sigma_AN_truth, sigma_AN_est, sigma_AN_meas):
     return
 
 
-def plot_ast_rate(time, omega_AN_A_truth, omega_AN_A_est, omega_AN_A_meas):
+def plot_ast_rate(time, meas_time, omega_AN_A_truth, omega_AN_A_est, omega_AN_A_meas):
     plt.gcf()
     fig, ax = plt.subplots(3, sharex=True, figsize=(12,6))
     fig.add_subplot(111, frameon=False)
     plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
 
-    ax[0].plot(time, omega_AN_A_meas[:, 0], 'k*', label='measurement', markersize=1)
-    ax[1].plot(time, omega_AN_A_meas[:, 1], 'k*', markersize=1)
-    ax[2].plot(time, omega_AN_A_meas[:, 2], 'k*', markersize=1)
+    ax[0].plot(meas_time, omega_AN_A_meas[:, 0], 'k*', label='measurement', markersize=1)
+    ax[1].plot(meas_time, omega_AN_A_meas[:, 1], 'k*', markersize=1)
+    ax[2].plot(meas_time, omega_AN_A_meas[:, 2], 'k*', markersize=1)
 
     ax[0].plot(time, omega_AN_A_truth[:, 0], label='truth')
     ax[1].plot(time, omega_AN_A_truth[:, 1])
@@ -360,6 +360,68 @@ def plot_ast_rate(time, omega_AN_A_truth, omega_AN_A_est, omega_AN_A_meas):
     return
 
 
+def plot_ast_attitude_error(time, sigma_err, P):
+    """Plot the asteroid attitude estimation error and associated covariance."""
+    plt.gcf()
+    fig, ax = plt.subplots(3, sharex=True, figsize=(12,6))
+    fig.add_subplot(111, frameon=False)
+    plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
+
+    ax[0].plot(time, sigma_err[:, 0], label='error')
+    ax[0].plot(time, 2*np.sqrt(P[:, 6, 6]), 'k--', label=r'$2\sigma$')
+    ax[0].plot(time, -2*np.sqrt(P[:, 6, 6]), 'k--')
+
+    ax[1].plot(time, sigma_err[:, 1])
+    ax[1].plot(time, 2*np.sqrt(P[:, 7, 7]), 'k--')
+    ax[1].plot(time, -2*np.sqrt(P[:, 7, 7]), 'k--')
+
+    ax[2].plot(time, sigma_err[:, 2])
+    ax[2].plot(time, 2*np.sqrt(P[:, 8, 8]), 'k--')
+    ax[2].plot(time, -2*np.sqrt(P[:, 8, 8]), 'k--')
+
+    plt.xlabel('Time [sec]')
+    plt.title('Attitude Error and Covariance')
+
+    ax[0].set_ylabel(r'$\sigma_{AN_{1}}$ Error [rad]')
+    ax[1].set_ylabel(r'$\sigma_{AN_{2}}$ Error [rad]')
+    ax[2].set_ylabel(r'$\sigma_{AN_{3}}$ Error [rad]')
+
+    ax[0].legend()
+
+    return
+
+
+def plot_ast_rate_error(time, omega_err, P):
+    """Plot the asteroid rate estimation error and associated covariance."""
+    plt.gcf()
+    fig, ax = plt.subplots(3, sharex=True, figsize=(12,6))
+    fig.add_subplot(111, frameon=False)
+    plt.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)
+
+    ax[0].plot(time, omega_err[:, 0], label='error')
+    ax[0].plot(time, 2*np.sqrt(P[:, 9, 9]), 'k--', label=r'$2\sigma$')
+    ax[0].plot(time, -2*np.sqrt(P[:, 9, 9]), 'k--')
+
+    ax[1].plot(time, omega_err[:, 1])
+    ax[1].plot(time, 2*np.sqrt(P[:, 10, 10]), 'k--')
+    ax[1].plot(time, -2*np.sqrt(P[:, 10, 10]), 'k--')
+
+    ax[2].plot(time, omega_err[:, 2])
+    ax[2].plot(time, 2*np.sqrt(P[:, 11, 11]), 'k--')
+    ax[2].plot(time, -2*np.sqrt(P[:, 11, 11]), 'k--')
+
+    plt.xlabel('Time [sec]')
+    plt.title('Position Error and Covariance')
+
+    ax[0].set_ylabel(r'${}^A\omega_{AN_{1}}$ Error [rad/s]')
+    ax[1].set_ylabel(r'${}^A\omega_{AN_{2}}$ Error [rad/s]')
+    ax[2].set_ylabel(r'${}^A\omega_{AN_{3}}$ Error [rad/s]')
+
+    ax[0].legend()
+
+    return
+
+
 def run(show_plots):
     """
     The scenarios can be run with the followings setups parameters:
@@ -373,6 +435,8 @@ def run(show_plots):
 
     # Create simulation variable names
     simTaskName = "simTask"
+    measTaskName = "measTask"
+    fswTaskName = "fswTask"
     simProcessName = "simProcess"
 
     #  Create a sim module as an empty container
@@ -384,9 +448,10 @@ def run(show_plots):
     dynProcess = scSim.CreateNewProcess(simProcessName)
 
     # create the dynamics task and specify the simulation time step information
-    simulationTimeStep = macros.sec2nano(2.0)
-    simulationTime = macros.sec2nano(2000.0)
-    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
+    simulationTimeStep = macros.sec2nano(1.0)
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep, 3))
+    dynProcess.addTask(scSim.CreateNewTask(measTaskName, simulationTimeStep, 2))
+    dynProcess.addTask(scSim.CreateNewTask(fswTaskName, simulationTimeStep, 1))
 
     # setup celestial object ephemeris module
     gravBodyEphem = planetEphemeris.PlanetEphemeris()
@@ -485,7 +550,7 @@ def run(show_plots):
 
     # Create an SRP model
     srp = radiationPressure.RadiationPressure()  # default model is the SRP_CANNONBALL_MODEL
-    srp.area = 1.1  # m^3
+    srp.area = 3.  # m^3
     srp.coefficientReflection = 0.9
     scObject.addDynamicEffector(srp)
     srp.sunEphmInMsg.subscribeTo(sunPlanetStateMsg)
@@ -500,32 +565,38 @@ def run(show_plots):
     simpleNavMeas.ModelTag = 'SimpleNav'
     simpleNavMeas.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
     pos_sigma_sc = 40.0
-    vel_sigma_sc = 0.1
-    att_sigma_sc = 2.0 * math.pi / 180.0
-    rate_sigma_sc = 0.3 * math.pi / 180.0
+    vel_sigma_sc = 0.05
+    att_sigma_sc = 0. * math.pi / 180.0
+    rate_sigma_sc = 0. * math.pi / 180.0
     sun_sigma_sc = 0.0
     dv_sigma_sc = 0.0
     p_matrix_sc = [[pos_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., pos_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., pos_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., vel_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., vel_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., vel_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., att_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., att_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., att_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_sc, 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_sc, 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., sun_sigma_sc, 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., sun_sigma_sc, 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., sun_sigma_sc, 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., dv_sigma_sc, 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., dv_sigma_sc, 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., dv_sigma_sc]]
-    walk_bounds_sc = [[10.], [10.], [10.], [0.1], [0.1], [0.1], [0.005], [0.005], [0.005], [0.002], [0.002], [0.002], [0.], [0.], [0.], [0.], [0.], [0.]]
+                   [0., pos_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., pos_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., vel_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., vel_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., vel_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., att_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., att_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., att_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_sc, 0., 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_sc, 0., 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_sc, 0., 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., sun_sigma_sc, 0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., sun_sigma_sc, 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., sun_sigma_sc, 0., 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., dv_sigma_sc, 0., 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., dv_sigma_sc, 0.],
+                   [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., dv_sigma_sc]]
+    walk_bounds_sc = [[10.], [10.], [10.], [0.01], [0.01], [0.01], [0.005], [0.005], [0.005], [0.002], [0.002], [0.002], [0.], [0.], [0.], [0.], [0.], [0.]]
     simpleNavMeas.PMatrix = p_matrix_sc
     simpleNavMeas.walkBounds = walk_bounds_sc
+
+    simpleNavMeas2 = simpleNav.SimpleNav()
+    simpleNavMeas2.ModelTag = 'SimpleNav2'
+    simpleNavMeas2.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
+    simpleNavMeas2.PMatrix = p_matrix_sc
+    simpleNavMeas2.walkBounds = walk_bounds_sc
 
     # Set up planetNav for Bennu "measurements"
     planetNavMeas = planetNav.PlanetNav()
@@ -533,20 +604,20 @@ def run(show_plots):
     # Define the Pmatrix for planetNav, no uncertainty on position and velocity of the body
     pos_sigma_p = 0.0
     vel_sigma_p = 0.0
-    att_sigma_p = 2.0 * math.pi / 180.0
-    rate_sigma_p = 0.3 * math.pi / 180.0
+    att_sigma_p = 1.0 * math.pi / 180.0
+    rate_sigma_p = 0.1 * math.pi / 180.0
     p_matrix_p = [[pos_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., pos_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., pos_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., vel_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., vel_sigma_p, 0., 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., vel_sigma_p, 0., 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., att_sigma_p, 0., 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., att_sigma_p, 0., 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., att_sigma_p, 0., 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_p, 0., 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_p, 0.],
-               [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_p]]
+                  [0., pos_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                  [0., 0., pos_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0., 0.],
+                  [0., 0., 0., vel_sigma_p, 0., 0., 0., 0., 0., 0., 0., 0.],
+                  [0., 0., 0., 0., vel_sigma_p, 0., 0., 0., 0., 0., 0., 0.],
+                  [0., 0., 0., 0., 0., vel_sigma_p, 0., 0., 0., 0., 0., 0.],
+                  [0., 0., 0., 0., 0., 0., att_sigma_p, 0., 0., 0., 0., 0.],
+                  [0., 0., 0., 0., 0., 0., 0., att_sigma_p, 0., 0., 0., 0.],
+                  [0., 0., 0., 0., 0., 0., 0., 0., att_sigma_p, 0., 0., 0.],
+                  [0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_p, 0., 0.],
+                  [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_p, 0.],
+                  [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., rate_sigma_p]]
     walk_bounds_p = [[0.], [0.], [0.], [0.], [0.], [0.], [0.005], [0.005], [0.005], [0.002], [0.002], [0.002]]
     planetNavMeas.PMatrix = p_matrix_p
     planetNavMeas.walkBounds = walk_bounds_p
@@ -589,6 +660,22 @@ def run(show_plots):
     rwMotorTorqueConfig.controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueConfig.rwMotorTorqueOutMsg)
 
+    # Create the Lyapunov feedback controller
+    waypointFeedback = smallBodyWaypointFeedback.SmallBodyWaypointFeedback()
+    waypointFeedback.asteroidEphemerisInMsg.subscribeTo(planetNavMeas.ephemerisOutMsg)
+    waypointFeedback.sunEphemerisInMsg.subscribeTo(sunEphemerisMsg)
+    waypointFeedback.navAttInMsg.subscribeTo(simpleNavMeas2.attOutMsg)
+    waypointFeedback.A_sc = 1.  # Surface area of the spacecraft, m^2
+    waypointFeedback.M_sc = mass  # Mass of the spacecraft, kg
+    waypointFeedback.IHubPntC_B = unitTestSupport.np2EigenMatrix3d(I)  # sc inertia
+    waypointFeedback.mu_ast = mu  # Gravitational constant of the asteroid
+    waypointFeedback.x1_ref = [-2000., 0., 0.]
+    waypointFeedback.x2_ref = [0.0, 0.0, 0.0]
+
+    extForceTorqueModule = extForceTorque.ExtForceTorque()
+    extForceTorqueModule.cmdForceBodyInMsg.subscribeTo(waypointFeedback.forceOutMsg)
+    scObject.addDynamicEffector(extForceTorqueModule)
+
     # Set up the small body EKF
     smallBodyNav = smallBodyNavEKF.SmallBodyNavEKF()
     smallBodyNav.ModelTag = "smallBodyNavEKF"
@@ -596,62 +683,69 @@ def run(show_plots):
     # Set the filter parameters (sc area, mass, gravitational constants, etc.)
     smallBodyNav.A_sc = 1.  # Surface area of the spacecraft, m^2
     smallBodyNav.M_sc = mass  # Mass of the spacecraft, kg
-    smallBodyNav.IHubPntC_B = unitTestSupport.np2EigenMatrix3d(I)  # sc inertia
-    smallBodyNav.IWheelPntC_B = (RW1.Js*np.identity(3)).tolist()  # wheel inertia
     smallBodyNav.mu_ast = mu  # Gravitational constant of the asteroid
 
     # Set the process noise
-    Q = np.identity(18)
-    Q[0,0] = Q[1,1] = Q[2,2] = 5.
-    Q[3,3] = Q[4,4] = Q[5,5] = 0.0001
-    Q[0:3,3:6] = Q[3:6,0:3] = 0.0001   # Cross position and velocity
+    Q = np.zeros((12,12))
+    Q[0,0] = Q[1,1] = Q[2,2] = 0.0000001
+    Q[3,3] = Q[4,4] = Q[5,5] = 0.000001
+    Q[6,6] = Q[7,7] = Q[8,8] = 0.000001
+    Q[9,9] = Q[10,10] = Q[11,11] = 0.0000001
     smallBodyNav.Q = Q.tolist()
 
     # Set the measurement noise
-    R = np.identity(18)
-    R[0,0] = 45.  # position sigmas
-    R[1,1] = R[2,2] = 20.
-    R[3,3] = R[4,4] = R[5,5] = 0.1   # velocity sigmas
-    R[0:3,3:6] = R[3:6,0:3] = 0.001   # Cross position and velocity
-    smallBodyNav.R = R.tolist()  # Measurement Noise
+    R = np.zeros((12,12))
+    R[0,0] = R[1,1] = R[2,2] = pos_sigma_sc  # position sigmas
+    R[3,3] = R[4,4] = R[5,5] = vel_sigma_sc   # velocity sigmas
+    R[6,6] = R[7,7] = R[8,8] = att_sigma_p
+    R[9,9] = R[10,10] = R[11,11] = rate_sigma_p
+    smallBodyNav.R = np.multiply(R, R).tolist()  # Measurement Noise
 
     # Set the initial guess, x_0
     x_0 = np.zeros(18)
-    # x_0[0:3] = np.array([2500., -750., 810.])
-    x_0[0:3] = np.array([3000., -1000., 1000.])
-    x_0[3:6] = v_BO_N
-    x_0[6] = 0.2
-    x_0[13] = 0.1
+    x_0[0:3] = np.array([2458., -704.08, 844.275])
+    x_0[3:6] = np.array([1.475, -0.176, 0.894])
+    x_0[6:9] = np.array([-0.58, 0.615, 0.125])
+    x_0[11] = 0.0004
     smallBodyNav.x_hat_k = unitTestSupport.np2EigenVectorXd(x_0)
     # Set the covariance to something large
-    smallBodyNav.P_k = (1E9*np.identity(18)).tolist()
+    smallBodyNav.P_k = (0.1*np.identity(12)).tolist()
 
     # Connect the relevant modules to the smallBodyEKF input messages
     smallBodyNav.navTransInMsg.subscribeTo(simpleNavMeas.transOutMsg)
-    smallBodyNav.navAttInMsg.subscribeTo(simpleNavMeas.attOutMsg)
+    smallBodyNav.navAttInMsg.subscribeTo(simpleNavMeas2.attOutMsg)
     smallBodyNav.asteroidEphemerisInMsg.subscribeTo(planetNavMeas.ephemerisOutMsg)
     smallBodyNav.sunEphemerisInMsg.subscribeTo(sunEphemerisMsg)
-    for i in range(3):
-        smallBodyNav.addRWToFilter(rwStateEffector.rwOutMsgs[i])
+    smallBodyNav.cmdForceBodyInMsg.subscribeTo(waypointFeedback.forceOutMsg)
     smallBodyNav.addThrusterToFilter(thrusterMsg)
 
     # Connect the smallBodyEKF output messages to the relevant modules
-    trackingErrorData.attNavInMsg.subscribeTo(simpleNavMeas.attOutMsg)
-    sunPointData.transNavInMsg.subscribeTo(simpleNavMeas.transOutMsg)
+    trackingErrorData.attNavInMsg.subscribeTo(simpleNavMeas2.attOutMsg)
+    sunPointData.transNavInMsg.subscribeTo(simpleNavMeas2.transOutMsg)
+    waypointFeedback.navTransInMsg.subscribeTo(smallBodyNav.navTransOutMsg)
+
+    # Set the waypoint feedback gains
+    waypointFeedback.K1 = unitTestSupport.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
+    waypointFeedback.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Add all models to the task
     scSim.AddModelToTask(simTaskName, scObject, ModelPriority=100)
     scSim.AddModelToTask(simTaskName, srp, ModelPriority=99)
     scSim.AddModelToTask(simTaskName, gravBodyEphem, ModelPriority=99)
-    scSim.AddModelToTask(simTaskName, ephemConverter, ModelPriority=98)
-    scSim.AddModelToTask(simTaskName, simpleNavMeas, ModelPriority=97)
-    scSim.AddModelToTask(simTaskName, planetNavMeas, ModelPriority=96)
-    scSim.AddModelToTask(simTaskName, sunPointWrap, sunPointData, ModelPriority=95)
-    scSim.AddModelToTask(simTaskName, trackingErrorWrap, trackingErrorData, ModelPriority=94)
-    scSim.AddModelToTask(simTaskName, mrpFeedbackControlWrap, mrpFeedbackControlData, ModelPriority=93)
-    scSim.AddModelToTask(simTaskName, rwMotorTorqueWrap, rwMotorTorqueConfig, ModelPriority=92)
     scSim.AddModelToTask(simTaskName, rwStateEffector, ModelPriority=91)
-    scSim.AddModelToTask(simTaskName, smallBodyNav, ModelPriority=90)
+    scSim.AddModelToTask(simTaskName, extForceTorqueModule, ModelPriority=91)
+    scSim.AddModelToTask(simTaskName, simpleNavMeas2, ModelPriority=90)
+    scSim.AddModelToTask(simTaskName, ephemConverter, ModelPriority=98)
+
+    scSim.AddModelToTask(measTaskName, simpleNavMeas, ModelPriority=97)
+    scSim.AddModelToTask(measTaskName, planetNavMeas, ModelPriority=96)
+
+    scSim.AddModelToTask(fswTaskName, smallBodyNav, ModelPriority=90)
+    scSim.AddModelToTask(fswTaskName, waypointFeedback, ModelPriority=89)
+    scSim.AddModelToTask(fswTaskName, sunPointWrap, sunPointData, ModelPriority=95)
+    scSim.AddModelToTask(fswTaskName, trackingErrorWrap, trackingErrorData, ModelPriority=94)
+    scSim.AddModelToTask(fswTaskName, mrpFeedbackControlWrap, mrpFeedbackControlData, ModelPriority=93)
+    scSim.AddModelToTask(fswTaskName, rwMotorTorqueWrap, rwMotorTorqueConfig, ModelPriority=92)
 
     #   Setup data logging before the simulation is initialized
     sc_truth_recorder = scObject.scStateOutMsg.recorder()
@@ -663,11 +757,11 @@ def run(show_plots):
     sc_att_meas_recorder = simpleNavMeas.attOutMsg.recorder()
     scSim.AddModelToTask(simTaskName, sc_truth_recorder)
     scSim.AddModelToTask(simTaskName, ast_truth_recorder)
-    scSim.AddModelToTask(simTaskName, state_recorder)
-    scSim.AddModelToTask(simTaskName, sc_meas_recorder)
-    scSim.AddModelToTask(simTaskName, sc_att_meas_recorder)
+    scSim.AddModelToTask(fswTaskName, state_recorder)
+    scSim.AddModelToTask(measTaskName, sc_meas_recorder)
+    scSim.AddModelToTask(measTaskName, sc_att_meas_recorder)
     scSim.AddModelToTask(simTaskName, ast_ephemeris_recorder)
-    scSim.AddModelToTask(simTaskName, ast_ephemeris_meas_recorder)
+    scSim.AddModelToTask(measTaskName, ast_ephemeris_meas_recorder)
 
     if vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
@@ -679,7 +773,24 @@ def run(show_plots):
     scSim.InitializeSimulation()
 
     #   configure a simulation stop time and execute the simulation run
+    simulationTime = macros.sec2nano(1000.0)
     scSim.ConfigureStopTime(simulationTime)
+    scSim.ExecuteSimulation()
+
+    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(1000.))
+    scSim.disableTask(measTaskName)
+    scSim.ExecuteSimulation()
+
+    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(2000.))
+    scSim.enableTask(measTaskName)
+    scSim.ExecuteSimulation()
+
+    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(3000.))
+    scSim.disableTask(measTaskName)
+    scSim.ExecuteSimulation()
+
+    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(4000.))
+    scSim.enableTask(measTaskName)
     scSim.ExecuteSimulation()
 
     # retrieve logged spacecraft position relative to asteroid
@@ -687,10 +798,6 @@ def run(show_plots):
     r_BN_N_meas = sc_meas_recorder.r_BN_N
     v_BN_N_truth = sc_truth_recorder.v_BN_N
     v_BN_N_meas = sc_meas_recorder.v_BN_N
-    sigma_BN_truth = sc_truth_recorder.sigma_BN
-    sigma_BN_meas = sc_att_meas_recorder.sigma_BN
-    omega_BN_B_truth = sc_truth_recorder.omega_BN_B
-    omega_BN_B_meas = sc_att_meas_recorder.omega_BN_B
     r_AN_N = ast_truth_recorder.PositionVector
     v_AN_N = ast_truth_recorder.VelocityVector
     sigma_AN_truth = ast_ephemeris_recorder.sigma_BN
@@ -700,16 +807,29 @@ def run(show_plots):
     x_hat = state_recorder.state
     P = state_recorder.covar
 
+    time = sc_truth_recorder.times() * macros.NANO2SEC
+    meas_time = sc_meas_recorder.times() * macros.NANO2SEC
+
     # Compute the relative position and velocity of the s/c in the small body hill frame
     r_BO_O_truth = []
     v_BO_O_truth = []
     r_BO_O_meas = []
     v_BO_O_meas = []
-    for rd_N, vd_N, rc_N, vc_N, rd_N_meas, vd_N_meas in zip(r_BN_N_truth, v_BN_N_truth, r_AN_N, v_AN_N, r_BN_N_meas, v_BN_N_meas):
+    for rd_N, vd_N, rc_N, vc_N in zip(r_BN_N_truth, v_BN_N_truth, r_AN_N, v_AN_N):
         dcm_ON = orbitalMotion.hillFrame(rc_N, vc_N)
 
         r_BO_O_truth.append(np.matmul(dcm_ON, rd_N-rc_N))
         v_BO_O_truth.append(np.matmul(dcm_ON, vd_N-vc_N))
+
+    for idx, t in enumerate(meas_time):
+        truth_idx = np.where(time == t)[0][0]
+
+        rc_N = r_AN_N[truth_idx, :]
+        vc_N = v_AN_N[truth_idx, :]
+        rd_N_meas = r_BN_N_meas[idx, :]
+        vd_N_meas = v_BN_N_meas[idx, :]
+
+        dcm_ON = orbitalMotion.hillFrame(rc_N, vc_N)
 
         r_BO_O_meas.append(np.matmul(dcm_ON, rd_N_meas-rc_N))
         v_BO_O_meas.append(np.matmul(dcm_ON, vd_N_meas-vc_N))
@@ -717,13 +837,12 @@ def run(show_plots):
     #
     #   plot the results
     #
-    time = sc_truth_recorder.times() * macros.NANO2SEC
-    plot_position(time, np.array(r_BO_O_truth), x_hat[:,0:3], np.array(r_BO_O_meas))
+    plot_position(time, meas_time, np.array(r_BO_O_truth), x_hat[:,0:3], np.array(r_BO_O_meas))
     figureList = {}
     pltName = fileName + "1"
     figureList[pltName] = plt.figure(1)
 
-    plot_velocity(time, np.array(v_BO_O_truth), x_hat[:,3:6], np.array(v_BO_O_meas))
+    plot_velocity(time, meas_time, np.array(v_BO_O_truth), x_hat[:,3:6], np.array(v_BO_O_meas))
     pltName = fileName + "2"
     figureList[pltName] = plt.figure(2)
 
@@ -735,19 +854,19 @@ def run(show_plots):
     pltName = fileName + "4"
     figureList[pltName] = plt.figure(4)
 
-    plot_sc_att(time, np.array(sigma_BN_truth), x_hat[:,12:15], np.array(sigma_BN_meas))
+    plot_ast_att(time, meas_time, np.array(sigma_AN_truth), x_hat[:,6:9], np.array(sigma_AN_meas))
     pltName = fileName + "5"
     figureList[pltName] = plt.figure(5)
 
-    plot_sc_rate(time, np.array(omega_BN_B_truth), x_hat[:,15:], np.array(omega_BN_B_meas))
+    plot_ast_rate(time, meas_time, np.array(omega_AN_A_truth), x_hat[:,9:12], np.array(omega_AN_A_meas))
     pltName = fileName + "6"
     figureList[pltName] = plt.figure(6)
 
-    plot_ast_att(time, np.array(sigma_AN_truth), x_hat[:,6:9], np.array(sigma_AN_meas))
+    plot_ast_attitude_error(time, np.subtract(sigma_AN_truth, x_hat[:,6:9]), P)
     pltName = fileName + "7"
     figureList[pltName] = plt.figure(7)
 
-    plot_ast_rate(time, np.array(omega_AN_A_truth), x_hat[:,9:12], np.array(omega_AN_A_meas))
+    plot_ast_rate_error(time, np.subtract(omega_AN_A_truth, x_hat[:,9:12]), P)
     pltName = fileName + "8"
     figureList[pltName] = plt.figure(8)
 

--- a/src/architecture/msgPayloadDefC/SmallBodyNavMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/SmallBodyNavMsgPayload.h
@@ -20,7 +20,7 @@
 #ifndef AVS_SMALLBODYNAVMSGPAYLOAD_H
 #define AVS_SMALLBODYNAVMSGPAYLOAD_H
 
-#define SMALL_BODY_NAV_N_STATES 18
+#define SMALL_BODY_NAV_N_STATES 12
 
 //! @brief Full states and covariances associated with spacecraft navigation about a small body
 typedef struct{

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_Documentation/Images/moduleIOSmallBodyNavigation.svg
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_Documentation/Images/moduleIOSmallBodyNavigation.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xl="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="32 62 730 566" width="730" height="566">
+<svg xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns="http://www.w3.org/2000/svg" viewBox="32 62 730 566" width="730" height="566">
   <defs>
     <font-face font-family="Helvetica Neue" font-size="12" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
       <font-face-src>
@@ -14,9 +14,9 @@
     </marker>
   </defs>
   <metadata> Produced by OmniGraffle 7.11.3 
-    <dc:date>2021-07-20 16:23:27 +0000</dc:date>
+    <dc:date>2023-04-13 20:29:59 +0000</dc:date>
   </metadata>
-  <g id="Canvas_1" stroke-dasharray="none" fill-opacity="1" stroke="none" stroke-opacity="1" fill="none">
+  <g id="Canvas_1" stroke-dasharray="none" fill-opacity="1" stroke-opacity="1" fill="none" stroke="none">
     <title>Canvas 1</title>
     <g id="Canvas_1: Layer 1">
       <title>Layer 1</title>
@@ -36,19 +36,11 @@
         </text>
       </g>
       <g id="Graphic_9">
-        <rect x="575.5" y="268" width="185.08202" height="71" fill="#c0ffc0"/>
-        <rect x="575.5" y="268" width="185.08202" height="71" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-        <text transform="translate(580.5 289.164)" fill="black">
+        <rect x="575.5" y="312" width="185.08202" height="71" fill="#c0ffc0"/>
+        <rect x="575.5" y="312" width="185.08202" height="71" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(580.5 333.164)" fill="black">
           <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="34.64501" y="11">transNavOutMsg(C)</tspan>
           <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="29.203008" y="25.336">NavTransMsgPayload</tspan>
-        </text>
-      </g>
-      <g id="Graphic_10">
-        <rect x="575.5" y="367" width="185.08202" height="71" fill="#c0ffc0"/>
-        <rect x="575.5" y="367" width="185.08202" height="71" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-        <text transform="translate(580.5 388.164)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="41.08901" y="11">attNavOutMsg(C)</tspan>
-          <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="35.98301" y="25.336">NavAttMsgPayload</tspan>
         </text>
       </g>
       <g id="Graphic_11">
@@ -63,10 +55,7 @@
         <path d="M 490.082 347.5 L 529.09375 347.5 L 529.09375 203.66667 L 565.6 203.66667" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
       <g id="Line_15">
-        <path d="M 490.082 347.5 L 529.09375 347.5 L 529.09375 303.5 L 565.6 303.5" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
-      </g>
-      <g id="Line_16">
-        <path d="M 490.082 347.5 L 529.053 347.5 L 529.053 402.5 L 565.6 402.5" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <line x1="490.082" y1="347.5" x2="565.6" y2="347.5" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
       <g id="Line_17">
         <path d="M 490.082 347.5 L 528.81595 347.5 L 528.81595 501.66667 L 566.1 501.66667" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
@@ -99,8 +88,8 @@
         <rect x="33" y="556.33333" width="185.08202" height="71" fill="#c0ffc0"/>
         <rect x="33" y="556.33333" width="185.08202" height="71" stroke="#666" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
         <text transform="translate(38 577.49733)" fill="black">
-          <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="61.43501" y="11">rwInMsgs</tspan>
-          <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="27.199008" y="25.336">RWSpeedMsgPayload</tspan>
+          <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="29.749008" y="11">cmdForceBodyInMsg</tspan>
+          <tspan font-family="Helvetica Neue" font-size="12" font-weight="400" fill="black" x="11.863008" y="25.336">CmdForceBodyMsgPayload</tspan>
         </text>
       </g>
       <g id="Graphic_23">
@@ -123,7 +112,7 @@
         <path d="M 218.08202 98.5 L 261 98.5 L 261 349 L 295.1 349" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
       <g id="Line_75">
-        <path d="M 218.08202 591.8333 L 228.08202 591.8333 L 247.65356 592.0511 L 261 592.0511 L 261 348.16667" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <path d="M 218.08202 591.8333 L 228.08202 591.8333 L 247.65356 592.0511 L 261 592.0511 L 261 348.16666" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
       <g id="Line_76">
         <path d="M 218.08202 197.3944 C 241.9202 197.45305 261 197.5 261 197.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
@@ -135,7 +124,7 @@
         <path d="M 218.08202 394.5 C 241.9202 394.5 261 394.5 261 394.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
       <g id="Line_79">
-        <path d="M 218.08202 493.3944 C 241.9202 493.45305 261 493.5 261 493.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <path d="M 218.08202 493.3944 C 241.9202 493.45304 261 493.5 261 493.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
       </g>
     </g>
   </g>

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
@@ -62,24 +62,21 @@ def smallBodyNavEKFTestFunction(show_plots):
     # Set the filter parameters (sc area, mass, gravitational constants, etc.)
     module.A_sc = 1.  # Surface area of the spacecraft, m^2
     module.M_sc = 100.  # Mass of the spacecraft, kg
-    I = [82.12, 0.0, 0.0, 0.0, 98.40, 0.0, 0.0, 0.0, 121.0]
-    module.IHubPntC_B = unitTestSupport.np2EigenMatrix3d(I)  # sc inertia
-    module.IWheelPntC_B = ((50./6000.0*macros.RPM)*np.identity(3)).tolist()  # wheel inertia
     module.mu_ast = 5.2  # Gravitational constant of the asteroid
-    module.Q = (0.1*np.identity(18)).tolist()  # Process Noise
-    module.R = (0.1*np.identity(18)).tolist()  # Measurement Noise
+    module.Q = (0.1*np.identity(12)).tolist()  # Process Noise
+    module.R = (0.1*np.identity(12)).tolist()  # Measurement Noise
 
     bennu_radius = 1.355887692*orbitalMotion.AU*1000.0  # meters
     bennu_velocity = np.sqrt(orbitalMotion.MU_SUN*(1000.**3)/bennu_radius) # m/s, assumes circular orbit
 
-    x_0 = [2010., 1510., 1010., 0., 2., 0., 0.14, 0., 0., 0., 0., 0., 0.13, 0., 0., 0., 0., 0.]
+    x_0 = [2010., 1510., 1010., 0., 2., 0., 0.14, 0., 0., 0., 0., 0.]
     module.x_hat_k = unitTestSupport.np2EigenVectorXd(x_0)
-    module.P_k = (1000.*np.identity(18)).tolist()
+    module.P_k = (0.1*np.identity(12)).tolist()
 
     # Configure blank module input messages
     navTransInMsgData = messaging.NavTransMsgPayload()
     navTransInMsgData.r_BN_N = [bennu_radius + 1000., 1000., 1000.]
-    navTransInMsgData.v_BN_N = [0., bennu_velocity+1., 0.]
+    navTransInMsgData.v_BN_N = [0., bennu_velocity + 1., 0.]
     navTransInMsg = messaging.NavTransMsg().write(navTransInMsgData)
 
     navAttInMsgData = messaging.NavAttMsgPayload()
@@ -97,26 +94,23 @@ def smallBodyNavEKFTestFunction(show_plots):
     sunEphemerisInMsgData = messaging.EphemerisMsgPayload()
     sunEphemerisInMsg = messaging.EphemerisMsg().write(sunEphemerisInMsgData)
 
-    rwConfigLogInMsgData = messaging.RWConfigLogMsgPayload()
-    rwConfigLogInMsgData.Js = 50./6000.0*macros.RPM
-    rwConfigLogInMsg = messaging.RWConfigLogMsg().write(rwConfigLogInMsgData)
-
     THROutputInMsgData = messaging.THROutputMsgPayload()
     THROutputInMsg = messaging.THROutputMsg().write(THROutputInMsgData)
+
+    cmdForceInMsgData = messaging.CmdForceBodyMsgPayload()
+    cmdForceInMsg = messaging.CmdForceBodyMsg().write(cmdForceInMsgData)
 
     # subscribe input messages to module
     module.navTransInMsg.subscribeTo(navTransInMsg)
     module.navAttInMsg.subscribeTo(navAttInMsg)
     module.asteroidEphemerisInMsg.subscribeTo(asteroidEphemerisInMsg)
     module.sunEphemerisInMsg.subscribeTo(sunEphemerisInMsg)
-    module.addRWToFilter(rwConfigLogInMsg)
     module.addThrusterToFilter(THROutputInMsg)
+    module.cmdForceBodyInMsg.subscribeTo(cmdForceInMsg)
 
     # setup output message recorder objects
     navTransOutMsgRec = module.navTransOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, navTransOutMsgRec)
-    navAttOutMsgRec = module.navAttOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, navAttOutMsgRec)
     smallBodyNavOutMsgRec = module.smallBodyNavOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, smallBodyNavOutMsgRec)
     smallBodyNavOutMsgRecC = module.smallBodyNavOutMsgC.recorder()
@@ -124,25 +118,22 @@ def smallBodyNavEKFTestFunction(show_plots):
     asteroidEphemerisOutMsgRec = module.asteroidEphemerisOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, asteroidEphemerisOutMsgRec)
 
-
     unitTestSim.InitializeSimulation()
-    unitTestSim.ConfigureStopTime(macros.sec2nano(10.5))
+    unitTestSim.ConfigureStopTime(macros.sec2nano(10.))
     unitTestSim.ExecuteSimulation()
 
     x_hat = smallBodyNavOutMsgRec.state
     x_hat_c_wrapped = smallBodyNavOutMsgRecC.state
-    covar = smallBodyNavOutMsgRec.covar
-    true_x_hat = np.array([[1000.1, 1000., 1000., 0., 1.0, 0., 0.1, 0., 0., 0., 0., 0., 0.1, 0., 0., 0., 0., 0.]])
-
-    # print(x_hat[0,:])
-    # print(x_hat_c_wrapped)
+    true_x_hat = np.array([[1.33666664e+03,  1.18333330e+03,  1.00333330e+03, -4.77594532e-06,
+                            1.33332617,     -6.10976335e-06,  1.13333333e-01,  0.00000000,
+                            0.00000000,      0.00000000,      0.00000000,      0.00000000]])
 
     testFailCount, testMessages = unitTestSupport.compareArray(
-        true_x_hat, np.array([x_hat[0,:]]), 0.1, "x_hat",
+        true_x_hat, np.array([x_hat[-1,:]]), 0.1, "x_hat",
         testFailCount, testMessages)
 
     testFailCount, testMessages = unitTestSupport.compareArray(
-        true_x_hat, np.array([x_hat_c_wrapped[0,:]]), 0.1, "x_hat_c_wrapped",
+        true_x_hat, np.array([x_hat_c_wrapped[-1,:]]), 0.1, "x_hat_c_wrapped",
         testFailCount, testMessages)
 
     plt.figure(1)
@@ -168,28 +159,6 @@ def smallBodyNavEKFTestFunction(show_plots):
     plt.ylabel('v_BO_O (m/s)')
     plt.title('Estimated Spacecraft Velocity')
 
-    plt.figure(3)
-    plt.clf()
-    plt.figure(3, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,12], label='s1')
-    plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,13], label='s2')
-    plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,14], label='s3')
-    plt.legend(loc='upper left')
-    plt.xlabel('Time (s)')
-    plt.ylabel('sigma_BN (rad)')
-    plt.title('Estimated Spacecraft Attitude')
-
-    plt.figure(4)
-    plt.clf()
-    plt.figure(4, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
-    plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,15], label='omega1')
-    plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,16], label='omega2')
-    plt.plot(navTransOutMsgRec.times() * 1.0E-9, x_hat[:,17], label='omega3')
-    plt.legend(loc='upper left')
-    plt.xlabel('Time (s)')
-    plt.ylabel('omega_BN_B (rad/s)')
-    plt.title('Estimated Spacecraft Rate')
-
     plt.figure(5)
     plt.clf()
     plt.figure(5, figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
@@ -214,8 +183,6 @@ def smallBodyNavEKFTestFunction(show_plots):
 
     if show_plots:
         plt.show()
-
-
 
     if testFailCount == 0:
         print("PASSED: " + module.ModelTag)

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
@@ -31,7 +31,7 @@ def test_smallBodyNavEKF(show_plots):
     **Validation Test Description**
 
     This unit test checks that the filter converges to a constant state estimate under the presence of static measurements.
-    No reaction wheels or thrusters are used, but a message for each is created and connected to avoid warnings.
+    No thrusters are used, but a message for each is created and connected to avoid warnings.
 
     **Test Parameters**
 

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -47,7 +47,7 @@ public:
     void addThrusterToFilter(Message<THROutputMsgPayload> *tmpThrusterMsg);  //!< Adds thruster message
 
 private:
-    void readMessages();  //!< Reads input messages
+    void readMessages(uint64_t CurrentSimNanos);  //!< Reads input messages
     void writeMessages(uint64_t CurrentSimNanos);  //!< Writes output messages
     void predict(uint64_t CurrentSimNanos);  //!< Prediction step of Kalman filter
     void aprioriState(uint64_t CurrentSimNanos);  //!< Computes the apriori state
@@ -120,6 +120,7 @@ private:
     Eigen::MatrixXd k2_phi;  //!< k2 STM constant for RK4 integration
     Eigen::MatrixXd k3_phi;  //!< k3 STM constant for RK4 integration
     Eigen::MatrixXd k4_phi;  //!< k4 STM constant for RK4 integration
+    bool newMeasurements;  //! Keeps track of whether or not new measurements have been written
 
     double mu_sun;  //!< Gravitational parameter of the sun
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -53,8 +53,9 @@ private:
     void aprioriState(uint64_t CurrentSimNanos);  //!< Computes the apriori state
     void aprioriCovar(uint64_t CurrentSimNanos);  //!< Computes the apriori covariance
     void checkMRPSwitching();  //!< Checks the MRPs for switching
-    void computeDynamicsMatrix();  //!< Computes the new dynamics matrix, A_k
+    void computeDynamicsMatrix(Eigen::VectorXd x_hat);  //!< Computes the new dynamics matrix, A_k
     void measurementUpdate();  //!< Computes the measurement update for the EKF
+    void computeEquationsOfMotion(Eigen::VectorXd x_hat, Eigen::MatrixXd Phi); //!< Computes the EOMs of the state and state transition matrix
 
 public:
     ReadFunctor<NavTransMsgPayload> navTransInMsg;  //!< Translational nav input message
@@ -111,6 +112,14 @@ private:
     Eigen::MatrixXd M;  //!<
     Eigen::MatrixXd H_k1;  //!< Jacobian of measurement model
     Eigen::MatrixXd I_full;  //!< numStates x numStates identity matrix
+    Eigen::VectorXd k1;  //!< k1 constant for RK4 integration
+    Eigen::VectorXd k2;  //!< k2 constant for RK4 integration
+    Eigen::VectorXd k3;  //!< k3 constant for RK4 integration
+    Eigen::VectorXd k4;  //!< k4 constant for RK4 integration
+    Eigen::MatrixXd k1_phi;  //!< k1 STM constant for RK4 integration
+    Eigen::MatrixXd k2_phi;  //!< k2 STM constant for RK4 integration
+    Eigen::MatrixXd k3_phi;  //!< k3 STM constant for RK4 integration
+    Eigen::MatrixXd k4_phi;  //!< k4 STM constant for RK4 integration
 
     double mu_sun;  //!< Gravitational parameter of the sun
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -105,6 +105,8 @@ private:
     Eigen::MatrixXd P_k1_;  //!< Apriori estimation error covariance
     Eigen::MatrixXd P_k1;  //!< Updated estimation error covariance
     Eigen::MatrixXd A_k;  //!< State dynamics matrix
+    Eigen::MatrixXd Phi_k;  //!< State transition matrix
+    Eigen::MatrixXd Phi_dot_k;  //!< Rate of change of STM
     Eigen::MatrixXd L;  //!<
     Eigen::MatrixXd M;  //!<
     Eigen::MatrixXd H_k1;  //!< Jacobian of measurement model

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -25,9 +25,7 @@
 #include "cMsgCInterface/NavTransMsg_C.h"
 #include "cMsgCInterface/NavAttMsg_C.h"
 #include "cMsgCInterface/EphemerisMsg_C.h"
-#include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
 #include "cMsgCInterface/SmallBodyNavMsg_C.h"
-#include "architecture/msgPayloadDefC/RWConfigLogMsgPayload.h"
 #include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/messaging/messaging.h"
@@ -35,7 +33,7 @@
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/macroDefinitions.h"
 
-/*! @brief This module estimates relative spacecraft position and velocity with respect to the body, attitude and attitude rate of the body wrt. the inertial frame, and the attitude and attitude rate of the spacecraft with respect to the inertial frame
+/*! @brief This module estimates relative spacecraft position and velocity with respect to the body and attitude and attitude rate of the body wrt. the inertial frame
  */
 class SmallBodyNavEKF: public SysModel {
 public:
@@ -46,7 +44,6 @@ public:
     void Reset(uint64_t CurrentSimNanos);  //!< Resets module
     void UpdateState(uint64_t CurrentSimNanos);  //!< Updates state
     void addThrusterToFilter(Message<THROutputMsgPayload> *tmpThrusterMsg);  //!< Adds thruster message
-    void addRWToFilter(Message<RWConfigLogMsgPayload> *tmpRWMsg);   //!< Adds rw message
 
 private:
     void readMessages();  //!< Reads input messages
@@ -63,16 +60,13 @@ public:
     ReadFunctor<NavAttMsgPayload> navAttInMsg;  //!< Attitude nav input message
     ReadFunctor<EphemerisMsgPayload> asteroidEphemerisInMsg;  //!< Small body ephemeris input message
     ReadFunctor<EphemerisMsgPayload> sunEphemerisInMsg;  //!< Sun ephemeris input message
-    std::vector<ReadFunctor<RWConfigLogMsgPayload>> rwInMsgs;  //!< Reaction wheel speed and torque input messages
     std::vector<ReadFunctor<THROutputMsgPayload>> thrusterInMsgs;  //!< thruster input msg vector
 
     Message<NavTransMsgPayload> navTransOutMsg;  //!< Translational nav output message
-    Message<NavAttMsgPayload> navAttOutMsg;  //!< Attitude nav output message
     Message<SmallBodyNavMsgPayload> smallBodyNavOutMsg;  //!< Small body nav output msg - states and covariances
     Message<EphemerisMsgPayload> asteroidEphemerisOutMsg;  //!< Small body ephemeris output message
 
     NavTransMsg_C navTransOutMsgC = {};  //!< C-wrapped Translational nav output message
-    NavAttMsg_C navAttOutMsgC = {};  //!< C-wrapped Attitude nav output message
     SmallBodyNavMsg_C smallBodyNavOutMsgC = {};  //!< C-wrapped Small body nav output msg - states and covariances
     EphemerisMsg_C asteroidEphemerisOutMsgC = {};  //!< C-wrapped Small body ephemeris output message
 
@@ -83,8 +77,6 @@ public:
     double rho;  //!< Surface reflectivity
     double A_sc;  //!< Surface area of the spacecraft
     double M_sc;  //!< Mass of the spacecraft
-    Eigen::Matrix3d IHubPntC_B;  //!< sc inertia
-    Eigen::Matrix3d IWheelPntC_B;  //!< wheel inertia
     double mu_ast;  //!< Gravitational constant of the asteroid
     Eigen::MatrixXd Q;  //!< Process Noise
     Eigen::MatrixXd R;  //!< Measurement Noise
@@ -97,13 +89,11 @@ private:
     NavAttMsgPayload navAttInMsgBuffer;  //!< Message buffer for input attitude nav message
     EphemerisMsgPayload asteroidEphemerisInMsgBuffer;  //!< Message buffer for asteroid ephemeris
     EphemerisMsgPayload sunEphemerisInMsgBuffer;  //!< Message buffer for sun ephemeris
-    std::vector<RWConfigLogMsgPayload> rwConfigLogInMsgBuffer; //!< Buffer for rw speed messages
     std::vector<THROutputMsgPayload> thrusterInMsgBuffer; //!< Buffer for thruster force and torques
 
     uint64_t prevTime;  //!< Previous time, ns
     uint64_t numStates;  //!< Number of states
     Eigen::Vector3d thrust_B;  //!< Thrust expressed in body-frame components
-    Eigen::Vector3d torque_B;  //!< Torque expressed in body-frame components
     Eigen::VectorXd x_hat_dot_k;  //!< Rate of change of state estimate
     Eigen::VectorXd x_hat_k1_;  //!< Apriori state estimate for time k+1
     Eigen::VectorXd x_hat_k1;  //!< Update state estimate for time k+1
@@ -116,7 +106,6 @@ private:
     Eigen::MatrixXd H_k1;  //!< Jacobian of measurement model
     Eigen::MatrixXd I_full;  //!< numStates x numStates identity matrix
 
-
     double mu_sun;  //!< Gravitational parameter of the sun
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector
     Eigen::Vector3d o_hat_1;  //!< First asteroid orbit frame base vector
@@ -126,8 +115,6 @@ private:
     double F_ddot;  //!< Second time derivative of true anomaly
     Eigen::Matrix3d dcm_ON;  //!< DCM from the inertial frame to the small-body's hill frame
     Eigen::Vector3d r_SO_O;  //!< Vector from the small body's origin to the inertial frame origin in small-body hill frame components
-    Eigen::Vector3d Omega_B;  //!< Speed of the reaction wheels in the spacecraft body frame
-    Eigen::Vector3d Omega_dot_B;  //!< Accleration of the reaction wheels in the spacecraft body frame
 };
 
 

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -26,6 +26,7 @@
 #include "cMsgCInterface/NavAttMsg_C.h"
 #include "cMsgCInterface/EphemerisMsg_C.h"
 #include "cMsgCInterface/SmallBodyNavMsg_C.h"
+#include "cMsgCInterface/CmdForceBodyMsg_C.h"
 #include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/messaging/messaging.h"
@@ -60,6 +61,7 @@ public:
     ReadFunctor<NavAttMsgPayload> navAttInMsg;  //!< Attitude nav input message
     ReadFunctor<EphemerisMsgPayload> asteroidEphemerisInMsg;  //!< Small body ephemeris input message
     ReadFunctor<EphemerisMsgPayload> sunEphemerisInMsg;  //!< Sun ephemeris input message
+    ReadFunctor<CmdForceBodyMsgPayload> cmdForceBodyInMsg;  //!< Command force body in message
     std::vector<ReadFunctor<THROutputMsgPayload>> thrusterInMsgs;  //!< thruster input msg vector
 
     Message<NavTransMsgPayload> navTransOutMsg;  //!< Translational nav output message
@@ -90,10 +92,12 @@ private:
     EphemerisMsgPayload asteroidEphemerisInMsgBuffer;  //!< Message buffer for asteroid ephemeris
     EphemerisMsgPayload sunEphemerisInMsgBuffer;  //!< Message buffer for sun ephemeris
     std::vector<THROutputMsgPayload> thrusterInMsgBuffer; //!< Buffer for thruster force and torques
+    CmdForceBodyMsgPayload cmdForceBodyInMsgBuffer; //!< Buffer for the commanded force input
 
     uint64_t prevTime;  //!< Previous time, ns
     uint64_t numStates;  //!< Number of states
     Eigen::Vector3d thrust_B;  //!< Thrust expressed in body-frame components
+    Eigen::Vector3d cmdForce_B;  //!< External force expressed in body-frame components
     Eigen::VectorXd x_hat_dot_k;  //!< Rate of change of state estimate
     Eigen::VectorXd x_hat_k1_;  //!< Apriori state estimate for time k+1
     Eigen::VectorXd x_hat_k1;  //!< Update state estimate for time k+1

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.i
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.i
@@ -40,9 +40,6 @@ struct NavAttMsg_C;
 struct EphemerisMsg_C;
 %include "architecture/msgPayloadDefC/SmallBodyNavMsgPayload.h"
 struct SmallBodyNavMsg_C;
-%include "architecture/msgPayloadDefC/RWConfigLogMsgPayload.h"
-struct RWConfigLogMsg_C;
-%include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
 
 %pythoncode %{
 import sys

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.i
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.i
@@ -40,6 +40,8 @@ struct NavAttMsg_C;
 struct EphemerisMsg_C;
 %include "architecture/msgPayloadDefC/SmallBodyNavMsgPayload.h"
 struct SmallBodyNavMsg_C;
+%include "architecture/msgPayloadDefC/CmdForceBodyMsgPayload.h"
+struct CmdForceBodyMsg_C;
 
 %pythoncode %{
 import sys


### PR DESCRIPTION
* **Tickets addressed:** bsk-296
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR makes changes to the SmallBodNavEKF in order to increase the number of potential use cases of the filter, such as cases where the user does not require attitude estimation, requires a different force input message for translational control, or requires an attitude estimate when measurements are not present.

To fulfill these needs, the spacecraft attitude estimation component of the filter is removed. Spacecraft attitude estimation should be performed with dedicated filters as its inclusion in this filter narrows the potential use cases of the filter. An optional CmdForceBodyInMsg was also added to the filter. This allows for the use of a module like extForceTorque to send force commands to the filter. When this was added, a bug was identified in the dynamics and corrected (force was not being divided my mass of the spacecraft). Finally, in order to allow the filter to run without measurement updates, STM propagation was added to the filter, which replaces the covariance propagation and integration using the state dynamics matrix. Modifications were also made so the apriori covariance and state estimate could be written to the output messages in the event that no measurements are available. 

## Verification
The changes were validated by updating the corresponding unit test and scenario script.

## Documentation
The documentation was updated to reflect these changes.

## Future work
N/A
