### PR TITLE
Feature/320 deprecation system

### DIFF
--- a/docs/source/Support/Developer.rst
+++ b/docs/source/Support/Developer.rst
@@ -10,13 +10,10 @@ The following support files help with writing Basilisk modules.
 
    Developer/CodingGuidlines
    Developer/Debugging
+   Developer/deprecatingCode
    Developer/makingNewBskModule
    Developer/addSphinxDoc
    Developer/bskModuleCheckoutList
    Developer/UnderstandingBasilisk
    Developer/migratingBskModuleToBsk2
    Developer/MigratingToPython3
-
-
-
-

--- a/docs/source/Support/Developer/deprecatingCode.rst
+++ b/docs/source/Support/Developer/deprecatingCode.rst
@@ -1,0 +1,240 @@
+.. _deprecatingCode:
+
+Deprecating code in Basilisk
+============================
+
+Motivation
+----------
+The nature of a fast evolving software such as Basilisk is that systems are consistently improving, many times making older functionality obsolete. 
+Thus, we face the challenge of handling older code while we move towards the new systems. 
+We cannot simply remove old functionality, as we don't want user code to break overnight. 
+Instead, we enter a phase of deprecation, when we warn users about the use of deprecated code, 
+but otherwise continue to allow it and support it. After enough time has passed for our users to update 
+their code, the deprecated functionality can be removed.
+
+This support page explains the different mechanisms we have available in Basilisk to mark code as deprecated.
+Deprecated code will cause deprecation warnings to pop-up in the user's console, but otherwise it should
+work as expected.
+
+Deprecating Python Code
+-----------------------
+For code that is entirely defined in Python, we can make use of the utility decorators and descriptors
+defined in ``Basilisk.utilities.deprecated``. This section shows how to deprecate functions, classes, attributes,
+and properties.
+
+To illustrate this functionality, let's imagine the following code:
+
+.. code-block:: python
+
+    def standaloneFun(arg):
+        ...
+
+    class MyClass:
+
+        def __init__(self):
+            self.myAttribute = 0
+            self._myPropertyInner = 0
+
+        def myFun1(self):
+            ...
+
+        @property
+        def myProperty(self):
+            return self._myPropertyInner * 2
+        
+        @myProperty.setter
+        def myProperty(self, value: int):
+            self._myPropertyInner = value / 2
+
+There is a standalone function ``standaloneFun``, a class ``MyClass`` with two attributes
+``myAttribute`` and ``_myPropertyInner``, a class method ``myFun1``, and a property ``myProperty``
+with a getter and setter (which makes use of the ``_myPropertyInner`` private attribute).
+
+If we want to deprecate the **standalone function** and the **class method**, the syntax is
+as follows:
+
+.. code-block:: python
+
+    from Basilisk.utilities import deprecated
+
+    @deprecated.deprecated("2099/05/05", "Use standaloneFun_new() instead!")
+    def standaloneFun(arg):
+        ...
+
+    class MyClass:
+
+        ...
+
+        @deprecated.deprecated("2000/05/05", "myFun1 is super old!")
+        def myFun1(self):
+            ...
+
+        ...
+
+The first argument to ``@deprecated.deprecated`` must be a string with the date when the function is expected
+to be removed (as a rule of thumb, between 6 to 12 months after the release of
+the deprecated code). The second argument is a message that is shown directly
+to users. Here, you may explain why the function is deprecated, alternative functions, 
+links to documentation or scenarios that show how to translate deprecated code...
+
+If you want to deprecate a **class**, then use:
+
+.. code-block:: python
+
+    from Basilisk.utilities import deprecated
+
+    @deprecated.deprecated("2099/05/05", "This entire class is replaced by MyOtherClass")
+    class MyClass:
+        ...
+
+This is the same syntax as deprecating functions, and the arguments behave in the same way.
+
+If you want to deprecate an **attribute**, that is, a class variable, then do:
+
+.. code-block:: python
+
+    from Basilisk.utilities import deprecated
+
+    class MyClass:
+        
+        myAttribute = deprecated.DeprecatedAttribute(
+            "2099/05/05", "myAttribute is no longer used in the simulation"
+        )
+
+        def __init__(self) -> None:
+            with deprecated.ignore("myAttribute"):  # Prevents warnings here
+                self.myAttribute = 0
+
+            ...
+
+The input arguments to ``deprecated.DeprecatedAttribute`` are the same as the arguments
+for ``deprecated.deprecated``. Note that if you want to initialize the attribute to
+some variable (or otherwise manipulate it in any way) without raising deprecation
+warnings, you should use the ``deprecated.ignore`` context manager.
+
+Finally, if you need to deprecate a **property**, then use:
+
+.. code-block:: python
+
+    from Basilisk.utilities import deprecated
+
+    class MyClass:
+        
+        @property
+        def myProperty(self):
+            return self.myPropertyInner * 2
+
+        @myProperty.setter
+        def myProperty(self, value: int):
+            self.myPropertyInner = value / 2
+
+        myProperty = deprecated.DeprecatedProperty(
+            "2099/05/05", "myProperty is no longer used in the simulation", myProperty
+        )
+
+The first two arguments to ``deprecated.DeprecatedProperty`` are the same as the
+arguments to ``deprecated.deprecated`` or ``deprecated.DeprecatedAttribute``.
+The third argument, however, shold be the name of the property to deprecate.
+
+Deprecating C++ Code Wrapped by SWIG
+------------------------------------
+This section explains how to deprecate code that is written in C++ and exposed to 
+Python through a SWIG interface. Note that deprecation warnings will be raised only
+when the Python wrappers to C++ functionality are invoked. Currently, it is not
+possible to emit deprecation warnings when the deprecated functionality is called from
+C++.
+
+In order to deprecate functions, classes, or variables in C++, we use special
+macros in the SWIG file that is exposing
+the deprecated functionality. For example, let's consider we have this C++ code:
+
+.. code-block:: cpp
+
+    // example.h
+
+    void standaloneFun(int, double) {};
+
+    struct MyClass
+    {
+        void myFun() {};
+
+        int myAttribute;
+    };
+
+with the following SWIG interface file:
+
+.. code-block::
+    
+    // example.i
+
+    %module example
+    %{
+       #include "example.h"
+    %}
+
+    %include "example.h"
+
+If we want to deprecate the **standalone function** and **class function**, then we
+would change the SWIG file to:
+
+.. code-block::
+    
+    // example.i
+
+    %module example
+    %{
+       #include "example.h"
+    %}
+
+    %include "swig_deprecated.i"
+    %deprecated_function(standaloneFun, "2023/01/01", "You should use standaloneFunNew")
+    %deprecated_function(MyClass::myFun, "2023/01/01", "myFun has no effects.")
+
+    %include "example.h"
+
+In the code above, we have included ``"swig_deprecated.i"``, which makes the
+``%deprecated_function`` macro available. Then, we have called this macro **before we included the header file** 
+``"example.h"``. The first input to the macro is the SWIG identifier for the function.
+For standalone functions this is simple the function name, but for class functions this is
+``[CLASS_NAME]::[FUNCTION_NAME]``. The next two arguments are the expected removal date
+and message, as covered in the previous section.
+
+If we want to deprecate an entire **class**, then the SWIG file ought to change to:
+
+.. code-block::
+    
+    // example.i
+
+    %module example
+    %{
+       #include "example.h"
+    %}
+
+    %include "swig_deprecated.i"
+    %deprecated_function(MyClass::MyClass, "2023/01/01", "Use MyNewClass.")
+
+    %include "example.h"
+
+Again, we use ``%deprecated_function`` before ``%include "example.h"``. This time, however,
+we need to target ``[CLASS_NAME]::[CLASS_NAME]``.
+
+Finally, to deprecate a class variable, the SWIG file would change to:
+
+.. code-block::
+    
+    // example.i
+
+    %module example
+    %{
+       #include "example.h"
+    %}
+
+    %include "swig_deprecated.i"
+    %deprecated_variable(MyClass, myAttribute, "2023/01/01", "Use MyNewClass.")
+
+    %include "example.h"
+
+This time, we call the macro ``%deprecated_variable``, although always 
+before ``%include "example.h"``. In this case, the two first arguments to ``%deprecated_variable``
+are the name of the class that contains the variable, and then the name of the varible.
+The final two arguments are the expected removal date and the message.

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -57,6 +57,7 @@ Version |release|
   body connected to the spacecraft hub. To simulate the maneuver, this module must be connected to the
   :ref:`prescribedMotionStateEffector` dynamics module.
 - Corrected default value of ``accuracyNanos`` in :ref:`simSynch` to be 0.01 seconds.
