### PR TITLE
Feature/312 eigen swig int support

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -50,6 +50,7 @@ Version |release|
 - Bug fix made to :ref:`eclipse`: Saturn, Jupiter, Uranus, and Neptune radii were incorrectly being assigned the 
   radius of Mars. 
 - Added custom planet name to :ref:`eclipse` in case the user wants to use a body not contained within the module.
+- Removed all instances of using ``unitTestSupport.np2EigenVectorXd()``, as this function is now unneeded.
 
 
 Version 2.1.7 (March 24, 2023)

--- a/examples/OpNavScenarios/scenariosOpNav/CNN_ImageGen/scenario_CNNImages.py
+++ b/examples/OpNavScenarios/scenariosOpNav/CNN_ImageGen/scenario_CNNImages.py
@@ -86,8 +86,8 @@ class scenario_OpNav(BSKSim):
             self.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
         if self.filterUse == "bias":
             self.get_FswModel().pixelLineFilterData.stateInit = rN.tolist() + vN.tolist() + bias
-        # self.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        # self.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        # self.get_DynModel().scObject.hub.r_CN_NInit = rN  # m   - r_CN_N
+        # self.get_DynModel().scObject.hub.v_CN_NInit = vN  # m/s - v_CN_N
         self.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
         self.get_DynModel().cameraMod.fieldOfView = np.deg2rad(55)

--- a/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_LimbAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_LimbAttOD.py
@@ -83,8 +83,8 @@ class scenario_OpNav(BSKSim):
 
         MRP= [0,-0.3,0]
         self.get_FswModel().relativeODData.stateInit = (rN+rError).tolist() + (vN+vError).tolist()
-        self.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.get_DynModel().scObject.hub.r_CN_NInit = rN  # m   - r_CN_N
+        self.get_DynModel().scObject.hub.v_CN_NInit = vN  # m/s - v_CN_N
         self.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
         qNoiseIn = np.identity(6)

--- a/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_OpNavAttODMC.py
+++ b/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_OpNavAttODMC.py
@@ -80,8 +80,8 @@ class scenario_OpNav(BSKSim):
         MRP= [0,0,0]
         self.get_FswModel().relativeODData.stateInit = (rN + rError).tolist() + (vN + vError).tolist()
 
-        self.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.get_DynModel().scObject.hub.r_CN_NInit = rN  # m   - r_CN_N
+        self.get_DynModel().scObject.hub.v_CN_NInit = vN  # m/s - v_CN_N
         self.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
 
@@ -155,4 +155,3 @@ if __name__ == "__main__":
     # Configure a scenario in the base simulation
     TheScenario = scenario_OpNav()
     run(TheScenario)
-

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_CNNAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_CNNAttOD.py
@@ -90,8 +90,8 @@ class scenario_OpNav(BSKScenario):
             self.masterSim.get_FswModel().relativeODData.stateInit = (rN + rError).tolist() + (vN + vError).tolist()
         if self.filterUse == "bias":
             self.masterSim.get_FswModel().relativeODData.stateInit = (rN + rError).tolist() + (vN + vError).tolist() + bias
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN  # m   - r_CN_N
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN  # m/s - v_CN_N
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
 

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttOD.py
@@ -111,8 +111,8 @@ class scenario_OpNav(BSKScenario):
             self.masterSim.get_FswModel().relativeODData.stateInit = (rN + rError).tolist() + (vN + vError).tolist()
         if self.filterUse == "bias":
             self.masterSim.get_FswModel().relativeODData.stateInit = (rN + rError).tolist() + (vN + vError).tolist() + bias
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
 

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttODLimb.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttODLimb.py
@@ -92,8 +92,8 @@ class scenario_OpNav(BSKScenario):
 
         MRP= [0,-0.3,0]
         self.masterSim.get_FswModel().relativeODData.stateInit = (rN+rError).tolist() +  (vN+vError).tolist()
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
         qNoiseIn = np.identity(6)

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavHeading.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavHeading.py
@@ -106,8 +106,8 @@ class scenario_OpNav(BSKScenario):
             self.masterSim.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
         if self.filterUse == "bias":
             self.masterSim.get_FswModel().pixelLineFilterData.stateInit = rN.tolist() + vN.tolist() + bias
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN  # m   - r_CN_N
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN  # m/s - v_CN_N
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
         # Search

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavOD.py
@@ -84,8 +84,8 @@ class scenario_OpNav(BSKScenario):
             self.masterSim.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
         if self.filterUse == "bias":
             self.masterSim.get_FswModel().pixelLineFilterData.stateInit = rN.tolist() + vN.tolist() + bias
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
 

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavODLimb.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavODLimb.py
@@ -80,8 +80,8 @@ class scenario_OpNav(BSKScenario):
 
         MRP= [0,-0.3,0]
         self.masterSim.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
 

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPoint.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPoint.py
@@ -86,8 +86,8 @@ class scenario_OpNav(BSKScenario):
             self.masterSim.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
         if self.filterUse == "bias":
             self.masterSim.get_FswModel().pixelLineFilterData.stateInit = rN.tolist() + vN.tolist() + bias
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
         # Search

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPointLimb.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPointLimb.py
@@ -82,8 +82,8 @@ class scenario_OpNav(BSKScenario):
             self.masterSim.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
         if self.filterUse == "bias":
             self.masterSim.get_FswModel().pixelLineFilterData.stateInit = rN.tolist() + vN.tolist() + bias
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
         # Search

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_faultDetOpNav.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_faultDetOpNav.py
@@ -91,8 +91,8 @@ class scenario_OpNav(BSKScenario):
 
         MRP= [0,-0.3,0]
         self.masterSim.get_FswModel().relativeODData.stateInit = rN.tolist() + vN.tolist()
-        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = unitTestSupport.np2EigenVectorXd(rN)  # m   - r_CN_N
-        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = unitTestSupport.np2EigenVectorXd(vN)  # m/s - v_CN_N
+        self.masterSim.get_DynModel().scObject.hub.r_CN_NInit = rN  # m   - r_CN_N
+        self.masterSim.get_DynModel().scObject.hub.v_CN_NInit = vN  # m/s - v_CN_N
         self.masterSim.get_DynModel().scObject.hub.sigma_BNInit = [[MRP[0]], [MRP[1]], [MRP[2]]]  # sigma_BN_B
         self.masterSim.get_DynModel().scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # rad/s - omega_BN_B
 

--- a/examples/scenarioAlbedo.py
+++ b/examples/scenarioAlbedo.py
@@ -367,14 +367,14 @@ def run(show_plots, albedoData, multipleInstrument, multiplePlanet, useEclipse, 
         T2 = macros.sec2nano(1000.)
         # Set second spacecraft states for decrease in altitude
         vVt = vVt + [0.0, 375300, 0.0]  # m - v_CN_N
-        velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+        velRef.setState(vVt)
         scSim.ConfigureStopTime(T1 + T2)
         scSim.ExecuteSimulation()
         # get the current spacecraft states
         T3 = macros.sec2nano(500.)
         # Set second spacecraft states for decrease in altitude
         vVt = [0.0, 0.0, 0.0]  # m - v_CN_N
-        velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+        velRef.setState(vVt)
         scSim.ConfigureStopTime(T1 + T2 + T3)
         scSim.ExecuteSimulation()
         simulationTime = T1 + T2 + T3

--- a/examples/scenarioAsteroidArrival.py
+++ b/examples/scenarioAsteroidArrival.py
@@ -610,7 +610,7 @@ def run(show_plots):
     # Apply a delta V and set the new velocity state in the circular capture orbit
     vHat = vN / np.linalg.norm(vN)
     vN = vN + Delta_V_Parking_Orbit * vHat
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vN))
+    velRef.setState(vN)
 
     # Travel in a circular orbit at r0, incorporating several attitude pointing modes
     runDvBurn(burnTime, -1, velAsteroidGuidanceConfig.attRefOutMsg)
@@ -634,7 +634,7 @@ def run(show_plots):
     vHat = vN / vData
     vVt = vN + vHat * (v0p - vData)
     # Update state manager's velocity
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+    velRef.setState(vVt)
 
     # Run thruster burn mode along with sun-pointing during the transfer orbit
     runDvBurn(burnTime, -1, velAsteroidGuidanceConfig.attRefOutMsg)
@@ -652,7 +652,7 @@ def run(show_plots):
     vHat = vN / vData
     vVt2 = vN + vHat * (v1p - vData)
     # Update state manager's velocity
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vVt2))
+    velRef.setState(vVt2)
 
     # Run thruster burn visualization along with attitude pointing modes
     runDvBurn(burnTime, -1, velAsteroidGuidanceConfig.attRefOutMsg)
