### PR TITLE
Fixes C msg read error

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -65,6 +65,7 @@ Version |release|
 - fixed the time evaluation in :ref:`msisAtmosphere`
 - Added an optional ``controllerStatus`` variable and ``deviceStatusInMsg`` message to the :ref:`simpleInstrumentController` to 
   match the functionality of the corresponding data and power modules
+- Corrected tasks priorities in several scenarios and added checks in two modules to ensure that C MSG read errors are not thrown
 
 
 Version 2.1.7 (March 24, 2023)

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -207,7 +207,7 @@ def run(show_plots):
     scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
-    scSim.AddModelToTask(simTaskName, scObject)
+    scSim.AddModelToTask(simTaskName, scObject, ModelPriority=100)
 
     # clear prior gravitational body and SPICE setup definitions
     gravFactory = simIncludeGravBody.gravBodyFactory()
@@ -245,13 +245,13 @@ def run(show_plots):
     # Note that all variables are initialized to zero.  Thus, not setting this
     # vector would leave it's components all zero for the simulation.
     scObject.addDynamicEffector(extFTObject)
-    scSim.AddModelToTask(simTaskName, extFTObject)
+    scSim.AddModelToTask(simTaskName, extFTObject, ModelPriority=90)
 
     # add the simple Navigation sensor module.  This sets the SC attitude, rate, position
     # velocity navigation message
     sNavObject = simpleNav.SimpleNav()
     sNavObject.ModelTag = "SimpleNavigation"
-    scSim.AddModelToTask(simTaskName, sNavObject)
+    scSim.AddModelToTask(simTaskName, sNavObject, ModelPriority=100)
     sNavObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
 
     # Create the initial imaging target
@@ -262,7 +262,7 @@ def run(show_plots):
     imagingTarget.minimumElevation = np.radians(10.)
     imagingTarget.maximumRange = 1e9
     imagingTarget.addSpacecraftToModel(scObject.scStateOutMsg)
-    scSim.AddModelToTask(simTaskName, imagingTarget, ModelPriority=1000)
+    scSim.AddModelToTask(simTaskName, imagingTarget, ModelPriority=100)
 
     # Create a ground station in Singapore
     singaporeStation = groundLocation.GroundLocation()
@@ -272,7 +272,7 @@ def run(show_plots):
     singaporeStation.minimumElevation = np.radians(5.)
     singaporeStation.maximumRange = 1e9
     singaporeStation.addSpacecraftToModel(scObject.scStateOutMsg)
-    scSim.AddModelToTask(simTaskName, singaporeStation, ModelPriority=1000)
+    scSim.AddModelToTask(simTaskName, singaporeStation, ModelPriority=100)
 
     # Create a "transmitter"
     transmitter = spaceToGroundTransmitter.SpaceToGroundTransmitter()
@@ -281,14 +281,14 @@ def run(show_plots):
     transmitter.packetSize = -8E6   # bits
     transmitter.numBuffers = 2
     transmitter.addAccessMsgToTransmitter(singaporeStation.accessOutMsgs[-1])
-    scSim.AddModelToTask(simTaskName, transmitter, ModelPriority=102)
+    scSim.AddModelToTask(simTaskName, transmitter, ModelPriority=99)
 
     # Create an instrument
     instrument = simpleInstrument.SimpleInstrument()
     instrument.ModelTag = "instrument1"
     instrument.nodeBaudRate = 8E6  # baud, assumes the instantaneous writing of a single image
     instrument.nodeDataName = "boulder"
-    scSim.AddModelToTask(simTaskName, instrument, ModelPriority=101)
+    scSim.AddModelToTask(simTaskName, instrument, ModelPriority=90)
 
     # Create a partitionedStorageUnit and attach the instrument to it
     dataMonitor = partitionedStorageUnit.PartitionedStorageUnit()
@@ -298,7 +298,7 @@ def run(show_plots):
     dataMonitor.addDataNodeToModel(transmitter.nodeDataOutMsg)
     dataMonitor.addPartition("boulder")
     dataMonitor.addPartition("santiago")
-    scSim.AddModelToTask(simTaskName, dataMonitor, ModelPriority=100)
+    scSim.AddModelToTask(simTaskName, dataMonitor, ModelPriority=89)
     transmitter.addStorageUnitToTransmitter(dataMonitor.storageUnitDataOutMsg)
 
     #
@@ -319,7 +319,7 @@ def run(show_plots):
     mrpControlConfig = mrpFeedback.mrpFeedbackConfig()
     mrpControlWrap = scSim.setModelDataWrap(mrpControlConfig)
     mrpControlWrap.ModelTag = "mrpFeedback"
-    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig, ModelPriority=901)
+    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig, ModelPriority=98)
     mrpControlConfig.guidInMsg.subscribeTo(locPointConfig.attGuidOutMsg)
     mrpControlConfig.K = 5.5
     mrpControlConfig.Ki = -1  # make value negative to turn off integral feedback
