### PR TITLE
Feature/bsk 462 rounding

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -72,6 +72,7 @@ Version |release|
 - Fixed a bug in the conanfile where the ``stderr`` output from a ``subprocess.Popen`` call was being interpreted as an
   error. Rather, the process return code (0 for success, and anything else for failure) indicates the success.
 - The ``MAX_N_CSS_MEAS`` define is increased to 32 matching the maximum number of coarse sun sensors.
+- mixed bug in time to nano-seconds conversions in ``macros.py`` support file
 
 
 Version 2.2.0 (June 28, 2023)

--- a/examples/BskSim/scenarios/scenario_AttModes.py
+++ b/examples/BskSim/scenarios/scenario_AttModes.py
@@ -145,7 +145,7 @@ def runScenario(scenario):
     attitudeModeTime = macros.min2nano(10.)
     attitudeMode = ["hillPoint", "inertial3D"]
 
-    currentSimulationTime = 0.
+    currentSimulationTime = 0
     while currentSimulationTime < simulationTime:
 
         # Configure alternating FSW mode

--- a/src/utilities/macros.py
+++ b/src/utilities/macros.py
@@ -21,25 +21,30 @@
 
 import math
 
+
 #   function to convert seconds to an integer nanoseconds value
 def sec2nano(time):
     """convert seconds to nano-seconds"""
     return int(time*1E9+0.5)
 
+
 #   function to convert minutes to an integer nanoseconds value
 def min2nano(time):
     "convert minutes to nano-seconds"
-    return int((time*1E9+0.5)*60)
+    return int(time*1E9*60 + 0.5)
+
 
 #   function to convert hours to an integer nanoseconds value
 def hour2nano(time):
     """convert hours to nano-seconds"""
-    return int((time*1E9+0.5)*60*60)
+    return int(time*1E9*60*60 + 0.5)
+
 
 #   function to convert days to an integer nanoseconds value
 def day2nano(time):
     """convert days to nano-seconds"""
-    return int((time*1E9+0.5)*60*60*24)
+    return int(time*1E9*60*60*24 + 0.5)
+
 
 #   variable to convert nano-seconds to seconds
 NANO2SEC = 1E-9


### PR DESCRIPTION
* **Tickets addressed:** bsk-462
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In macros.py the time conversions were not adding the 0.5 rounding value in the proper place.  Thus, 0.5 was added to hours, minutes or days values.

## Verification
All unit tests still run.

## Documentation
Update release notes

## Future work
none
