### PR TITLE
Feature/fix first start

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-1.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-1.rst
@@ -44,9 +44,20 @@ The integer priority defaults to -1 which means that this process is executed af
 
 The next steps create task lists that are contained in a process or task group.  The first argument is the string name that identifies the task being created.  The second argument is the task update rate in nano-seconds.  Here the ``macros.sec2nano()`` method is a convenient tool to convert seconds to nano-seconds.  When the BSK simulation increments its time variable, it does so in nano-second time steps, the smallest time unit in Basilisk.  It is chosen to be small enough such that no dynamics, sensor or algorithm module should require a smaller time step.  However, it is still large enough such that with a 64-bit unsigned integer we can simulate a mission lifetime of 584 years.
 
-As with the ``Process`` creation, the ``Task`` creation by default has a priority of -1. This means that the task lists are evaluated after any prioritized task lists within the process and in the order they are created.  To set a positive priority value to a task use::
+As with the ``Process`` creation, the ``Task`` creation by default has a priority of -1. This means that the task
+lists are evaluated after any prioritized task lists within the process and in the order they are created.
+To set a positive priority value to a task use::
 
     dynProcess.addTask(scSim.CreateNewTask("name", updateRate, priority))
+
+It is possible to hold a task initially dormant for a period of time by specifying the optional ``FirstStart``
+input parameter in units of nano-seconds.  The task will then be first executed at this time ``FirstStart``.
+But, afterwards the task execution resumes at the original ``updateRate`` interval.  For example, consider::
+
+    dynProcess.addTask(scSim.CreateNewTask("name", updateRate, priority, FirstStart=delayStartTime))
+
+For example, if the first task execution occurs at ``delayStartTime`` of 1s, and ``updateRate`` is set to 5s,
+then the task is exectuted at 1s, 5s, 10s, 15s, etc.
 
 To initialize processes and tasks, call the ``InitializeSimulation()`` method which ensures all Basilisk compute and initialized and the modules with a task are reset.
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -95,6 +95,11 @@ Version |release|
 - Added condition in :ref:`thrustCMEstimation` to avoid measurement updates when input ``attGuidInMsg`` has not been written.
 - Added :ref:`scenarioSepMomentumManagement` to show how to use a dual-gimbaled electric thruster to perform contunuous
   momentum management.
+- Clarified documentation of the input variable ``FirstStart`` of the method  ``CreateNewTask()``.
+- Marked the method ``CreateNewTask()`` input variable ``InputDelay`` as depreciated.  This variable
+  was never implemented and did nothing.
+
+
 
 Version 2.2.0 (June 28, 2023)
 -----------------------------

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -444,9 +444,9 @@ def run(show_plots):
 
     # create the dynamics task and specify the simulation time step information
     simulationTimeStep = macros.sec2nano(1.0)
-    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep, 3))
-    dynProcess.addTask(scSim.CreateNewTask(measTaskName, simulationTimeStep, 2))
-    dynProcess.addTask(scSim.CreateNewTask(fswTaskName, simulationTimeStep, 1))
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
+    dynProcess.addTask(scSim.CreateNewTask(measTaskName, simulationTimeStep))
+    dynProcess.addTask(scSim.CreateNewTask(fswTaskName, simulationTimeStep))
 
     # setup celestial object ephemeris module
     gravBodyEphem = planetEphemeris.PlanetEphemeris()

--- a/src/architecture/system_model/sys_model_task.cpp
+++ b/src/architecture/system_model/sys_model_task.cpp
@@ -18,8 +18,6 @@
  */
 
 #include "sys_model_task.h"
-#include <cstring>
-#include <iostream>
 
 /*! The task constructor.  */
 SysModelTask::SysModelTask()

--- a/src/architecture/system_model/sys_model_task.cpp
+++ b/src/architecture/system_model/sys_model_task.cpp
@@ -36,8 +36,8 @@ SysModelTask::SysModelTask()
 /*! A construction option that allows the user to set some task parameters.
  Note that the only required argument is InputPeriod.
  @param InputPeriod The amount of nanoseconds between calls to this Task.
- @param InputDelay How long to delay the input by in nanoseconds
- @param FirstStartTime The offset in nanoseconds in a given frame to start the Task with.
+ @param FirstStartTime The amount of time in nanoseconds to hold a task dormant before starting.
+        After this time the task is executed at integer amounts of InputPeriod again
  */
 SysModelTask::SysModelTask(uint64_t InputPeriod, uint64_t InputDelay,
                                  uint64_t FirstStartTime)

