### PR TITLE
Refactor/489 thruster platform reference

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -74,6 +74,8 @@ Version |release|
 - The ``MAX_N_CSS_MEAS`` define is increased to 32 matching the maximum number of coarse sun sensors.
 - mixed bug in time to nano-seconds conversions in ``macros.py`` support file
 - Created :ref:`thrusterPlatformState` to map the thruster configuration information to body frame given the time-varying platform states.
+- Updated :ref:`thrusterPlatformReference` to add an input and output thruster config msg, and integral feedback term
+  which dumps steady-state momentum in case of uncertainties on the CM location.
 
 
 Version 2.2.0 (June 28, 2023)

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -131,10 +131,31 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
         tprComputeFinalRotation(r_CMd_M, r_TM_F, T_F, FM);
     }
 
+    double theta1 = atan2(FM[1][2], FM[1][1]);
+    double theta2 = atan2(FM[2][0], FM[0][0]);
+
+    /*! bound reference angles between limits */
+    if ((configData->theta1Max > epsilon) && (theta1 > configData->theta1Max)) {
+        theta1 = configData->theta1Max;
+    }
+    else if ((configData->theta1Max > epsilon) && (theta1 < -configData->theta1Max)) {
+        theta1 = -configData->theta1Max;
+    }
+    if ((configData->theta2Max > epsilon) && (theta2 > configData->theta2Max)) {
+        theta2 = configData->theta2Max;
+    }
+    else if ((configData->theta2Max > epsilon) && (theta2 < -configData->theta2Max)) {
+        theta2 = -configData->theta2Max;
+    }
+
+    /*! rewrite DCM with updated angles */
+    double EulerAngles123[3] = {theta1, theta2, 0.0};
+    Euler1232C(EulerAngles123, FM);
+
     /*! extract theta1 and theta2 angles */
-    hingedRigidBodyRef1Out.theta = atan2(FM[1][2], FM[1][1]);
+    hingedRigidBodyRef1Out.theta = theta1;
     hingedRigidBodyRef1Out.thetaDot = 0;