+- Added a deprecation system for Basilisk. For developers, see :ref:`deprecatingCode`.
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/architecture/_GeneralModuleFiles/swig_deprecated.i
+++ b/src/architecture/_GeneralModuleFiles/swig_deprecated.i
@@ -1,0 +1,67 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module swig_deprecated
+
+/** Used to deprecate a function in C++ that is exposed to Python through SWIG.
+
+'function' is the SWIG identifier of the function. If it is a standalone function,
+then this is simply its name. If it's a class function, then this should be
+[CLASS_NAME]::[FUNCTION_NAME]
+
+'removal_date' is the expected removal date in the format 'YYYY/MM/DD'. Think of
+an amount of time that would let users update their code, and then add that duration
+to today's date to find a reasonable removal date.
+
+'message' is a text that is directly shown to the users. Here, you may explain
+why the function is deprecated, alternative functions, links to documentation
+or scenarios that show how to translate deprecated code...
+
+See src\architecture\utilitiesSelfCheck\swigDeprecatedCheck.i
+*/
+%define %deprecated_function(function, removal_date, message)
+%pythonprepend function %{
+    from Basilisk.utilities import deprecated
+    deprecated.deprecationWarn(f"{__name__}.function".replace("::","."), `removal_date`, `message`)
+%}
+%enddef
+
+/** Used to deprecate a public class variable in C++ that is exposed to Python through SWIG.
+
+'class' is the SWIG identifier of the class.
+
+'variable' is the name of the variable.
+
+'removal_date' is the expected removal date in the format 'YYYY/MM/DD'. Think of
+an amount of time that would let users update their code, and then add that duration
+to today's date to find a reasonable removal date.
+
+'message' is a text that is directly shown to the users. Here, you may explain
+why the variable is deprecated, alternative variables, links to documentation
+or scenarios that show how to translate deprecated code...
+
+See src\architecture\utilitiesSelfCheck\swigDeprecatedCheck.i
+*/
+%define %deprecated_variable(class, variable, removal_date, message)
+%extend class {
+    %pythoncode %{
+    from Basilisk.utilities import deprecated
+    variable = deprecated.DeprecatedProperty(`removal_date`, `message`, variable)
+    %}
+}
+%enddef

