### PR TITLE
Camera module crash on Ubuntu 22.04 gcc 9

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -40,14 +40,18 @@ Version |release|
   :ref:`spinningBodyTwoDOFStateEffector` module.
 - Corrected an error with :ref:`thrusterStateEffector` where if there are multiple instances of the
   thruster state effector then the last effector will over-write all the state of the earlier thrusters.
-- Corrected an error with :ref:`magnetometer` where the RNG seed was passed to the Gauss-Markov noise model within the constructor and could therefore not be modified after creating the object. Furthermore, the noise model is now only used if all three components of the standard deviation parameter are initialized to a positive value.
+- Corrected an error with :ref:`magnetometer` where the RNG seed was passed to the Gauss-Markov noise model within the
+  constructor and could therefore not be modified after creating the object. Furthermore, the noise model is now only
+  used if all three components of the standard deviation parameter are initialized to a positive value.
 - Removed fswAuto and associated documenation, as the tool was outdated.
 - Changed how C modules are wrapped as C++ classes. This makes handling C modules the same as C++ modules,
   removing the need for "Config" and "Wrap" objects. Updated all scenarios and test files for this new syntax.
   To convert prior script to use the new syntax, see :ref:`bskPrinciples-2` for the simple new
   syntaxt to add C-modules.
-- Modified :ref:`mrpFeedback` to enable the use of a modified control law, and added the integral control torque feedback output message.
-
+- Modified :ref:`mrpFeedback` to enable the use of a modified control law, and added the integral control torque
+  feedback output message.
+- Resolved a crash, induced by uninitialized memory, in the Camera module. The crash was first seen on Ubuntu 22 with
+  gcc 9.5
 
 Version 2.2.0 (June 28, 2023)
 -----------------------------

--- a/src/simulation/sensors/camera/_UnitTest/test_camera.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_camera.py
@@ -62,7 +62,6 @@ except ImportError:
     (0, 0, 0, 0, 0)
     , (2, 2, 2, 1, 3)
 ])
