### PR TITLE
Magnetometer fix noise initialization

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -40,6 +40,7 @@ Version |release|
   :ref:`spinningBodyTwoDOFStateEffector` module.
 - Corrected an error with :ref:`thrusterStateEffector` where if there are multiple instances of the
   thruster state effector then the last effector will over-write all the state of the earlier thrusters.
+- Corrected an error with :ref:`magnetometer` where the RNG seed was passed to the Gauss-Markov noise model within the constructor and could therefore not be modified after creating the object. Furthermore, the noise model is now only used if all three components of the standard deviation parameter are initialized to a positive value.
 
 
 Version 2.2.0 (June 28, 2023)

--- a/src/simulation/sensors/magnetometer/magnetometer.cpp
+++ b/src/simulation/sensors/magnetometer/magnetometer.cpp
@@ -124,12 +124,15 @@ void Magnetometer::computeTrueOutput()
 void Magnetometer::applySensorErrors()
 {
     //! - If any of the standard deviation vector elements is not positive, do not use noise error from RNG.
-    double n0 = 0.0;
-    for (unsigned i = 0; i < this->senNoiseStd.size(); i++){
-        if ((this->senNoiseStd(i) <= 0.0)) {n0++;}
-    }    
-    if (n0 == this->senNoiseStd.size()) {this->tamSensed_S = this->tamTrue_S;}
-    else {
+    bool anyNoiseComponentUninitialized = false;
+    for (unsigned i = 0; i < this->senNoiseStd.size(); i++) {
+        if ((this->senNoiseStd(i) <= 0.0)) {
+            anyNoiseComponentUninitialized = true;
+        }
+    }
+    if (anyNoiseComponentUninitialized) {
+        this->tamSensed_S = this->tamTrue_S;
+    } else {
         //! - Get current error from random number generator
         this->noiseModel.computeNextState();
         Eigen::Vector3d currentError = this->noiseModel.getCurrentState();

--- a/src/simulation/sensors/magnetometer/magnetometer.cpp
+++ b/src/simulation/sensors/magnetometer/magnetometer.cpp
@@ -37,7 +37,6 @@ Magnetometer::Magnetometer()
     this->senNoiseStd.fill(-1.0); // Tesla
     this->walkBounds.fill(0.0);
     this->noiseModel = GaussMarkov(this->numStates);
-    this->noiseModel.setRNGSeed(this->RNGSeed);
     this->scaleFactor = 1.0;
     this->maxOutput = 1e200; // Tesla
     this->minOutput = -1e200; // Tesla
@@ -77,6 +76,7 @@ void Magnetometer::Reset(uint64_t CurrentSimNanos)
     this->noiseModel.setUpperBounds(this->walkBounds);
     auto nMatrix = (this->senNoiseStd * 1.5).asDiagonal();
     this->noiseModel.setNoiseMatrix(nMatrix);
+    this->noiseModel.setRNGSeed(this->RNGSeed);
     Eigen::MatrixXd satBounds;
     satBounds.resize(this->numStates, 2);
     satBounds(0, 0) = this->minOutput;


### PR DESCRIPTION
* **Tickets addressed:** #411
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
- Fix #411 by moving the line `this->noiseModel.setRNGSeed(this->RNGSeed); ` from the magnetometer's constructor to the `Reset` method
- Also, fix the beginning of `Magnetometer::applySensorErrors` which checks that the 3 components of the noise std are initialized. Previously, unlike what is written in the comment at line 126, the noise model was disabled if all three components of this->senNoiseStd are uninitialized. Now the code already disables the noise model if only one of the 3 components of this->senNoiseStd is uninitialized.

## Verification
The noise of two magnetometers with different RNG seeds were plotted: before the fix, they were correlated, and after the fix they are not correlated anymore.

The magnetometer's unit test was not edited to check that the noise model was set up with the proper RNG seed because the `noiseModel` member variable is private within the `Magnetometer` class.