### PR TITLE
thrusterStateEffector nameOfKappaState bug

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,7 +10,9 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
-- text here
+- There was an issue with :ref:`thrusterStateEffector` where if there are multiple instances of the
+  thruster state effector then the last effector will over-write all the state of the earlier thrusters.
+  This is corrected in the current release.
 
 Version 2.2.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -38,6 +38,8 @@ Version |release|
 - A new integrated example script :ref:`scenarioSmallBodyLandmarks` demonstrates the use of the pinhole camera module
 - Created a new example scenario :ref:`scenarioSpinningBodiesTwoDOF` that showcases the different capabilities of the
   :ref:`spinningBodyTwoDOFStateEffector` module.
+- Corrected an error with :ref:`thrusterStateEffector` where if there are multiple instances of the
+  thruster state effector then the last effector will over-write all the state of the earlier thrusters.
 
 
 Version 2.2.0 (June 28, 2023)

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -45,6 +45,7 @@ ThrusterStateEffector::ThrusterStateEffector()
     CallCounts = 0;
     this->prevCommandTime = -1.0;  // initialize to a negative number to allow an onTime command at t=0
     this->mDotTotal = 0.0;
+    this->nameOfKappaState = "kappaState" + std::to_string(this->effectorID);
     this->effectorID++;
 
     // clear all vectors

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.cpp
@@ -34,6 +34,11 @@ DynParamManager::~DynParamManager()
 StateData* DynParamManager::registerState(uint32_t nRow, uint32_t nCol,
     std::string stateName)
 {
+    if (stateName == "") {
+        bskLogger.bskLog(BSK_ERROR, "Your state name can't be an empty string.  Come on.  You get null.");
+        return nullptr;
+    }
+
     std::map<std::string, StateData>::iterator it;
     it = stateContainer.stateMap.find(stateName);
     if(it != stateContainer.stateMap.end())


### PR DESCRIPTION
* **Tickets addressed:** bsk-404
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The missing line was added to store the nameOfKappaState variable before the effectorID variable gets updated.

## Future work
No future work is foreseen.