@@ -672,7 +672,7 @@ def run(show_plots):
     vHat = vN / vData
     vVt = vN + vHat * (v2p - vData)
     # Update state manager's velocity
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+    velRef.setState(vVt)
 
     # Run thruster burn section with science pointing mode
     runDvBurn(burnTime, -1, velAsteroidGuidanceConfig.attRefOutMsg)
@@ -690,7 +690,7 @@ def run(show_plots):
     vHat = vN / vData
     vVt = vN + vHat * (v3p - vData)
     # Update state manager's velocity
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+    velRef.setState(vVt)
 
     # Run thruster visualization with science pointing mode
     runDvBurn(burnTime, -1, velAsteroidGuidanceConfig.attRefOutMsg)
@@ -708,7 +708,7 @@ def run(show_plots):
     vHat = vN / vData
     vVt = vN + vHat * (v3p - vData)
     # Update state manager's velocity
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+    velRef.setState(vVt)
 
     # Run thruster visualization with science-pointing mode
     runDvBurn(burnTime, -1, velAsteroidGuidanceConfig.attRefOutMsg)
@@ -776,4 +776,3 @@ if __name__ == "__main__":
     run(
         True  # show_plots
     )
-

--- a/examples/scenarioGroundMapping.py
+++ b/examples/scenarioGroundMapping.py
@@ -261,7 +261,7 @@ def run(show_plots, useCentral):
     groundMap = groundMapping.GroundMapping()
     groundMap.ModelTag = "groundMapping"
     for map_idx in range(N):
-        groundMap.addPointToModel(unitTestSupport.np2EigenVectorXd(mapping_points[map_idx,:]))
+        groundMap.addPointToModel(mapping_points[map_idx,:])
     groundMap.minimumElevation = np.radians(45.)
     groundMap.maximumRange = 1e9
     groundMap.cameraPos_B = [0, 0, 0]

--- a/examples/scenarioJupiterArrival.py
+++ b/examples/scenarioJupiterArrival.py
@@ -223,7 +223,7 @@ def run(show_plots):
     # Apply delta V and set new velocity state
     vHat = vN / np.linalg.norm(vN)
     vN = vN + Delta_V_Parking_Orbit*vHat
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vN))
+    velRef.setState(vN)
     
     # Run the simulation for 2nd chunk
     scSim.ConfigureStopTime(simulationTime + macros.sec2nano(300000))
@@ -303,4 +303,3 @@ if __name__ == "__main__":
     run(
         True  # show_plots
     )
-

--- a/examples/scenarioOrbitManeuver.py
+++ b/examples/scenarioOrbitManeuver.py
@@ -240,7 +240,7 @@ def run(show_plots, maneuverCase):
         vVt = vVt - (1. - np.cos(Delta_i)) * v0 * vHat + np.sin(Delta_i) * v0 * hHat
 
         # After computing the maneuver specific Delta_v's, the state managers velocity is updated through
-        velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+        velRef.setState(vVt)
         T2 = macros.sec2nano(P * 0.25)
     else:
         # Hohmann Transfer to GEO
@@ -253,7 +253,7 @@ def run(show_plots, maneuverCase):
         vHat = vVt / v0
         vVt = vVt + vHat * (v0p - v0)
         # After computing the maneuver specific Delta_v's, the state managers velocity is updated through
-        velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+        velRef.setState(vVt)
 
     # To start up the simulation again, note that the total simulation time must be provided,
     # not just the next incremental simulation time.
@@ -274,7 +274,7 @@ def run(show_plots, maneuverCase):
         vHat = np.cross(hHat, rHat)
         v0 = np.dot(vHat, vVt)
         vVt = vVt - (1. - np.cos(Delta_i)) * v0 * vHat + np.sin(Delta_i) * v0 * hHat
-        velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+        velRef.setState(vVt)
         T3 = macros.sec2nano(P * 0.25)
     else:
         # Hohmann Transfer to GEO
@@ -284,7 +284,7 @@ def run(show_plots, maneuverCase):
         T3 = macros.sec2nano(0.25 * (np.pi) / n1)
         vHat = vVt / v1
         vVt = vVt + vHat * (v1p - v1)
-        velRef.setState(unitTestSupport.np2EigenVectorXd(vVt))
+        velRef.setState(vVt)
 
     # run simulation for 3rd chunk
     scSim.ConfigureStopTime(simulationTime + T2 + T3)

--- a/examples/scenarioPatchedConics.py
+++ b/examples/scenarioPatchedConics.py
@@ -253,7 +253,7 @@ def run(show_plots):
     v_S_E = v_S_E + vHat * deltaV1
 
     vN = v_S_E + vel_N_Earth
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vN))
+    velRef.setState(vN)
 
     # run simulation for 2nd chunk
     scSim.ConfigureStopTime(simulationTime + macros.sec2nano(110000))
@@ -291,8 +291,8 @@ def run(show_plots):
     depVel_N_Earth = [29.7859 * 1000, 0, 0]
     rN = rN + pos_N_Earth
     vN = vN + depVel_N_Earth
-    posRef.setState(unitTestSupport.np2EigenVectorXd(rN))
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vN))
+    posRef.setState(rN)
+    velRef.setState(vN)
 
     scSim.ConfigureStopTime(simulationTime + macros.sec2nano(110000) + T2 - oneWeek*1)
     scSim.ExecuteSimulation()
@@ -348,8 +348,8 @@ def run(show_plots):
     rN = rN - pos_N_Jup
     vN = vN - vel_N_Jup
 
-    posRef.setState(unitTestSupport.np2EigenVectorXd(rN))
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vN))
+    posRef.setState(rN)
+    velRef.setState(vN)
 
     # Setup data logging before the simulation is initialized
 

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -496,7 +496,7 @@ def run(show_plots):
         rho_Prime_H[0] = 0.0
         rho_Prime_H[1] = -1.5*n*xOff
         unusedPos, vd = orbitalMotion.hill2rv(rc, vc, rho_H, rho_Prime_H)
-        servicerVel.setState(unitTestSupport.np2EigenVectorXd(vd))
+        servicerVel.setState(vd)
 
     def relativeEllipse(A0, xOff, B0=-1):
         rd = unitTestSupport.EigenVector3d2np(servicerPos.getState())
@@ -516,7 +516,7 @@ def run(show_plots):
         if B0 >= 0.0:
             rho_Prime_H[2] = -B0*n*np.sin(beta)
         unusedPos, vd = orbitalMotion.hill2rv(rc, vc, rho_H, rho_Prime_H)
-        servicerVel.setState(unitTestSupport.np2EigenVectorXd(vd))
+        servicerVel.setState(vd)
 
     #
     #   configure a simulation stop time and execute the simulation run

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -707,7 +707,7 @@ def run(show_plots):
     x_0[3:6] = np.array([1.475, -0.176, 0.894])
     x_0[6:9] = np.array([-0.58, 0.615, 0.125])
     x_0[11] = 0.0004
-    smallBodyNav.x_hat_k = unitTestSupport.np2EigenVectorXd(x_0)
+    smallBodyNav.x_hat_k = x_0
     # Set the covariance to something large
     smallBodyNav.P_k = (0.1*np.identity(12)).tolist()
 

--- a/examples/scenarioSmallBodyNavUKF.py
+++ b/examples/scenarioSmallBodyNavUKF.py
@@ -460,7 +460,7 @@ def run(show_plots):
     x_0 = np.zeros(9)
     x_0[0:3] = r_CA_A
     x_0[3:6] = v_CA_A - np.cross(omega_AN_A,r_CA_A)
-    smallBodyNav.x_hat_k = unitTestSupport.np2EigenVectorXd(x_0)
+    smallBodyNav.x_hat_k = x_0
 
     # set the initial state covariance
     P_k_pos = 1e4

--- a/examples/scenarioSpacecraftLocation.py
+++ b/examples/scenarioSpacecraftLocation.py
@@ -156,7 +156,7 @@ def run(show_plots):
     scLocation.primaryScStateInMsg.subscribeTo(scObject.scStateOutMsg)
     scLocation.rEquator = earth.radEquator
     scLocation.rPolar = earth.radEquator*0.98
-    scLocation.aHat_B = unitTestSupport.np2EigenVectorXd([0, 1, 0])
+    scLocation.aHat_B = [0, 1, 0]
     scLocation.theta = np.radians(10.)
     scLocation.maximumRange = 55.
     scSim.AddModelToTask(simTaskName, scLocation)

