### PR TITLE
Update daylight savings issue in environment base classes

### DIFF
--- a/run_all_test.py
+++ b/run_all_test.py
@@ -1,4 +1,4 @@
 from os import system
 
-system('cd src && pytest -n auto')
 system('cd dist3 && ctest -C Release')
+system('cd src && pytest -n auto')

--- a/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
+++ b/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
@@ -220,13 +220,13 @@ def run(show_plots, orbitCase, setEpoch):
     #   and must be adjusted by a factor of 1e-3 to match kg/m^3
     print(densData[-1])
     print(refAtmoData[5]*1000)
-    if not unitTestSupport.isDoubleEqualRelative(densData[-1], refAtmoData[5]*1000., accuracy):
+    if np.testing.assert_allclose(densData[-1], refAtmoData[5]*1000., atol=accuracy):
         testFailCount += 1
         testMessages.append("FAILED:  NRLMSISE-00 failed density unit test with a value difference of "+str(densData[0]-refAtmoData[5]*1000))
 
     print(tempData[-1])
     print(refAtmoData[-1])
-    if not unitTestSupport.isDoubleEqualRelative(tempData[-1], refAtmoData[-1], accuracy):
+    if np.testing.assert_allclose(tempData[-1], refAtmoData[-1], atol=accuracy):
         testFailCount += 1
         testMessages.append(
         "FAILED:  NRLMSISE-00 failed temperature unit test with a value difference of "+str(tempData[-1]-refAtmoData[-1]))

--- a/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
+++ b/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
@@ -219,17 +219,17 @@ def run(show_plots, orbitCase, setEpoch):
     #   Test atmospheric density calculation; note that refAtmoData is in g/cm^3,
     #   and must be adjusted by a factor of 1e-3 to match kg/m^3
     print(densData[-1])
-    print(refAtmoData[5])
+    print(refAtmoData[5]*1000)
     if not unitTestSupport.isDoubleEqualRelative(densData[-1], refAtmoData[5]*1000., accuracy):
         testFailCount += 1
-        testMessages.append("FAILED:  NRLMSISE-00 failed density unit test with a value difference of "+str(densData[0]-refAtmoData[5]))
+        testMessages.append("FAILED:  NRLMSISE-00 failed density unit test with a value difference of "+str(densData[0]-refAtmoData[5]*1000))
 
     print(tempData[-1])
     print(refAtmoData[-1])
     if not unitTestSupport.isDoubleEqualRelative(tempData[-1], refAtmoData[-1], accuracy):
         testFailCount += 1
         testMessages.append(
-        "FAILED:  NRLMSISE-00 failed temperature unit test with a value difference of "+str(tempData[0]-refAtmoData[-1]))
+        "FAILED:  NRLMSISE-00 failed temperature unit test with a value difference of "+str(tempData[-1]-refAtmoData[-1]))
 
     snippentName = "unitTestPassFail" + str(orbitCase) + str(setEpoch)
     if testFailCount == 0:

--- a/src/simulation/environment/_GeneralModuleFiles/atmosphereBase.cpp
+++ b/src/simulation/environment/_GeneralModuleFiles/atmosphereBase.cpp
@@ -43,7 +43,7 @@ AtmosphereBase::AtmosphereBase()
     this->epochDateTime.tm_hour = EPOCH_HOUR;
     this->epochDateTime.tm_min = EPOCH_MIN;
     this->epochDateTime.tm_sec = (int) round(EPOCH_SEC);
-    this->epochDateTime.tm_isdst = 0;
+    this->epochDateTime.tm_isdst = -1;
 
     //! - turn off minimum and maximum reach features
     this->envMinReach = -1;
@@ -117,7 +117,6 @@ void AtmosphereBase::Reset(uint64_t CurrentSimNanos)
         this->epochDateTime.tm_hour = epochMsg.hours;
         this->epochDateTime.tm_min = epochMsg.minutes;
         this->epochDateTime.tm_sec = (int) round(epochMsg.seconds);
-        this->epochDateTime.tm_isdst = 0;
         mktime(&this->epochDateTime);
     } else {
         customSetEpochFromVariable();

--- a/src/simulation/environment/_GeneralModuleFiles/magneticFieldBase.cpp
+++ b/src/simulation/environment/_GeneralModuleFiles/magneticFieldBase.cpp
@@ -45,6 +45,7 @@ MagneticFieldBase::MagneticFieldBase()
     this->epochDateTime.tm_hour = EPOCH_HOUR;
     this->epochDateTime.tm_min = EPOCH_MIN;
     this->epochDateTime.tm_sec = (int) round(EPOCH_SEC);
+    this->epochDateTime.tm_isdst = -1;
 
 
     //! - zero the planet message, and set the DCM to an identity matrix
@@ -106,7 +107,6 @@ void MagneticFieldBase::Reset(uint64_t CurrentSimNanos)
         this->epochDateTime.tm_hour = epochMsg.hours;
         this->epochDateTime.tm_min = epochMsg.minutes;
         this->epochDateTime.tm_sec = (int) round(epochMsg.seconds);
-        this->epochDateTime.tm_isdst = 0;
         mktime(&this->epochDateTime);
     } else {
         customSetEpochFromVariable();


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The MSIS module was failing when run from Australia in June, compared to running it from the US or on 
the GitHub CI servers.  The issues was a difference in the system daylight savings time flag in the time structure.
Now, in the atmosphere and magnetic field base classes the time default time structures are set to not 
use the daylight savings flag.

## Verification
All unit tests pass again.

## Documentation
None

## Future work
None