### PR TITLE
Feature/480 Fix tests and examples when built without viz support

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -81,6 +81,7 @@ Version |release|
   utility method ``useSphericalHarmonicsGravityModel`` has been added to planetary body objects, which makes the body
   use spherical harmonics and loads them from a file with a single command. Similarly, the methods ``usePolyhedralGravityModel``
   and ``usePointMassGravityModel`` have been added.
+- Fixed examples and tests to run even when Basilisk is built with ``--vizInterface False``.
 
 Version 2.2.0 (June 28, 2023)
 -----------------------------

--- a/examples/BskSim/scenarios/scenario_BasicOrbitFormation.py
+++ b/examples/BskSim/scenarios/scenario_BasicOrbitFormation.py
@@ -129,11 +129,6 @@ Illustration of Simulation Results
 
 # Import utilities
 from Basilisk.utilities import orbitalMotion, macros, vizSupport
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
 
 # Get current file path
 import sys, os, inspect
@@ -174,7 +169,7 @@ class scenario_BasicOrbitFormation(BSKSim, BSKScenario):
         self.log_outputs()
 
         # if this scenario is to interface with the BSK Viz, uncomment the following line
-        if vizFound:
+        if vizSupport.vizFound:
             viz = vizSupport.enableUnityVisualization(self, self.DynModels.taskName
                                                       , [self.get_DynModel().scObject, self.get_DynModel().scObject2]
                                                       , rwEffectorList=[self.DynModels.rwStateEffector, self.DynModels.rwStateEffector2]

--- a/examples/BskSim/scenarios/scenario_RelativePointingFormation.py
+++ b/examples/BskSim/scenarios/scenario_RelativePointingFormation.py
@@ -128,11 +128,6 @@ the Earth's shadow. 0.0 corresponds with total eclipse and 1.0 corresponds with 
 
 # Import utilities
 from Basilisk.utilities import orbitalMotion, macros, vizSupport
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
 
 # Get current file path
 import sys, os, inspect
@@ -175,7 +170,7 @@ class scenario_RelativePointingFormation(BSKSim, BSKScenario):
         self.log_outputs()
 
         # if this scenario is to interface with the BSK Viz, uncomment the following line
-        if vizFound:
+        if vizSupport.vizFound:
             viz = vizSupport.enableUnityVisualization(self, self.DynModels.taskName
                                                       , [self.get_DynModel().scObject, self.get_DynModel().scObject2]
                                                       , rwEffectorList=[self.DynModels.rwStateEffector, self.DynModels.rwStateEffector2]

--- a/examples/scenarioAsteroidArrival.py
+++ b/examples/scenarioAsteroidArrival.py
@@ -209,9 +209,8 @@ from Basilisk.architecture import messaging
 
 try:
     from Basilisk.simulation import vizInterface
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -457,7 +456,7 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, scRec)
     scSim.AddModelToTask(simTaskName, astRec)
 
-    if vizFound:
+    if vizSupport.vizFound:
         # Set up the sensor for the science-pointing mode
         genericSensor = vizInterface.GenericSensor()
         genericSensor.r_SB_B = cameraLocation
@@ -529,7 +528,7 @@ def run(show_plots):
     def runPanelSunPointing(simTime):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(sunPointGuidance.attRefOutMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 0  # antenna off
             genericSensor.isHidden = 1
             thrusterMsgInfo.thrustForce = 0
@@ -542,7 +541,7 @@ def run(show_plots):
     def runSensorSciencePointing(simTime):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(sciencePointGuidance.attRefOutMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 0  # antenna off
             genericSensor.isHidden = 0
             thrusterMsgInfo.thrustForce = 0
@@ -555,7 +554,7 @@ def run(show_plots):
     def runAntennaEarthPointing(simTime):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(earthPointGuidance.attRefOutMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 3  # antenna in send and receive mode
             genericSensor.isHidden = 1
             thrusterMsgInfo.thrustForce = 0
@@ -568,7 +567,7 @@ def run(show_plots):
     def runDvBurn(simTime, burnSign, planetMsg):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(planetMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 0  # antenna off
             genericSensor.isHidden = 1
         if burnSign > 0:
@@ -583,7 +582,7 @@ def run(show_plots):
             simulationTime += macros.sec2nano(minTime)
             scSim.ConfigureStopTime(simulationTime)
             scSim.ExecuteSimulation()
-            if vizFound:
+            if vizSupport.vizFound:
                 thrusterMsgInfo.thrustForce = thrusterMsgInfo.maxThrust
                 thrMsg.write(thrusterMsgInfo, simulationTime)
             simulationTime += macros.sec2nano(simTime - minTime)

--- a/examples/scenarioCustomGravBody.py
+++ b/examples/scenarioCustomGravBody.py
@@ -88,11 +88,6 @@ from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody,
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import unitTestSupport
 
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -209,7 +204,7 @@ def run(show_plots):
     # to save the BSK data to a file, uncomment the saveFile line below
     # Note that the gravitational body information is pulled automatically from the spacecraft object(s)
     # Even if custom gravitational bodies are added, this information is pulled by the method below
-    if vizFound:
+    if vizSupport.vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
                                                   # , saveFile=fileName
                                                   )

--- a/examples/scenarioDataToViz.py
+++ b/examples/scenarioDataToViz.py
@@ -79,9 +79,8 @@ from Basilisk.utilities import unitTestSupport
 
 try:
     from Basilisk.simulation import vizInterface
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -169,7 +168,7 @@ def run(show_plots, attType):
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
     # to save the BSK data to a file, uncomment the saveFile line below
-    if vizFound:
+    if vizSupport.vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scList
                                                   # , saveFile=fileName
                                                   )

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -80,9 +80,8 @@ from Basilisk.utilities import (SimulationBaseClass, macros,
 try:
     from Basilisk.simulation import vizInterface
 
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -300,7 +299,7 @@ def run(show_plots):
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
     # to save the BSK data to a file, uncomment the saveFile line below
-    if vizFound:
+    if vizSupport.vizFound:
         # setup MSM information
         msmInfoServicer = vizInterface.MultiSphereInfo()
         msmInfoServicer.msmChargeInMsg.subscribeTo(MSMmodule.chargeMsmOutMsgs[0])

--- a/examples/scenarioDeployingPanel.py
+++ b/examples/scenarioDeployingPanel.py
@@ -281,25 +281,26 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, pwr1Log)
     scSim.AddModelToTask(simTaskName, pwr2Log)
 
-    viz = vizSupport.enableUnityVisualization(scSim, simTaskName,
-                                              [scObject
-                                                  , [panel1.ModelTag, panel1.hingedRigidBodyConfigLogOutMsg]
-                                                  , [panel2.ModelTag, panel2.hingedRigidBodyConfigLogOutMsg]
-                                               ]
-                                              # , saveFile=__file__
-                                              )
+    if vizSupport.vizFound:
+        viz = vizSupport.enableUnityVisualization(scSim, simTaskName,
+                                                  [scObject
+                                                      , [panel1.ModelTag, panel1.hingedRigidBodyConfigLogOutMsg]
+                                                      , [panel2.ModelTag, panel2.hingedRigidBodyConfigLogOutMsg]
+                                                   ]
+                                                  # , saveFile=__file__
+                                                  )
 
-    vizSupport.createCustomModel(viz
-                                 , simBodiesToModify=[panel1.ModelTag]
-                                 , modelPath="CUBE"
-                                 , scale=[3, 1, 0.1]
-                                 , color=vizSupport.toRGBA255("blue"))
-    vizSupport.createCustomModel(viz
-                                 , simBodiesToModify=[panel2.ModelTag]
-                                 , modelPath="CUBE"
-                                 , scale=[3, 1, 0.1]
-                                 , color=vizSupport.toRGBA255("blue"))
-    viz.settings.orbitLinesOn = -1
+        vizSupport.createCustomModel(viz
+                                     , simBodiesToModify=[panel1.ModelTag]
+                                     , modelPath="CUBE"
+                                     , scale=[3, 1, 0.1]
+                                     , color=vizSupport.toRGBA255("blue"))
+        vizSupport.createCustomModel(viz
+                                     , simBodiesToModify=[panel2.ModelTag]
+                                     , modelPath="CUBE"
+                                     , scale=[3, 1, 0.1]
+                                     , color=vizSupport.toRGBA255("blue"))
+        viz.settings.orbitLinesOn = -1
 
     scSim.InitializeSimulation()
     scSim.ConfigureStopTime(simulationTime)

--- a/examples/scenarioFlybySpice.py
+++ b/examples/scenarioFlybySpice.py
@@ -255,9 +255,8 @@ from Basilisk.utilities import vizSupport
 # import general simulation support files
 try:
     from Basilisk.simulation import vizInterface
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # import FSW Algorithm related support
 from Basilisk.fswAlgorithms import hillPoint
@@ -481,7 +480,7 @@ def run(planetCase):
     # Set the initial simulation time
     simulationTime = macros.sec2nano(0)
 
-    if vizFound:
+    if vizSupport.vizFound:
         # Set up antenna transmission to Earth visualization
         transceiverHUD = vizInterface.Transceiver()
         transceiverHUD.r_SB_B = [0.23, 0., 1.38]
@@ -513,7 +512,7 @@ def run(planetCase):
     def runVelocityPointing(simTime, planetMsg):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(planetMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 0  # antenna off
         attError.sigma_R0R = [np.tan(90.*macros.D2R/4), 0, 0]
         simulationTime += macros.sec2nano(simTime)
@@ -523,7 +522,7 @@ def run(planetCase):
     def runAntennaEarthPointing(simTime):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(earthPointGuidance.attRefOutMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 3  # antenna in send and receive mode
         attError.sigma_R0R = [0, 0, 0]
         simulationTime += macros.sec2nano(simTime)
@@ -533,7 +532,7 @@ def run(planetCase):
     def runPanelSunPointing(simTime):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(sunPointGuidance.attRefOutMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 0  # antenna off
         attError.sigma_R0R = [0, 0, 0]
         simulationTime += macros.sec2nano(simTime)
@@ -543,7 +542,7 @@ def run(planetCase):
     def runSensorSciencePointing(simTime):
         nonlocal simulationTime
         attError.attRefInMsg.subscribeTo(sciencePointGuidance.attRefOutMsg)
-        if vizFound:
+        if vizSupport.vizFound:
             transceiverHUD.transceiverState = 0  # antenna off
         attError.sigma_R0R = [-1./3., 1./3., -1./3.]
         simulationTime += macros.sec2nano(simTime)

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -116,9 +116,8 @@ from Basilisk.utilities import (SimulationBaseClass, macros,
 
 try:
     from Basilisk.simulation import vizInterface
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -442,7 +441,7 @@ def run(show_plots):
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
     # to save the BSK data to a file, uncomment the saveFile line below
-    if vizFound:
+    if vizSupport.vizFound:
         servicerLight = vizInterface.Light()
         servicerLight.label = "Main Light"
         servicerLight.position = [0.2, -1.0, 1.01]

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -111,9 +111,8 @@ from Basilisk.utilities import vizSupport
 try:
     from Basilisk.simulation import vizInterface
 
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -391,7 +390,7 @@ def run(show_plots):
     #
     # setup Vizard visualization elements
     #
-    if vizFound:
+    if vizSupport.vizFound:
         genericSensorHUD = vizInterface.GenericSensor()
         genericSensorHUD.r_SB_B = [0.0, 1.0, 1.0]
         genericSensorHUD.fieldOfView.push_back(
@@ -504,7 +503,7 @@ def run(show_plots):
     simpleInsControl.imaged = 0
 
     # update targeting line to point to Santiago and be blue
-    if vizFound:
+    if vizSupport.vizFound:
         vizSupport.targetLineList[0].lineColor = vizSupport.toRGBA255("blue")
         vizSupport.targetLineList[0].toBodyName = "Santiago Target"
         vizSupport.updateTargetLineList(viz)

--- a/examples/scenarioGroundMapping.py
+++ b/examples/scenarioGroundMapping.py
@@ -101,9 +101,8 @@ from Basilisk.utilities import vizSupport
 try:
     from Basilisk.simulation import vizInterface
 
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioHelioTransSpice.py
+++ b/examples/scenarioHelioTransSpice.py
@@ -185,8 +185,9 @@ def run():
     scSim.ExecuteSimulation()
 
     # change true orbit line color
-    colorMsgContent.colorRGBA = vizSupport.toRGBA255("Cyan")
-    colorMsg.write(colorMsgContent)
+    if vizSupport.vizFound:
+        colorMsgContent.colorRGBA = vizSupport.toRGBA255("Cyan")
+        colorMsg.write(colorMsgContent)
     simulationTime = macros.sec2nano(4.5 * 365 * day)
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()

--- a/examples/scenarioOrbitManeuver.py
+++ b/examples/scenarioOrbitManeuver.py
@@ -196,14 +196,15 @@ def run(show_plots, maneuverCase):
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataRec)
 
-    # if this scenario is to interface with the BSK Viz, uncomment the following lines
-    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
-                                              , oscOrbitColorList=[vizSupport.toRGBA255("yellow")]
-                                              , trueOrbitColorList=[vizSupport.toRGBA255("turquoise")]
-                                              # , saveFile=fileName
-                                              )
-    viz.settings.mainCameraTarget = "earth"
-    viz.settings.trueTrajectoryLinesOn = 1
+    if vizSupport.vizFound:
+        # if this scenario is to interface with the BSK Viz, uncomment the following lines
+        viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
+                                                  , oscOrbitColorList=[vizSupport.toRGBA255("yellow")]
+                                                  , trueOrbitColorList=[vizSupport.toRGBA255("turquoise")]
+                                                  # , saveFile=fileName
+                                                  )
+        viz.settings.mainCameraTarget = "earth"
+        viz.settings.trueTrajectoryLinesOn = 1
 
     #
     #   initialize Simulation

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -98,9 +98,8 @@ from Basilisk.utilities import (SimulationBaseClass, macros,
 
 try:
     from Basilisk.simulation import vizInterface
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -431,7 +430,7 @@ def run(show_plots):
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
     # to save the BSK data to a file, uncomment the saveFile line below
-    if vizFound:
+    if vizSupport.vizFound:
         servicerLight = vizInterface.Light()
         servicerLight.label = "Main Light"
         servicerLight.position = [1.0, 0.0, 0.00]

--- a/examples/scenarioSensorThermal.py
+++ b/examples/scenarioSensorThermal.py
@@ -88,13 +88,6 @@ from Basilisk.architecture import messaging
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
 
-try:
-    from Basilisk.simulation import vizInterface
-
-    vizFound = True
-except ImportError:
-    vizFound = False
-
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -487,15 +487,16 @@ def run(show_plots):
 
     fileName = 'scenarioSmallBodyFeedbackControl'
 
-    vizInterface = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
-                                                            # , saveFile=fileName
-                                                            )
-    vizSupport.createStandardCamera(vizInterface, setMode=0, bodyTarget='bennu', setView=0)
+    if vizSupport.vizFound:
+        vizInterface = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
+                                                                # , saveFile=fileName
+                                                                )
+        vizSupport.createStandardCamera(vizInterface, setMode=0, bodyTarget='bennu', setView=0)
 
-    # vizInterface.settings.showSpacecraftLabels = 1
-    vizInterface.settings.showCSLabels = 1
-    vizInterface.settings.planetCSon = 1
-    vizInterface.settings.orbitLinesOn = -1
+        # vizInterface.settings.showSpacecraftLabels = 1
+        vizInterface.settings.showCSLabels = 1
+        vizInterface.settings.planetCSon = 1
+        vizInterface.settings.orbitLinesOn = -1
 
     # initialize Simulation
     scSim.InitializeSimulation()

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -106,11 +106,6 @@ from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeRW
 from Basilisk.utilities import unitTestSupport
 
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -759,7 +754,7 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, ast_ephemeris_recorder)
     scSim.AddModelToTask(measTaskName, ast_ephemeris_meas_recorder)
 
-    if vizFound:
+    if vizSupport.vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
                                                   # , saveFile=fileName
                                                   )

--- a/examples/scenarioSpacecraftLocation.py
+++ b/examples/scenarioSpacecraftLocation.py
@@ -57,11 +57,6 @@ from Basilisk.utilities import (SimulationBaseClass, macros,
                                 orbitalMotion, simIncludeGravBody,
                                 unitTestSupport, vizSupport)
 
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -230,7 +225,7 @@ def run(show_plots):
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
     # to save the BSK data to a file, uncomment the saveFile line below
-    if vizFound:
+    if vizSupport.vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, [scObject, scObject2]
                                                   # , saveFile=fileName,
                                                   )

--- a/examples/scenarioSpinningBodiesTwoDOF.py
+++ b/examples/scenarioSpinningBodiesTwoDOF.py
@@ -254,33 +254,34 @@ def run(show_plots, numberPanels):
         scBodyList.append(["panel1", spinningBody.spinningBodyConfigLogOutMsgs[0]])
         scBodyList.append(["panel2", spinningBody.spinningBodyConfigLogOutMsgs[1]])
 
-    viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scBodyList
-                                              # , saveFile=fileName + str(numberPanels)
-                                              )
+    if vizSupport.vizFound:
+        viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scBodyList
+                                                  # , saveFile=fileName + str(numberPanels)
+                                                  )
 
