### PR TITLE
Disable encryption build option for ZMQ conan dependency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -184,8 +184,8 @@ class BasiliskConan(ConanFile):
             self.requires.add("xz_utils/5.4.0")
 
         if self.options.vizInterface or self.options.opNav:
-            self.requires.add("libsodium/1.0.18")
             self.requires.add("protobuf/3.17.1")
+            self.options['zeromq'].encryption = False  # Basilisk does not use data streaming encryption.
             self.requires.add("cppzmq/4.5.0")
 
     def configure(self):

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -51,7 +51,8 @@ Version |release|
   radius of Mars. 
 - Added custom planet name to :ref:`eclipse` in case the user wants to use a body not contained within the module.
 - Removed all instances of using ``unitTestSupport.np2EigenVectorXd()``, as this function is now unneeded.
-- Created a :ref:`facetSRPDynamicEffector` dynamics module to calculate the B frame SRP force and torque acting on a static spacecraft.
+- Created a :ref:`facetSRPDynamicEffector` dynamics module to calculate the B frame SRP force and torque acting on a
+  static spacecraft.
 - fixed ``PCI2PCPF()`` and ``PCPF2PCI`` methods in :ref:`geodeticConversion` to use the correct DCM
 - updated :ref:`geodeticConversion` to be able to account for planet ellipsoidal shape if polar radius is provided
 - Google Test C/C++ testing framework added
@@ -62,15 +63,17 @@ Version |release|
 - Added a deprecation system for Basilisk. For developers, see :ref:`deprecatingCode`.
 - Changed the units of plasma flux in :ref:`dentonFluxModel` and :ref:`PlasmaFluxMsgPayload` from
   [cm^-2 s^-1 sr^-2 eV^-1] to [m^-2 s^-1 sr^-2 eV^-1], because m^-2 is used more frequently in computations
-- Fixed a bug in eclipse that caused potentially occluding bodies to be skipped if a prior body was closer to the sun than
-  the spacecraft
+- Fixed a bug in eclipse that caused potentially occluding bodies to be skipped if a prior body was closer to the sun
+  than the spacecraft
 - fixed the time evaluation in :ref:`msisAtmosphere`
-- Added an optional ``controllerStatus`` variable and ``deviceStatusInMsg`` message to the :ref:`simpleInstrumentController` to 
-  match the functionality of the corresponding data and power modules
-- Corrected tasks priorities in several scenarios and added checks in two modules to ensure that C MSG read errors are not thrown
-- Fixed bug where message struct members of bool python types are returned as empty dicts instead of array of bools
+- Added an optional ``controllerStatus`` variable and ``deviceStatusInMsg`` message to the
+  :ref:`simpleInstrumentController` to match the functionality of the corresponding data and power modules
+- Corrected tasks priorities in several scenarios and added checks in two modules to ensure that C MSG read errors are
+  not thrown
+- Fixed bug where message struct members of bool python types are returned as empty dicts instead of array of boolsgit
 - Refactored the :ref:`prescribedMotionStateEffector` dynamics module to vary the prescribed states across the dynamics
   integration time step.
+- The encryption build option for the project's conan zmq dependency is disabled because it is uneeded.
 
 
 Version 2.1.7 (March 24, 2023)


### PR DESCRIPTION
* **Tickets addressed:** #376 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR disables the encryption build option for ZMQ conan dependency. The project doesn't use encryption with its use of zmq. Disabling this has the effect of removing the transient libsodium dependency for conan and the build. All for a slightly faster build.

## Verification
CI runs successfully.

## Documentation
None needed and none invalidated. 

## Future work
None