-# update "module" in this function name to reflect the module name
 def test_module(show_plots, gauss, darkCurrent, saltPepper, cosmic, blurSize):
     """
         **Validation Test Description**

--- a/src/simulation/sensors/camera/_UnitTest/test_camera.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_camera.py
@@ -98,9 +98,9 @@ def test_module(show_plots, gauss, darkCurrent, saltPepper, cosmic, blurSize):
 
     # Clean up
     imagePath = path + '/' + image
-    savedImage1 = '/'.join(imagePath.split('/')[:-1]) + '/' + str(gauss) + str(gauss) + str(darkCurrent) \
+    savedImage1 = '/'.join(imagePath.split('/')[:-1]) + '/' + str(gauss) + str(darkCurrent) \
                   + str(saltPepper) + str(cosmic) + str(blurSize) + '0.000000.png'
-    savedImage2 = '/'.join(imagePath.split('/')[:-1]) + '/' + str(gauss) + str(gauss) + str(darkCurrent) \
+    savedImage2 = '/'.join(imagePath.split('/')[:-1]) + '/' + str(gauss) + str(darkCurrent) \
                   + str(saltPepper) + str(cosmic) + str(blurSize) + '0.500000.png'
     try:
         os.remove(savedImage1)
@@ -147,7 +147,7 @@ def cameraTest(show_plots, image, gauss, darkCurrent, saltPepper, cosmic, blurSi
     module.filename = imagePath
     module.saveImages = True
     # make each image saved have a unique name for this test case
-    module.saveDir = '/'.join(imagePath.split('/')[:-1]) + '/' + str(gauss) + str(gauss) + str(darkCurrent) \
+    module.saveDir = '/'.join(imagePath.split('/')[:-1]) + '/' + str(gauss) + str(darkCurrent) \
                            + str(saltPepper) + str(cosmic) + str(blurSize)
 
     # Create input message and size it because the regular creator of that message

--- a/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
@@ -24,7 +24,6 @@ import colorsys
 import inspect
 import math
 import os
-
 import numpy as np
 import pytest
 
@@ -43,9 +42,9 @@ except ImportError:
     reasonErr = "python Pillow package not installed---can't test Cameras module"
 
 # Import all of the modules that we are going to be called in this simulation
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
+from Basilisk.utilities import macros
+from Basilisk.utilities import SimulationBaseClass
 
 try:
     from Basilisk.simulation import camera
@@ -62,15 +61,15 @@ except ImportError:
 @pytest.mark.skipif(importErr, reason= reasonErr)
 @pytest.mark.parametrize("HSV", [
     [0, 0, 0]
-    , [1.0, +20.0, -30.0]
-    , [-1.0, +20.0, -30.0]
-    , [3.14159, +100, -100]
+    , [1.0, 20.0, -30.0]
+    , [-1.0, 20.0, -30.0]
+    , [3.14159, 100, -100]
 ])
 @pytest.mark.parametrize("BGR", [
     [0, 0, 0]
     , [10, 20, 30]
-    , [-10, -30, +50]
-    , [-100, +200, +20]
+    , [-10, -30, 50]
+    , [-100, 200, 20]
 ])
 # update "module" in this function name to reflect the module name
 def test_module(show_plots, HSV, BGR):
@@ -242,6 +241,6 @@ def trueColorAdjust(image, corrupted, HSV, BGR):
 # stand-along python script
 #
 if __name__ == "__main__":
-    hsvAdjust = [1.0, +20.0, -30.0]
+    hsvAdjust = [1.0, 20.0, -30.0]
     bgrAdjust = [-100, 0, 0]
     cameraColorTest("tv_test.png", hsvAdjust, bgrAdjust)

--- a/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
@@ -25,6 +25,7 @@ import inspect
 import math
 import os
 
+import numpy as np
 import pytest
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -155,9 +156,8 @@ def cameraColorTest(image, HSV, BGR):
     module.sigma_CB = [0, 0, 1]
 
     # Noise parameters
-    # BGR and HSV are python lists of the form [0, 0, 0]
-    module.bgrPercent = camera.IntVector(BGR)
-    module.hsv = camera.DoubleVector(HSV)
+    module.bgrPercent = np.array(BGR)
+    module.hsv = np.array(HSV)
 
     # Setup logging on the test module output message so that we get all the writes to it
     dataLog = module.cameraConfigOutMsg.recorder()

--- a/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
@@ -178,10 +178,6 @@ def cameraColorTest(image, HSV, BGR):
     return [testFailCount, ''.join(testMessages)]
 
 
-# these points correspond to the included 'tv_test.png'
-testPoints = [(100, 300), (250, 300), (450, 300), (600, 300), (700, 300), (950, 300), (1100, 300), (300, 800),
-              (880, 780)]
-
 def rgb_to_hsv(rgb):
     hsv = colorsys.rgb_to_hsv(rgb[0], rgb[1], rgb[2])
     return [hsv[0] * 180., hsv[1] * 255., hsv[2]]
@@ -195,6 +191,10 @@ def hsv_to_rgb(hsv):
 def trueColorAdjust(image, corrupted, HSV, BGR):
     input_rgb = Image.open(image).load()
     output = Image.open(corrupted).load()
+
+    # these points correspond to the included 'tv_test.png'
+    testPoints = [(100, 300), (250, 300), (450, 300), (600, 300), (700, 300), (950, 300), (1100, 300), (300, 800),
+                  (880, 780)]
 
     for point in testPoints:
         px = point[0]

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -326,8 +326,9 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
     /*! - Update the camera config data no matter if an image is present*/
     this->cameraConfigOutMsg.write(&cameraMsg, this->moduleID, CurrentSimNanos);
     
-    cv::Mat imageCV, blurred;
-    if (this->saveDir !=""){
+    cv::Mat imageCV;
+    cv::Mat blurred;
+    if (this->saveDir != ""){
         localPath = this->saveDir + std::to_string(CurrentSimNanos*1E-9) + ".png";
     }
     /*! - Read in the bitmap*/

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -386,9 +386,9 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
             }
         }
         /*! If the permanent image buffer is not populated, it will be equal to null*/
-        if (this->pointImageOut != NULL) {
+        if (this->pointImageOut != nullptr) {
             free(this->pointImageOut);
-            this->pointImageOut = NULL;
+            this->pointImageOut = nullptr;
         }
         /*! - Encode the cv mat into a png for the future modules to decode it the same way */
         std::vector<unsigned char> buf;

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -62,8 +62,8 @@ void Camera::Reset(uint64_t currentSimNanos)
  * @return void
  */
 void Camera::hsvAdjust(const cv::Mat& mSrc, cv::Mat &mDst){
-    cv::Mat hsv;
-    cvtColor(mSrc, hsv, cv::COLOR_BGR2HSV);
+    cv::Mat localHsv;
+    cvtColor(mSrc, localHsv, cv::COLOR_BGR2HSV);
     
     for (int j = 0; j < mSrc.rows; j++) {
         for (int i = 0; i < mSrc.cols; i++) {
@@ -73,23 +73,23 @@ void Camera::hsvAdjust(const cv::Mat& mSrc, cv::Mat &mDst){
             // convert radians to degrees and multiply by 2
             // user assumes range hue range is 0-2pi and not 0-180
             int input_degrees = (int) (this->hsv[0] * R2D);
-            int h_360 = (hsv.at<cv::Vec3b>(j, i)[0] * 2) + input_degrees;
+            int h_360 = (localHsv.at<cv::Vec3b>(j, i)[0] * 2) + input_degrees;
             h_360 = (int) (h_360 -  360 * std::floor(h_360 * (1. / 360.)));
             h_360 = h_360/2;
             if(h_360 == 180){ h_360 = 0; }
-            hsv.at<cv::Vec3b>(j, i)[0] = (unsigned char) h_360;
+            localHsv.at<cv::Vec3b>(j, i)[0] = (unsigned char) h_360;
 
             int values[3];
             for(int k = 1; k < 3; k++){
-                values[k] = (int) (hsv.at<cv::Vec3b>(j, i)[k] * (this->hsv[k]/100. + 1.));
+                values[k] = (int) (localHsv.at<cv::Vec3b>(j, i)[k] * (this->hsv[k] / 100. + 1.));
                 // saturate S and V values to [0,255]
                 if(values[k] < 0){ values[k] = 0; }
                 if(values[k] > 255){ values[k] = 255; }
-                hsv.at<cv::Vec3b>(j, i)[k] = (unsigned char) values[k];
+                localHsv.at<cv::Vec3b>(j, i)[k] = (unsigned char) values[k];
             }
         }
     }
-    cvtColor(hsv, mDst, cv::COLOR_HSV2BGR);
+    cvtColor(localHsv, mDst, cv::COLOR_HSV2BGR);
 }
 
 /*!

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -62,7 +62,7 @@ void Camera::Reset(uint64_t CurrentSimNanos)
  * @param mDst destination of modified image
  * @return void
  */
-void Camera::HSVAdjust(const cv::Mat mSrc, cv::Mat &mDst){
+void Camera::HSVAdjust(const cv::Mat& mSrc, cv::Mat &mDst){
     cv::Mat hsv;
     cvtColor(mSrc, hsv, cv::COLOR_BGR2HSV);
     
@@ -100,10 +100,10 @@ void Camera::HSVAdjust(const cv::Mat mSrc, cv::Mat &mDst){
  * @param mDst destination of modified image
  * @return void
  */
-void Camera::BGRAdjustPercent(const cv::Mat mSrc, cv::Mat &mDst){
+void Camera::BGRAdjustPercent(const cv::Mat& mSrc, cv::Mat &mDst){
     cv::Mat mBGR = cv::Mat(mSrc.size(), mSrc.type());
     mSrc.convertTo(mBGR, mSrc.type());
-    
+
     // BGR values range [0, 255]
     // if value after adjustment is < 0 take 0
     // if value after is > 255 take 255
@@ -131,7 +131,7 @@ void Camera::BGRAdjustPercent(const cv::Mat mSrc, cv::Mat &mDst){
  * @param StdDev standard deviation of pixel value
  * @return void
  */
-void Camera::AddGaussianNoise(const cv::Mat mSrc, cv::Mat &mDst, double Mean, double StdDev)
+void Camera::AddGaussianNoise(const cv::Mat& mSrc, cv::Mat &mDst, double Mean, double StdDev)
 {
     cv::Mat mSrc_16SC;
     //CV_16SC3 means signed 16 bit shorts three channels
@@ -153,7 +153,7 @@ void Camera::AddGaussianNoise(const cv::Mat mSrc, cv::Mat &mDst, double Mean, do
  * @param pb probability of hot pixels
  * @return void
  */
-void Camera::AddSaltPepper(const cv::Mat mSrc, cv::Mat &mDst, float pa, float pb){
+void Camera::AddSaltPepper(const cv::Mat& mSrc, cv::Mat &mDst, float pa, float pb){
     /*! These lines will make the hot and dead pixels different every time.*/
     // uint64 initValue = time(0);
     // RNG rng(initValue);
@@ -199,7 +199,7 @@ void Camera::AddSaltPepper(const cv::Mat mSrc, cv::Mat &mDst, float pa, float pb
  * @param maxSize max length of cosmic ray
  * @return void
  */
-void Camera::AddCosmicRay(const cv::Mat mSrc, cv::Mat &mDst, float probThreshhold, double randOffset, int maxSize){
+void Camera::AddCosmicRay(const cv::Mat& mSrc, cv::Mat &mDst, float probThreshhold, double randOffset, int maxSize){
     /*! Uses the current sim time and the random offset to ensure a different ray every time.*/
     uint64 initValue = CurrentSimNanos;
     cv::RNG rng((uint64) (initValue + time(0) + randOffset));
@@ -231,7 +231,7 @@ void Camera::AddCosmicRay(const cv::Mat mSrc, cv::Mat &mDst, float probThreshhol
  * @param num number of cosmic rays to be added
  * @return void
  */
-void Camera::AddCosmicRayBurst(const cv::Mat mSrc, cv::Mat &mDst, double num){
+void Camera::AddCosmicRayBurst(const cv::Mat& mSrc, cv::Mat &mDst, double num){
     cv::Mat mCosmic = cv::Mat(mSrc.size(), mSrc.type());
     mSrc.convertTo(mCosmic, mSrc.type());
     for(int i = 0; i < std::round(num); i++){
@@ -254,7 +254,7 @@ void Camera::AddCosmicRayBurst(const cv::Mat mSrc, cv::Mat &mDst, double num){
  * @param blurparam size of blur to apply
  * @return void
  */
-void Camera::ApplyFilters(cv::Mat mSource, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam){
+void Camera::ApplyFilters(cv::Mat &mSource, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam){
 
     cv::Mat mFilters(mSource.size(), mSource.type());
     mSource.convertTo(mFilters, mSource.type());

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -43,10 +43,7 @@ Camera::Camera()
 
 
 /*! This is the destructor */
-Camera::~Camera()
-{
-    return;
-}
+Camera::~Camera() = default;
 
 
 /*! This method performs a complete reset of the module.  Local module variables that retain time varying states between function calls are reset to their default values.

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -36,37 +36,9 @@
 /*! The constructor for the Camera module. It also sets some default values at its creation.  */
 Camera::Camera()
 {
-    this->pointImageOut = NULL;
-    
-    /*! Default values for the camera.  */
-    this->cameraID = 1;
-    this->resolution[0] = 512;
-    this->resolution[1] = 512;
     this->renderRate = (uint64_t) (60*1E9);
     v3SetZero(this->cameraPos_B);
     v3SetZero(this->sigma_CB);
-    this->cameraIsOn = 0;
-    this->filename = "";
-    this->fieldOfView = 0.7;
-    strcpy(this->skyBox, "black");
-    this->saveImages = 0;
-    this->saveDir = "";
-    this->postProcessingOn = 0;
-    this->ppAperture = 0;
-    this->ppFocalLength = 0;
-    this->ppFocusDistance = 0;
-    this->ppMaxBlurSize = 0;
-
-    /*! Default values for the perturbations.  */
-    this->gaussian = 0;
-    this->darkCurrent = 0;
-    this->saltPepper = 0;
-    this->cosmicRays = 0;
-    this->blurParam = 0;
-    this->hsv = std::vector<double>{0., 0., 0.};
-    this->bgrPercent = std::vector<int>{0, 0, 0};
-    
-    return;
 }
 
 

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -279,8 +279,11 @@ void Camera::applyFilters(cv::Mat &mSource,
     }
     if(blurparam > 0){
         int blurSize = (int) std::round(blurparam);
-        if (blurSize%2 == 0){blurSize+=1;}
-        blur(mFilters, mFilters, cv::Size(blurSize, blurSize), cv::Point(-1 , -1));
+        if (blurSize%2 == 0){ blurSize+=1; }
+        cv::blur(mFilters,
+                 mFilters,
+                 cv::Size(blurSize, blurSize),
+                 cv::Point(-1 , -1));
     }
     if(darkCurrent > 0){
         float scale = 15;

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -48,9 +48,9 @@ Camera::~Camera() = default;
 /*! This method performs a complete reset of the module.  Local module variables that retain time varying states
  * between function calls are reset to their default values.
  @return void
- @param CurrentSimNanos current time (ns)
+ @param currentSimNanos current time (ns)
  */
-void Camera::Reset(uint64_t CurrentSimNanos)
+void Camera::Reset(uint64_t currentSimNanos)
 {
 }
 
@@ -308,9 +308,9 @@ void Camera::ApplyFilters(cv::Mat &mSource,
  @return void
  @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
  */
-void Camera::UpdateState(uint64_t CurrentSimNanos)
+void Camera::UpdateState(uint64_t currentSimNanos)
 {
-    this->localCurrentSimNanos = CurrentSimNanos;
+    this->localCurrentSimNanos = currentSimNanos;
     std::string localPath;
     CameraImageMsgPayload imageBuffer = {};
     CameraImageMsgPayload imageOut;
@@ -338,12 +338,12 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
     cameraMsg.ppMaxBlurSize = this->ppMaxBlurSize;
     
     /*! - Update the camera config data no matter if an image is present*/
-    this->cameraConfigOutMsg.write(&cameraMsg, this->moduleID, CurrentSimNanos);
+    this->cameraConfigOutMsg.write(&cameraMsg, this->moduleID, currentSimNanos);
     
     cv::Mat imageCV;
     cv::Mat blurred;
     if (this->saveDir != ""){
-        localPath = this->saveDir + std::to_string(CurrentSimNanos*1E-9) + ".png";
+        localPath = this->saveDir + std::to_string(currentSimNanos*1E-9) + ".png";
     }
     /*! - Read in the bitmap*/
     if(this->imageInMsg.isLinked())
@@ -367,7 +367,7 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
             }
         }
     }
-    else if(imageBuffer.valid == 1 && imageBuffer.timeTag >= CurrentSimNanos){
+    else if(imageBuffer.valid == 1 && imageBuffer.timeTag >= currentSimNanos){
         /*! - Recast image pointer to CV type*/
         std::vector<unsigned char> vectorBuffer((char*)imageBuffer.imagePointer,
                                                 (char*)imageBuffer.imagePointer + imageBuffer.imageBufferLength);
@@ -405,10 +405,10 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
         memcpy(this->pointImageOut, &buf[0], imageOut.imageBufferLength*sizeof(char));
         imageOut.imagePointer = this->pointImageOut;
         
-        this->imageOutMsg.write(&imageOut, this->moduleID, CurrentSimNanos);
+        this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
     }
     else{
         /*! - If no image is present, write zeros in message */
-        this->imageOutMsg.write(&imageOut, this->moduleID, CurrentSimNanos);
+        this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
     }
 }

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -52,7 +52,6 @@ Camera::~Camera() = default;
  */
 void Camera::Reset(uint64_t CurrentSimNanos)
 {
-    return;
 }
 
 /*!
@@ -379,13 +378,11 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
         imageOut.imagePointer = this->pointImageOut;
         
         this->imageOutMsg.write(&imageOut, this->moduleID, CurrentSimNanos);
-        
-        return;
     }
     else{
         /*! - If no image is present, write zeros in message */
         this->imageOutMsg.write(&imageOut, this->moduleID, CurrentSimNanos);
-        return;}
+    }
  
 }
 

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -202,7 +202,7 @@ void Camera::AddSaltPepper(const cv::Mat& mSrc, cv::Mat &mDst, float pa, float p
  */
 void Camera::AddCosmicRay(const cv::Mat& mSrc, cv::Mat &mDst, float probThreshhold, double randOffset, int maxSize){
     /*! Uses the current sim time and the random offset to ensure a different ray every time.*/
-    uint64 initValue = CurrentSimNanos;
+    uint64 initValue = this->localCurrentSimNanos;
     cv::RNG rng((uint64) (initValue + time(0) + randOffset));
     
     float prob = (float) (rng.uniform(0.0, 1.0));
@@ -310,7 +310,7 @@ void Camera::ApplyFilters(cv::Mat &mSource,
  */
 void Camera::UpdateState(uint64_t CurrentSimNanos)
 {
-    this->CurrentSimNanos = CurrentSimNanos;
+    this->localCurrentSimNanos = CurrentSimNanos;
     std::string localPath;
     CameraImageMsgPayload imageBuffer = {};
     CameraImageMsgPayload imageOut;

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -276,11 +276,11 @@ void Camera::ApplyFilters(cv::Mat mSource, cv::Mat &mDst, double gaussian, doubl
         float scale = 15;
         AddGaussianNoise(mFilters, mFilters, darkCurrent * scale, 0.0);
     }
-    if (abs(this->hsv[0])+abs(this->hsv[1])+abs(this->hsv[2]) > 0.00001) {
-        HSVAdjust(mFilters, mFilters);
+    if (this->hsv.cwiseAbs().sum() > 0.00001) {
+        this->HSVAdjust(mFilters, mFilters);
     }
-    if (abs(this->bgrPercent[0])+abs(this->bgrPercent[1])+abs(this->bgrPercent[2]) != 0) {
-        BGRAdjustPercent(mFilters, mFilters);
+    if (this->bgrPercent.cwiseAbs().sum() != 0) {
+        this->BGRAdjustPercent(mFilters, mFilters);
     }
     if (saltPepper > 0){
         float scale = 0.00002f;

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -19,7 +19,8 @@
 /*
     Camera Module
 
-    Note:   This module simulates a camera. It writes a camera message with it's specs and image requests, as well as provides a template for image coruption
+    Note:   This module simulates a camera. It writes a camera message with its specs and image requests,
+    as well as provides a template for image corruption
     Author: Thibaud Teil
     Date:   October 03, 2019
  
@@ -41,12 +42,11 @@ Camera::Camera()
     v3SetZero(this->sigma_CB);
 }
 
-
 /*! This is the destructor */
 Camera::~Camera() = default;
 
-
-/*! This method performs a complete reset of the module.  Local module variables that retain time varying states between function calls are reset to their default values.
+/*! This method performs a complete reset of the module.  Local module variables that retain time varying states
+ * between function calls are reset to their default values.
  @return void
  @param CurrentSimNanos current time (ns)
  */
@@ -179,11 +179,13 @@ void Camera::AddSaltPepper(const cv::Mat& mSrc, cv::Mat &mDst, float pa, float p
     
     /*!  Chooses random pixels to be stuck or dead in the amount calculated previously.*/
     for(int counter = 0; counter < amount1; counter++){
-        mSaltPepper.at<cv::Vec3b>(rng.uniform(0, mSaltPepper.rows), rng.uniform(0, mSaltPepper.cols)) = black;
+        mSaltPepper.at<cv::Vec3b>(rng.uniform(0, mSaltPepper.rows),
+                                  rng.uniform(0, mSaltPepper.cols)) = black;
     }
     
     for(int counter = 0; counter < amount2; counter++){
-        mSaltPepper.at<cv::Vec3b>(rng.uniform(0, mSaltPepper.rows), rng.uniform(0, mSaltPepper.cols)) = white;
+        mSaltPepper.at<cv::Vec3b>(rng.uniform(0, mSaltPepper.rows),
+                                  rng.uniform(0, mSaltPepper.cols)) = white;
     }
     
     mSaltPepper.convertTo(mDst, mSrc.type());
@@ -208,7 +210,8 @@ void Camera::AddCosmicRay(const cv::Mat& mSrc, cv::Mat &mDst, float probThreshho
         cv::Mat mCosmic = cv::Mat(mSrc.size(), mSrc.type());
         mSrc.convertTo(mCosmic, mSrc.type());
     
-        /*!  Chooses a random point on the image. Then chooses a second random point within 50 pixels in either direction.*/
+        /*!  Chooses a random point on the image. Then chooses a second random point within 50 pixels
+         * in either direction.*/
         int x = rng.uniform(0, mCosmic.rows);
         int y = rng.uniform(0, mCosmic.cols);
         int deltax = rng.uniform(-maxSize/2, maxSize/2);
@@ -234,16 +237,21 @@ void Camera::AddCosmicRayBurst(const cv::Mat& mSrc, cv::Mat &mDst, double num){
     cv::Mat mCosmic = cv::Mat(mSrc.size(), mSrc.type());
     mSrc.convertTo(mCosmic, mSrc.type());
     for(int i = 0; i < std::round(num); i++){
-        /*! Threshold defined such that 1 provides a 1/50 chance of getting a ray, and 10 will get about 5 rays per image*/
-        /*! Currently length is limited to 50 pixels*/
-        AddCosmicRay(mCosmic, mCosmic, (float) (1/(std::pow(num,2))), i+1, 50);
+        /*! Threshold defined such that 1 provides a 1/50 chance of getting a ray, and 10 will get about
+         * 5 rays per image. Currently length is limited to 50 pixels*/
+        AddCosmicRay(mCosmic,
+                     mCosmic,
+                     (float) (1/(std::pow(num,2))),
+                     i+1,
+                     50);
     }
     mCosmic.convertTo(mDst, mSrc.type());
 }
 
 /*!
- * Applys all of the various pertubations to an image with user specified levels.
- * Each parameter is a double scaling actor. A parameter of 0 will result in the respective perturbation not being applied.
+ * Applies all of the various perturbations to an image with user specified levels.
+ * Each parameter is a double scaling actor. A parameter of 0 will result in the respective perturbation not
+ * being applied.
  * @param mSource source image
  * @param mDst destination of modified image
  * @param gaussian scaling factor for gaussian noise
@@ -253,7 +261,13 @@ void Camera::AddCosmicRayBurst(const cv::Mat& mSrc, cv::Mat &mDst, double num){
  * @param blurparam size of blur to apply
  * @return void
  */
-void Camera::ApplyFilters(cv::Mat &mSource, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam){
+void Camera::ApplyFilters(cv::Mat &mSource,
+                          cv::Mat &mDst,
+                          double gaussian,
+                          double darkCurrent,
+                          double saltPepper,
+                          double cosmicRays,
+                          double blurparam){
 
     cv::Mat mFilters(mSource.size(), mSource.type());
     mSource.convertTo(mFilters, mSource.type());
@@ -289,7 +303,8 @@ void Camera::ApplyFilters(cv::Mat &mSource, cv::Mat &mDst, double gaussian, doub
     mFilters.convertTo(mDst, mSource.type());
 }
 
-/*! This module reads an OpNav image and extracts circle information from its content using OpenCV's HoughCircle Transform. It performs a greyscale, a bur, and a threshold on the image to facilitate circle-finding. 
+/*! This module reads an OpNav image and extracts circle information from its content using OpenCV's HoughCircle
+ * Transform. It performs a greyscale, a bur, and a threshold on the image to facilitate circle-finding.
  @return void
  @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
  */
@@ -304,7 +319,7 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
     /* zero output messages */
     imageOut = this->imageOutMsg.zeroMsgPayload;
     cameraMsg = this->cameraConfigOutMsg.zeroMsgPayload;
-    
+
     /*! - Populate the camera message */
     cameraMsg.cameraID = this->cameraID;
     strcpy(cameraMsg.parentName, this->parentName);
@@ -339,7 +354,13 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
     /* Added for debugging purposes*/
     if (!this->filename.empty()){
         imageCV = imread(this->filename, cv::IMREAD_COLOR);
-        ApplyFilters(imageCV, blurred, this->gaussian, this->darkCurrent, this->saltPepper, this->cosmicRays, this->blurParam);
+        ApplyFilters(imageCV,
+                     blurred,
+                     this->gaussian,
+                     this->darkCurrent,
+                     this->saltPepper,
+                     this->cosmicRays,
+                     this->blurParam);
         if (this->saveImages == 1){
             if (!cv::imwrite(localPath, blurred)) {
                 bskLogger.bskLog(BSK_WARNING, "camera: wasn't able to save the camera module image" );
@@ -348,10 +369,17 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
     }
     else if(imageBuffer.valid == 1 && imageBuffer.timeTag >= CurrentSimNanos){
         /*! - Recast image pointer to CV type*/
-        std::vector<unsigned char> vectorBuffer((char*)imageBuffer.imagePointer, (char*)imageBuffer.imagePointer + imageBuffer.imageBufferLength);
+        std::vector<unsigned char> vectorBuffer((char*)imageBuffer.imagePointer,
+                                                (char*)imageBuffer.imagePointer + imageBuffer.imageBufferLength);
         imageCV = cv::imdecode(vectorBuffer, cv::IMREAD_COLOR);
         
-        ApplyFilters(imageCV, blurred, this->gaussian, this->darkCurrent, this->saltPepper, this->cosmicRays, this->blurParam);
+        ApplyFilters(imageCV,
+                     blurred,
+                     this->gaussian,
+                     this->darkCurrent,
+                     this->saltPepper,
+                     this->cosmicRays,
+                     this->blurParam);
         if (this->saveImages == 1){
             if (!cv::imwrite(localPath, blurred)) {
                 bskLogger.bskLog(BSK_WARNING, "camera: wasn't able to save the camera module image" );
@@ -383,6 +411,4 @@ void Camera::UpdateState(uint64_t CurrentSimNanos)
         /*! - If no image is present, write zeros in message */
         this->imageOutMsg.write(&imageOut, this->moduleID, CurrentSimNanos);
     }
- 
 }
-

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -52,44 +52,43 @@ public:
     void AddCosmicRayBurst(const cv::Mat, cv::Mat &mDst, double);
     void ApplyFilters(cv::Mat, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam);
 public:
-    std::string filename;                //!< Filename for module to read an image directly
+    std::string filename{};                //!< Filename for module to read an image directly
     ReadFunctor<CameraImageMsgPayload> imageInMsg;      //!< camera image input message
     Message<CameraImageMsgPayload> imageOutMsg;         //!< camera image output message
     Message<CameraConfigMsgPayload> cameraConfigOutMsg; //!< The name of the CameraConfigMsg output message
-    std::string saveDir;                 //!< The name of the directory to save images
-    uint64_t sensorTimeTag;              //!< [ns] Current time tag for sensor out
-    int32_t saveImages;                  //!< [-] 1 to save images to file for debugging
+    std::string saveDir{};                 //!< The name of the directory to save images
+    uint64_t sensorTimeTag{};              //!< [ns] Current time tag for sensor out
+    int32_t saveImages{};                  //!< [-] 1 to save images to file for debugging
     
     /*! Camera parameters */
-    int cameraIsOn; //!< [-] Is the camera currently taking images
-    int cameraID; //!< [-] Is the camera currently taking images
-    int resolution[2];         //!< [-] Camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
-    uint64_t renderRate;       //!< [ns] Frame time interval at which to capture images in units of nanosecond
-    double fieldOfView;        //!< [r] camera y-axis field of view edge-to-edge
-    double cameraPos_B[3];     //!< [m] Camera position in body frame
-    double sigma_CB[3];        //!< [-] MRP defining the orientation of the camera frame relative to the body frame
-    char skyBox[MAX_STRING_LENGTH]; //!< [-] name of skyboz in use
-    int postProcessingOn;       //!< Enable post-processing of camera image. Value of 0 (protobuffer default) to use viz default which is off, -1 for false, 1 for true
-    double ppFocusDistance;     //!< Distance to the point of focus, minimum value of 0.1, Value of 0 to turn off this parameter entirely.
-    double ppAperture;          //!<  Ratio of the aperture (known as f-stop or f-number). The smaller the value is, the shallower the depth of field is. Valid Setting Range: 0.05 to 32. Value of 0 to turn off this parameter entirely.
-    double ppFocalLength;       //!< [m] Valid setting range: 0.001m to 0.3m. Value of 0 to turn off this parameter entirely.
-    int ppMaxBlurSize;          //!< Convolution kernel size of the bokeh filter, which determines the maximum radius of bokeh. It also affects the performance (the larger the kernel is, the longer the GPU time is required). Depth textures Value of 1 for Small, 2 for Medium, 3 for Large, 4 for Extra Large. Value of 0 to turn off this parameter entirely.
-
     char parentName[MAX_STRING_LENGTH]{};  //!< [-] Name of the parent body to which the camera should be attached
+    int cameraIsOn{}; //!< [-] Is the camera currently taking images
+    int cameraID{1}; //!< [-] Is the camera currently taking images
+    int resolution[2]{512, 512};         //!< [-] Camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
+    uint64_t renderRate{};       //!< [ns] Frame time interval at which to capture images in units of nanosecond
+    double fieldOfView{0.7};       //!< [r] camera y-axis field of view edge-to-edge
+    double cameraPos_B[3]{};     //!< [m] Camera position in body frame
+    double sigma_CB[3]{};        //!< [-] MRP defining the orientation of the camera frame relative to the body frame
+    char skyBox[MAX_STRING_LENGTH]{"black"}; //!< [-] name of skyboz in use
+    int postProcessingOn{};       //!< Enable post-processing of camera image. Value of 0 (protobuffer default) to use viz default which is off, -1 for false, 1 for true
+    double ppFocusDistance{};     //!< Distance to the point of focus, minimum value of 0.1, Value of 0 to turn off this parameter entirely.
+    double ppAperture{};          //!<  Ratio of the aperture (known as f-stop or f-number). The smaller the value is, the shallower the depth of field is. Valid Setting Range: 0.05 to 32. Value of 0 to turn off this parameter entirely.
+    double ppFocalLength{};       //!< [m] Valid setting range: 0.001m to 0.3m. Value of 0 to turn off this parameter entirely.
+    int ppMaxBlurSize{};          //!< Convolution kernel size of the bokeh filter, which determines the maximum radius of bokeh. It also affects the performance (the larger the kernel is, the longer the GPU time is required). Depth textures Value of 1 for Small, 2 for Medium, 3 for Large, 4 for Extra Large. Value of 0 to turn off this parameter entirely.
 
     /*! Noise paramters */
-    double gaussian;        //!< Gaussian noise level
-    double darkCurrent;    //!< Dark current intensity
-    double saltPepper;    //!< Stuck and Dark pixels probability
-    double cosmicRays;        //!< Random cosmic rays (number)
-    double blurParam;        //!< Blur over image in pixels
-    std::vector<double> hsv;    //!< (double) HSV color correction, H (-pi/pi) hue shift, S and V are percent multipliers
-    std::vector<int> bgrPercent; //!< (int) BGR color correction values as percent
+    double gaussian{};        //!< Gaussian noise level
+    double darkCurrent{};    //!< Dark current intensity
+    double saltPepper{};    //!< Stuck and Dark pixels probability
+    double cosmicRays{};        //!< Random cosmic rays (number)
+    double blurParam{};        //!< Blur over image in pixels
+    std::vector<double> hsv{};    //!< (double) HSV color correction, H (-pi/pi) hue shift, S and V are percent multipliers
+    std::vector<int> bgrPercent{}; //!< (int) BGR color correction values as percent
 
     BSKLogger bskLogger;                      //!< -- BSK Logging
 private:
-    uint64_t CurrentSimNanos;
-    void* pointImageOut;      //!< void pointer for image memory passing
+    uint64_t CurrentSimNanos{};
+    void* pointImageOut{nullptr};      //!< void pointer for image memory passing
 };
 
 /* @} */

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -82,8 +82,8 @@ public:
     double saltPepper{};    //!< Stuck and Dark pixels probability
     double cosmicRays{};        //!< Random cosmic rays (number)
     double blurParam{};        //!< Blur over image in pixels
-    std::vector<double> hsv{};    //!< (double) HSV color correction, H (-pi/pi) hue shift, S and V are percent multipliers
-    std::vector<int> bgrPercent{}; //!< (int) BGR color correction values as percent
+    Eigen::Vector3d hsv{Eigen::Vector3d::Zero()};    //!< (double) HSV color correction, H (-pi/pi) hue shift, S and V are percent multipliers
+    Eigen::Vector3d bgrPercent{Eigen::Vector3d::Zero()}; //!< (int) BGR color correction values as percent
 
     BSKLogger bskLogger;                      //!< -- BSK Logging
 private:

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -50,7 +50,14 @@ public:
     void AddSaltPepper(const cv::Mat&, cv::Mat &mDst, float, float);
     void AddCosmicRay(const cv::Mat&, cv::Mat &mDst, float, double, int);
     void AddCosmicRayBurst(const cv::Mat&, cv::Mat &mDst, double);
-    void ApplyFilters(cv::Mat &mSource, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam);
+    void ApplyFilters(cv::Mat &mSource,
+                      cv::Mat &mDst,
+                      double gaussian,
+                      double darkCurrent,
+                      double saltPepper,
+                      double cosmicRays,
+                      double blurparam);
+
 public:
     std::string filename{};                //!< Filename for module to read an image directly
     ReadFunctor<CameraImageMsgPayload> imageInMsg;      //!< camera image input message
@@ -86,12 +93,11 @@ public:
     Eigen::Vector3d bgrPercent{Eigen::Vector3d::Zero()}; //!< (int) BGR color correction values as percent
 
     BSKLogger bskLogger;                      //!< -- BSK Logging
+
 private:
     uint64_t CurrentSimNanos{};
     void* pointImageOut{nullptr};      //!< void pointer for image memory passing
 };
 
 /* @} */
-
 #endif
-

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -42,8 +42,8 @@ public:
     Camera();
     ~Camera();
     
-    void UpdateState(uint64_t CurrentSimNanos);
-    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos) override;
+    void Reset(uint64_t CurrentSimNanos) override;
     void HSVAdjust(const cv::Mat&, cv::Mat &mDst);
     void BGRAdjustPercent(const cv::Mat&, cv::Mat &mDst);
     void AddGaussianNoise(const cv::Mat&, cv::Mat &mDst, double, double);

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -50,13 +50,7 @@ public:
     void addSaltPepper(const cv::Mat&, cv::Mat &mDst, float, float);
     void addCosmicRay(const cv::Mat&, cv::Mat &mDst, float, double, int);
     void addCosmicRayBurst(const cv::Mat&, cv::Mat &mDst, double);
-    void applyFilters(cv::Mat &mSource,
-                      cv::Mat &mDst,
-                      double gaussian,
-                      double darkCurrent,
-                      double saltPepper,
-                      double cosmicRays,
-                      double blurparam);
+    void applyFilters(cv::Mat &mSource, cv::Mat &mDst);
 
 public:
     std::string filename{};                //!< Filename for module to read an image directly

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -61,7 +61,6 @@ public:
     int32_t saveImages;                  //!< [-] 1 to save images to file for debugging
     
     /*! Camera parameters */
-    char parentName[MAX_STRING_LENGTH];  //!< [-] Name of the parent body to which the camera should be attached
     int cameraIsOn; //!< [-] Is the camera currently taking images
     int cameraID; //!< [-] Is the camera currently taking images
     int resolution[2];         //!< [-] Camera resolution, width/height in pixels (pixelWidth/pixelHeight in Unity) in pixels
@@ -76,6 +75,7 @@ public:
     double ppFocalLength;       //!< [m] Valid setting range: 0.001m to 0.3m. Value of 0 to turn off this parameter entirely.
     int ppMaxBlurSize;          //!< Convolution kernel size of the bokeh filter, which determines the maximum radius of bokeh. It also affects the performance (the larger the kernel is, the longer the GPU time is required). Depth textures Value of 1 for Small, 2 for Medium, 3 for Large, 4 for Extra Large. Value of 0 to turn off this parameter entirely.
 
+    char parentName[MAX_STRING_LENGTH]{};  //!< [-] Name of the parent body to which the camera should be attached
 
     /*! Noise paramters */
     double gaussian;        //!< Gaussian noise level

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -44,13 +44,13 @@ public:
     
     void UpdateState(uint64_t currentSimNanos) override;
     void Reset(uint64_t currentSimNanos) override;
-    void HSVAdjust(const cv::Mat&, cv::Mat &mDst);
-    void BGRAdjustPercent(const cv::Mat&, cv::Mat &mDst);
-    void AddGaussianNoise(const cv::Mat&, cv::Mat &mDst, double, double);
-    void AddSaltPepper(const cv::Mat&, cv::Mat &mDst, float, float);
-    void AddCosmicRay(const cv::Mat&, cv::Mat &mDst, float, double, int);
-    void AddCosmicRayBurst(const cv::Mat&, cv::Mat &mDst, double);
-    void ApplyFilters(cv::Mat &mSource,
+    void hsvAdjust(const cv::Mat&, cv::Mat &mDst);
+    void bgrAdjustPercent(const cv::Mat&, cv::Mat &mDst);
+    void addGaussianNoise(const cv::Mat&, cv::Mat &mDst, double, double);
+    void addSaltPepper(const cv::Mat&, cv::Mat &mDst, float, float);
+    void addCosmicRay(const cv::Mat&, cv::Mat &mDst, float, double, int);
+    void addCosmicRayBurst(const cv::Mat&, cv::Mat &mDst, double);
+    void applyFilters(cv::Mat &mSource,
                       cv::Mat &mDst,
                       double gaussian,
                       double darkCurrent,

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -42,8 +42,8 @@ public:
     Camera();
     ~Camera();
     
-    void UpdateState(uint64_t CurrentSimNanos) override;
-    void Reset(uint64_t CurrentSimNanos) override;
+    void UpdateState(uint64_t currentSimNanos) override;
+    void Reset(uint64_t currentSimNanos) override;
     void HSVAdjust(const cv::Mat&, cv::Mat &mDst);
     void BGRAdjustPercent(const cv::Mat&, cv::Mat &mDst);
     void AddGaussianNoise(const cv::Mat&, cv::Mat &mDst, double, double);

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -44,13 +44,13 @@ public:
     
     void UpdateState(uint64_t CurrentSimNanos);
     void Reset(uint64_t CurrentSimNanos);
-    void HSVAdjust(const cv::Mat, cv::Mat &mDst);
-    void BGRAdjustPercent(const cv::Mat, cv::Mat &mDst);
-    void AddGaussianNoise(const cv::Mat, cv::Mat &mDst, double, double);
-    void AddSaltPepper(const cv::Mat, cv::Mat &mDst, float, float);
-    void AddCosmicRay(const cv::Mat, cv::Mat &mDst, float, double, int);
-    void AddCosmicRayBurst(const cv::Mat, cv::Mat &mDst, double);
-    void ApplyFilters(cv::Mat, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam);
+    void HSVAdjust(const cv::Mat&, cv::Mat &mDst);
+    void BGRAdjustPercent(const cv::Mat&, cv::Mat &mDst);
+    void AddGaussianNoise(const cv::Mat&, cv::Mat &mDst, double, double);
+    void AddSaltPepper(const cv::Mat&, cv::Mat &mDst, float, float);
+    void AddCosmicRay(const cv::Mat&, cv::Mat &mDst, float, double, int);
+    void AddCosmicRayBurst(const cv::Mat&, cv::Mat &mDst, double);
+    void ApplyFilters(cv::Mat &mSource, cv::Mat &mDst, double gaussian, double darkCurrent, double saltPepper, double cosmicRays, double blurparam);
 public:
     std::string filename{};                //!< Filename for module to read an image directly
     ReadFunctor<CameraImageMsgPayload> imageInMsg;      //!< camera image input message

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -95,7 +95,7 @@ public:
     BSKLogger bskLogger;                      //!< -- BSK Logging
 
 private:
-    uint64_t CurrentSimNanos{};
+    uint64_t localCurrentSimNanos{};
     void* pointImageOut{nullptr};      //!< void pointer for image memory passing
 };
 

--- a/src/simulation/sensors/camera/camera.i
+++ b/src/simulation/sensors/camera/camera.i
@@ -25,7 +25,7 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 %include "swig_conly_data.i"
-
+%include "swig_eigen.i"
 %include "stdint.i"
 %include "std_string.i"
 %include "std_vector.i"


### PR DESCRIPTION
* **Tickets addressed:** bsk-[#432](https://github.com/AVSLab/basilisk/issues/432)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The first commit initializes a previously uninitialized `char[]`. The second goes a step further and moves all initialization (which can be) to class based initializers. Commit three changes `hsv` and `bgrPercent` to safer `Eigen::Vector3d` types where the size of the value is fixed at compile time (unlike a std::vector). The remaining commits are small refactors and cleanups.

## Verification
This was compiled on an Ubuntu 22 with gcc 9.5 machine. It passed those tests following the change. Ideally we'd have a CI check for this, but that remains to be future work. 

## Documentation
None invalidated, none new needed.

## Future work
We should expand the coverage of our CI runs to include more key parameters (e.g. current and previous OSs and compilers).

As for the Camera module I have intentions to significantly refactor/rewrite it later this year and so am interested to hear if anyone has thoughts of what to include in that effort. So this PR is me exercising restraint 😄 before embarking on that effort. 