-    vizSupport.createCustomModel(viz
-                                 , simBodiesToModify=[scObject.ModelTag]
-                                 , modelPath="CYLINDER"
-                                 , scale=[diameter, diameter, height / 2]
-                                 , color=vizSupport.toRGBA255("blue"))
-    if numberPanels == 1:
         vizSupport.createCustomModel(viz
-                                     , simBodiesToModify=["panel"]
+                                     , simBodiesToModify=[scObject.ModelTag]
                                      , modelPath="CYLINDER"
-                                     , scale=[2 * radius, 2 * radius, thickness]
-                                     , color=vizSupport.toRGBA255("green"))
-    elif numberPanels == 2:
-        vizSupport.createCustomModel(viz
-                                     , simBodiesToModify=["panel1"]
-                                     , modelPath="CUBE"
-                                     , scale=[width, length, thickness]
-                                     , color=vizSupport.toRGBA255("green"))
-        vizSupport.createCustomModel(viz
-                                     , simBodiesToModify=["panel2"]
-                                     , modelPath="CUBE"
-                                     , scale=[width, length, thickness]
-                                     , color=vizSupport.toRGBA255("green"))
-    viz.settings.orbitLinesOn = -1
+                                     , scale=[diameter, diameter, height / 2]
+                                     , color=vizSupport.toRGBA255("blue"))
+        if numberPanels == 1:
+            vizSupport.createCustomModel(viz
+                                         , simBodiesToModify=["panel"]
+                                         , modelPath="CYLINDER"
+                                         , scale=[2 * radius, 2 * radius, thickness]
+                                         , color=vizSupport.toRGBA255("green"))
+        elif numberPanels == 2:
+            vizSupport.createCustomModel(viz
+                                         , simBodiesToModify=["panel1"]
+                                         , modelPath="CUBE"
+                                         , scale=[width, length, thickness]
+                                         , color=vizSupport.toRGBA255("green"))
+            vizSupport.createCustomModel(viz
+                                         , simBodiesToModify=["panel2"]
+                                         , modelPath="CUBE"
+                                         , scale=[width, length, thickness]
+                                         , color=vizSupport.toRGBA255("green"))
+        viz.settings.orbitLinesOn = -1
 
     # Initialize the simulation
     scSim.InitializeSimulation()

