### PR TITLE
Feature/fix msis

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -62,6 +62,7 @@ Version |release|
   [cm^-2 s^-1 sr^-2 eV^-1] to [m^-2 s^-1 sr^-2 eV^-1], because m^-2 is used more frequently in computations
 - Fixed a bug in eclipse that caused potentially occluding bodies to be skipped if a prior body was closer to the sun than
   the spacecraft
+- fixed the time evaluation in :ref:`msisAtmosphere`
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
+++ b/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
@@ -224,7 +224,7 @@ void MsisAtmosphere::evaluateAtmosphereModel(AtmoPropsMsgPayload *msg, double cu
     localDateTime = this->epochDateTime;
     localDateTime.tm_sec += (int) round(currentTime);   // sets the current seconds
     mktime(&localDateTime);
-    this->msisInput.year = localDateTime.tm_yday;
+    this->msisInput.year = localDateTime.tm_year + 1900;
     this->msisInput.doy = localDateTime.tm_yday + 1;    // Jan 1 is the 1st day of year, not 0th
     this->msisInput.sec = localDateTime.tm_sec;
 

--- a/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
+++ b/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
@@ -222,11 +222,12 @@ void MsisAtmosphere::evaluateAtmosphereModel(AtmoPropsMsgPayload *msg, double cu
     //! Update time.
     struct tm localDateTime;                            // []       date/time structure
     localDateTime = this->epochDateTime;
-    localDateTime.tm_sec += (int) round(currentTime);   // sets the current seconds
+    localDateTime.tm_sec += (int) currentTime;   // sets the current seconds
     mktime(&localDateTime);
     this->msisInput.year = localDateTime.tm_year + 1900;
     this->msisInput.doy = localDateTime.tm_yday + 1;    // Jan 1 is the 1st day of year, not 0th
-    this->msisInput.sec = localDateTime.tm_sec;
+    double fracSecond = currentTime - (int) currentTime;
+    this->msisInput.sec = localDateTime.tm_hour * 3600.0 + localDateTime.tm_min * 60.0 + localDateTime.tm_sec + fracSecond;
 
 
     //WIP - need to actually figure out how to pull in these values.

--- a/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
+++ b/src/simulation/environment/MsisAtmosphere/msisAtmosphere.cpp
@@ -229,8 +229,7 @@ void MsisAtmosphere::evaluateAtmosphereModel(AtmoPropsMsgPayload *msg, double cu
     double fracSecond = currentTime - (int) currentTime;
     this->msisInput.sec = localDateTime.tm_hour * 3600.0 + localDateTime.tm_min * 60.0 + localDateTime.tm_sec + fracSecond;
 
-
-    //WIP - need to actually figure out how to pull in these values.
+    // WIP - need to actually figure out how to pull in these values.
     this->msisInput.lst = this->msisInput.sec/3600.0 + this->msisInput.g_long/15.0;
 
     //!  NRLMSISE-00 uses different models depending on the altitude.


### PR DESCRIPTION
* **Tickets addressed:** bsk-351
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fixed MSIS module to correctly compute the seconds elapses since midnight.

## Verification
The math in the method was spot checked to ensure the correct values are computed

## Documentation
None

## Future work
None
