### PR TITLE
Fix incorrect conversion macro in accuracyNanos

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,6 +56,7 @@ Version |release|
 - Created a :ref:`prescribedRot2DOF` fsw module to profile a prescribed 2 DOF rotational maneuver for a secondary rigid
   body connected to the spacecraft hub. To simulate the maneuver, this module must be connected to the
   :ref:`prescribedMotionStateEffector` dynamics module.
+- Corrected default value of ``accuracyNanos`` in :ref:`simSynch` to be 0.01 seconds.
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/simulation/simSynch/simSynch.cpp
+++ b/src/simulation/simSynch/simSynch.cpp
@@ -28,7 +28,7 @@ ClockSynch::ClockSynch()
 {
 	this->timeInitialized = false;
 	this->startSimTimeNano = 0;
-	this->accuracyNanos = (int64_t) (0.01*NANO2SEC);
+	this->accuracyNanos = (int64_t) (0.01*SEC2NANO);
 	this->accelFactor = 1.0;
 	this->displayTime = false;
     return;


### PR DESCRIPTION
* **Tickets addressed:** Closes #333
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The following was being used, which incorrectly set the `accuracyNanos` to 0:
```
this->accuracyNanos = (int64_t) (0.01*NANO2SEC);
```
which was changed to:
```
this->accuracyNanos = (int64_t) (0.01*SEC2NANO);
```

## Verification
N/A

## Documentation
N/A

## Future work
Issue #333 mentioned creating a scenario that features `simSynch`.