--- a/src/architecture/system_model/sys_model_task.cpp
+++ b/src/architecture/system_model/sys_model_task.cpp
@@ -152,7 +152,7 @@ void SysModelTask::AddNewObject(SysModel *NewModel, int32_t Priority)
 void SysModelTask::updatePeriod(uint64_t newPeriod)
 {
     uint64_t newStartTime;
-    //! - If the requested time is above the min time, set the next time based on the previos time plus the new period
+    //! - If the requested time is above the min time, set the next time based on the previous time plus the new period
     if(this->NextStartTime > this->TaskPeriod)
     {
         newStartTime = (this->NextStartTime/newPeriod)*newPeriod;
@@ -170,5 +170,4 @@ void SysModelTask::updatePeriod(uint64_t newPeriod)
     //! - Change the period of the task so that future calls will be based on the new period
     this->TaskPeriod = newPeriod;
 
-    
 }

--- a/src/architecture/system_model/sys_model_task.cpp
+++ b/src/architecture/system_model/sys_model_task.cpp
@@ -29,7 +29,6 @@ SysModelTask::SysModelTask()
     this->TaskPeriod = 1000;
     this->NextStartTime = 0;
     this->NextPickupTime = 0;
-    this->PickupDelay = 0;
     this->FirstTaskTime = 0;
     this->taskActive = true;
 }
@@ -39,11 +38,9 @@ SysModelTask::SysModelTask()
  @param FirstStartTime The amount of time in nanoseconds to hold a task dormant before starting.
         After this time the task is executed at integer amounts of InputPeriod again
  */
-SysModelTask::SysModelTask(uint64_t InputPeriod, uint64_t InputDelay,
-                                 uint64_t FirstStartTime)
+SysModelTask::SysModelTask(uint64_t InputPeriod, uint64_t FirstStartTime)
 {
     this->TaskPeriod = InputPeriod;
-    this->PickupDelay = InputDelay;
     this->NextStartTime = FirstStartTime;
     this->NextPickupTime = this->NextStartTime + this->TaskPeriod;
     this->FirstTaskTime = FirstStartTime;

--- a/src/architecture/system_model/sys_model_task.h
+++ b/src/architecture/system_model/sys_model_task.h
@@ -59,7 +59,7 @@ public:
     uint64_t NextPickupTime;  //!< [ns] Next time read Task outputs
     uint64_t TaskPeriod;  //!< [ns] Cycle rate for Task
     uint64_t PickupDelay;  //!< [ns] Time between dispatches
-    uint64_t FirstTaskTime;  //!< [ns] Time to start Task for first time
+    uint64_t FirstTaskTime;  //!< [ns] Time to start Task for first time.  After this time the normal periodic updates resume.
 	bool taskActive;  //!< -- Flag indicating whether the Task has been disabled
   BSKLogger bskLogger;                      //!< -- BSK Logging
 };

--- a/src/architecture/system_model/sys_model_task.h
+++ b/src/architecture/system_model/sys_model_task.h
@@ -37,8 +37,7 @@ class SysModelTask
     
 public:
     SysModelTask();
-    SysModelTask(uint64_t InputPeriod, uint64_t InputDelay=0,
-                   uint64_t FirstStartTime=0); //!< class method
+    SysModelTask(uint64_t InputPeriod, uint64_t FirstStartTime=0); //!< class method
     ~SysModelTask();
     void AddNewObject(SysModel *NewModel, int32_t Priority = -1);
     void SelfInitTaskList();
@@ -58,7 +57,6 @@ public:
     uint64_t NextStartTime;  //!< [ns] Next time to start task
     uint64_t NextPickupTime;  //!< [ns] Next time read Task outputs
     uint64_t TaskPeriod;  //!< [ns] Cycle rate for Task
-    uint64_t PickupDelay;  //!< [ns] Time between dispatches
     uint64_t FirstTaskTime;  //!< [ns] Time to start Task for first time.  After this time the normal periodic updates resume.
 	bool taskActive;  //!< -- Flag indicating whether the Task has been disabled
   BSKLogger bskLogger;                      //!< -- BSK Logging

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -373,18 +373,22 @@ class SimBaseClass:
         self.pyProcList.append(proc)
         return proc
 
