### PR TITLE
Fix warning of unused capture in lambda setStates

### DIFF
--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -82,7 +82,7 @@ ExtendedStateVector ExtendedStateVector::operator*(const double rhs) const
 
 void ExtendedStateVector::setStates(std::vector<DynamicObject*>& dynPtrs) const
 {
-    this->apply([this, &dynPtrs](const size_t& dynObjIndex,
+    this->apply([&dynPtrs](const size_t& dynObjIndex,
                                  const std::string& stateName,
                                  const Eigen::MatrixXd& thisState) {
         StateData& stateData =


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
There was an unused capture in a lambda in `ExtendedStateVector::setStates`, which was (rightfully) raising warnings in some linters and compilers.

## Verification
N/A

## Documentation
N/A

## Future work
N/A