### PR TITLE
Refactor/418 mrp feedback control law flag

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -46,6 +46,7 @@ Version |release|
   removing the need for "Config" and "Wrap" objects. Updated all scenarios and test files for this new syntax.
   To convert prior script to use the new syntax, see :ref:`bskPrinciples-2` for the simple new
   syntaxt to add C-modules.
+- Modified :ref:`mrpFeedback` to enable the use of a modified control law, and added the integral control torque feedback output message.
 
 
 Version 2.2.0 (June 28, 2023)

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
@@ -39,6 +39,7 @@
 void SelfInit_mrpFeedback(mrpFeedbackConfig *configData, int64_t moduleID)
 {
     CmdTorqueBodyMsg_C_init(&configData->cmdTorqueOutMsg);
+    CmdTorqueBodyMsg_C_init(&configData->intFeedbackTorqueOutMsg);
 }
 
 
@@ -109,6 +110,7 @@ void Update_mrpFeedback(mrpFeedbackConfig *configData, uint64_t callTime,
     RWSpeedMsgPayload      wheelSpeeds;        /* Reaction wheel speed message */
     RWAvailabilityMsgPayload wheelsAvailability; /* Reaction wheel availability message */
     CmdTorqueBodyMsgPayload controlOut;        /* output message */
+    CmdTorqueBodyMsgPayload intFeedbackOut;    /* output int feedback msg */
 
     double              dt;                 /* [s] control update period */
     double              Lr[3];              /* required control torque vector [Nm] */
@@ -208,6 +210,10 @@ void Update_mrpFeedback(mrpFeedbackConfig *configData, uint64_t callTime,
     /*! - set the output message and write it out */
     v3Copy(Lr, controlOut.torqueRequestBody);
     CmdTorqueBodyMsg_C_write(&controlOut, &configData->cmdTorqueOutMsg, moduleID, callTime);
+
+    /*! - write the output integral feedback torque */
+    v3Scale(-1.0, v3_5, intFeedbackOut.torqueRequestBody);
+    CmdTorqueBodyMsg_C_write(&intFeedbackOut, &configData->intFeedbackTorqueOutMsg, moduleID, callTime);
 
     return;
 }

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
@@ -194,7 +194,12 @@ void Update_mrpFeedback(mrpFeedbackConfig *configData, uint64_t callTime,
         }
     }
 
