### PR TITLE
Incorrect radii assignments in eclipse module.

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -47,6 +47,8 @@ Version |release|
   format, with_quirc QR code lib. Users that have Basilisk control the build of these modules through the External
   Modules CMake integration will need to manual toggle these OpenCV build options.
 - Updated :ref:`SmallBodyNavEKF` with several bug fixes. Removed spacecraft attitude estimation component.
+- Bug fix made to :ref:`eclipse`: Saturn, Jupiter, Uranus, and Neptune radii were incorrectly being assigned the 
+  radius of Mars. 
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/simulation/environment/eclipse/eclipse.cpp
+++ b/src/simulation/environment/eclipse/eclipse.cpp
@@ -276,13 +276,13 @@ double Eclipse::getPlanetEquatorialRadius(std::string planetSpiceName)
     } else if (planetSpiceName == "mars") {
         return REQ_MARS*1000.0;
     } else if (planetSpiceName == "jupiter barycenter") {
-        return REQ_MARS*1000.0;
+        return REQ_JUPITER*1000.0;
     } else if (planetSpiceName == "saturn") {
-        return REQ_MARS*1000.0;
+        return REQ_SATURN*1000.0;
     } else if (planetSpiceName == "uranus") {
-        return REQ_MARS*1000.0;
+        return REQ_URANUS*1000.0;
     } else if (planetSpiceName == "neptune") {
-        return REQ_MARS*1000.0;
+        return REQ_NEPTUNE*1000.0;
     } else {
         bskLogger.bskLog(BSK_ERROR, "Eclipse: unrecognized planetSpiceName.");
         return 1.0;


### PR DESCRIPTION
* **Tickets addressed:** bsk-302
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The radii of Saturn, Jupiter, Uranus, and Neptune were being set to the radius of Mars in the eclipse module. This commit corrects this issue, replacing the incorrect assignments with the correct ones. 

## Verification
No unit tests were added or modified for this PR. 

## Documentation
Documentation was not invalidated. Rather, the module functionality did not match the documentation. Release notes were updated to notify users of the bug fix. 

## Future work
N/A
