### PR TITLE
Fix memory leak in SWIG typemap of 2D array

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -15,6 +15,8 @@ Version |release|
   This is corrected in the current release.
 - Doing a clean Basilisk build with `opNav` flag on fails building openCV.  The conan
   install script is updated this is corrected in the current release.
+- We found a slow memory leak if messages with arrays or vectors were accessed from python.  The ``swig``
+  issue has now been fixed in the current release.
 
 Version 2.2.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -35,6 +35,7 @@ Version |release|
 -----------------
 - Created a new :ref:`pinholeCamera` module to support generation of landmarks-based measurements around a
   small body.
+- Corrected a memory leak in the ``swig`` access to standard vectors inside messages.
 - A new integrated example script :ref:`scenarioSmallBodyLandmarks` demonstrates the use of the pinhole camera module
 - Created a new example scenario :ref:`scenarioSpinningBodiesTwoDOF` that showcases the different capabilities of the
   :ref:`spinningBodyTwoDOFStateEffector` module.

--- a/src/architecture/_GeneralModuleFiles/swig_conly_data.i
+++ b/src/architecture/_GeneralModuleFiles/swig_conly_data.i
@@ -200,6 +200,7 @@ ARRAYINTASLIST(unsigned int)
             PyList_Append(locRow, outObject);
         }
         PyList_Append($result, locRow);
+        Py_DECREF(locRow);
     }
 }
 


### PR DESCRIPTION
* **Tickets addressed:** hotfix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Manually lower reference count so that arrays are correctly garbage collected.

## Verification
Existing tests + use of ´objgraph´ to check the leak is not longer there.
