### PR TITLE
Feature/bsk 451 sonoma support

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
       - name: "Install wheel and conan package"
-        run: source .venv/bin/activate && pip3 install wheel conan==1.59.0 pytest datashader holoviews pytest-xdist
+        run: source .venv/bin/activate && pip3 install wheel conan==1.61.0 pytest datashader holoviews pytest-xdist
       - name: "Build basilisk"
         run: source .venv/bin/activate && python3 conanfile.py
       - name: "Run Python Tests"
@@ -108,7 +108,7 @@ jobs:
         shell: pwsh
         run: |
             venv\Scripts\activate
-            pip install wheel conan==1.59.0 parse six pytest-xdist
+            pip install wheel conan==1.61.0 parse six pytest-xdist
       - name: "Add basilisk and cmake path to env path"
         shell: pwsh
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,19 +19,19 @@ endColor = '\033[0m'
 
 try:
     from conans import __version__ as conan_version
-    # check conan version
-    if conan_version < "1.40.1":
+    if int(conan_version[0]) >= 2:
+        print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
+        print("use version 1.40.1 to 1.xx.0 to work with the conan repo changes." + endColor)
+        exit(0)
+    from conans.tools import Version
+    # check conan version 1.xx
+    if conan_version < Version("1.40.1"):
         print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
         print("use version 1.40.1+ to work with the conan repo changes from 2021." + endColor)
         exit(0)
-    if conan_version > "1.59.0":
-        print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
-        print("use version 1.40.1 to 1.59.0 to work with the conan repo changes." + endColor)
-        exit(0)
-    from conans.tools import Version
     from conans import ConanFile, CMake, tools
 except ModuleNotFoundError:
-    print("Please make sure you install python conan package\nRun command `pip install conan` "
+    print("Please make sure you install python conan (version 1.xx, not 2.xx) package\nRun command `pip install conan` "
           "for Windows\nRun command `pip3 install conan` for Linux/MacOS")
     sys.exit(1)
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -29,7 +29,7 @@ Version 2.1.7
   issue between the two code bases.  BSK is reverting to using ZMQ 4.3.0 for now to avoid this issue.
 - Building Basilisk with ``opNav`` mode was no longer working as a conan package dependency issue came up.
   This has been corrected in the new version by specifying ``xz_utils/5.4.0`` in ``conanfile.py``.  Note
-  that building with ``opNav`` now also appears to require ``conan==1.59.0``.
+  that building with ``opNav`` now also appears to require ``conan>=1.59.0``, but less than 2.0.0.
 
 Version 2.1.6
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -65,6 +65,7 @@ Version |release|
   and angular rate (optional) are within the requirement limits and sends an imaging command to a :ref:`simpleInstrument`.
 - Added a new scenario :ref:`scenarioHohmann` that performs a Hohmann transfer with attitude mode changes.
   The basic attiude flight modes are implemented using the Basilisk event system.
+- updated conan support to latest `1.xx` version to provide support for macOS Sonoma
 
 
 

--- a/docs/source/bskPkgRequired.txt
+++ b/docs/source/bskPkgRequired.txt
@@ -3,5 +3,5 @@
 ``matplotlib``
 ``pytest``
 ``Pillow``
-``conan>=1.40.1, <=1.59.0``
+``conan>=1.40.1, <2.00.0``
 ``parse>=1.18.0``


### PR DESCRIPTION
* **Tickets addressed:** bsk-451
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Updated the Conan file to allow newer 1.xx Conan version to be used.  Updated how we check for correct Conan version and updated all associated documentation.  Version Conan 1.61 support macOS Sonoma.  Updating the workflow scripts to use 1.61 as well.

## Verification
Did a clean build with a range of Conan version and always got the expect result or error message.

## Documentation
Updated required Conan version documentation.

## Future work
We need to migrate to Conan 2.x at some point in the future.