### PR TITLE
Feature/update conan dependencies

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -174,7 +174,7 @@ class BasiliskConan(ConanFile):
     def requirements(self):
         if self.options.opNav:
             self.requires.add("pcre/8.45")
-            self.requires.add("opencv/4.1.2")
+            self.requires.add("opencv/4.1.2#b610ad323f67adc1b51e402cb5d68d70")
             self.options['opencv'].with_ffmpeg = False  # video frame encoding lib
             self.options['opencv'].with_ade = False  # graph manipulations framework
             self.options['opencv'].with_tiff = False  # generate image in TIFF format

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -13,6 +13,8 @@ Version |release|
 - There was an issue with :ref:`thrusterStateEffector` where if there are multiple instances of the
   thruster state effector then the last effector will over-write all the state of the earlier thrusters.
   This is corrected in the current release.
+- Doing a clean Basilisk build with `opNav` flag on fails building openCV.  The conan
+  install script is updated this is corrected in the current release.
 
 Version 2.2.0
 -------------


### PR DESCRIPTION
* **Tickets addressed:** bsk-413
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Basilisk install process with `opNav` flag on is broken because of the underlying `conan` `openCV/4.1.2` version has changed.  This PR sets the earlier version of `openCV/4.1.2` to be included.

## Verification
Deleted `.conan` and did a completely clean build.  All tests are passing.

## Documentation
Updated known issues files.

## Future work
N/A
