### PR TITLE
Feature/421 fix import error in ReadFunctor of C++ messages

### DIFF
--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -39,23 +39,32 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 if type(source) == messageType:
                     self.__subscribe_to(source)
                     return
-                from Basilisk.architecture.messaging.messageType ## Payload import messageType ## _C
-                if type(source) == messageType ## _C:
-                    self.__subscribe_to_C(source)
-                else:
-                    raise Exception('tried to subscribe ReadFunctor<messageTypePayload> to output message type'
-                                    + str(type(source)))
+                
+                try:
+                    from Basilisk.architecture.messaging.messageType ## Payload import messageType ## _C
+                    if type(source) == messageType ## _C:
+                        self.__subscribe_to_C(source)
+                        return
+                except ImportError:
+                    pass
+    
+                raise Exception('tried to subscribe ReadFunctor<messageTypePayload> to output message type'
+                                + str(type(source)))
 
 
             def isSubscribedTo(self, source):
                 if type(source) == messageType:
                     return self.__is_subscribed_to(source)
-                else:
+                
+                try:
                     from Basilisk.architecture.messaging.messageType ## Payload import messageType ## _C
-                    if type(source) == messageType ## _C:
-                        return self.__is_subscribed_to_C(source)
-                    else:
-                        return 0
+                except ImportError:
+                    return 0
+                
+                if type(source) == messageType ## _C:
+                    return self.__is_subscribed_to_C(source)
+                else:
+                    return 0
         %}
 };
 


### PR DESCRIPTION
* **Tickets addressed:** Closes #421 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
In some cases, an import error was raised for the methods `subscribeTo` and `isSubscribedTo` of `ReadFunctor` of C++ messages. Now, a more descriptive error is thrown for `subscribeTo`, while `isSubscribedTo` now always returns 0 when there is a mismatch between the message type of the functor and of the message passed to the function.

## Verification
Existing tests work. A manual check to assert the desired behaviour.

## Documentation
N/A

## Future work
N/A
