### PR TITLE
Minor improvement to Mac OS install instructions

### DIFF
--- a/docs/source/Install/installOnMacOS.rst
+++ b/docs/source/Install/installOnMacOS.rst
@@ -120,7 +120,7 @@ Installing required python support packages
 -  Basilisk uses ``conan`` for package managing. In order to do so, users
    must ensure ``wheel`` is installed and install ``conan``::
 
-       (.venv) $ pip3 install wheel conan
+       (.venv) $ pip3 install wheel "conan>=1.40.1, <=1.59.0"
 
    The conan repositories information is automatically setup by ``conanfile.py``.
 


### PR DESCRIPTION


* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Clarify the version requirement for conan in the sample script. Without this, the first run for somebody on Mac OS will result in a conan error. The version requirements are actually documented elsewhere, however we should just give users the correct command to copy/paste in the first place.

## Verification
Executed command manually on local machine.

## Documentation
N/A

## Future work
N/A
