### PR TITLE
Feature/bsk 307 c msg read

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-7.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-7.rst
@@ -26,13 +26,21 @@ The sample simulation script creates both a C and C++ module which have their in
 
 .. warning::
 
-    Basilisk C modules contain C wrapped message objects and thus can only write to a stand-alone C wrapped message interface.  Similarly, a C++ module contains C++ message objects and can only write to a C++ stand-alone message.  You can't have a C module write to a C++ stand-alone message.
+    Basilisk C modules contain C wrapped message objects and thus can only write to a stand-alone C wrapped
+    message interface.  Similarly, a C++ module contains C++ message objects and can only write to a C++
+    stand-alone message.  You can't have a C module write to a C++ stand-alone message.
 
-In the following sample code, a C and C++ Basilisk module are created.  To create a C wrapped stand-alone message the ``messaging`` package must be imported from ``Basilisk.architecture``.  Next, assume a message of type ``SomeMsg`` needs to be created.  This is done using::
+In the following sample code, a C and C++ Basilisk module are created.  To create a C wrapped stand-alone
+message the ``messaging`` package must be imported from ``Basilisk.architecture``.  Next, assume a message
+of type ``SomeMsg`` needs to be created.  This is done using::
 
     cStandAloneMsg = messaging.SomeMsg_C()
+    cStandAloneMsg.write(messaging.SomeMsgPayload())
 
-To enable a C module ``someCModule`` to redirect its output message ``dataOutMsg`` writing to this stand-alone message use::
+Be sure to provide an empty payload structure to the C-wrapped message object.  Otherwise a ``read()``
+operation on this stand-alone msg object will cause a segmentation fault.
+To enable a C module ``someCModule`` to redirect its output message ``dataOutMsg`` writing to this stand-alone
+message use::
 
     messaging.SomeMsg_C_addAuthor(someCModule.dataOutMsg, cStandAloneMsg)
 
@@ -55,11 +63,18 @@ To redirect the output of a C++ module ``someCppModule`` to this stand-alone mes
 .. note::
 
     If you want to record the output of ``someCModule`` be sure to record ``cStandAloneMsg``
-    instead of ``someCModule.dataOutMsg``.  The later is no longer being written to.  In C++
+    instead of ``someCModule.dataOutMsg``.  The later is no longer being written to
+    unless you use the ``.read()`` method which sync's up the payload content.  In C++
     we are setting ``cppStandAloneMsg`` equal to ``someCppModule.dataOutMsg``.  Here recording either
     will give the same result.
 
-To see the message states of both the module internal message objects and the stand-alone messages, the sample script shows how to use ``.read()`` to read the current state of the message object.  This will return a copy of the message payload structure.  The same method can be used to access both C and C++ wrapped messages.  After executing the script you should see the following terminal output:
+To see the message states of both the module internal message objects and the stand-alone messages,
+the sample script shows how to use ``.read()`` to read the current state of the message object.
+This will return a copy of the message payload structure.  The same method can be used to access both
+C and C++ wrapped messages. For the C-wrapped message object, the ``.read()`` command will also copy
+the content from the stand-alone message to the module message.  This is why the ``.read()`` command
+below on the module output message returns the correct value.
+After executing the script you should see the following terminal output:
 
 .. code-block::
 
@@ -71,7 +86,7 @@ To see the message states of both the module internal message objects and the st
     BSK_INFORMATION: C Module ID 1 ran Update at 1.000000s
     BSK_INFORMATION: C++ Module ID 2 ran Update at 1.000000s
     mod1.dataOutMsg:
-    [0.0, 0.0, 0.0]
+    [2.0, 0.0, 0.0]
     cMsg:
     [2.0, 0.0, 0.0]
     mod2.dataOutMsg:

--- a/docs/source/codeSamples/bsk-7.py
+++ b/docs/source/codeSamples/bsk-7.py
@@ -50,6 +50,7 @@ def run():
     # create stand-alone message with a C interface and re-direct
     # the C module output message writing to this stand-alone message
     cMsg = messaging.CModuleTemplateMsg_C()
+    cMsg.write(messaging.CModuleTemplateMsgPayload())
     messaging.CModuleTemplateMsg_C_addAuthor(mod1.dataOutMsg, cMsg)
 
     # create stand-along message with a C++ interface and re-direct

--- a/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
@@ -54,7 +54,6 @@ typedef struct {type};
 
     def read(self):
         """read the message payload."""
-        self.subscribeTo(self)
         return {type}_C_read(self)
     %}}
 }};

--- a/src/architecture/messaging/msgAutoSource/msg_C.cpp.in
+++ b/src/architecture/messaging/msgAutoSource/msg_C.cpp.in
@@ -51,8 +51,8 @@ void {type}_C_write({type}Payload *data, {type}_C *destination, int64_t moduleID
 
 //! C interface to read to a message
 {type}Payload {type}_C_read({type}_C *source) {{
-    if (!source->header.isLinked) {{
-        BSK_PRINT(MSG_ERROR,"In C input msg, you are trying to read an un-connected message of type {type}.");
+    if (!source->headerPointer->isWritten) {{
+        BSK_PRINT(MSG_ERROR,"In C input msg, you are trying to read an un-written message of type {type}.");
     }}
     //! ensure the current message container has a copy of a subscribed message.
     //! Does nothing if the message is writing to itself


### PR DESCRIPTION
* **Tickets addressed:** bsk-307
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fixed the issue where a `.read()` command on a C-wrapped message would subscribe the msg object back
onto itself.

## Verification
Expanded the unit test to be more inclusive and cover these issues.

## Documentation
Updated bsk Principles tutorial No. 7 to explain the latest behavior on how to step a C-wrapped stand-alone
message, how to add a recorder, and how to use the `.read()` method on a C-wrapped message.

