### PR TITLE
Feature/fix compiler warnings

### DIFF
--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -104,8 +104,6 @@ void ThrusterDynamicEffector::writeOutputMessages(uint64_t CurrentClock)
  */
 bool ThrusterDynamicEffector::ReadInputs()
 {
-    
-    std::vector<double>::iterator CmdIt;
     uint64_t i;
     bool dataGood;
     
@@ -147,7 +145,6 @@ void ThrusterDynamicEffector::ConfigureThrustRequests(double currentTime)
 {
     std::vector<THRSimConfig>::iterator it;
     std::vector<double>::iterator CmdIt;
-    std::vector<THRTimePair>::iterator PairIt;
     //! - Iterate through the list of thruster commands that we read in.
     for(CmdIt = NewThrustCmds.begin(), it = this->thrusterData.begin();
         it != this->thrusterData.end(); it++, CmdIt++)

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -92,7 +92,6 @@ void ThrusterStateEffector::Reset(uint64_t CurrentSimNanos)
 bool ThrusterStateEffector::ReadInputs()
 {
     // Initialize local variables
-    std::vector<double>::iterator CmdIt;
     uint64_t i;
     bool dataGood;
     

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -594,8 +594,6 @@ void VSCMGStateEffector::WriteOutputMessages(uint64_t CurrentClock)
  */
 void VSCMGStateEffector::ReadInputs()
 {
-//
-	std::vector<double>::iterator CmdIt;
 	uint64_t i;
 
     /* zero the incoming commands */

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -47,8 +47,8 @@ class FacetSRPDynamicEffector: public SysModel, public DynamicEffector
 public:                                                             
     FacetSRPDynamicEffector();                                      //!< The module constructor
     ~FacetSRPDynamicEffector();                                     //!< The module destructor
-    void linkInStates(DynParamManager& states);                     //!< Method for giving the effector access to the hub states
-    void computeForceTorque(double integTime, double timeStep);     //!< Method for computing the SRP force and torque about point B
+    void linkInStates(DynParamManager& states) override;            //!< Method for giving the effector access to the hub states
+    void computeForceTorque(double integTime, double timeStep) override;  //!< Method for computing the SRP force and torque about point B
     void Reset(uint64_t currentSimNanos) override;                  //!< Reset method
     void UpdateState(uint64_t currentSimNanos) override;            //!< Method for updating the effector states
     void writeOutputMessages(uint64_t currentClock);                //!< Method for writing the output messages

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -52,7 +52,7 @@ public:
     void updateEnergyMomContributions(double integTime,
                                       Eigen::Vector3d & rotAngMomPntCContr_B,
                                       double & rotEnergyContr,
-                                      Eigen::Vector3d omega_BN_B); //!< Method for computing the energy and momentum of the effector
+                                      Eigen::Vector3d omega_BN_B) override; //!< Method for computing the energy and momentum of the effector
     void computePrescribedMotionInertialStates(); //!< Method for computing the effector's states relative to the inertial frame
 
     double mass;                                        //!< [kg] Effector mass

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -479,9 +479,6 @@ void ReactionWheelStateEffector::writeOutputStateMessages(uint64_t integTimeNano
  */
 void ReactionWheelStateEffector::ReadInputs()
 {
-//
-	std::vector<double>::iterator CmdIt;
-	uint64_t i;
 
 	//! read the incoming command array, or zero if not connected
     if (this->rwMotorCmdInMsg.isLinked()) {
@@ -493,6 +490,7 @@ void ReactionWheelStateEffector::ReadInputs()
 
 	//! - Set the NewRWCmds vector.  Using the data() method for raw speed
 	RWCmdMsgPayload *CmdPtr;
+    uint64_t i;
 	for(i=0, CmdPtr = NewRWCmds.data(); i<ReactionWheelData.size(); CmdPtr++, i++)
 	{
 		CmdPtr->u_cmd = this->incomingCmdBuffer.motorTorque[i];

--- a/src/simulation/environment/albedo/albedo.cpp
+++ b/src/simulation/environment/albedo/albedo.cpp
@@ -300,8 +300,6 @@ void Albedo::readMessages() {
 void Albedo::writeMessages(uint64_t CurrentSimNanos) {
     AlbedoMsgPayload localMessage;
     memset(&localMessage, 0x0, sizeof(localMessage));
-    std::vector<int64_t>::iterator it;
-    std::vector<AlbedoMsgPayload>::iterator albedoIt;
 
     //! - Write albedo output messages for each instrument
     for (long unsigned int idx=0; idx<this->albOutMsgs.size(); idx++) {
@@ -563,7 +561,7 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
         Eigen::Vector3d gdlla;
         Eigen::Vector3d r_dAP_N, r_SdA_N, r_IdA_N;
         Eigen::Vector3d rHat_dAP_N, sHat_SdA_N, rHat_IdA_N;
-        int ilat = 0, ilon = 0, ImaxIdx = 0, IIdx = 0;  // index
+        int ilat = 0, ilon = 0, IIdx = 0;  // index
         double lon1 = 0.0, lon2 = 0.0, lat1 = 0.0, lat2 = 0.0, tempmax = 0.0, tempfov = 0.0;
         double f1 = 0.0, f2 = 0.0, f3 = 0.0;
         double dArea = 0.0, alb_I = 0.0, alb_Imax = 0.0;
@@ -610,7 +608,7 @@ void Albedo::computeAlbedo(int idx, int instIdx, SpicePlanetStateMsgPayload plan
                         tempmax = this->ALB[idx][ilat][ilon] * tempmax;
                     }
                     alb_Imax = alb_Imax + tempmax * shadowFactorAtdA;
-                    ImaxIdx++;
+
                     if (f3 >= cos(fov)) {
                         //! - Sunlit portion of the planet seen by the instrument (fov)
                         //! - Albedo flux ratio at instrument's position [-]

--- a/src/simulation/environment/magneticFieldWMM/GeomagnetismLibrary.c
+++ b/src/simulation/environment/magneticFieldWMM/GeomagnetismLibrary.c
@@ -1888,10 +1888,10 @@ int MAG_readMagneticModel_SHDF(char *filename, MAGtype_MagneticModel *(*magnetic
             for(i = 0; i < NOOFPARAMS; i++)
             {
 
-                paramkeylength = strlen(paramkeys[i]);
+                paramkeylength = (int) strlen(paramkeys[i]);
                 if(!strncmp(line, paramkeys[i], paramkeylength))
                 {
-                    paramvaluelength = strlen(line) - paramkeylength;
+                    paramvaluelength = (int) strlen(line) - paramkeylength;
                     strncpy(paramvalue, line + paramkeylength, paramvaluelength);
                     paramvalue[paramvaluelength] = '\0';
                     strcpy(paramvalues[i], paramvalue);
@@ -2625,7 +2625,7 @@ int MAG_GetUTMParameters(double Latitude,
                 *CentralMeridian = (6 * temp_zone - 183) * M_PI / 180.0;
             else
                 *CentralMeridian = (6 * temp_zone + 177) * M_PI / 180.0;
-            *Zone = temp_zone;
+            *Zone = (int) temp_zone;
             if(Latitude < 0) *Hemisphere = 'S';
             else *Hemisphere = 'N';
         }

--- a/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
+++ b/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
@@ -90,7 +90,6 @@ bool SpaceToGroundTransmitter::customReadMessages(){
     }
     if(this->groundLocationAccessInMsgs.size() > 0)
     {
-        std::vector<int64_t>::iterator it;
         for(long unsigned int c=0; c<this->groundLocationAccessInMsgs.size(); c++)
         {
             tmpDataRead = this->groundLocationAccessInMsgs.at(c).isWritten();

--- a/src/simulation/power/_GeneralModuleFiles/powerNodeBase.cpp
+++ b/src/simulation/power/_GeneralModuleFiles/powerNodeBase.cpp
@@ -58,7 +58,6 @@ void PowerNodeBase::Reset(uint64_t CurrentSimNanos)
  */
 void PowerNodeBase::writeMessages(uint64_t CurrentClock)
 {
-    std::vector<int64_t>::iterator it;
     //! - write power output message
     this->nodePowerOutMsg.write(&this->nodePowerMsg, this->moduleID, CurrentClock);
 

--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.cpp
@@ -347,7 +347,6 @@ void DataFileToViz::UpdateState(uint64_t CurrentSimNanos)
                 /* check if RW states are provided */
                 if (this->rwScOutMsgs.size() > 0) {
                     if (this->rwScOutMsgs[scCounter].size() > 0) {
-                        std::vector<std::string>::iterator rwDevice;
                         for (long unsigned int rwCounter = 0; rwCounter < this->rwScOutMsgs[scCounter].size(); rwCounter++) {
 
                             RWConfigLogMsgPayload rwOutMsg;


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When compiling BSK in Xcode there were a few compiler warnings about un-used variables, missing `override` statements, etc.  With this branch now BSK compiles free of these warnings except for the swig related `springs` depreciation warnings.

## Verification
Did a clean compile and manually checked that only `sprintf()` related depreciation warnings were present.

## Documentation
None

## Future work
None
