### PR TITLE
Increase number css measurements csswls

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -71,6 +71,7 @@ Version |release|
   prior versions of Xcode.
 - Fixed a bug in the conanfile where the ``stderr`` output from a ``subprocess.Popen`` call was being interpreted as an
   error. Rather, the process return code (0 for success, and anything else for failure) indicates the success.
+- The ``MAX_N_CSS_MEAS`` define is increased to 32 matching the maximum number of coarse sun sensors.
 
 
 Version 2.2.0 (June 28, 2023)

--- a/src/architecture/msgPayloadDefC/SunlineFilterMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/SunlineFilterMsgPayload.h
@@ -25,7 +25,7 @@
 #define SKF_N_STATES_SWITCH 6
 #define EKF_N_STATES_SWITCH 5
 #define SKF_N_STATES_HALF 3
-#define MAX_N_CSS_MEAS 8
+#define MAX_N_CSS_MEAS 32
 
 /*! @brief structure for filter-states output for the unscented kalman filter
  implementation of the sunline state estimator*/

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
@@ -56,6 +56,10 @@ void Reset_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime, int64_t module
     }
 
     configData->cssConfigInBuffer = CSSConfigMsg_C_read(&configData->cssConfigInMsg);
+    if (configData->cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "cssWIsEst.cssDataInMsg.nCSS must not be greater than "
+                                                  "MAX_N_CSS_MEAS value.");
+    }
 
     configData->priorSignalAvailable = 0;
     v3SetZero(configData->dOld);

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.c
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.c
@@ -65,7 +65,11 @@ void Reset_okeefeEKF(okeefeEKFConfig *configData, uint64_t callTime,
 
     /*! - Read in coarse sun sensor configuration information.*/
     cssConfigInBuffer = CSSConfigMsg_C_read(&configData->cssConfigInMsg);
-    
+    if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "okeefeEKF.cssConfigInMsg.nCSS must not be greater than "
+                                                  "MAX_N_CSS_MEAS value.");
+    }
+
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
     for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i++)
     {

--- a/src/fswAlgorithms/attDetermination/sunlineEKF/sunlineEKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineEKF/sunlineEKF.c
@@ -65,6 +65,10 @@ void Reset_sunlineEKF(sunlineEKFConfig *configData, uint64_t callTime,
 
     /*! - Read in mass properties and coarse sun sensor configuration information.*/
     cssConfigInBuffer = CSSConfigMsg_C_read(&configData->cssConfigInMsg);
+    if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "sunlineEKF.cssConfigInMsg.nCSS must not be greater than "
+                                                  "MAX_N_CSS_MEAS value.");
+    }
 
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
     for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i++)

--- a/src/fswAlgorithms/attDetermination/sunlineSEKF/sunlineSEKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineSEKF/sunlineSEKF.c
@@ -64,6 +64,10 @@ void Reset_sunlineSEKF(sunlineSEKFConfig *configData, uint64_t callTime,
 
     /*! - Read coarse sun sensor configuration information.*/
     cssConfigInBuffer = CSSConfigMsg_C_read(&configData->cssConfigInMsg);
+    if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "sunlineSEKF.cssConfigInMsg.nCSS must not be greater than "
+                                                  "MAX_N_CSS_MEAS value.");
+    }
 
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
     for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i++)

--- a/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineSuKF/sunlineSuKF.c
@@ -67,7 +67,11 @@ void Reset_sunlineSuKF(SunlineSuKFConfig *configData, uint64_t callTime,
 
     /*! - Read in mass properties and coarse sun sensor configuration information.*/
     cssConfigInBuffer = CSSConfigMsg_C_read(&configData->cssConfigInMsg);
-    
+    if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "sunlineSuKF.cssConfigInMsg.nCSS must not be greater than "
+                                                  "MAX_N_CSS_MEAS value.");
+    }
+
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
     for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i++)
     {

--- a/src/fswAlgorithms/attDetermination/sunlineUKF/sunlineUKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineUKF/sunlineUKF.c
@@ -67,6 +67,10 @@ void Reset_sunlineUKF(SunlineUKFConfig *configData, uint64_t callTime,
 
     /*! - Read in mass properties and coarse sun sensor configuration information.*/
     cssConfigInBuffer = CSSConfigMsg_C_read(&configData->cssConfigInMsg);
+    if (cssConfigInBuffer.nCSS > MAX_N_CSS_MEAS) {
+        _bskLog(configData->bskLogger, BSK_ERROR, "sunlineUKF.cssConfigInMsg.nCSS must not be greater than "
+                                                  "MAX_N_CSS_MEAS value.");
+    }
 
     /*! - For each coarse sun sensor, convert the configuration data over from structure to body*/
     for(uint32_t i=0; i<cssConfigInBuffer.nCSS; i = i+1)


### PR DESCRIPTION
* **Tickets addressed:** bsk-467 #467
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
The `#MAX_N_CSS_MEAS` define is set to 8. The cssWls module calls a `memset` ☹️ on line 90 in `computeWlsResiduals()`, which computes the size of memory to set to 0x0 from the number of coarse sun sensors. The residuals variable which is being set has a size of 8 x `double`. If one has more than 8 coarse sun sensors then the `memset` will stomp more than 8 x `double` amount of memory. Many spacecraft employ more than 8 CSS and therefore the filter would expect to compute more than 8 measurement residuals. This PR changes the max number of measurements to be the same value as the max number of CSS. 

## Verification
CI runs successfully.

## Documentation
None needed, none invalidated.

## Future work
NA