--- a/examples/scenarioTwoChargedSC.py
+++ b/examples/scenarioTwoChargedSC.py
@@ -76,13 +76,6 @@ from Basilisk.utilities import (SimulationBaseClass, macros,
                                 orbitalMotion, simIncludeGravBody,
                                 unitTestSupport, RigidBodyKinematics, vizSupport, SpherePlot)
 
-try:
-    from Basilisk.simulation import vizInterface
-
-    vizFound = True
-except ImportError:
-    vizFound = False
-
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
@@ -256,7 +249,7 @@ def run(show_plots):
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
     # to save the BSK data to a file, uncomment the saveFile line below
-    if vizFound:
+    if vizSupport.vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, dynTaskName, [scObjectLeader, scObjectFollower]
                                                   # , saveFile=fileName,
                                                   )

--- a/src/simulation/vizard/dataFileToViz/_UnitTest/test_dataFileToViz.py
+++ b/src/simulation/vizard/dataFileToViz/_UnitTest/test_dataFileToViz.py
@@ -43,9 +43,8 @@ from Basilisk.utilities import vizSupport
 
 try:
     from Basilisk.simulation import vizInterface
-    vizFound = True
 except ImportError:
-    vizFound = False
+    pass
 
 path = os.path.dirname(os.path.abspath(__file__))
 
@@ -287,7 +286,7 @@ def run(show_plots, convertPosUnits, attType, checkThruster, checkRW, verbose):
     viz = vizSupport.enableUnityVisualization(unitTestSim, unitTaskName, [scObject1, scObject2]
                                               # , saveFile=__file__
                                               )
-    if vizFound:
+    if vizSupport.vizFound:
         # over-ride the default to not read the SC states from scObjects, but set them directly
         # to read from the dataFileToFiz output message
         viz.scData.clear()


### PR DESCRIPTION
* **Tickets addressed:** Closes #480 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Approach 2 from the Issue ticket #480 was taken.

> Protect all usages of vizSupport.enableUnityVisualization with if vizFound blocks. A lot of example scripts already do this, some via vizSupport.vizFound and some by repeating the logic from vizSupport. I'd probably make everything consistently use vizSupport.vizFound.

## Verification

Tests were validated by running locally (macOS, aarch64) and in our CI server (Linux, amd64). Some of the example scripts were manually executed locally as a sanity check.

No tests were added, as this fixes broken tests.

## Documentation

There should be no documentation changes.

## Future work

None.