@@ -336,7 +336,7 @@ def run(show_plots):
     simpleInsControlWrap.ModelTag = "instrumentController"
     simpleInsControlConfig.attGuidInMsg.subscribeTo(locPointConfig.attGuidOutMsg)
     simpleInsControlConfig.locationAccessInMsg.subscribeTo(imagingTarget.accessOutMsgs[-1])
-    scSim.AddModelToTask(simTaskName, simpleInsControlWrap, simpleInsControlConfig, ModelPriority=900)
+    scSim.AddModelToTask(simTaskName, simpleInsControlWrap, simpleInsControlConfig, ModelPriority=97)
     instrument.nodeStatusInMsg.subscribeTo(simpleInsControlConfig.deviceCmdOutMsg)
 
     #

--- a/examples/scenarioGroundMapping.py
+++ b/examples/scenarioGroundMapping.py
@@ -212,7 +212,7 @@ def run(show_plots, useCentral):
 
     timeInitString = '2020 MAY 21 18:28:03 (UTC)'
     gravFactory.createSpiceInterface(bskPath + '/supportData/EphemerisData/', timeInitString)
-    scSim.AddModelToTask(simTaskName, gravFactory.spiceObject, None, -1)
+    scSim.AddModelToTask(simTaskName, gravFactory.spiceObject, ModelPriority=100)
 
     # Attach gravity model to spacecraft
     scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))
@@ -244,13 +244,13 @@ def run(show_plots, useCentral):
     extFTObject = extForceTorque.ExtForceTorque()
     extFTObject.ModelTag = "externalDisturbance"
     scObject.addDynamicEffector(extFTObject)
-    scSim.AddModelToTask(simTaskName, extFTObject)
+    scSim.AddModelToTask(simTaskName, extFTObject, ModelPriority=95)
 
     # add the simple Navigation sensor module.  This sets the SC attitude, rate, position
     # velocity navigation message
     sNavObject = simpleNav.SimpleNav()
     sNavObject.ModelTag = "SimpleNavigation"
-    scSim.AddModelToTask(simTaskName, sNavObject)
+    scSim.AddModelToTask(simTaskName, sNavObject, ModelPriority=99)
     sNavObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
 
     # Generate the mapping points
@@ -291,13 +291,13 @@ def run(show_plots, useCentral):
     ephemConverter = ephemerisConverter.EphemerisConverter()
     ephemConverter.ModelTag = "ephemConverter"
     ephemConverter.addSpiceInputMsg(gravFactory.spiceObject.planetStateOutMsgs[0])
-    scSim.AddModelToTask(simTaskName, ephemConverter)
+    scSim.AddModelToTask(simTaskName, ephemConverter, ModelPriority=98)
 
     # Setup nadir pointing guidance module
     locPointConfig = locationPointing.locationPointingConfig()
     locPointWrap = scSim.setModelDataWrap(locPointConfig)
     locPointWrap.ModelTag = "locPoint"
-    scSim.AddModelToTask(simTaskName, locPointWrap, locPointConfig, ModelPriority=99)
+    scSim.AddModelToTask(simTaskName, locPointWrap, locPointConfig, ModelPriority=97)
     locPointConfig.pHat_B = [0, 0, 1]
     locPointConfig.scAttInMsg.subscribeTo(sNavObject.attOutMsg)
     locPointConfig.scTransInMsg.subscribeTo(sNavObject.transOutMsg)
@@ -307,7 +307,7 @@ def run(show_plots, useCentral):
     mrpControlConfig = mrpFeedback.mrpFeedbackConfig()
     mrpControlWrap = scSim.setModelDataWrap(mrpControlConfig)
     mrpControlWrap.ModelTag = "MRP_Feedback"
-    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig, ModelPriority=901)
+    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig, ModelPriority=96)
     mrpControlConfig.guidInMsg.subscribeTo(locPointConfig.attGuidOutMsg)
     mrpControlConfig.K = 5.5
     mrpControlConfig.Ki = -1  # make value negative to turn off integral feedback

--- a/examples/scenarioMomentumDumping.py
+++ b/examples/scenarioMomentumDumping.py
@@ -118,8 +118,8 @@ def run(show_plots):
     simulationTime = macros.min2nano(5)
     simulationTimeStepFsw = macros.sec2nano(1)
     simulationTimeStepDyn = macros.sec2nano(0.1)
-    dynProcess.addTask(scSim.CreateNewTask(fswTask, simulationTimeStepFsw))
     dynProcess.addTask(scSim.CreateNewTask(dynTask, simulationTimeStepDyn))
+    dynProcess.addTask(scSim.CreateNewTask(fswTask, simulationTimeStepFsw))
     
     #
     # setup the simulation tasks/objects

--- a/examples/scenarioSensorThermal.py
+++ b/examples/scenarioSensorThermal.py
@@ -157,7 +157,7 @@ def run(show_plots):
     gravFactory.createSpiceInterface(bskPath + '/supportData/EphemerisData/'
                                      , '2021 MAY 04 07:47:48.965 (UTC)'
                                      )
