### PR TITLE
hotfix: docstring param name in scenarioBasicOrbitStream.py

### DIFF
--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -96,7 +96,8 @@ def run(show_plots, liveStream, timeStep, orbitCase, useSphericalHarmonics, plan
 
     Args:
         show_plots (bool): Determines if the script should display plots
-        livePlots (bool): Determines if the script should use live plotting
+        liveStream (bool): Determines if the script should use live data streaming
+        timeStep (double): Integration update time in seconds
         orbitCase (str):
 
             ======  ============================


### PR DESCRIPTION
* **Tickets addressed:** hotfix
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Docstring mentions a liveplots param - was this a previously existing feature? 
![image](https://github.com/AVSLab/basilisk/assets/120187203/414c0ea9-3835-4b02-9fd1-bc5a5ba3b38d)

https://github.com/AVSLab/basilisk/discussions/301
Updated docstring to liveStream instead. 

## Verification
N/A

## Documentation
N/A

## Future work
N/A
