### PR TITLE
fix issue with scenario script writing Viz binary by default

### DIFF
--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -444,7 +444,7 @@ def run(show_plots):
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, [scObject, scObject2]
                                                   , rwEffectorList=[rwStateEffector, None]
                                                   , lightList=[[servicerLight], None]
-                                                  , saveFile=fileName
+                                                  # , saveFile=fileName
                                                   )
 
         viz.settings.trueTrajectoryLinesOn = -1


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The BSK scenario scripts are setup to save off the simulation data to a Vizard binary file.  However, 
the script should have the file saving turned off by default.  I found a file that didn't do this.  As a result,
every time we run our complete unit test suite a Vizard binary file was being created and saved off.  This 
PR fixes this.

## Verification
Did a clean build, removed prior `_VizFiles` folder and didn't see the Vizard binary file being saved off by default.

## Documentation
None

## Future work
None