-    scSim.AddModelToTask(simTaskName, gravFactory.spiceObject)
+    scSim.AddModelToTask(simTaskName, gravFactory.spiceObject, ModelPriority=100)
 
     # Set up the orbit using classical orbit elements
     oe = orbitalMotion.ClassicElements()
@@ -179,12 +179,12 @@ def run(show_plots):
     extFTObject = extForceTorque.ExtForceTorque()
     extFTObject.ModelTag = "externalDisturbance"
     scObject.addDynamicEffector(extFTObject)
-    scSim.AddModelToTask(simTaskName, extFTObject)
+    scSim.AddModelToTask(simTaskName, extFTObject, 97)
 
     # Add the simple Navigation sensor module.  This sets the SC attitude, rate, position
     sNavObject = simpleNav.SimpleNav()
     sNavObject.ModelTag = "SimpleNavigation"
-    scSim.AddModelToTask(simTaskName, sNavObject)
+    scSim.AddModelToTask(simTaskName, sNavObject, ModelPriority=101)
     sNavObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
 
     # Create the ephemeris converter
@@ -192,7 +192,7 @@ def run(show_plots):
     ephemConverter.ModelTag = "ephemConverter"
     ephemConverter.addSpiceInputMsg(gravFactory.spiceObject.planetStateOutMsgs[0])
     ephemConverter.addSpiceInputMsg(gravFactory.spiceObject.planetStateOutMsgs[1])
-    scSim.AddModelToTask(simTaskName, ephemConverter)
+    scSim.AddModelToTask(simTaskName, ephemConverter, ModelPriority=100)
 
     # Set up sun pointing guidance module
     locPointConfig = locationPointing.locationPointingConfig()
@@ -208,7 +208,7 @@ def run(show_plots):
     mrpControlConfig = mrpFeedback.mrpFeedbackConfig()
     mrpControlWrap = scSim.setModelDataWrap(mrpControlConfig)
     mrpControlWrap.ModelTag = "mrpFeedback"
-    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig, ModelPriority=901)
+    scSim.AddModelToTask(simTaskName, mrpControlWrap, mrpControlConfig, ModelPriority=98)
     mrpControlConfig.guidInMsg.subscribeTo(locPointConfig.attGuidOutMsg)
     mrpControlConfig.K = 5.5
     mrpControlConfig.Ki = -1  # make value negative to turn off integral feedback

--- a/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.c
@@ -132,8 +132,12 @@ void Reset_sunlineSuKF(SunlineSuKFConfig *configData, uint64_t callTime,
                                (int32_t) configData->numStates, configData->sQnoise);
     mTranspose(configData->sQnoise, configData->numStates,
                configData->numStates, configData->sQnoise);
-
-    configData->cssSensorInBuffer = CSSArraySensorMsg_C_read(&configData->cssDataInMsg);
+    
+    if (CSSArraySensorMsg_C_isWritten(&configData->cssDataInMsg)){
+        configData->cssSensorInBuffer = CSSArraySensorMsg_C_read(&configData->cssDataInMsg);
+    } else {
+        configData->cssSensorInBuffer = CSSArraySensorMsg_C_zeroMsgPayload();
+    }
 
     if (badUpdate <0){
         _bskLog(configData->bskLogger, BSK_WARNING, "Reset method contained bad update");

--- a/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
@@ -84,8 +84,8 @@ void Reset_thrMomentumDumping(thrMomentumDumpingConfig *configData, uint64_t cal
     mSetZero(configData->thrOnTimeRemaining, 1, MAX_EFF_CNT);
 
     /*! - set the time tag of the last Delta_p message */
-    DeltaHInMsg = CmdTorqueBodyMsg_C_read(&configData->deltaHInMsg);
     if (CmdTorqueBodyMsg_C_isWritten(&configData->deltaHInMsg)) {
+        DeltaHInMsg = CmdTorqueBodyMsg_C_read(&configData->deltaHInMsg);
         /* prior message has been written, copy its time tag as the last prior message */
         configData->lastDeltaHInMsgTime = CmdTorqueBodyMsg_C_timeWritten(&configData->deltaHInMsg);
     } else {


### PR DESCRIPTION
* **Tickets addressed:** bsk-360
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This commit fixes a C message read error from being output when several scenario files are run and/or modules are used. The following scenario files required a re-assignment of task priorities:

- scenarioGroundLocationImaging.py
- scenarioGroundMapping.py
- scenarioMomentumDumping.py
- scenarioSensorThermal.py

Furthermore, the following two modules required a MsgType_C_isWritten() check be added to the Reset() function. This ensures that the aforementioned error is not thrown upon an initial reset of the module when the corresponding message has not been written yet. 

- sunlineSuKF
- thrMomentumDumping

## Verification
These changes were validated by running the following scenario scripts to ensure the C msg read error was not thrown:

- scenarioGroundLocationImaging.py
- scenarioGroundMapping.py
- scenarioMomentumDumping.py
- scenarioSensorThermal.py
- scenarioCSSFilters.py

No unit tests were changed.

## Documentation
No documentation was invalidated from these changes. Release notes were updated.

## Future work
N/A