--- a/src/architecture/utilitiesSelfCheck/_UnitTest/test_swigDeprecated.py
+++ b/src/architecture/utilitiesSelfCheck/_UnitTest/test_swigDeprecated.py
@@ -1,0 +1,81 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import pytest
+
+from Basilisk.architecture import swigDeprecatedCheck
+from Basilisk.utilities import deprecated
+
+
+def get_class_without_warning():
+    with deprecated.catch_warnings():
+        deprecated.filterwarnings(
+            "ignore", "SwigDeprecatedTestClass.SwigDeprecatedTestClass"
+        )
+        return swigDeprecatedCheck.SwigDeprecatedTestClass()
+
+
+def test_test1():
+    """Checks that stand-alone functions generates appropriate warnings"""
+    with pytest.warns(deprecated.BSKUrgentDeprecationWarning, match="(.*)test1 Msg"):
+        swigDeprecatedCheck.test1(0, 0)
+
+
+def test_class():
+    """Checks that instantiating classes generates appropriate warnings"""
+    with pytest.warns(deprecated.BSKDeprecationWarning, match="(.*)class Msg"):
+        swigDeprecatedCheck.SwigDeprecatedTestClass()
+
+
+def test_test2():
+    """Checks that calling class methods generates appropriate warnings"""
+    testClass = get_class_without_warning()
+    with pytest.warns(deprecated.BSKUrgentDeprecationWarning, match="(.*)test2 Msg"):
+        testClass.test2()
+
+
+def test_test3():
+    """Checks that calling class methods generates appropriate warnings"""
+    testClass = get_class_without_warning()
+    with pytest.warns(deprecated.BSKDeprecationWarning, match="(.*)test3 Msg"):
+        testClass.test3()
+
+
+def test_test4_set():
+    """Checks that setting deprecated variables generates appropriate warnings"""
+    testClass = get_class_without_warning()
+    with pytest.warns(deprecated.BSKDeprecationWarning, match="(.*)test4 Msg"):
+        testClass.test4 = 1
+
+        assert testClass.test4 == 1
+
+
+def test_test4_get():
+    """Checks that calling deprecated variables generates appropriate warnings"""
+    testClass = get_class_without_warning()
+    with pytest.warns(deprecated.BSKDeprecationWarning, match="(.*)test4 Msg"):
+        _ = testClass.test4
+
+
+if __name__ == "__main__":
+    swigDeprecatedCheck.test1(0, 0)
+    test = swigDeprecatedCheck.SwigDeprecatedTestClass()
+    test.test2()
+    test.test3()
+    test.test4 = 5
+    print(test.test4)