-    def CreateNewTask(self, TaskName, TaskRate, InputDelay=0, FirstStart=0):
+    def CreateNewTask(self, TaskName, TaskRate, InputDelay=None, FirstStart=0):
         """
         Creates a simulation task on the C-level with a specific update-frequency (TaskRate), an optional delay, and
         an optional start time.
-
+        
         :param TaskName (str): Name of Task
         :param TaskRate (int): Number of nanoseconds to elapse before update() is called
-        :param InputDelay (int): Number of nanoseconds simulating a lag of the particular task# TODO: Check that this is [ns]
         :param FirstStart (int): Number of nanoseconds to elapse before task is officially enabled
         :return: simulationArchTypes.TaskBaseClass object
         """
-        Task = simulationArchTypes.TaskBaseClass(TaskName, TaskRate, InputDelay, FirstStart)
+
+        if InputDelay is not self.CreateNewTask.__defaults__[0]:
+            deprecated.deprecationWarn("InputDelay", "2024/12/13",
+                                       "This input variable is non-functional and now depreciated.")
+
+        Task = simulationArchTypes.TaskBaseClass(TaskName, TaskRate, FirstStart)
         self.TaskList.append(Task)
         return Task
 

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -389,7 +389,7 @@ class SimBaseClass:
         return Task
 
     # When this method is removed, remember to delete the 'oldSyntaxVariableLog' and
-    # 'allModels' attributes (as well as any mention of them) as they are not longer needed
+    # 'allModels' attributes (as well as any mention of them) as they are no longer needed
     @deprecated.deprecated("2024/09/06", 
         "Use the 'logger' function or 'PythonVariableLogger' instead of 'AddVariableForLogging'."
         " See 'http://hanspeterschaub.info/basilisk/Learn/bskPrinciples/bskPrinciples-6.html'"

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -377,11 +377,15 @@ class SimBaseClass:
         """
         Creates a simulation task on the C-level with a specific update-frequency (TaskRate), an optional delay, and
         an optional start time.
-        
-        :param TaskName (str): Name of Task
-        :param TaskRate (int): Number of nanoseconds to elapse before update() is called
-        :param FirstStart (int): Number of nanoseconds to elapse before task is officially enabled
-        :return: simulationArchTypes.TaskBaseClass object
+
+        Args:
+            TaskName (str): Name of Task
+            TaskRate (int): Number of nanoseconds to elapse before update() is called
+            InputDelay (int): (depreciated, unimplemented) Number of nanoseconds simulating a lag of the particular task
+            FirstStart (int): Number of nanoseconds to elapse before task is officially enabled
+
+        Returns:
+            simulationArchTypes.TaskBaseClass object
         """
 
         if InputDelay is not self.CreateNewTask.__defaults__[0]:

--- a/src/utilities/simulationArchTypes.py
+++ b/src/utilities/simulationArchTypes.py
@@ -52,10 +52,9 @@ class ProcessBaseClass(object):
 
 
 class TaskBaseClass(object):
-    def __init__(self, TaskName, TaskRate, InputDelay=0, FirstStart=0):
+    def __init__(self, TaskName, TaskRate, FirstStart=0):
         self.Name = TaskName
-        self.TaskData = sys_model_task.SysModelTask(TaskRate, InputDelay,
-                                                    FirstStart)
+        self.TaskData = sys_model_task.SysModelTask(TaskRate, FirstStart)
         self.TaskData.TaskName = TaskName
         self.TaskModels = []
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-355
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When creating a BSK task there is an optional argument to provide a time delay before the task begins to execute.
The documentation is not clear how this work and has been improved.  The `FirstStart` variable allows the task 
to remain dormant on start up for a period of then, and then execute at the `FirstStart` time.  After that normal
execution is resumed at integer multiple of the task update period.

Further, the optional `DelayInput` variable never actually did anything.  This input variable needs to be marked as depreciated in SimulationBaseClass and the internal use removed.

## Verification
All unit test pass again.  Documentation builds without issues. 

## Documentation
Documentation was updated to ensure `CreateNewTask()` method is properly documented.

## Future work
N/A
