### PR TITLE
Feature/doc warning fix

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -26,7 +26,6 @@ Basilisk Release Notes
       CAD asteroid or lunar surface terrain.
     - spacecraft charging related modules
     - support a way to do thread-safe messaging
-    - ability to integrate Python Basilisk modules in the same task and process as C/C++ modules
     - automated documentation build system when code is pushed to the repo
 
 

--- a/src/architecture/_GeneralModuleFiles/sys_model.h
+++ b/src/architecture/_GeneralModuleFiles/sys_model.h
@@ -29,7 +29,7 @@ class SysModel
 {
 public:
     SysModel();
-    SysModel(const SysModel &obj);
+    SysModel(const SysModel &obj); //!< constructor definition
 
     virtual ~SysModel(){};
 

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -301,7 +301,7 @@ void Camera::applyFilters(cv::Mat &mSource, cv::Mat &mDst){
 /*! This module reads an OpNav image and extracts circle information from its content using OpenCV's HoughCircle
  * Transform. It performs a greyscale, a bur, and a threshold on the image to facilitate circle-finding.
  @return void
- @param CurrentSimNanos The clock time at which the function was called (nanoseconds)
+ @param currentSimNanos The clock time at which the function was called (nanoseconds)
  */
 void Camera::UpdateState(uint64_t currentSimNanos)
 {

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -254,11 +254,6 @@ void Camera::addCosmicRayBurst(const cv::Mat& mSrc, cv::Mat &mDst, double num){
  * being applied.
  * @param mSource source image
  * @param mDst destination of modified image
- * @param gaussian scaling factor for gaussian noise
- * @param darkCurrent scaling factor for dark current
- * @param saltPepper scaling factor for hot and dead pixels
- * @param cosmicRays number of cosmic rays to add
- * @param blurparam size of blur to apply
  * @return void
  */
 void Camera::applyFilters(cv::Mat &mSource, cv::Mat &mDst){


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The BSK documentation build process had a few new doxygen warnings at the very beginning of the build process.  These are now fixed in this pull request.

## Verification
Did a clean build of the documentation and no warnings were present.

## Documentation
N/A

## Future work
Be sure to keep checking the full RST documentation build process log for warnings.