### PR TITLE
RST documentation throwing a warning

### DIFF
--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -80,3 +80,16 @@ void DynamicObject::integrateState(double integrateToThisTime)
         dynPtr->postIntegration(integrateToThisTime);
     }
 }
+
+/*! Initializes the dynamics and variables
+ */
+void DynamicObject::initializeDynamics()
+{
+}
+
+/*! Method to compute energy and momentum of the system
+ */
+void DynamicObject::computeEnergyMomentum(double t)
+{
+}
+

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -38,8 +38,8 @@ public:
 
 public:
     virtual ~DynamicObject() = default;               //!< -- Destructor
-    virtual void initializeDynamics() {};             //!< -- Initializes the dynamics and variables
-    virtual void computeEnergyMomentum(double t) {};  //!< -- Method to compute energy and momentum of the system
+    virtual void initializeDynamics();                //!< -- Initializes the dynamics and variables
+    virtual void computeEnergyMomentum(double t);     //!< -- Method to compute energy and momentum of the system
     virtual void UpdateState(uint64_t callTime) = 0;  //!< -- This hooks the dyn-object into Basilisk architecture
     virtual void equationsOfMotion(double t, double timeStep) = 0;     //!< -- This is computing F = Xdot(X,t)
     void integrateState(double t);                    //!< -- This method steps the state forward in time


### PR DESCRIPTION

* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The RST documentation is starting up with an error about two virtual methods not being defined.

Instead of declaring them as empty methods in the *.h file, this is now done in the *.cpp file where method documentation strings can be added.

## Verification
Did a clean build and all tests passed.  Documentation clean build completed without any warnings now.

## Documentation
None

## Future work
None
