### PR TITLE
Prescribed Spinning Bodies Message

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -60,6 +60,8 @@ Version |release|
     SWIG files (``.i``) for modules should include ``%include "sys_model.i"`` instead of ``%include "sys_model.h"``
     to take advantage of the new module variable logging feature.
 
+- Added prescribed angle and angle rates to :ref:`spinningBodyOneDOFStateEffector` and :ref:`spinningBodyTwoDOFStateEffector`
+  modules.
 - Created a :ref:`scanningInstrumentController`, similar to :ref:`simpleInstrumentController`, but which constantly checks if the attitude error
   and angular rate (optional) are within the requirement limits and sends an imaging command to a :ref:`simpleInstrument`.
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
@@ -26,6 +26,7 @@ import inspect
 import os
 import matplotlib.pyplot as plt
 import numpy
+import numpy as np
 import pytest
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -42,12 +43,13 @@ from Basilisk.architecture import messaging
 # uncomment this line if this test has an expected failure, adjust message as needed
 # @pytest.mark.xfail() # need to update how the RW states are defined
 # provide a unique test method name, starting with test_
-@pytest.mark.parametrize("cmdTorque, lock", [
-    (0.0, False)
-    , (0.0, True)
-    , (1.0, False)
+@pytest.mark.parametrize("cmdTorque, lock, thetaRef", [
+    (0.0, False, 0.0)
+    , (0.0, True, 0.0)
+    , (1.0, False, 0.0)
+    , (0.0, False, 20.0 * macros.D2R)
 ])
-def test_spinningBody(show_plots, cmdTorque, lock):
+def test_spinningBody(show_plots, cmdTorque, lock, thetaRef):
     r"""
     **Validation Test Description**
 
@@ -68,11 +70,11 @@ def test_spinningBody(show_plots, cmdTorque, lock):
 
     against their initial values.
     """
-    [testResults, testMessage] = spinningBody(show_plots, cmdTorque, lock)
+    [testResults, testMessage] = spinningBody(show_plots, cmdTorque, lock, thetaRef)
     assert testResults < 1, testMessage
 
 
-def spinningBody(show_plots, cmdTorque, lock):
+def spinningBody(show_plots, cmdTorque, lock, thetaRef):
     __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
@@ -85,7 +87,7 @@ def spinningBody(show_plots, cmdTorque, lock):
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.0001)  # update process rate update time
+    testProcessRate = macros.sec2nano(0.001)  # update process rate update time
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
@@ -116,7 +118,9 @@ def spinningBody(show_plots, cmdTorque, lock):
     spinningBody.sHat_S = [[0], [-1], [0]]
     spinningBody.thetaInit = 5.0 * macros.D2R
     spinningBody.thetaDotInit = -1.0 * macros.D2R
-    spinningBody.k = 1.0
+    spinningBody.k = 100.0
+    if thetaRef != 0.0:
+        spinningBody.c = 50
     if lock:
         spinningBody.thetaDotInit = 0.0
     spinningBody.ModelTag = "SpinningBody"
@@ -136,6 +140,13 @@ def spinningBody(show_plots, cmdTorque, lock):
         lockArray.effectorLockFlag = [1]
         lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
         spinningBody.motorLockInMsg.subscribeTo(lockMsg)
+
+    # Create the reference message
+    angleRef = messaging.HingedRigidBodyMsgPayload()
+    angleRef.theta = thetaRef
+    angleRef.thetaDot = 0.0
+    angleRefMsg = messaging.HingedRigidBodyMsg().write(angleRef)
+    spinningBody.spinningBodyRefInMsg.subscribeTo(angleRefMsg)
 
     # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, spinningBody)
@@ -258,8 +269,8 @@ def spinningBody(show_plots, cmdTorque, lock):
             testMessages.append(
                 "FAILED: Spinning Body integrated test failed rotational angular momentum unit test")
 
-    # Only check rotational energy if no torques are applied
-    if cmdTorque == 0.0:
+    # Only check rotational energy if no torques and no damping are applied
+    if cmdTorque == 0.0 and thetaRef == 0.0:
         for i in range(0, len(initialRotEnergy)):
             # check a vector values
             if not unitTestSupport.isArrayEqualRelative(finalRotEnergy[i], initialRotEnergy[i], 1, accuracy):
@@ -272,6 +283,11 @@ def spinningBody(show_plots, cmdTorque, lock):
             testFailCount += 1
             testMessages.append("FAILED: Spinning Body integrated test failed orbital energy unit test")
 
+    if thetaRef != 0.0:
+        if not unitTestSupport.isDoubleEqual(theta[-1], thetaRef, 0.01):
+            testFailCount += 1
+            testMessages.append("FAILED: Spinning Body integrated test failed angle convergence unit test")
+
     if testFailCount == 0:
         print("PASSED: " + " Spinning Body gravity integrated test")
 
@@ -282,4 +298,4 @@ def spinningBody(show_plots, cmdTorque, lock):
 
 
 if __name__ == "__main__":
-    spinningBody(True, 0.0, False)
+    spinningBody(True, 0.0, False, 0.0 * macros.D2R)

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
@@ -38,22 +38,23 @@
 class SpinningBodyOneDOFStateEffector: public StateEffector, public SysModel {
 
 public:
-    double mass = 1.0;                                          //!< [kg] mass of spinning body
-    double k = 0.0;                                             //!< [N-m/rad] torsional spring constant
-    double c = 0.0;                                             //!< [N-m-s/rad] rotational damping coefficient
-    double thetaInit = 0.0;                                     //!< [rad] initial spinning body angle
-    double thetaDotInit = 0.0;                                  //!< [rad/s] initial spinning body angle rate
-    std::string nameOfThetaState;                               //!< -- identifier for the theta state data container
-    std::string nameOfThetaDotState;                            //!< -- identifier for the thetaDot state data container
-    Eigen::Vector3d r_SB_B;                                     //!< [m] vector pointing from body frame B origin to spinning frame S origin in B frame components
-    Eigen::Vector3d r_ScS_S;                                    //!< [m] vector pointing from spinning frame S origin to point Sc (center of mass of the spinner) in S frame components
-    Eigen::Vector3d sHat_S;                                     //!< -- spinning axis in S frame components.
-    Eigen::Matrix3d IPntSc_S;                                   //!< [kg-m^2] Inertia of spinning body about point Sc in S frame components
-    Eigen::Matrix3d dcm_S0B;                                    //!< -- DCM from the body frame to the S0 frame (S frame for theta=0)
-    Message<HingedRigidBodyMsgPayload> spinningBodyOutMsg;      //!< state output message
-    Message<SCStatesMsgPayload> spinningBodyConfigLogOutMsg;    //!< spinning body state config log message
-    ReadFunctor<ArrayMotorTorqueMsgPayload> motorTorqueInMsg;   //!< -- (optional) motor torque input message
-    ReadFunctor<ArrayEffectorLockMsgPayload> motorLockInMsg;    //!< -- (optional) motor lock flag input message
+    double mass = 1.0;                                               //!< [kg] mass of spinning body
+    double k = 0.0;                                                  //!< [N-m/rad] torsional spring constant
+    double c = 0.0;                                                  //!< [N-m-s/rad] rotational damping coefficient
+    double thetaInit = 0.0;                                          //!< [rad] initial spinning body angle
+    double thetaDotInit = 0.0;                                       //!< [rad/s] initial spinning body angle rate
+    std::string nameOfThetaState;                                    //!< -- identifier for the theta state data container
+    std::string nameOfThetaDotState;                                 //!< -- identifier for the thetaDot state data container
+    Eigen::Vector3d r_SB_B;                                          //!< [m] vector pointing from body frame B origin to spinning frame S origin in B frame components
+    Eigen::Vector3d r_ScS_S;                                         //!< [m] vector pointing from spinning frame S origin to point Sc (center of mass of the spinner) in S frame components
+    Eigen::Vector3d sHat_S;                                          //!< -- spinning axis in S frame components.
+    Eigen::Matrix3d IPntSc_S;                                        //!< [kg-m^2] Inertia of spinning body about point Sc in S frame components
+    Eigen::Matrix3d dcm_S0B;                                         //!< -- DCM from the body frame to the S0 frame (S frame for theta=0)
+    Message<HingedRigidBodyMsgPayload> spinningBodyOutMsg;           //!< state output message
+    Message<SCStatesMsgPayload> spinningBodyConfigLogOutMsg;         //!< spinning body state config log message
+    ReadFunctor<ArrayMotorTorqueMsgPayload> motorTorqueInMsg;        //!< -- (optional) motor torque input message
+    ReadFunctor<ArrayEffectorLockMsgPayload> motorLockInMsg;         //!< -- (optional) motor lock flag input message
+    ReadFunctor<HingedRigidBodyMsgPayload> spinningBodyRefInMsg;     //!< -- (optional) spinning body reference input message name
 
     SpinningBodyOneDOFStateEffector();  //!< -- Contructor
     ~SpinningBodyOneDOFStateEffector() override; //!< -- Destructor
@@ -73,6 +74,8 @@ private:
     static uint64_t effectorID;         //!< [] ID number of this panel
     double u = 0.0;                     //!< [N-m] optional motor torque
     int lockFlag = 0;                   //!< [] flag for locking the rotation axis
+    double thetaRef = 0.0;              //!< [rad] spinning body reference angle
+    double thetaDotRef = 0.0;           //!< [rad] spinning body reference angle rate
 
     // Terms needed for back substitution
     Eigen::Vector3d aTheta;             //!< -- rDDot_BN term for back substitution

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
@@ -30,6 +30,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 %include "swig_eigen.i"
+%include <std_array.i>
 
 %include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
@@ -44,7 +45,7 @@ struct ArrayMotorTorqueMsg_C;
 %include "architecture/msgPayloadDefC/ArrayEffectorLockMsgPayload.h"
 struct ArrayEffectorLockMsg_C;
 %include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
-struct SpinningBodyMsg_C;
+struct HingedRigidBodyMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
@@ -25,6 +25,9 @@ The following table lists all the module input and output messages.  The module 
     * - motorLockInMsg
       - :ref:`ArrayEffectorLockMsgPayload`
       - (Optional) Input message for locking the axis
+    * - spinningBodyRefInMsg
+      - :ref:`HingedRigidBodyMsgPayload`
+      - (Optional) Input message for prescribing the angle and angle rate
     * - spinningBodyConfigLogOutMsg
       - :ref:`SCStatesMsgPayload`
       - Output message containing the spinning body inertial position and attitude states
@@ -95,6 +98,14 @@ This section is to outline the steps needed to setup a Spinning Body State Effec
     lockArray.motorTorque = [1]
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
     spinningBody.motorLockInMsg.subscribeTo(lockMsg)
+
+#. (Optional) Connect an angle and angle rate reference message::
+
+    angleRef = messaging.HingedRigidBodyMsgPayload()
+    angleRef.theta = thetaRef
+    angleRef.thetaDot = thetaDotRef
+    angleRefMsg = messaging.HingedRigidBodyMsg().write(angleRef)
+    spinningBody.spinningBodyRefInMsg.subscribeTo(angleRefMsg)
 
 #. The angular states of the body are created using an output message ``spinningBodyOutMsg``.
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
@@ -43,14 +43,16 @@ from Basilisk.architecture import messaging
 # @pytest.mark.xfail() # need to update how the RW states are defined
 # provide a unique test method name, starting with test_
 
-@pytest.mark.parametrize("cmdTorque1, lock1, cmdTorque2, lock2", [
-    (0.0, False, 0.0, False)
-    , (0.0, True, 0.0, False)
-    , (0.0, False, 0.0, True)
-    , (0.0, True, 0.0, True)
-    , (1.0, False, -2.0, False)
+@pytest.mark.parametrize("cmdTorque1, lock1, theta1Ref, cmdTorque2, lock2, theta2Ref", [
+    (0.0, False, 0.0, 0.0, False, 0.0)
+    , (0.0, True, 0.0, 0.0, False, 0.0)
+    , (0.0, False, 0.0, 0.0, True, 0.0)
+    , (0.0, True, 0.0, 0.0, True, 0.0)
+    , (1.0, False, 0.0, -2.0, False, 0.0)
+    , (0.0, False, 10.0 * macros.D2R, 0.0, False, -5.0 * macros.D2R)
+    , (0.0, False, -5.0 * macros.D2R, 0.0, False, 10.0 * macros.D2R)
 ])
-def test_spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
+def test_spinningBody(show_plots, cmdTorque1, lock1, theta1Ref, cmdTorque2, lock2, theta2Ref):
     r"""
     **Validation Test Description**
 
@@ -71,11 +73,11 @@ def test_spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
 
     against their initial values.
     """
-    [testResults, testMessage] = spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2)
+    [testResults, testMessage] = spinningBody(show_plots, cmdTorque1, lock1, theta1Ref, cmdTorque2, lock2, theta2Ref)
     assert testResults < 1, testMessage
 
 
-def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
+def spinningBody(show_plots, cmdTorque1, lock1, theta1Ref, cmdTorque2, lock2, theta2Ref):
     __tracebackhide__ = True
 
     testFailCount = 0  # zero unit test result counter
@@ -91,7 +93,7 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.0001)  # update process rate update time
+    testProcessRate = macros.sec2nano(0.0002)  # update process rate update time
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
@@ -113,8 +115,11 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
     spinningBody.s2Hat_S2 = [[0], [-1], [0]]
     spinningBody.theta1Init = 0 * macros.D2R
     spinningBody.theta2Init = 5 * macros.D2R
-    spinningBody.k1 = 1.0
-    spinningBody.k2 = 2.0
+    spinningBody.k1 = 1000.0
+    spinningBody.k2 = 500.0
+    if theta1Ref != 0.0 or theta2Ref != 0.0:
+        spinningBody.c1 = 500
+        spinningBody.c2 = 200
     if lock1:
         spinningBody.theta1DotInit = 0 * macros.D2R
     else:
@@ -145,6 +150,19 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
     spinningBody.motorLockInMsg.subscribeTo(lockMsg)
 
+    # Create the reference messages
+    angle1Ref = messaging.HingedRigidBodyMsgPayload()
+    angle1Ref.theta = theta1Ref
+    angle1Ref.thetaDot = 0.0
+    angle1RefMsg = messaging.HingedRigidBodyMsg().write(angle1Ref)
+    spinningBody.spinningBodyRefInMsgs[0].subscribeTo(angle1RefMsg)
+
+    angle2Ref = messaging.HingedRigidBodyMsgPayload()
+    angle2Ref.theta = theta2Ref
+    angle2Ref.thetaDot = 0.0
+    angle2RefMsg = messaging.HingedRigidBodyMsg().write(angle2Ref)
+    spinningBody.spinningBodyRefInMsgs[1].subscribeTo(angle2RefMsg)
+
     # Define mass properties of the rigid hub of the spacecraft
     scObject.hub.mHub = 750.0
     scObject.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
@@ -154,7 +172,7 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
     scObject.hub.r_CN_NInit = [[-4020338.690396649], [7490566.741852513], [5248299.211589362]]
     scObject.hub.v_CN_NInit = [[-5199.77710904224], [-3436.681645356935], [1041.576797498721]]
     scObject.hub.sigma_BNInit = [[0.0], [0.0], [0.0]]
-    scObject.hub.omega_BN_BInit = [[0.1], [-0.1], [0.1]]
+    scObject.hub.omega_BN_BInit = [[0.01], [-0.01], [0.01]]
 
     # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, spinningBody)
@@ -293,7 +311,7 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
             testMessages.append(
                 "FAILED: Spinning Body integrated test failed rotational angular momentum unit test")
 
-    if cmdTorque1 == 0 and cmdTorque2 == 0:
+    if cmdTorque1 == 0 and cmdTorque2 == 0 and theta1Ref == 0.0 and theta2Ref == 0.0:
         for i in range(0, len(initialRotEnergy)):
             # check a vector values
             if not unitTestSupport.isArrayEqualRelative(finalRotEnergy[i], initialRotEnergy[i], 1, accuracy):
@@ -306,6 +324,15 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
             testFailCount += 1
             testMessages.append("FAILED: Spinning Body integrated test failed orbital energy unit test")
 
+    if theta1Ref != 0.0 or theta2Ref != 0.0:
+        if not unitTestSupport.isDoubleEqual(theta1[-1], theta1Ref, 0.01):
+            testFailCount += 1
+            testMessages.append("FAILED: Spinning Body integrated test failed angle 1 convergence unit test")
+
+        if not unitTestSupport.isDoubleEqual(theta2[-1], theta2Ref, 0.01):
+            testFailCount += 1
+            testMessages.append("FAILED: Spinning Body integrated test failed angle 2 convergence unit test")
+
     if testFailCount == 0:
         print("PASSED: " + " Spinning Body gravity integrated test")
 
@@ -316,4 +343,4 @@ def spinningBody(show_plots, cmdTorque1, lock1, cmdTorque2, lock2):
 
 
 if __name__ == "__main__":
-    spinningBody(True, 0.0, False, 0.0, False)
+    spinningBody(True, 0.0, False, 0.0 * macros.D2R, 0.0, False, 0.0 * macros.D2R)

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
@@ -61,10 +61,11 @@ public:
     Eigen::Matrix3d IS2PntSc2_S2;       //!< [kg-m^2] Inertia of upper spinning body about point Sc2 in S2 frame components
     Eigen::Matrix3d dcm_S10B;           //!< -- DCM from the body frame to the S10 frame (S1 frame for theta1=0)
     Eigen::Matrix3d dcm_S20S1;          //!< -- DCM from the S1 frame to the S20 frame (S2 frame for theta2=0)
-    std::vector<Message<HingedRigidBodyMsgPayload>*> spinningBodyOutMsgs;       //!< vector of state output messages
-    std::vector<Message<SCStatesMsgPayload>*> spinningBodyConfigLogOutMsgs;     //!< vector of spinning body state config log messages
+    std::vector<Message<HingedRigidBodyMsgPayload>*> spinningBodyOutMsgs {new Message<HingedRigidBodyMsgPayload>, new Message<HingedRigidBodyMsgPayload>};       //!< vector of state output messages
+    std::vector<Message<SCStatesMsgPayload>*> spinningBodyConfigLogOutMsgs {new Message<SCStatesMsgPayload>, new Message<SCStatesMsgPayload>};     //!< vector of spinning body state config log messages
     ReadFunctor<ArrayMotorTorqueMsgPayload> motorTorqueInMsg;                   //!< -- (optional) motor torque input message name
     ReadFunctor<ArrayEffectorLockMsgPayload> motorLockInMsg;                    //!< -- (optional) motor lock input message name
+    std::vector<ReadFunctor<HingedRigidBodyMsgPayload>> spinningBodyRefInMsgs {ReadFunctor<HingedRigidBodyMsgPayload>(), ReadFunctor<HingedRigidBodyMsgPayload>()};    //!< (optional) vector of spinning body reference input messages
 
     SpinningBodyTwoDOFStateEffector();      //!< -- Contructor
     ~SpinningBodyTwoDOFStateEffector();     //!< -- Destructor
@@ -96,6 +97,10 @@ private:
     double u2 = 0.0;                //!< [N-m] optional motor torque for second axis
     int lockFlag1 = 0;              //!< [] flag for locking the first rotation axis
     int lockFlag2 = 0;              //!< [] flag for locking the second rotation axis
+    double theta1Ref = 0.0;         //!< [rad] spinning body reference angle
+    double theta1DotRef = 0.0;      //!< [rad] spinning body reference angle rate
+    double theta2Ref = 0.0;         //!< [rad] spinning body reference angle
+    double theta2DotRef = 0.0;      //!< [rad] spinning body reference angle rate
     double mass = 1.0;              //!< [kg] mass of the spinner system
 
     // Terms needed for back substitution

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.rst
@@ -27,6 +27,9 @@ The following table lists all the module input and output messages.  The module 
     * - motorLockInMsg
       - :ref:`ArrayEffectorLockMsgPayload`
       - (Optional) Input message for locking the axis
+    * - spinningBodyRefInMsgs
+      - :ref:`HingedRigidBodyMsgPayload`
+      - (Optional) Input array of messages for prescribing the angles and angle rates
     * - spinningBodyConfigLogOutMsgs
       - :ref:`SCStatesMsgPayload`
       - Output vector of messages containing the spinning body inertial position and attitude states
@@ -108,6 +111,20 @@ This section is to outline the steps needed to setup a Spinning Body 2 DoF State
     lockArray.motorTorque = [1, 0]
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
     spinningBody.motorLockInMsg.subscribeTo(lockMsg)
+
+#. (Optional) Connect angle and angle rate reference messages::
+
+    angle1Ref = messaging.HingedRigidBodyMsgPayload()
+    angle1Ref.theta = theta1Ref
+    angle1Ref.thetaDot = theta1DotRef
+    angle1RefMsg = messaging.HingedRigidBodyMsg().write(angle1Ref)
+    spinningBody.spinningBodyRefInMsgs[0].subscribeTo(angle1RefMsg)
+
+    angle2Ref = messaging.HingedRigidBodyMsgPayload()
+    angle2Ref.theta = theta2Ref
+    angle2Ref.thetaDot = theta2DotRef
+    angle2RefMsg = messaging.HingedRigidBodyMsg().write(angle2Ref)
+    spinningBody.spinningBodyRefInMsgs[1].subscribeTo(angle2RefMsg)
 
 #. The angular states of the body are created using an output vector of messages ``spinningBodyOutMsgs``.
 


### PR DESCRIPTION
* **Tickets addressed:** #178
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
Added a reference input message which, if linked and written, introduces a reference angle and angle rate to bother one and two-degree-of-freedom spinning bodies modules. The first commit adds the changes, the second commit improves the unit tests, and the last two relate to documentation.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
Added another parameter to the unit test to check for angle convergence when a non-zero reference is given.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
Added the additional input message to the module table and included a code snippet to show how to connect it.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A.
