### PR TITLE
Fix message members python bool types returned as empty dict

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -68,6 +68,7 @@ Version |release|
 - Added an optional ``controllerStatus`` variable and ``deviceStatusInMsg`` message to the :ref:`simpleInstrumentController` to 
   match the functionality of the corresponding data and power modules
 - Corrected tasks priorities in several scenarios and added checks in two modules to ensure that C MSG read errors are not thrown
+- Fixed bug where message struct members of bool python types are returned as empty dicts instead of array of bools
 
 
 Version 2.1.7 (March 24, 2023)

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -94,7 +94,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
             return np.array(self.__timeWritten_vector())
 
         def explore_and_find_subattr(self,attr,attr_name,content):
-            if "method" in str(type(attr)) or "bool" in str(type(attr)):
+            if "method" in str(type(attr)):
                 # The attribute is a method, nothing to do here
                 pass
             elif isinstance(attr,list):

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -15,8 +15,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 */
 
-
-
 %pythoncode %{
     import numpy as np
 %};
@@ -45,7 +43,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 if type(source) == messageType ## _C:
                     self.__subscribe_to_C(source)
                 else:
-                    raise Exception('tried to subscribe ReadFunctor<messageTypePayload> to output message type' + str(type(source)))
+                    raise Exception('tried to subscribe ReadFunctor<messageTypePayload> to output message type'
+                                    + str(type(source)))
 
 
             def isSubscribedTo(self, source):
@@ -56,10 +55,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                     if type(source) == messageType ## _C:
                         return self.__is_subscribed_to_C(source)
                     else:
-                        return 0                
-
-
-
+                        return 0
         %}
 };
 
@@ -69,7 +65,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 %extend Message<messageTypePayload>{
     %pythoncode %{
         def write(self, payload, time=0, moduleID=0):
-            """write the message payload.
+            """Write the message payload.
             The 2nd argument is time in nanoseconds.  It is optional and defaults to 0.
             The 3rd argument is the module ID which defaults to 0.
             """
@@ -78,7 +74,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
             return self
 
         def read(self):
-            """read the message payload"""
+            """Read the message payload."""
             readMsg = self.addSubscriber()
             return readMsg()
     %}
@@ -93,17 +89,17 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         def timesWritten(self):
             return np.array(self.__timeWritten_vector())
 
-        def explore_and_find_subattr(self,attr,attr_name,content):
+        def explore_and_find_subattr(self, attr, attr_name, content):
             if "method" in str(type(attr)):
                 # The attribute is a method, nothing to do here
                 pass
-            elif isinstance(attr,list):
+            elif isinstance(attr, list):
                 # The attribute is a list of yet to be determined types
                 if len(attr) > 0:
                     if "Basilisk" in str(type(attr[0])):
                         # The attribute is a list of swigged BSK objects
-                        for el,k in zip(attr,range(len(attr))):
-                            self.explore_and_find_subattr(el,attr_name + "[" + str(k) + "]",content)
+                        for el, k in zip(attr, range(len(attr))):
+                            self.explore_and_find_subattr(el, attr_name + "[" + str(k) + "]", content)
                     else:
                         # The attribute is a list of common types 
                         content[attr_name] = attr
@@ -117,11 +113,12 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 else:
                     for subattr_name in  dir(attr):
                         if not subattr_name.startswith("__") and subattr_name != "this":
-                            self.explore_and_find_subattr(getattr(attr,subattr_name),attr_name + "." + subattr_name,content)
+                            self.explore_and_find_subattr(getattr(attr, subattr_name),
+                                                          attr_name + "." + subattr_name,
+                                                          content)
             else:
                 # The attribute has a common type
                 content[attr_name] = attr
-
 
         # This __getattr__ is written in message.i.
         # It lets us return message struct attribute record as lists for plotting, etc.
@@ -130,12 +127,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
             data_record = []
             for rec in data.iterator():
                 content = {}
-                self.explore_and_find_subattr(rec.__getattribute__(name),name,content)
+                self.explore_and_find_subattr(rec.__getattribute__(name), name, content)
                 if len(content) == 1 and "." not in str(list(content.keys())[0]):
                     data_record.append(next(iter(content.values())))
                 else:
                     data_record.append(content)
-
 
             return np.array(data_record)
 
@@ -159,4 +155,3 @@ typedef struct messageType;
     %}
 };
 %enddef
-


### PR DESCRIPTION
* **Tickets addressed:** resolves #373
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This is a simple fix of removing the `bool` type from being passed on. A full description of the problem is found at #373 

## Verification
Correct behavior is exhibited and all tests and scenarios pass. I'm looking at adding further unit tests on the generated code for messages. If it's not part of this PR it will be in a ticket that I pick up right after (being a good Basilisk citizen 😄  ).

## Documentation
No new documentation needed and none invalidated.

## Future work
None