--- a/src/architecture/utilitiesSelfCheck/swigDeprecatedCheck.i
+++ b/src/architecture/utilitiesSelfCheck/swigDeprecatedCheck.i
@@ -1,0 +1,44 @@
+/*
+ ISC License
+
+ Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+%module swigDeprecatedCheck
+
+// The following lines show how to deprecate a stand-alone C++ function,
+// an entire C++ class, two C++ class functions, and finally a C++ class variable
+%include "swig_deprecated.i"
+%deprecated_function(test1, "2023/01/01", "test1 Msg")
+%deprecated_function(SwigDeprecatedTestClass::SwigDeprecatedTestClass, "2099/01/01", "class Msg")
+%deprecated_function(SwigDeprecatedTestClass::test2, "2023/01/01", "test2 Msg")
+%deprecated_function(SwigDeprecatedTestClass::test3, "2099/01/01", "test3 Msg")
+%deprecated_variable(SwigDeprecatedTestClass, test4, "2099/01/01", "test4 Msg")
+
+// The following just defines a class and function for us to deprecate
+%inline {
+
+void test1(int, double) {};
+
+struct SwigDeprecatedTestClass
+{
+    void test2() {};
+    void test3() {};
+
+    int test4;
+};
+
+}

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -3,5 +3,3 @@
 markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.
-filterwarnings =
-    ignore:BSK Deprecation:DeprecationWarning

--- a/src/tests/test_deprecated.py
+++ b/src/tests/test_deprecated.py
@@ -1,0 +1,158 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+r"""
+This test demonstrates how to deprecate functions, classes, attributes, 
+and properties defined in Python code. To learn how to deprecate C++ code
+exposed to users through SWIG, see:
+
+    src\architecture\utilitiesSelfCheck\_UnitTest\swigDeprecatedCheck.i
+"""
+import pytest
+
+# The following block represents the target code before deprecations:
+"""
+def standaloneFun(arg):
+    ...
+
+class PythonTest:
+
+    def __init__(self) -> None:
+        self.myAttribute = 0
+        self.myPropertyInner = 0
+
+    def myFun1(self):
+        ...
+
+    @property
+    def myProperty(self):
+        return self.myPropertyInner * 2
+    
+    @myProperty.setter
+    def myProperty(self, value: int):
+        self.myPropertyInner = value / 2
+"""
+
+# The following is the code with all elements deprecated
+from Basilisk.utilities import deprecated
+
+
+@deprecated.deprecated("2099/05/05", "Use standaloneFun_new() instead!")
+def standaloneFun(arg):
+    ...
+
+
+@deprecated.deprecated("2099/05/05", "This entire class is replaced by RustTest")
+class PythonTest:
+    myAttribute = deprecated.DeprecatedAttribute(
+        "2099/05/05", "myAttribute is no longer used in the simulation"
+    )
+
+    def __init__(self) -> None:
+        with deprecated.ignore("myAttribute"):  # Prevents warnings here
+            self.myAttribute = 0
+        self.myPropertyInner = 0
+
+    @deprecated.deprecated("2000/05/05", "myFun1 is super old!")
+    def myFun1(self):
+        ...
+
+    @property
+    def myProperty(self):
+        return self.myPropertyInner * 2
+
+    @myProperty.setter
+    def myProperty(self, value: int):
+        self.myPropertyInner = value / 2
+
+    myProperty = deprecated.DeprecatedProperty(
+        "2099/05/05", "myProperty is no longer used in the simulation", myProperty
+    )
+
+
+# This test shows how calling or using the classes/functions/attributes
+# will raise warnings
+def test_correctWarnings():
+    """Shows how calling or using the deprecated classes/functions/attributes
+    will raise warnings"""
+
+    with pytest.warns(deprecated.BSKDeprecationWarning):
+        standaloneFun(0)
+
+    with pytest.warns(deprecated.BSKDeprecationWarning):
+        test = PythonTest()
+
+    with pytest.warns(deprecated.BSKDeprecationWarning):
+        test.myAttribute = 5
+
+    with pytest.warns(deprecated.BSKDeprecationWarning):
+        stored = test.myAttribute
+        assert stored == 5  # Check it still works despite being deprecated
+
+    # Note the BSKUrgentDeprecationWarning because the removal date is passed
+    with pytest.warns(deprecated.BSKUrgentDeprecationWarning):
+        test.myFun1()
+
+    with pytest.warns(deprecated.BSKDeprecationWarning):
+        test.myProperty = 10
+
+    with pytest.warns(deprecated.BSKDeprecationWarning):
+        stored = test.myProperty
+        assert stored == 10
+
+
+def test_ignoreWarnings():
+    """Checks that the ignoring deprecation functionality is working correctly"""
+    import warnings
+
+    # Here, we intend to supress all BSKDeprecationWarning, so any that are raised
+    # should be reported as errors
+    warnings.filterwarnings("error", category=deprecated.BSKDeprecationWarning)
+
+    with deprecated.ignore("standaloneFun"):
+        standaloneFun(0)
+
+    with deprecated.ignore("PythonTest"):
+        test = PythonTest()
+
+    # This will ignore only calls to myAttribute to PythonTest
+    with deprecated.ignore("PythonTest.myAttribute"):
+        test.myAttribute = 5
+
+    # This will ignore every call to any deprecated myAttribute (not only in PythonTest)
+    with deprecated.ignore("myAttribute"):
+        _ = test.myAttribute
+
+    with deprecated.ignore("PythonTest.myProperty"):
+        test.myProperty = 0
+
+    with deprecated.ignore("myProperty"):
+        _ = test.myProperty
+
+    # BSKUrgentDeprecationWarning cannot be ignored!
+    with pytest.warns(deprecated.BSKUrgentDeprecationWarning):
+        with deprecated.ignore("myFun1"):  # does nothing
+            test.myFun1()
+
+
+if __name__ == "__main__":
+    standaloneFun(0)
+    testClass = PythonTest()
+    testClass.myFun1()
+    testClass.myAttribute = 1
+    testClass.myProperty = 2

--- a/src/tests/test_scenarioAttitudePointingPyDEPRECATED.py
+++ b/src/tests/test_scenarioAttitudePointingPyDEPRECATED.py
@@ -1,7 +1,7 @@
 #
 #  ISC License
 #
-#  Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
 #
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
@@ -32,12 +32,13 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import deprecated
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
-sys.path.append(path + '/../../examples')
+sys.path.append(path + "/../../examples")
 import scenarioAttitudePointingPyDEPRECATED
 
 
@@ -45,6 +46,7 @@ import scenarioAttitudePointingPyDEPRECATED
 # @pytest.mark.skipif(conditionstring)
 # uncomment this line if this test has an expected failure, adjust message as needed
 # @pytest.mark.xfail(True)
+
 
 # The following 'parametrize' function decorator provides the parameters and expected results for each
 #   of the multiple test runs for this test.
@@ -58,7 +60,9 @@ def test_bskAttitudePointingPD(show_plots):
     testMessages = []  # create empty array to store test log messages
 
     try:
-        figureList = scenarioAttitudePointingPyDEPRECATED.run(show_plots)
+        # Ignore the deprecation warning, as this is expected
+        with deprecated.ignore("run"):
+            figureList = scenarioAttitudePointingPyDEPRECATED.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
             unitTestSupport.saveScenarioFigure(pltName, plt, path)

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -1,7 +1,7 @@
 
 # ISC License
 #
-# Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+# Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -33,6 +33,7 @@ from Basilisk.architecture import bskLogging
 from Basilisk.architecture import sim_model
 from Basilisk.utilities import simulationArchTypes
 from Basilisk.utilities.simulationProgessBar import SimulationProgressBar
+from Basilisk.utilities import deprecated
 
 # Point the path to the module storage area
 
@@ -367,6 +368,12 @@ class SimBaseClass:
         self.TotalSim.addNewProcess(proc.processData)
         return proc
 
+    @deprecated.deprecated(
+        "2024/04/01",
+        "PythonProcess and Python modules that inherit from "
+        "'simulationArchTypes.PythonModelClass' are deprecated. "
+        "See 'examples/scenarioAttitudePointingPy' for details.",
+    )
     def CreateNewPythonProcess(self, procName, priority = -1):
         """
         Creates the python analog of a sim-level process, that exists only on the python level in self.pyProcList
@@ -375,15 +382,6 @@ class SimBaseClass:
         :param priority (int): Priority that determines when the model gets updated. (Higher number = Higher priority)
         :return: simulationArchTypes.PythonProcessClass object
         """
-        warnings.warn(
-            "BSK Deprecation: "
-            "PythonProcess and Python modules that inherit from "
-            "simulationArchTypes.PythonModelClass are deprecated. "
-            "See examples/scenarioAttitudePointingPy for details.",
-            category=DeprecationWarning,
-            stacklevel=2
-        )
-
         proc = simulationArchTypes.PythonProcessClass(procName, priority)
         i=0;
         for procLoc in self.pyProcList:

--- a/src/utilities/deprecated.py
+++ b/src/utilities/deprecated.py
@@ -1,0 +1,309 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import warnings
+from warnings import catch_warnings as catch_warnings
+import datetime
+import types
+from typing import Union, Literal, TYPE_CHECKING, Any
+
+
+class BSKDeprecationWarning(Warning):
+    __color__ = "\x1b[33;20m"  # Yellow
+
+
+class BSKUrgentDeprecationWarning(Warning):
+    __color__ = "\x1b[31;1m"  # Bold red
+
+
+def filterwarnings(
+    action: Literal["error", "ignore", "always", "default", "module", "once"],
+    identifier: str,
+    **kwargs: Any,
+):
+    """Use this function to create global deprecation warning filters.
+
+    The most common use of this function is suppressing warnings for deprecated systems
+    that you still intend to use. Imagine you want to ignore deprecation warnings
+    for the method `myMethod` in class `ValidClass` in module `my_module`. You would add
+    the following line to your simulation script::
+
+        deprecated.filterwarnings("ignore", "my_module.ValidClass.myMethod")
+
+    Note that deprecation warnings should not be ignored blindly. Deprecated code WILL
+    be removed in future releases, so use warning suppression carefully.
+
+    Args:
+        action (Literal["error", "ignore", "always", "default", "module", "once"]):
+            Controls how the filtered warnings will behave.
+        identifier (str): The warning message must contain this string. This can be
+            the function or variable identifier (qualified name) in order to hide
+            deprecation warnings for specific features.
+        **kwargs (Any): Any other keyword arguments are passed directly to
+            `warnings.filterwarnings`.
+    """
+    warnings.filterwarnings(
+        action, f".*{identifier}.*", category=BSKDeprecationWarning, **kwargs
+    )
+
+
+class ignore:
+    """Use this context manager to ignore warnings in a precise section of code.
+
+    The most common use of this function is suppressing warnings for specific calls.
+    Imagine you want to ignore deprecation warnings for the method `myMethod` in
+    class `ValidClass` in module `my_module` for a single call to this function.
+    You would do::
+
+        myClass = my_module.ValidClass()
+
+        with deprecated.ignore("my_module.ValidClass.myMethod"):
+            myClass.myMethod() # Does not raise a warning
+
+        myClass.myMethod() # Raises a warning
+
+    Note that deprecation warnings should not be ignored blindly. Deprecated code WILL
+    be removed in future releases, so use warning suppression carefully.
+    """
+
+    def __init__(self, identifier: str) -> None:
+        self.catch = catch_warnings()
+        self.identifier = identifier
+
+    def __enter__(self):
+        self.catch.__enter__()
+        filterwarnings("ignore", self.identifier)
+
+    def __exit__(self, *exc_info):
+        self.catch.__exit__(*exc_info)
+
+
+def deprecationWarn(id: str, removalDate: Union[datetime.date, str], msg: str):
+    """Utility function to raise deprecation warnings inside a function body.
+
+    This function should rarely be used on its own. For deprecated Python code,
+    prefer the `@deprecated` decorator. For deprecated C++ code, use the SWIG
+    macros in `swig_deprecated.i`.
+
+    Args:
+        id (str): An identifier for the deprecated feature (function/variable
+            qualified name)
+        removalDate (Union[datetime.date, str]): The date when we expect to remove this
+            deprecated feature, in the format 'YYYY/MM/DD' or as a ``datetime.date``.
+            Think of an amount of time that would let users update their code, and then
+            add that duration to today's date to find a reasonable removal date.
+        msg (str, optional): a text that is directly shown to the users. Here, you may
+            explain why the function is deprecated, alternative functions, links to
+            documentation or scenarios that show how to translate deprecated code...
+    """
+
+    id = id.replace(")", "").replace("(", "")
+    if isinstance(removalDate, str):
+        removalDate = datetime.datetime.strptime(removalDate, r"%Y/%m/%d").date()
+
+    if removalDate > datetime.date.today():
+        warnings.warn(
+            f"{id} will be removed after {removalDate}: {msg}",
+            category=BSKDeprecationWarning,
+            stacklevel=3,
+        )
+    else:
+        warnings.warn(
+            f"{id} will be removed soon: {msg}",
+            category=BSKUrgentDeprecationWarning,
+            stacklevel=3,
+        )
+
+
+def deprecated(removalDate: str, msg: str):
+    """A decorator for functions or classes that are deprecated.
+
+    Usage::
+
+        @deprecated.deprecated("2024/05/28", "Use MyNewClass")
+        class MyClass:
+            ...
+
+    or::
+
+        @deprecated.deprecated("2024/05/28", "myFun is unsafe now")
+        def myFun(a, b):
+            ...
+
+    or::
+
+        class ValidClass:
+
+            @deprecated.deprecated("2024/05/28", "myMethod is slow, use myBetterMethod")
+            def myMethod(self, a, b):
+                ...
+
+    Args:
+        removalDate (Union[datetime.date, str]): The date when we expect to remove this
+            deprecated feature, in the format 'YYYY/MM/DD' or as a ``datetime.date``.
+            Think of an amount of time that would let users update their code, and then
+            add that duration to today's date to find a reasonable removal date.
+        msg (str, optional): a text that is directly shown to the users. Here, you may
+            explain why the function is deprecated, alternative functions, links to
+            documentation or scenarios that show how to translate deprecated code...
+    """
+
+    def wrapper(func):
+        id = f"{func.__module__}.{func.__qualname__}"
+
+        def inner_wrapper(*args, **kwargs):
+            deprecationWarn(id, removalDate, msg)
+            return func(*args, **kwargs)
+
+        return inner_wrapper
+
+    return wrapper
+
+
+class DeprecatedAttribute:
+    """Use this descriptor to deprecate class attributes (variables).
+
+    If you want to deprecate ``myAttribute`` in the following class::
+
+        class MyClass:
+
+            def __init__(self) -> None:
+                self.myAttribute = 0
+
+    You can use the following syntax::
+
+        class PythonTest:
+
+            myAttribute = deprecated.DeprecatedAttribute("2099/05/05", "myAttribute is no longer used in the simulation")
+
+            def __init__(self) -> None:
+                with deprecated.ignore("myAttribute"): # Prevents warnings here
+                    self.myAttribute = 0
+
+    The attribute will work as before, but deprecation warnings will be raised
+    everytime it's used (read or set).
+    """
+
+    def __init__(self, removalDate: str, msg: str) -> None:
+        self.removalDate = removalDate
+        self.msg = msg
+
+    def __set_name__(self, owner, name):
+        self.id = f"{owner.__module__}.{owner.__qualname__}.{name}"
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        deprecationWarn(self.id, self.removalDate, self.msg)
+        return getattr(obj, f"_{self.name}")
+
+    def __set__(self, obj, value):
+        deprecationWarn(self.id, self.removalDate, self.msg)
+        setattr(obj, f"_{self.name}", value)
+
+
+class DeprecatedProperty:  # type: ignore
+    """Use this descriptor to deprecate class properties.
+
+    If you want to deprecate ``myProperty`` in the following class::
+
+        class MyClass:
+
+            @property
+            def myProperty(self):
+                return 0
+
+            @myProperty.setter
+            def myProperty(self, value: int):
+                ...
+
+    You can use the following syntax::
+
+        class PythonTest:
+
+            @property
+            def myProperty(self):
+                return 0
+
+            @myProperty.setter
+            def myProperty(self, value: int):
+                ...
+
+            myProperty = deprecated.DeprecatedProperty(
+                "2099/05/05",
+                "myProperty is no longer used in the simulation",
+                myProperty)
+
+    The property will work as before, but deprecation warnings will be raised
+    everytime it's used (read or set).
+    """
+
+    def __init__(self, removalDate: str, msg: str, property: property) -> None:
+        self.removalDate = removalDate
+        self.msg = msg
+        self.property = property
+
+        if not hasattr(self.property, "__get__") or not hasattr(
+            self.property, "__set__"
+        ):
+            raise ValueError("DeprecatedProperty must be given an existing property")
+
+    def __set_name__(self, owner, name):
+        self.id = f"{owner.__module__}.{owner.__qualname__}.{name}"
+
+    def __get__(self, *args, **kwargs):
+        deprecationWarn(self.id, self.removalDate, self.msg)
+        return self.property.__get__(*args, **kwargs)
+
+    def __set__(self, *args, **kwargs):
+        deprecationWarn(self.id, self.removalDate, self.msg)
+        self.property.__set__(*args, **kwargs)
+
+    def __delete__(self, *args, **kwargs):
+        self.property.__delete__(*args, **kwargs)
+
+
+# Typing hack so that linters don't complain about redefining properties
+if TYPE_CHECKING:
+
+    def DeprecatedProperty(removalDate: str, msg: str) -> Any:  # type: ignore
+        ...
+
+
+# Monkey patching showwarning to modify the behaviour for our warnings
+def formatwarning(
+    message,
+    category,
+    filename,
+    lineno,
+    line=None,
+    __defaultformatwarning=warnings.formatwarning,
+):
+    """Hook to write a warning to a file; replace if you like."""
+    if issubclass(category, (BSKDeprecationWarning, BSKUrgentDeprecationWarning)):
+        message = category(str(message) + "\x1b[0m")  # Append the color reset character
+
+        # Produce a "fake object" with sole attribute __name__ which is the name of
+        # the actual category prepended by the color character
+        category = types.SimpleNamespace(
+            __name__=category.__color__ + category.__name__
+        )
+
+    return __defaultformatwarning(message, category, filename, lineno, line)
+
+
+warnings.formatwarning = formatwarning


### PR DESCRIPTION
* **Tickets addressed:** #320
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR addresses a deprecation system for Python code or SWIGed C++ code. Deprecation warnings are emitted through Python's warning system. When a system is marked as deprecated, a removal date and message must be provided, which will be shown to users when they try to use deprecated functionality. The new `deprecated` module also comes with utilities to hide deprecation warnings.

Developers who want to deprecate their code can do so through helpful decorators in Python or SWIG macros for C++ code. See `test_deprecated` and `swigDeprecatedCheck.i` for examples on how these deprecation marks can be used.

When a deprecation warning is raised, the removal date is checked. If this date is before the current date (today), then instead of raising a `BSKDeprecationWarning`, a `BSKUrgentDeprecationWarning` is raised. `BSKUrgentDeprecationWarning` cannot be ignored, so code that was supressing deprecation warnings will start to raise them.

This feature is useful to us as maintainers because we will get notified when a feature is due for removal. The idea is that tests/examples that willingly use deprecated code will have code to suppress these warnings. However, when the removal date is past, these suppressions will stop working and we will see the "urgent" warnings when running pytest.
 
## Verification
There are two tests added, one for Python deprecation and other for SWIG deprecation.

## Documentation
Should we write a `.rst` about how to write/suppress deprecation warnings?

## Future work
Find a mechanism to suppress C++ functionality that is never SWIGed.
