### PR TITLE
Fix C/C++ test invocation in windows CI job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -143,4 +143,4 @@ jobs:
         shell: pwsh
         run: |
           cd dist3
-          (Get-ChildItem -Directory).FullName | ForEach-Object { ctest --gtest_output "json:../ctest/ctest-results-windows-${{ matrix.python-version }}.json"; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}}
+          ctest --gtest_output "json:../ctest/ctest-results-windows-${{ matrix.python-version }}.json"; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}


### PR DESCRIPTION
* **Tickets addressed:** resolves #357
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When the C/C++ test invocation was added the `for-each` loop was copy and pasted, resulting in the tests being run multiple times.

## Verification
The CI should run successfully and the logs should show a single Google Tests run.

## Documentation
None needed, none invalidated. 

## Future work
None.
