### PR TITLE
Bsk 474/fix drag effector

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -19,6 +19,8 @@ Version |release|
   issue has now been fixed in the current release.
 - The :ref:`facetSRPDynamicEffector` module was double counting a cosine term in the SRP force calculation. This is
   corrected in the current release.
+- The :ref:`facetDragDynamicEffector` module was missing a negative sign in the drag torque calculation. This is
+  corrected in the current release.
 
 Version 2.2.0
 -------------

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -132,7 +132,7 @@ void FacetDragDynamicEffector::plateDrag(){
 		projectedArea = this->scGeometry.facetAreas[i] * projectionTerm;
 		if(projectedArea > 0.0){
 			facetDragForce = 0.5 * pow(this->v_B.norm(), 2.0) * this->scGeometry.facetCoeffs[i] * projectedArea * this->atmoInData.neutralDensity * (-1.0)*this->v_hat_B;
-			facetDragTorque = facetDragForce.cross(this->scGeometry.facetLocations_B[i]);
+			facetDragTorque = (-1)*facetDragForce.cross(this->scGeometry.facetLocations_B[i]);
 			totalDragForce = totalDragForce + facetDragForce;
 			totalDragTorque = totalDragTorque + facetDragTorque;
 		}


### PR DESCRIPTION
* **Tickets addressed:** bsk-474
* **Review:** By commit  
* **Merge strategy:** "squash and merge"

## Description
This PR fixes the drag torque calculation, where a negative sign was missing. Now, the torque is calculated as $T = -F\times r$.

## Verification
The unit test was also updated to test the drag torque.

## Documentation
N/A

## Future work
N/A
