### PR TITLE
Eclipse skips over potentially occluding bodies

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -60,6 +60,8 @@ Version |release|
 - Added a deprecation system for Basilisk. For developers, see :ref:`deprecatingCode`.
 - Changed the units of plasma flux in :ref:`dentonFluxModel` and :ref:`PlasmaFluxMsgPayload` from
   [cm^-2 s^-1 sr^-2 eV^-1] to [m^-2 s^-1 sr^-2 eV^-1], because m^-2 is used more frequently in computations
+- Fixed a bug in eclipse that caused potentially occluding bodies to be skipped if a prior body was closer to the sun than
+  the spacecraft
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/simulation/environment/eclipse/_UnitTest/test_eclipse.py
+++ b/src/simulation/environment/eclipse/_UnitTest/test_eclipse.py
@@ -236,9 +236,9 @@ def unitEclipse(show_plots, eclipseCondition, planet):
 
     eclipseObject = eclipse.Eclipse()
     eclipseObject.addSpacecraftToModel(scObject_0.scStateOutMsg)
-    eclipseObject.addPlanetToModel(gravFactory.spiceObject.planetStateOutMsgs[0])   # earth
-    eclipseObject.addPlanetToModel(gravFactory.spiceObject.planetStateOutMsgs[1])   # mars
     eclipseObject.addPlanetToModel(gravFactory.spiceObject.planetStateOutMsgs[3])   # venus
+    eclipseObject.addPlanetToModel(gravFactory.spiceObject.planetStateOutMsgs[1])   # mars
+    eclipseObject.addPlanetToModel(gravFactory.spiceObject.planetStateOutMsgs[0])   # earth
     eclipseObject.sunInMsg.subscribeTo(gravFactory.spiceObject.planetStateOutMsgs[2])   # sun
 
     unitTestSim.AddModelToTask(testTaskName, eclipseObject)

--- a/src/simulation/environment/eclipse/eclipse.cpp
+++ b/src/simulation/environment/eclipse/eclipse.cpp
@@ -135,18 +135,17 @@ void Eclipse::UpdateState(uint64_t CurrentSimNanos)
             // If spacecraft is closer to sun than planet
             // then eclipse not possible
             if (r_HB_N.norm() < s_HP_N.norm()) {
-                break;
+                idx++;
+                continue;
+            } 
+            else{
+                // Find the closest planet and save its distance and vector index slot
+                if (s_BP_N.norm() < eclipsePlanetDistance || eclipsePlanetKey < 0) {
+                    eclipsePlanetDistance = s_BP_N.norm();
+                    eclipsePlanetKey = idx;
+                }
+                idx++;
             }
-            
-            // Find the closest planet and save its distance and vector index slot
-            if (idx == 0) {
-                eclipsePlanetDistance = s_BP_N.norm();
-                eclipsePlanetKey = idx;
-            } else if (s_BP_N.norm() < eclipsePlanetDistance) {
-                eclipsePlanetDistance = s_BP_N.norm();
-                eclipsePlanetKey = idx;
-            }
-            idx++;
         }
         
         // If planetkey is not -1 then we have a planet for which


### PR DESCRIPTION
* **Tickets addressed:** bsk-315
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
A correction was made to the eclipse module to ensure that all bodies are considered for occlusion. A break statement was causing a `for` loop to prematurely stop considering occluding bodies. The order in which the planets are added to the eclipse module in the unit test was changed to ensure this is checked for. 

## Verification
The unit test was slightly modified to ensure this is caught in the future. 

## Documentation
No documentation was impacted, only the release notes were updated.

## Future work
N/A