-    v3Add(guidCmd.omega_RN_B, v3_4, v3_8);
+    if (configData->controlLawType == 0) {
+        v3Add(guidCmd.omega_RN_B, v3_4, v3_8);      /* v3_8 = omega_RN_B + K_I * z */
+    }
+    else {
+        v3Copy(omega_BN_B, v3_8);                        /* v3_8 = omega_BN_B */
+    }
     v3Cross(v3_8, v3_6, v3_9);
     v3Subtract(Lr, v3_9, Lr);
 

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.h
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.h
@@ -50,6 +50,7 @@ typedef struct {
     RWAvailabilityMsg_C rwAvailInMsg;                   //!< RW availability input message (Optional)
     RWArrayConfigMsg_C rwParamsInMsg;                   //!< RW parameter input message.  (Optional)
     CmdTorqueBodyMsg_C cmdTorqueOutMsg;                 //!< commanded spacecraft external control torque output message
+    CmdTorqueBodyMsg_C intFeedbackTorqueOutMsg;         //!< commanded integral feedback control torque output message
     AttGuidMsg_C guidInMsg;                             //!< attitude guidance input message
     VehicleConfigMsg_C vehConfigInMsg;                  //!< vehicle configuration input message
 

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.h
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.h
@@ -37,6 +37,7 @@ typedef struct {
     double P;                           //!< [N*m*s]   Rate error feedback gain applied
     double Ki;                          //!< [N*m]     Integration feedback error on rate error
     double integralLimit;               //!< [N*m]     Integration limit to avoid wind-up issue
+    int    controlLawType;              //!<           Flag to choose between the two control laws available
     uint64_t priorTime;                 //!< [ns]      Last time the attitude control is called
     double z[3];                        //!< [rad]     integral state of delta_omega
     double int_sigma[3];                //!< [s]       integral of the MPR attitude error

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.rst
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.rst
@@ -17,27 +17,34 @@ provides information on what this message is used for.
 
     Figure 1: ``mrpFeedback()`` Module I/O Illustration
 
-.. table:: Module I/O Messages
-    :widths: 25 25 100
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
 
-    +-----------------------+-----------------------------------+---------------------------------------------------+
-    | Msg Variable Name     | Msg Type                          | Description                                       |
-    +=======================+===================================+===================================================+
-    | cmdTorqueOutMsg       | :ref:`CmdTorqueBodyMsgPayload`    | Control torque output message                     |
-    +-----------------------+-----------------------------------+---------------------------------------------------+
-    | guidInMsg             | :ref:`AttGuidMsgPayload`          | The name of the attitude guidance input message   |
-    +-----------------------+-----------------------------------+---------------------------------------------------+
-    | vehConfigInMsg        | :ref:`VehicleConfigMsgPayload`    | Name of the vehicle configuration input message   |
-    +-----------------------+-----------------------------------+---------------------------------------------------+
-    | rwParamsInMsg         | :ref:`RWArrayConfigMsgPayload`    | (Optional) The name of the RW array configuration |
-    |                       |                                   | input message                                     |
-    +-----------------------+-----------------------------------+---------------------------------------------------+
-    | rwSpeedsInMsg         | :ref:`RWSpeedMsgPayload`          | (Optional) The name for the reaction wheel speeds |
-    |                       |                                   | message                                           |
-    +-----------------------+-----------------------------------+---------------------------------------------------+
-    | rwAvailInMsg          | :ref:`RWAvailabilityMsgPayload`   | (Optional) The name of the RWs availability       |
-    |                       |                                   | message                                           |
-    +-----------------------+-----------------------------------+---------------------------------------------------+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - cmdTorqueOutMsg
+      - :ref:`CmdTorqueBodyMsgPayload`
+      - Control torque output message
+    * - intFeedbackTorqueOutMsg
+      - :ref:`CmdTorqueBodyMsgPayload`
+      - Integral feedback control torque output message
+    * - guidInMsg
+      - :ref:`AttGuidMsgPayload`
+      - Attitude guidance input message
+    * - vehConfigInMsg
+      - :ref:`VehicleConfigMsgPayload`
+      - Vehicle configuration input message
+    * - rwParamsInMsg
+      - :ref:`RWArrayConfigMsgPayload`
+      - Reaction wheel array configuration input message
+    * - rwSpeedsInMsg
+      - :ref:`RWSpeedMsgPayload`
+      - Reaction wheel speeds message
+    * - rwAvailInMsg
+      - :ref:`RWAvailabilityMsgPayload`
+      - Reaction wheel availability message.
 
 
 Detailed Module Description
@@ -142,7 +149,7 @@ Because :math:`(\delta\pmb\omega + [K_{I}]{\bf z} )^{T}  ([\widetilde{\delta\pmb
 
 This proves the new control is globally stabilizing.  Asymptotic stability is shown following the same steps as for the  nonlinear integral feedback control in Eq. (8.104) in `Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__.
 
-One of the goals set forth at the beginning of the example was avoiding quadratic $\bm\omega$ feedback terms to reduce the odds of control saturation during periods with large :math:`\pmb\omega` values.  However, the control in Eq. :eq:`eq:GusRW` contains a product of :math:`\bf z` and :math:`\pmb\omega`.  Let us study this term in more detail.  The :math:`\pmb\omega` expression with this product terms is found to be
+One of the goals set forth at the beginning of the example was avoiding quadratic :math:`\pmb\omega` feedback terms to reduce the odds of control saturation during periods with large :math:`\pmb\omega` values.  However, the control in Eq. :eq:`eq:GusRW` contains a product of :math:`\bf z` and :math:`\pmb\omega`.  Let us study this term in more detail.  The :math:`\pmb\omega` expression with this product terms is found to be
 
 .. math::
     :label: eq:mrp:1
@@ -178,3 +185,14 @@ The gains :math:`K` and :math:`P` must be set to positive values.  The integral 
 If the ``rwParamsInMsg`` is specified, then the associated ``rwSpeedsInMsg`` is required as well.
 
 The ``rwAvailInMsg`` is optional and is used to selectively include RW devices in the control solution.
+
+The ``controlLawType`` is an input that enables the user to choose between two different control laws. When ``controlLawType = 0``, the control law is that specified in :eq:`eq:Lr`. Otherwise, the control law takes the form:
+
+.. math::
+
+    {\bf L}_{r} =  -K \pmb\sigma - [P] \delta\pmb\omega - [P][K_{I}] {\bf z}  - [I_{\text{RW}}](-\dot{\pmb\omega}_{r} + [\tilde{\pmb\omega}]\pmb\omega_{r}) - {\bf L}
+    \\
+    + [\tilde{\pmb \omega}]
+    \left([I_{\text{RW}}]\pmb\omega + [G_{s}]{\bf h}_{s} \right).
+
+This control law is also asymptotically stable. The advantage when compared to :eq:`eq:Lr` is that in this one, the integral control feedback, which may contain integration errors, only appears once. On the downside, this control law depends quadratically on the angular rates of the spacecraft, and could cause a large control torque when the spacecraft is tumbling at a high rate. When unspecified, this parameter defaults to ``controlLawType = 0``.


### PR DESCRIPTION
* **Tickets addressed:** bsk-418
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This pull request modifies the mrpFeedback module to enable the user to choose between two slightly different types of control laws. An additional output is added, which contains the integral feedback control torque. Commit 1 adds this additional output message. In Commit 2, an input flag is added to enable the user to choose between the two control laws. Commit 3 and 4 update the unit test and documentation, respectively.

## Verification
The UnitTest is updated in order to verify the correct output of the new control law.

## Documentation
The documentation is updated to explain the new enhancements

## Future work
No future work is foreseen at the moment.
