### PR TITLE
remove two unused method parameters from documentation

### DIFF
--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
@@ -176,7 +176,6 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
 }
 
 /*! This method does the UT to the a-priori state to compute the a-priori measurements
-    @param CurrentSimNanos
     @return void
 */
 void SmallBodyNavUKF::measurementUT(){
@@ -238,7 +237,6 @@ void SmallBodyNavUKF::measurementUT(){
 }
 
 /*! This method collects the measurements and updates the estimation
-    @param CurrentSimNanos
     @return void
 */
 void SmallBodyNavUKF::kalmanUpdate(){


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Doxygen version 1.9.8 found 2 new documentation errors.  Two methods documented input 
parameters that the method didn't use.

## Verification
Documentation builds again without warnings.

## Documentation
None

## Future work
None