-    hingedRigidBodyRef2Out.theta = atan2(FM[2][0], FM[0][0]);
+    hingedRigidBodyRef2Out.theta = theta2;
     hingedRigidBodyRef2Out.thetaDot = 0;
 
     /*! write output spinning body messages */

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -39,12 +39,13 @@ enum momentumDumping{
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
 
-    /* declare these user-defined quantities */
+    /*! declare these user-defined quantities */
     double sigma_MB[3];                                   //!< orientation of the M frame w.r.t. the B frame
     double r_BM_M[3];                                     //!< position of B frame origin w.r.t. M frame origin, in M frame coordinates
     double r_FM_F[3];                                     //!< position of F frame origin w.r.t. M frame origin, in F frame coordinates
 
-    double K;                                             //!< momentum dumping time constant [1/s]
+    double K;                                             //!< momentum dumping proportional gain [1/s]
+    double Ki;                                            //!< momentum dumping integral gain [1]
 
     double theta1Max;                                     //!< absolute bound on tip angle [rad]
     double theta2Max;                                     //!< absolute bound on tilt angle [rad]
@@ -52,10 +53,13 @@ typedef struct {
     /*! declare variables for internal module calculations */
     RWArrayConfigMsgPayload   rwConfigParams;             //!< struct to store message containing RW config parameters in body B frame
     int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
+    double                    hsInt_M[3];                 //!< integral of RW momentum
+    double                    priorHs_M[3];               //!< prior RW momentum
+    uint64_t                  priorTime;                  //!< prior call time
 
-    /* declare module IO interfaces */
-    VehicleConfigMsg_C        vehConfigInMsg;            //!< input msg vehicle configuration msg (needed for CM location)
-    THRConfigMsg_C            thrusterConfigFInMsg;        //!< input thruster configuration msg
+    /*! declare module IO interfaces */
+    VehicleConfigMsg_C        vehConfigInMsg;             //!< input msg vehicle configuration msg (needed for CM location)
+    THRConfigMsg_C            thrusterConfigFInMsg;       //!< input thruster configuration msg
     RWSpeedMsg_C              rwSpeedsInMsg;              //!< input reaction wheel speeds message
     RWArrayConfigMsg_C        rwConfigDataInMsg;          //!< input RWA configuration message
     HingedRigidBodyMsg_C      hingedRigidBodyRef1OutMsg;  //!< output msg containing theta1 reference and thetaDot1 reference

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -46,7 +46,10 @@ typedef struct {
 
     double K;                                             //!< momentum dumping time constant [1/s]
 
-    /* declare variables for internal module calculations */
+    double theta1Max;                                     //!< absolute bound on tip angle [rad]
+    double theta2Max;                                     //!< absolute bound on tilt angle [rad]
+
+    /*! declare variables for internal module calculations */
     RWArrayConfigMsgPayload   rwConfigParams;             //!< struct to store message containing RW config parameters in body B frame
     int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.h
@@ -28,6 +28,7 @@
 #include "cMsgCInterface/CmdTorqueBodyMsg_C.h"
 #include "cMsgCInterface/HingedRigidBodyMsg_C.h"
 #include "cMsgCInterface/BodyHeadingMsg_C.h"
+#include "cMsgCInterface/THRConfigMsg_C.h"
 
 
 enum momentumDumping{
@@ -42,8 +43,6 @@ typedef struct {
     double sigma_MB[3];                                   //!< orientation of the M frame w.r.t. the B frame
     double r_BM_M[3];                                     //!< position of B frame origin w.r.t. M frame origin, in M frame coordinates
     double r_FM_F[3];                                     //!< position of F frame origin w.r.t. M frame origin, in F frame coordinates
-    double r_TF_F[3];                                     //!< position of the thrust application point w.r.t. F frame origin, in F frame coordinates
-    double T_F[3];                                        //!< thrust vector in F frame coordinates
 
     double K;                                             //!< momentum dumping time constant [1/s]
 
@@ -52,13 +51,15 @@ typedef struct {
     int                       momentumDumping;            //!< flag that assesses whether RW information is provided to perform momentum dumping
 
     /* declare module IO interfaces */
-    VehicleConfigMsg_C        vehConfigInMsg;             //!< input msg vehicle configuration msg (needed for CM location)
+    VehicleConfigMsg_C        vehConfigInMsg;            //!< input msg vehicle configuration msg (needed for CM location)
+    THRConfigMsg_C            thrusterConfigFInMsg;        //!< input thruster configuration msg
     RWSpeedMsg_C              rwSpeedsInMsg;              //!< input reaction wheel speeds message
     RWArrayConfigMsg_C        rwConfigDataInMsg;          //!< input RWA configuration message
     HingedRigidBodyMsg_C      hingedRigidBodyRef1OutMsg;  //!< output msg containing theta1 reference and thetaDot1 reference
     HingedRigidBodyMsg_C      hingedRigidBodyRef2OutMsg;  //!< output msg containing theta2 reference and thetaDot2 reference
     BodyHeadingMsg_C          bodyHeadingOutMsg;          //!< output msg containing the thrust heading in body frame coordinates
     CmdTorqueBodyMsg_C        thrusterTorqueOutMsg;       //!< output msg containing the opposite of the thruster torque to be compensated by RW's
+    THRConfigMsg_C            thrusterConfigBOutMsg;      //!< output msg containing the thruster configuration infor in B-frame
 
     BSKLogger *bskLogger;                                 //!< BSK Logging
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.i
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.i
@@ -26,6 +26,8 @@
 
 %include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
 struct VehicleConfigMsg_C;
+%include "architecture/msgPayloadDefC/THRConfigMsgPayload.h"
+struct THRConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
 struct RWArrayConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"


### PR DESCRIPTION
* **Tickets addressed:** bsk-489
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This refactor consists in providing the `thrusterPlatformReference` module with an input thruster configuration msg containing the configuration information of the thruster with respect to the platform frame. A similar message is provided as an output, containing the reference thruster configuration info in body-frame coordinates. Commit 1 implements these changes in the module.

An integral feedback term is provided as an input parameter. When the input is negative, or not provided, the integral feedback term is not added, and the control law defaults to a proportional type.

Two input parameters are defined to bound the absolute value of the reference angles. When the computed references exceed these bounds, they are set equal to the bounds. When the inputs are negative, the bounding of the reference angles is bypassed.

Commit 2 addresses an issue in the former version of the module, making sure that the momentum dumping routine is run only when the RW speed message is connected. Commit 3 implements the bounding of the reference angles. Commit 4 computes the integral feedback term and adds it to the control law. Commits 5 and 6 update the unit test and documentation, respectively.

## Verification
A unit test is provided to test the correctness of the output, reflecting the most recent changes.

## Documentation
Documentation is updated to reflect the changes.

## Future work
No future work is foreseen at the moment.