--- a/src/architecture/_GeneralModuleFiles/swig_eigen.i
+++ b/src/architecture/_GeneralModuleFiles/swig_eigen.i
@@ -20,328 +20,519 @@
 %{
     #include <Eigen/Dense>
     #include "architecture/utilities/avsEigenMRP.h"
+    #include <type_traits>
+    #include <limits>
+    #include <optional>
+    #include <variant>
+    #include <string>
+    #include <cassert>
+    #include <utility>
 %}
 
-%define EIGEN_MAT_WRAP(type)
+// Sometimes, the %typemap(out) cannot be used in an 'optimal' way. We are okay
+// with this as it is only a speed penalty in some special cases.
+#pragma SWIG nowarn=475
 
-%typemap(in) type {
-    #include <Eigen/Dense>
-
-    if(!PySequence_Check($input)) {
-        PyErr_SetString(PyExc_ValueError,"Expected some sort of list!  Does not appear to be that.");
-        return NULL;
-    }
-
-    Py_ssize_t rowLength = 0;
-    Eigen::MatrixXd matrixAssemble;
-    PyObject *obj = PySequence_GetItem($input, 0);
-    if(!PySequence_Check(obj)) {
-        rowLength = PySequence_Length($input);
-        matrixAssemble.resize(PySequence_Length($input), 1);
-        for(Py_ssize_t j=0; j<rowLength; j++)
-        {
-            matrixAssemble(j, 0) = PyFloat_AsDouble(PySequence_GetItem($input, j));
-        }
-    }
-    else
-    {
-        for(Py_ssize_t i=0; i<PySequence_Length($input); i++){
-            obj = PySequence_GetItem($input, i);
-            if(!PySequence_Check(obj)) {
-                printf("Row bad in matrix: %zd\n", i);
-                PyErr_SetString(PyExc_ValueError,"Need a list for each row");
-            }
-            if(!rowLength)
-            {
-                rowLength = PySequence_Length(obj);
-                matrixAssemble.resize(PySequence_Length($input), rowLength);
-                matrixAssemble.fill(0.0);
-            }
-            if(!rowLength || rowLength != PySequence_Length(obj))
-            {
-                printf("Row bad in matrix: %zd\n", i);
-                PyErr_SetString(PyExc_ValueError,"All rows must be the same length!");
-            }
-            for(Py_ssize_t j=0; j<rowLength; j++)
-            {
-                matrixAssemble(i, j) = PyFloat_AsDouble(PySequence_GetItem(obj, j));
-            }
-        }
-    }
-    $1 = (matrixAssemble);
+%fragment("static_fail", "header") {
+template<class>
+inline constexpr bool always_false_v = false;
 }
 
-%typemap(in) type & {
-    #include <Eigen/Dense>
-
-    if(!PySequence_Check($input)) {
-        PyErr_SetString(PyExc_ValueError,"Expected a list of lists!  Does not appear to be that.");
-        return NULL;
-    }
-    Py_ssize_t rowLength = 0;
-    Eigen::MatrixXd matrixAssemble;
-    for(Py_ssize_t i=0; i<PySequence_Length($input); i++){
-        PyObject *obj = PySequence_GetItem($input, i);
-        if(!PySequence_Check($input)) {
-            printf("Row bad in matrix: %zd\n", i);
-            PyErr_SetString(PyExc_ValueError,"Need a list for each row");
-        }
-        if(!rowLength)
-        {
-            rowLength = PySequence_Length(obj);
-            matrixAssemble.resize(PySequence_Length($input), rowLength);
-            matrixAssemble.fill(0.0);
-        }
-        if(!rowLength || rowLength != PySequence_Length(obj))
-        {
-            printf("Row bad in matrix: %zd\n", i);
-            PyErr_SetString(PyExc_ValueError,"All rows must be the same length!");
-        }
-        for(Py_ssize_t j=0; j<rowLength; j++)
-        {
-            matrixAssemble(i, j) = PyFloat_AsDouble(PySequence_GetItem(obj, j));
-        }
-    }
-    type localConvert = matrixAssemble;
-    $1 = new type();
-    *$1 = localConvert;
-}
-
-%typemap(typecheck) type {
-    $1 = PySequence_Check($input);
-}
-
-%typemap(typecheck) type & {
-    $1 = PySequence_Check($input);
-}
-
-%typemap(memberin) type {
-    $1 = $input;
-}
-
-%typemap(out) type {
-    int i, j;
-    #include <Eigen/Dense>
-    $result = PyList_New(0);
-    Eigen::MatrixXd readPtr = ($1);
-    for(i=0; i<readPtr.innerSize(); i++)
-    {
-        PyObject *locRow = PyList_New(0);
-        for(j=0; j<readPtr.outerSize(); j++)
-        {
-            PyObject *outObject = PyFloat_FromDouble((readPtr)(i,j));
-            PyList_Append(locRow, outObject);
-        }
-        PyList_Append($result, locRow);
-    }
-}
-
-%typemap(out) type * {
-    int i, j;
-    #include <Eigen/Dense>
-    $result = PyList_New(0);
-
-    if(!($1))
-    {
-        return Py_None;
-    }
-    Eigen::MatrixXd readPtr = *($1);
-    for(i=0; i<readPtr.innerSize(); i++)
-    {
-        PyObject *locRow = PyList_New(0);
-        for(j=0; j<readPtr.outerSize(); j++)
-        {
-            PyObject *outObject = PyFloat_FromDouble((readPtr)(i,j));
-            PyList_Append(locRow, outObject);
-        }
-        PyList_Append($result, locRow);
-    }
-}
-
-%enddef
-
-%define EIGEN_ROT_WRAP(type)
-
-%typemap(in) type {
-    #include <Eigen/Dense>
+%fragment("castPyToC", "header", fragment="static_fail") %{
+/*
+The following method takes a Python object and tries to convert it to the type T
+If this is succesful, the value is returned. If it is unsucessful, an appropriate 
+error message is returned.
+*/
+template<class T>
+std::variant<T, std::string> castPyToC(PyObject *input)
+{        
+    if (PyErr_Occurred()) return "castPyToC was pre-errored!";
     
-
-    if(!PySequence_Check($input)) {
-        PyErr_SetString(PyExc_ValueError,"Expected some sort of list!  Does not appear to be that.");
-        return NULL;
-    }
-
-    Py_ssize_t rowLength = 0;
-    Py_ssize_t colLength = 0;
-    Eigen::MatrixXd matrixAssemble;
-    PyObject *obj = PySequence_GetItem($input, 0);
-    if(!PySequence_Check(obj)) {
-        rowLength = PySequence_Length($input);
-        matrixAssemble.resize(PySequence_Length($input), 1);
-        for(Py_ssize_t j=0; j<rowLength; j++)
+    if constexpr (std::is_same_v<T, bool>)
+    {
+        if (!PyBool_Check(input))
         {
-            matrixAssemble(j, 0) = PyFloat_AsDouble(PySequence_GetItem($input, j));
+            return "Expected value to be a boolean.";
         }
+
+        return PyLong_AsLong(input) == 1;
+    }
+    else if constexpr (std::is_integral_v<T>)
+    {
+        // Before 3.10, PyLong_AsLong could call __int__, which silently casts float 
+        // objects to int (with loss of data). We want to prevent that, so instead we
+        // call PyNumber_Index beforehand, which will call __index__, which does not
+        // allow implicit casts to int (and appropriately raises a warning)
+        #if PY_MAJOR_VERSION <= 3 && PY_MINOR_VERSION < 10
+            input = PyNumber_Index(input);
+        #endif
+
+        int overflow{0};
+        long long cLongLong = PyLong_AsLongLongAndOverflow(input, &overflow);
+
+        if (PyErr_Occurred())
+        {
+            PyErr_Clear();
+            return "Cannot parse value as an integer.";
+        }
+
+        if (overflow != 0)
+        {
+            return "Integer value is too large or too small (overflows a long long).";
+        }
+
+        if (cLongLong > std::numeric_limits<T>::max())
+        {
+            return "Value is larger than maximum integer limit ("+ std::to_string(std::numeric_limits<T>::max()) +")";
+        }
+        if (cLongLong < std::numeric_limits<T>::min())
+        {
+            return "Value is smaller than minimum integer limit ("+ std::to_string(std::numeric_limits<T>::min()) +")";
+        }
+
+        return (T) cLongLong;
+    }
+    else if constexpr (std::is_floating_point_v<T>)
+    {
+        double val = PyFloat_AsDouble(input);
+        
+        if (PyErr_Occurred())
+        {
+            PyErr_Clear();
+            return "Cannot parse value as a floating point.";
+        }
+
+        return (T) val;    
     }
     else
     {
-        for(Py_ssize_t i=0; i<PySequence_Length($input); i++){
-            obj = PySequence_GetItem($input, i);
-            if(!PySequence_Check(obj)) {
-                printf("Row bad in matrix: %zd\n", i);
-                PyErr_SetString(PyExc_ValueError,"Need a list for each row");
-            }
-            if(!rowLength)
-            {
-                rowLength = PySequence_Length(obj);
-                matrixAssemble.resize(PySequence_Length($input), rowLength);
-                matrixAssemble.fill(0.0);
-                colLength = PySequence_Length($input);
-            }
-            if(!rowLength || rowLength != PySequence_Length(obj))
-            {
-                printf("Row bad in matrix: %zd\n", i);
-                PyErr_SetString(PyExc_ValueError,"All rows must be the same length!");
-            }
-            for(Py_ssize_t j=0; j<rowLength; j++)
-            {
-                matrixAssemble(i, j) = PyFloat_AsDouble(PySequence_GetItem(obj, j));
-            }
-        }
+        static_assert(always_false_v<T>, "The stored values are not booleans, integers, or floating points. I don't know how to translate them from Python!");
     }
-    if(rowLength == 3 && colLength<=1)
+}
+%}
+
+%fragment("castCToPy", "header", fragment="static_fail")
+{
+template<class T>
+PyObject * castCToPy(T input)
+{
+    if constexpr (std::is_same_v<T, bool>)
     {
-        $1 = (Eigen::Vector3d) (matrixAssemble);
+        // Using explicit cast to long to prevent compiler warnings
+        // is_same_v and is_integral_v should only let long pass anyway
+        return PyBool_FromLong((long) input);
     }
-    else if(rowLength == 4 && colLength<=1)
+    else if constexpr (std::is_integral_v<T>)
     {
-        Eigen::Matrix<double, 4, 1> tempQuat = (Eigen::Matrix<double, 4, 1>) (matrixAssemble);
-        $1 = ((Eigen::Quaterniond) tempQuat).toRotationMatrix();
+        return PyLong_FromLong((long) input);
     }
-    else if(rowLength==3 && colLength==3)
+    else if constexpr (std::is_floating_point_v<T>)
     {
-        $1 = (Eigen::Matrix3d) (matrixAssemble);
+        return PyFloat_FromDouble(input);
     }
     else
     {
-        printf("Unknown rotation dimensions: %zd %zd\n", rowLength, colLength);
-        PyErr_SetString(PyExc_ValueError,"I don't know how to handle that rotation dimension");
+        static_assert(always_false_v<T>, "The stored values are not booleans, integers, or floating points. I don't know how to translate them to Python!");
     }
 }
+}
 
-%typemap(in) type & {
-    #include <Eigen/Dense>
+%fragment("rotationConversion", "header")
+{
+/*
+Converts from one rotation type to other (for example, MRPd to Quaterniond).
+*/
+template<class From, class To>
+To rotationConversion(const From& input)
+{
+    // If we can convert from the type From to To, then just return input
+    // and let the implicit coversion handle the transformation
+    if constexpr (std::is_convertible_v<From, To>) {
+        return input;
+    }
+    // If we can convert the input to an MRPd, and from there to a rotation
+    // matrix, and from there to the To type, then do that
+    else if constexpr (
+        std::is_convertible_v<From, Eigen::MRPd>
+        && std::is_convertible_v<
+            decltype(std::declval<Eigen::MRPd>().toRotationMatrix()), 
+            To
+        >
+    ) {
+        return ((Eigen::MRPd) input).toRotationMatrix();
+    }
+    // If we can convert the input to a Quaterniond, and from there to a rotation
+    // matrix, and from there to the To type, then do that
+    else if constexpr (
+        std::is_convertible_v<From, Eigen::Quaterniond>
+        && std::is_convertible_v<
+            decltype(std::declval<Eigen::Quaterniond>().toRotationMatrix()), 
+            To
+        >    
+    ) {
+        return ((Eigen::Quaterniond) input).toRotationMatrix();
+    }
+    else {
+        assert(false); // No conversion function defined
+        return {};
+    }
+}
+}
 
-    if(!PySequence_Check($input)) {
-        PyErr_SetString(PyExc_ValueError,"Expected a list of lists!  Does not appear to be that.");
-        return NULL;
+%fragment("getInputSize", "header")
+{
+/*
+This function returns the size of the input.
+If the input is not a sequence, then an empty optional is returned.
+Otherwise, the number of rows and columns are returned in the pair.
+The number of columns are obtained from the first element of the input sequence.
+(i.e. ragged nested sequences are not checked)
+*/
+std::optional<std::pair<Py_ssize_t, Py_ssize_t>> getInputSize(PyObject *input)
+{
+    // Vectors and matrices must come from python sequences
+    if(!PySequence_Check(input)) {
+        return {};
     }
-    Py_ssize_t rowLength = 0;
-    Py_ssize_t colLength = 0;
-    Eigen::MatrixXd matrixAssemble;
-    for(Py_ssize_t i=0; i<PySequence_Length($input); i++){
-        PyObject *obj = PySequence_GetItem($input, i);
-        if(!PySequence_Check($input)) {
-            printf("Row bad in matrix: %zd\n", i);
-            PyErr_SetString(PyExc_ValueError,"Need a list for each row");
-        }
-        if(!rowLength)
-        {
-            rowLength = PySequence_Length(obj);
-            matrixAssemble.resize(PySequence_Length($input), rowLength);
-            matrixAssemble.fill(0.0);
-        }
-        if(!rowLength || rowLength != PySequence_Length(obj))
-        {
-            printf("Row bad in matrix: %zd\n", i);
-            PyErr_SetString(PyExc_ValueError,"All rows must be the same length!");
-        }
-        for(Py_ssize_t j=0; j<rowLength; j++)
-        {
-            matrixAssemble(i, j) = PyFloat_AsDouble(PySequence_GetItem(obj, j));
-        }
-    }
-    type localConvert = matrixAssemble;
-    $1 = new type();
-    if(rowLength == 3 && colLength<=1)
+
+    Py_ssize_t numberRows = PySequence_Length(input);
+
+    PyObject *firstItem = PySequence_GetItem(input, 0);
+    Py_ssize_t numberColumns = PySequence_Check(firstItem) ? PySequence_Length(firstItem) : 1;
+    return {{numberRows, numberColumns}};
+}
+}
+
+%fragment("checkPyObjectIsMatrixLike", "header", fragment="getInputSize") {
+
+/*
+This method returns an empty optional only if the given input is like the template type T.
+Otherwise, the returned optional contains a relevant error message.
+The size of the input is compared to the expected size of T (where dynamically
+sized matrix T allow any number of rows/columns). Moreover, an error is raised for
+ragged nested sequences (rows with different numbers of elements).
+*/
+template<class T>
+std::optional<std::string> checkPyObjectIsMatrixLike(PyObject *input)
+{
+    auto maybeSize = getInputSize(input);
+
+    if (!maybeSize)
     {
-        *$1 = (Eigen::Vector3d) (matrixAssemble);
+        return "Input is not a sequence";
     }
-    else if(rowLength == 4 && colLength<=1)
+
+    auto [numberRows, numberColumns] = maybeSize.value(); 
+
+    if (T::RowsAtCompileTime != -1 && T::RowsAtCompileTime != numberRows)
     {
-        Eigen::Matrix<double, 4, 1> tempQuat = (Eigen::Matrix<double, 4, 1>) (matrixAssemble);
-        *$1 = ((Eigen::Quaterniond) tempQuat).toRotationMatrix();
+        std::string errorMsg = "Input does not have the correct number of rows. Expected " 
+            + std::to_string(T::RowsAtCompileTime) + " but found " + std::to_string(numberRows);
+        return errorMsg;
     }
-    else if(rowLength==3 && colLength==3)
+
+    if (T::ColsAtCompileTime != -1 && T::ColsAtCompileTime != numberColumns)
     {
-        *$1 = (Eigen::Matrix3d) (matrixAssemble);
+        std::string errorMsg = "Input does not have the correct number of columns. Expected " 
+            + std::to_string(T::ColsAtCompileTime) + " but found " + std::to_string(numberColumns);
+        return errorMsg;
+    }
+
+    for(Py_ssize_t row=0; row<numberRows; row++)
+    {
+        PyObject *rowPyObj = PySequence_GetItem(input, row);
+        Py_ssize_t localNumberColumns = PySequence_Check(rowPyObj) ? PySequence_Length(rowPyObj) : 1;
+        if (localNumberColumns != numberColumns)
+        {
+            return "All rows must be the same length! Row " + std::to_string(row) + " is not.";
+        }
+    }
+    
+    return {};
+}
+}
+
+%fragment("pyObjToEigenMatrix", "header", fragment="castPyToC", fragment="getInputSize", fragment="checkPyObjectIsMatrixLike") {
+
+/*
+Creates a new Eigen::Matrix of the templated type T with the given 'input'.
+Might return a default-initialized T if an error occurred during translation.
+In that case, disambiguate using PyErr_Occurred().
+*/
+template<class T>
+T pyObjToEigenMatrix(PyObject *input)
+{
+    auto errorMsg = checkPyObjectIsMatrixLike<T>(input);
+    if (errorMsg)
+    {
+        PyErr_SetString(PyExc_ValueError,errorMsg.value().c_str());
+        return {};
+    }
+    // After the previous check, we can assume the input is a sequence
+    // that has correct size.
+
+    T result;
+
+    auto [numberRows, numberColumns] = getInputSize(input).value();
+    
+    // Resize can be called even for non-dynamic matrices as long as the
+    // fixed-sizes do not change. 
+    result.resize(numberRows, numberColumns);
+
+    for(Py_ssize_t row=0; row<numberRows; row++)
+    {
+        PyObject *rowPyObj = PySequence_GetItem(input, row);
+        for(Py_ssize_t col=0; col<numberColumns; col++)
+        {
+            // rowPyObj can be either a length 1 sequence or the value directly
+            PyObject *rowColPyObj = PySequence_Check(rowPyObj) ? PySequence_GetItem(rowPyObj, col) : rowPyObj;
+
+            auto valueOrErrorMsg = castPyToC<typename T::Scalar>(rowColPyObj);
+            if (std::holds_alternative<std::string>(valueOrErrorMsg))
+            {
+                PyErr_SetString(PyExc_ValueError, (
+                    "Row " + std::to_string(row) + ", Column " + std::to_string(col) +": "
+                    + std::get<std::string>(valueOrErrorMsg)
+                ).c_str());
+                return {};
+            }
+
+            result(row, col) = std::get<typename T::Scalar>(valueOrErrorMsg);
+        }
+    }
+
+    return result;
+}
+}
+
+%fragment("pyObjToRotation", "header", fragment="pyObjToEigenMatrix", fragment="getInputSize", fragment="rotationConversion")
+{
+/*
+Creates a new rotation of the templated type T with the given 'input'.
+Translation might fail, in which case the error flag will be set (disambiguate 
+using PyErr_Occurred()). If this happens, the returned value is undefined.
+*/
+template<class T>
+T pyObjToRotation(PyObject *input)
+{
+    auto maybeSize = getInputSize(input);
+
+    if (!maybeSize) // Not even a sequence
+    {
+        std::string errorMsg = "Input is not a sequence";
+        PyErr_SetString(PyExc_ValueError,errorMsg.c_str());
+        return {};
+    }
+
+    auto [numberRows, numberColumns] = maybeSize.value(); 
+
+    if (numberRows == 3 && numberColumns == 1)
+    {
+        return rotationConversion<Eigen::Vector3d, T>(pyObjToEigenMatrix<Eigen::Vector3d>(input));
+    }
+    else if (numberRows == 4 && numberColumns == 1)
+    {
+        return rotationConversion<Eigen::Vector4d, T>(pyObjToEigenMatrix<Eigen::Vector4d>(input));
+    }
+    else if (numberRows == 3 && numberColumns == 3)
+    {
+        return rotationConversion<Eigen::Matrix3d, T>(pyObjToEigenMatrix<Eigen::Matrix3d>(input));
     }
     else
     {
-        printf("Unknown rotation dimensions: %zd %zd\n", rowLength, colLength);
-        PyErr_SetString(PyExc_ValueError,"I don't know how to handle that rotation dimension");
+        std::string errorMsg = "Unknown rotation dimensions: " 
+            + std::to_string(numberRows) + "x" + std::to_string(numberColumns)
+            + ". Expected dimensions 3x1, 4x1, or 3x3.";
+        PyErr_SetString(PyExc_ValueError, errorMsg.c_str());
+        return {};
     }
 }
-
-%typemap(typecheck) type {
-    $1 = PySequence_Check($input);
 }
 
-%typemap(typecheck) type & {
-    $1 = PySequence_Check($input);
+%fragment("fillPyObjList", "header", fragment="castCToPy") {
+
+/*
+Copies the values in 'value' to the list PyObject in 'input'
+*/
+template<class T>
+void fillPyObjList(PyObject *input, const T& value)
+{
+    for(auto i=0; i<value.innerSize(); i++)
+    {
+        PyObject *locRow = PyList_New(0);
+        for(auto j=0; j<value.outerSize(); j++)
+        {            
+            PyList_Append(locRow, castCToPy<typename T::Scalar>(value(i,j)));
+        }
+        PyList_Append(input, locRow);
+    }
+}
+}
+
+%define EIGEN_MAT_WRAP(type, typeCheckPrecedence)
+
+%typemap(in, fragment="pyObjToEigenMatrix") type {
+    $1 = pyObjToEigenMatrix<type>($input);
+    if (PyErr_Occurred()) SWIG_fail;
 }
 
 %typemap(memberin) type {
-    $1 = $input;
+    $1 = std::move($input);
 }
 
-%typemap(out) type {
-    int i, j;
-    #include <Eigen/Dense>
-    $result = PyList_New(0);
-    Eigen::MatrixXd readPtr = ($1).vec();
-    for(i=0; i<readPtr.innerSize(); i++)
-    {
-        PyObject *locRow = PyList_New(0);
-        for(j=0; j<readPtr.outerSize(); j++)
-        {
-            PyObject *outObject = PyFloat_FromDouble((readPtr)(i,j));
-            PyList_Append(locRow, outObject);
-        }
-        PyList_Append($result, locRow);
-    }
+%typemap(in, fragment="pyObjToEigenMatrix") type & {
+    $1 = new type;
+    *$1 = pyObjToEigenMatrix<type>($input);
+    if (PyErr_Occurred()) SWIG_fail;
 }
 
-%typemap(out) type * {
-    int i, j;
-    #include <Eigen/Dense>
-    $result = PyList_New(0);
+%typemap(freearg) type & {
+    delete $1;
+}
 
+%typemap(typecheck, fragment="checkPyObjectIsMatrixLike", precedence= ## typeCheckPrecedence) type {
+    // PyErr_Fetch and PyErr_Restore preserve/restore the error status before this function
+    // We use the error flag to check whether conversion is valid, but we do not want to
+    // alter the previous error status of the program
+    PyObject *ty, *value, *traceback;
+    PyErr_Fetch(&ty, &value, &traceback);
+
+    pyObjToEigenMatrix<type>($input);
+    $1 = ! PyErr_Occurred();
+
+    PyErr_Restore(ty, value, traceback);
+}
+
+%typemap(out, optimal="1", fragment="fillPyObjList") type {
+    $result = PyList_New(0);
+    fillPyObjList<type>($result, $1);
+    if (PyErr_Occurred()) SWIG_fail;
+}
+
+%typemap(out, fragment="fillPyObjList") type * {
     if(!($1))
     {
-        return Py_None;
+        $result = SWIG_Py_Void();
     }
-    Eigen::MatrixXd readPtr = ($1)->vec();
-    for(i=0; i<readPtr.innerSize(); i++)
+    else
     {
-        PyObject *locRow = PyList_New(0);
-        for(j=0; j<readPtr.outerSize(); j++)
-        {
-            PyObject *outObject = PyFloat_FromDouble((readPtr)(i,j));
-            PyList_Append(locRow, outObject);
-        }
-        PyList_Append($result, locRow);
+        $result = PyList_New(0);
+        fillPyObjList<type>($result, *$1);
     }
+    if (PyErr_Occurred()) SWIG_fail;
 }
+
+%typemap(typecheck) type & = type;
+%typemap(typecheck) type && = type;
+
+%typemap(in) type && = type &;
+%typemap(freearg) type && = type &;
 
 %enddef
 
+%define EIGEN_ROT_WRAP(type, typeCheckPrecedence)
 
+%typemap(in, fragment="pyObjToRotation") type {
+    $1 = pyObjToRotation<type>($input);
+    if (PyErr_Occurred()) SWIG_fail;
+}
 
-//EIGEN_MAT_WRAP(const Eigen::MatrixXd)
-EIGEN_MAT_WRAP(Eigen::MatrixXd)
-EIGEN_MAT_WRAP(Eigen::Matrix3d)
-EIGEN_MAT_WRAP(Eigen::Vector3d)
-EIGEN_MAT_WRAP(Eigen::VectorXd)
-EIGEN_ROT_WRAP(Eigen::MRPd)
-EIGEN_ROT_WRAP(Eigen::Quaterniond)
+%typemap(in, fragment="pyObjToRotation") type & {
+    $1 = new type;
+    *$1 = pyObjToRotation<type>($input);
+    if (PyErr_Occurred()) SWIG_fail;
+}
+
+%typemap(freearg) type & {
+    delete $1;
+}
+
+%typemap(typecheck, fragment="getInputSize", precedence= ## typeCheckPrecedence) type {
+    auto maybeSize = getInputSize($input);
+
+    if (!maybeSize)
+    {
+        $1 = 0;
+    }
+    else
+    {
+        auto [numberRows, numberColumns] = maybeSize.value();
+        $1 = (
+            (numberRows == 3 && numberColumns == 1) ||
+            (numberRows == 4 && numberColumns == 1) ||
+            (numberRows == 3 && numberColumns == 3)
+        ) ? 1 : 0;
+    }
+}
+
+%typemap(out, optimal="1", fragment="fillPyObjList") type {
+    $result = PyList_New(0);
+    fillPyObjList($result, ($1).vec());
+    if (PyErr_Occurred()) SWIG_fail;
+}
+
+%typemap(out, fragment="fillPyObjList") type * {
+    if(!($1))
+    {
+        $result = SWIG_Py_Void();
+    }
+    else
+    {
+        $result = PyList_New(0);
+        fillPyObjList($result, (*$1).vec());
+    }
+    if (PyErr_Occurred()) SWIG_fail;
+}
+
+%typemap(typecheck) type & = type;
+%typemap(typecheck) type && = type;
+
+%typemap(in) type && = type &;
+%typemap(freearg) type && = type &;
+
+%enddef
+
+// Second value is the precedence for overloads. If two methods are overloaded
+// with different Eigen inputs, then the precedence determines which ones are
+// attempted first.
+//
+// Fully fixed-size types should have precendence 155 < precedence < 160
+// Types partially fixed-size should have precedence 160 < precedence < 165
+// Fully dynamically sized should have precedence 165 < precendence < 170
+//
+// Boolean matrices should have lower precendence than integer matrices, 
+// which should have lower precendence than double matrices.
+//
+// For reference, std::array has precendence 155, and std::vector has precendence 160
+//
+// If we were to pass a list of three integers from python to an overloaded method 'foo',
+// this would be the order in which they would be chosen (from first to last):
+//      foo(std::array<int>)
+//      foo(Vector3i)
+//      foo(Vector3d)
+//      foo(std::vector<int>)
+//      foo(VectorXi)
+//      foo(VectorXd)
+//      foo(MatrixXi)
+//      foo(MatrixXd)
+
+EIGEN_MAT_WRAP(Eigen::Vector3i, 158)
+EIGEN_MAT_WRAP(Eigen::Vector3d, 159)
+EIGEN_MAT_WRAP(Eigen::Matrix3d, 159)
+EIGEN_MAT_WRAP(Eigen::MatrixX3i,163)
+EIGEN_MAT_WRAP(Eigen::VectorXi, 163)
+EIGEN_MAT_WRAP(Eigen::VectorXd, 164)
+EIGEN_MAT_WRAP(Eigen::MatrixX3d,164)
+EIGEN_MAT_WRAP(Eigen::MatrixXi, 169)
+EIGEN_MAT_WRAP(Eigen::MatrixXd, 169)
+
+// Rotation wrappers work so that they can be set from Python on any
+// of the three ways we have of representing rotations: MRPs (3x1 vector),
+// quaternions (4x1 vector), or rotation matrix (3x3 vector).
+// 
+// Their return type, however, is always an MRPd.
+//
+// The precedence should be that of fixed-size double eigen matrices (159). 
+EIGEN_ROT_WRAP(Eigen::MRPd       , 159)
+EIGEN_ROT_WRAP(Eigen::Quaterniond, 159)

--- a/src/architecture/utilitiesSelfCheck/_UnitTest/test_swigEigen.py
+++ b/src/architecture/utilitiesSelfCheck/_UnitTest/test_swigEigen.py
@@ -1,0 +1,220 @@
+# ISC License
+#
+# Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+import pytest
+import numpy as np
+
+from Basilisk.architecture.swigEigenCheck import SwigEigenTestClass
+
+def getData(type: str):
+    if type.lower() == "mrpd":
+        return [0,0,0], [[0], [0], [0]]
+    if type.lower() == "quaterniond":
+        return [1,0,0,0], [[0], [0], [0]]
+    if type.lower() == "rotationmatrix":
+        return [
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1]
+            ], [[0], [0], [0]]
+    
+    scalar = type[-1]
+    isMatrix   = "matrix" in type.lower()
+    dimensions = type[:-1].lower().replace("matrix", "").replace("vector", "")
+
+    if len(dimensions) == 1:
+        if isMatrix:
+            dimensions += dimensions
+        else:
+            dimensions += "1"
+    
+    size = [7 if dim == "x" else int(dim) for dim in dimensions]
+    
+    i = 0.5
+    inputData = []
+    outputData = []
+    def lambda_gen(i): return int(i) if scalar == "i" else i
+    for _ in range(size[0]):
+        if size[1] == 1:
+            val = lambda_gen(i)
+            inputData.append( val )
+            outputData.append( [val] )
+            i += 1
+        else:
+            val = lambda_gen(i)
+            inputData.append([])
+            outputData.append([])
+            for _ in range(size[1]):
+                inputData[-1].append( val )
+                outputData[-1].append( val )
+                i += 1
+
+    return inputData, outputData
+
+@pytest.mark.parametrize("attr", [
+    "vector3i",
+    "vector3d",
+    "matrix3d",
+    "matrixX3i",
+    "vectorXi",
+    "vectorXd",
+    "matrixX3d",
+    "matrixXi",
+    "matrixXd",
+])
+@pytest.mark.parametrize("useNumpy", [False, True])
+def test_simpleInputOutput(attr: str, useNumpy: bool):
+    testClass = SwigEigenTestClass()
+
+    inputData, outputData = getData(attr)
+
+    setattr(testClass, attr, np.array(inputData) if useNumpy else inputData)
+    retrieved = getattr(testClass, attr)
+        
+    assert outputData == retrieved, f"{attr} {retrieved}"
+
+@pytest.mark.parametrize("keyword,attr,data",  [
+    ("not a sequence", "vector3d", 1),
+    ("number of rows", "vector3d", [1, 2]),
+    ("number of rows", "vector3d", [1, 2, 3, 4]),
+    ("number of columns", "vector3d", [[1, 2], [1, 2], [1, 2]]),
+    ("number of columns", "matrixX3d", [[1, 2, 3, 4]]),
+    ("rows must be the same length", "matrixXd", [[1, 2, 3], [1, 2, 3], [1, 2]]),
+    ("Unknown rotation dimensions", "mrpd", [1, 2]),
+    ("Unknown rotation dimensions", "mrpd", [1, 2, 3, 4, 5]),
+    ("Unknown rotation dimensions", "mrpd", [[1, 2], [1, 2], [1, 2]]),
+    ("parse value as an integer", "vector3i", [1.0, 0, 0]),
+    ("parse value as an integer", "vector3i", [1, 0, 1.0]),
+    ("parse value as a floating point", "vector3d", [1.0, 0, "0"]),
+    ("overflow", "vector3i", [int(1e99), 0, 0]),
+
+    # The size of int is implementation specific, so the following two tests could
+    # fail in some implementations
+    #("larger than maximum", "vector3i", [2147483647+1, 0, 0]),
+    #("smaller than minimum", "vector3i", [-2147483647-2, 0, 0]),
+])
+def test_illegal(keyword: str, attr: str, data):
+    testClass = SwigEigenTestClass()
+
+    with pytest.raises(ValueError, match=fr".*{keyword}.*"):
+        setattr(testClass, attr, data)
+
+@pytest.mark.parametrize("input",  ["mrpd", "quaterniond", "rotationMatrix"])
+@pytest.mark.parametrize("output", ["mrpd", "quaterniond"])
+def test_rotation(input: str, output: str):
+    testClass = SwigEigenTestClass()
+        
+    inpData, outData = getData(input)
+    
+    setattr(testClass, output, inpData)
+    retrieved = getattr(testClass, output)
+
+    squeezedRef       = [i if len(i) > 1 else i[0] for i in outData]
+    squeezedRetrieved = [i if len(i) > 1 else i[0] for i in retrieved]
+
+    assert squeezedRef == pytest.approx(squeezedRetrieved), f"{input} -> {output}"
+
+# The following test asserts that overloading precedence is respected
+# for all overloaded functions ending in "Precedence" in SwigEigenTestClass
+@pytest.mark.parametrize("functionName", [
+    attr
+    for attr in dir(SwigEigenTestClass)
+    if attr.startswith("test") and "Precedence" in attr
+])
+def test_precedence(functionName: str):
+    testClass = SwigEigenTestClass()
+    testData = [1, 2, 3]
+
+    assert getattr(testClass, functionName)(testData)
+
+# The following test asserts that the non-precedent overloaded functions
+# can be reached if the input is tuned so that the function that normally
+# takes precedence can no longer accept the input, and so the second function
+# is called. (For example, [1, 2] is not a valid input for Vector3d, but it
+# is for std::vector<int>)
+@pytest.mark.parametrize("functionName,testData", [
+    ("testArrayPrecedence",     [1, [2], 3]),
+    ("testVector3iPrecedence",  [1.0, 2.0, 3.0]),
+    ("testVector3dPrecedence",  [1, 2]),
+    ("testVectorXiPrecedence",  [1.0, 2.0]),
+    ("testVectorXdPrecedence",  [[1, 2], [3, 4]]),
+    ("testMatrixXiPrecedence",  [[1, 2], [3.0, 4]]),
+    ("testStdVectorPrecedence", [[1], 2, 3, 4, 5])
+
+])
+def test_antiPrecedence(functionName: str, testData):
+    testClass = SwigEigenTestClass()
+
+    assert not getattr(testClass, functionName)(testData)
+
+def test_nullPointerReturn():
+    testClass = SwigEigenTestClass()
+    data = [[1.0], [2.0], [3.0]]
+    testClass.vector3d = data
+
+    # returnVector3dPointer will return a nullptr if True is passed
+    # otherwise, it returns vector3d
+
+    assert testClass.returnVector3dPointer(True) is None
+    assert testClass.returnVector3dPointer(False) == data
+
+# Check that we can call functions with any qualifiers in the signature
+#   void qualifierTestValue   (      Eigen::Vector3d  )
+#   void qualifierTestConstRef(const Eigen::Vector3d& )
+#   void qualifierTestConst   (const Eigen::Vector3d  )
+#   void qualifierTestRef     (      Eigen::Vector3d& )
+#   void qualifierTestRvalue  (      Eigen::Vector3d&&)
+@pytest.mark.parametrize("qualifier", [
+    "Value",
+    "ConstRef",
+    "Const",
+    "Ref",
+    "Rvalue"
+])
+@pytest.mark.parametrize("attr", [
+    "vector3i",
+    "vector3d",
+    "matrix3d",
+    "matrixX3i",
+    "vectorXi",
+    "vectorXd",
+    "matrixX3d",
+    "matrixXi",
+    "matrixXd",
+    "quaterniond",
+    "mrpd"
+])
+def test_qualifiers(qualifier: str, attr: str):
+    testClass = SwigEigenTestClass()
+
+    functionName = f"qualifierTest{attr}{qualifier}"
+
+    inputData, outputData = getData(attr)
+
+    try:
+        getattr(testClass, functionName)(inputData)
+    except TypeError:
+        assert False, "Cannot call method with qualifiers from" + functionName
+
+    retrieved = getattr(testClass, attr)
+    
+    if attr in {"quaterniond", "mrpd"}:
+        squeezedRef       = [i if len(i) > 1 else i[0] for i in outputData]
+        squeezedRetrieved = [i if len(i) > 1 else i[0] for i in retrieved]
+
+        assert squeezedRef == pytest.approx(squeezedRetrieved)
+
+    else:
+        assert outputData == retrieved

--- a/src/architecture/utilitiesSelfCheck/swigEigenCheck.i
+++ b/src/architecture/utilitiesSelfCheck/swigEigenCheck.i
@@ -1,0 +1,103 @@
+/*
+ ISC License
+
+ Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+%module swigEigenCheck
+#pragma SWIG nowarn=509
+%{
+    #include <vector>
+    #include <array>
+%}
+
+%include "std_vector.i"
+%include "std_array.i"
+
+%template(IntVector) std::vector<int>;
+%template(IntArray3) std::array<int, 3>;
+
+%include "swig_eigen.i"
+
+%define ADD_QUALIFIER_FUNCTIONS(type, memberName)
+    void qualifierTest ## memberName ## Value   (      Eigen:: ## type   input) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## ConstRef(const Eigen:: ## type&  input) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## Const   (const Eigen:: ## type  input) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## Ref     (      Eigen:: ## type&  input) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## Rvalue  (      Eigen:: ## type&& input) {this-> ## memberName = input;};
+
+    // We overload the functions to test that the typecheck maps are working properly
+    void qualifierTest ## memberName ## Value   (      Eigen:: ## type   input, bool) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## ConstRef(const Eigen:: ## type&  input, bool) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## Const   (const Eigen:: ## type  input, bool) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## Ref     (      Eigen:: ## type&  input, bool) {this-> ## memberName = input;};
+    void qualifierTest ## memberName ## Rvalue  (      Eigen:: ## type&& input, bool) {this-> ## memberName = input;};
+%enddef
+
+%inline {
+
+struct SwigEigenTestClass
+{
+    Eigen::Vector3i vector3i;
+    Eigen::Vector3d vector3d;
+    Eigen::Matrix3d matrix3d;
+    Eigen::MatrixX3i matrixX3i;
+    Eigen::VectorXi vectorXi;
+    Eigen::VectorXd vectorXd;
+    Eigen::MatrixX3d matrixX3d;
+    Eigen::MatrixXi matrixXi;
+    Eigen::MatrixXd matrixXd;
+
+    Eigen::MRPd mrpd;
+    Eigen::Quaterniond quaterniond;
+
+    bool testArrayPrecedence(std::array<int, 3>) {return true;}
+    bool testArrayPrecedence(Eigen::Vector3i)    {return false;}
+
+    bool testVector3iPrecedence(Eigen::Vector3i) {return true;}
+    bool testVector3iPrecedence(Eigen::Vector3d) {return false;}
+
+    bool testVector3dPrecedence(Eigen::Vector3d)  {return true;}
+    bool testVector3dPrecedence(std::vector<int>) {return false;}
+
+    bool testStdVectorPrecedence(std::vector<int>) {return true;}
+    bool testStdVectorPrecedence(Eigen::VectorXi)  {return false;}
+
+    bool testVectorXiPrecedence(Eigen::VectorXi) {return true;}
+    bool testVectorXiPrecedence(Eigen::VectorXd)  {return false;}
+
+    bool testVectorXdPrecedence(Eigen::VectorXd) {return true;}
+    bool testVectorXdPrecedence(Eigen::MatrixXi)  {return false;}
+
+    bool testMatrixXiPrecedence(Eigen::MatrixXi) {return true;}
+    bool testMatrixXiPrecedence(Eigen::MatrixXd) {return false;}
+
+    Eigen::Vector3d* returnVector3dPointer(bool returnNull) {return returnNull ? nullptr : &this->vector3d;}
+
+    ADD_QUALIFIER_FUNCTIONS(Vector3i, vector3i)
+    ADD_QUALIFIER_FUNCTIONS(Vector3d, vector3d)
+    ADD_QUALIFIER_FUNCTIONS(Matrix3d, matrix3d)
+    ADD_QUALIFIER_FUNCTIONS(MatrixX3i, matrixX3i)
+    ADD_QUALIFIER_FUNCTIONS(VectorXi, vectorXi)
+    ADD_QUALIFIER_FUNCTIONS(VectorXd, vectorXd)
+    ADD_QUALIFIER_FUNCTIONS(MatrixX3d, matrixX3d)
+    ADD_QUALIFIER_FUNCTIONS(MatrixXi, matrixXi)
+    ADD_QUALIFIER_FUNCTIONS(MatrixXd, matrixXd)    
+    ADD_QUALIFIER_FUNCTIONS(MRPd, mrpd)  
+    ADD_QUALIFIER_FUNCTIONS(Quaterniond, quaterniond)  
+};
+
+}

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/_UnitTest/test_smallBodyNavEKF.py
@@ -70,7 +70,7 @@ def smallBodyNavEKFTestFunction(show_plots):
     bennu_velocity = np.sqrt(orbitalMotion.MU_SUN*(1000.**3)/bennu_radius) # m/s, assumes circular orbit
 
     x_0 = [2010., 1510., 1010., 0., 2., 0., 0.14, 0., 0., 0., 0., 0.]
-    module.x_hat_k = unitTestSupport.np2EigenVectorXd(x_0)
+    module.x_hat_k = x_0
     module.P_k = (0.1*np.identity(12)).tolist()
 
     # Configure blank module input messages
@@ -194,5 +194,3 @@ def smallBodyNavEKFTestFunction(show_plots):
 
 if __name__ == "__main__":
     test_smallBodyNavEKF(True)
-
-

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/_UnitTest/test_smallBodyNavUKF.py
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/_UnitTest/test_smallBodyNavUKF.py
@@ -71,7 +71,7 @@ def smallBodyNavUKFTestFunction(show_plots):
     vesta_velocity = np.sqrt(orbitalMotion.MU_SUN*(1000.**3)/vesta_radius) # m/s, assumes circular orbit
 
     x_0 = [2010., 1510., 1010., 0., 2., 0., 0.14, 0., 0.]
-    module.x_hat_k = unitTestSupport.np2EigenVectorXd(x_0)
+    module.x_hat_k = x_0
     module.P_k = [[1000., 0., 0., 0., 0., 0., 0., 0., 0.],
                [0., 1000., 0., 0., 0., 0., 0., 0., 0.],
                [0., 0., 1000., 0., 0., 0., 0., 0., 0.],
@@ -181,5 +181,3 @@ def smallBodyNavUKFTestFunction(show_plots):
 
 if __name__ == "__main__":
     test_smallBodyNavUKF(True)
-
-

--- a/src/simulation/environment/groundMapping/_UnitTest/test_groundMapping.py
+++ b/src/simulation/environment/groundMapping/_UnitTest/test_groundMapping.py
@@ -69,8 +69,8 @@ def groundMappingTestFunction():
     # Create the initial imaging target
     groundMap = groundMapping.GroundMapping()
     groundMap.ModelTag = "groundMapping"
-    groundMap.addPointToModel(unitTestSupport.np2EigenVectorXd([0., -0.1, 0.]))
-    groundMap.addPointToModel(unitTestSupport.np2EigenVectorXd([0., 0., math.tan(np.radians(22.5))+0.1]))
+    groundMap.addPointToModel([0., -0.1, 0.])
+    groundMap.addPointToModel([0., 0., math.tan(np.radians(22.5))+0.1])
     groundMap.minimumElevation = np.radians(45.)
     groundMap.maximumRange = 1e9
     groundMap.cameraPos_B = [0, 0, 0]
@@ -120,5 +120,3 @@ def groundMappingTestFunction():
 
 if __name__ == "__main__":
     test_groundMapping()
-
-

--- a/src/simulation/environment/spacecraftLocation/_UnitTest/test_unitSpacecraftLocation.py
+++ b/src/simulation/environment/spacecraftLocation/_UnitTest/test_unitSpacecraftLocation.py
@@ -76,7 +76,7 @@ def run(showplots, defaultPolarRadius, defaultPlanet, latitude, maxRange, cone):
     if maxRange:
         module.maximumRange = maxRange
     if cone != 0:
-        module.aHat_B = unitTestSupport.np2EigenVectorXd([0, 0, cone])
+        module.aHat_B = [0, 0, cone]
         module.theta = 80. * macros.D2R
 
     scSim.AddModelToTask(simTaskName, module)
@@ -159,4 +159,3 @@ if __name__ == '__main__':
         , -7000.*1000 # max range
         , 1            # cone case, 0-> no cone, 1 -> [0, 1, 0], -1 -> [0, -1, 0]
         )
-

--- a/src/simulation/environment/spacecraftLocation/spacecraftLocation.rst
+++ b/src/simulation/environment/spacecraftLocation/spacecraftLocation.rst
@@ -136,7 +136,7 @@ It this message is not connected, then zero planet position and attitude orienta
 
 To set a primary spacecraft body fixed sensor or communication axis :math:`\hat{\bf a}` and half-cone angle :math:`\theta`, use::
 
-    module.aHat_B = unitTestSupport.np2EigenVectorXd([xxx, xxx, xxx])
+    module.aHat_B = [xxx, xxx, xxx]
     module.theta = xxx * macros.D2R
 
 

--- a/src/utilities/unitTestSupport.py
+++ b/src/utilities/unitTestSupport.py
@@ -452,11 +452,9 @@ def np2EigenVectorXd(vec):
 
 def npList2EigenXdVector(list):
     """Conver a list of arrays to a list of eigen values"""
-    eigenList = bskUtilities.Eigen3dVector(len(list))
-    c = 0
+    eigenList = bskUtilities.Eigen3dVector()
     for pos in list:
-        eigenList[c] = np2EigenVectorXd(pos)
-        c += 1
+        eigenList.push_back(pos)
     return eigenList
 
 def EigenVector3d2np(eig):


### PR DESCRIPTION
* **Tickets addressed:** Closes #312
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
[SWIG typemaps](https://swig.org/Doc4.1/SWIGDocumentation.html#Typemaps) are how we tell SWIG to translate C++ objects to Python objects and vice-versa. `swig_eigen.i` is a file that provides these typemaps for Eigen matrices (`Eigen::Vector3d`, `Eigen::MatrixXd`, etc.). These objects are translated from and to Python lists (both pre this PR and after).

This PR, however, makes important changes on how this file is organized. `%fragment`s are used to define C++ functions that implement most of the behaviour, which allow us to somewhat reduce codebloat in SWIG wrappers. Typemaps then use these functions to perform their transformations and checks.

In terms of functionality, the most important changes comes from the use of type information to inform transformations. This is, when we want to translate a `MatrixX3i`, we now from this type that the input/output must have size `-1x3` and must be integer typed. Using this information, we can perform size checks on inputs (see `checkPyObjectIsMatrixLike`), as well as asserting that the types are correct.

Transformation between C and Python types is done in `castPyToC` and `castCToPy`. They make use of the type information of the matrix to select the appropriate Python/C API function (`PyLong_FromLong`, `PyFloat_AsDouble`, etc.). They also perform sanity checks on the inputs (mainly asserting that integral types are within bounds).

In terms of the typemaps themselves, there are some miscellaneous improvements:
- All operations are slightly faster: the previous typemaps performed several unnecessary copies of the data, which have been refactored out (by building in place instead of through `matrixAssemble`, using `optimal="1"`, using `std::move`, etc.)
- Removed a data leak: an old typemap was creating a type on the heap without deallocating it after use.
- Clearer error messages
- Stricter typecheck with appropriate precedence, which enables function overloading*.
- Support for rvalue references (think `Eigen::Vector3d&&`)

Rotation classes (`MRPd`, `Quaterniond`) are handled slightly differently, as they are always `double`-based and can be set from three different formats (MRP, Quaternion, Rotation Matrix), but are always output as as MRPs. This is legacy behaviour and has remained unchanged. However, they use essentially the same functions as the rest of Eigen types. The main difference is the use of `rotationConversion`, which will intelligently choose an appropriate transformation between any rotation format to another.

## Verification
A new test suit has been included: `src\architecture\utilitiesSelfCheck\_UnitTest\test_swigEigen.py`. This checks that input-output works as expected, that error messages are thrown as expected, that function overloading work with the intended precedence, and that all qualifier combinations are supported (reference, const reference, const, and rvalues).

## Documentation
User-facing interfaces are preserved. No changes necessary.

## Function overloading*
Now, it is possible to overload functions with different Eigen types, and SWIG will be able to call the "most specific" function. For a python input `[1, 2, 3]`, the following overloads would be called in this order of precedence:
```
void foo(std::array<int, 3>)
void foo(Vector3i)
void foo(Vector3d)
void foo(std::vector<int>)
void foo(VectorXi)
void foo(VectorXd)
void foo(MatrixXi)
void foo(MatrixXd)
```
The order is therefore: fixed-size before dynamically sized, boolean before int before double, and std before Eigen.

## Future work
Expand type maps for boolean types and unsigned integer as they are needed. Should be as easy as adding another `EIGEN_MAT_WRAP` statement to `swig_eigen`.
