### PR TITLE
input connector is a single msg, not vector of msgs

### DIFF
--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -1299,17 +1299,17 @@ The full list of required and optional generic storage parameters are provided i
         3 (sending and receiving).  Note that this value is replaced with the value from
         the transceiver state input message if such an input message is provided.
     * - ``batteryStateInMsg``
-      - vector<ReadFunctor<:ref:`PowerStorageStatusMsgPayload`>>
+      - ReadFunctor<:ref:`PowerStorageStatusMsgPayload`>
       -
       - No
       - incoming battery state msg, only connect one input message
     * - ``dataStorageStateInMsg``
-      - vector<ReadFunctor<:ref:`DataStorageStatusMsgPayload`>>
+      - ReadFunctor<:ref:`DataStorageStatusMsgPayload`>
       -
       - No
       - incoming data storage state msg, only connect one input message
     * - ``fuelTankStateInMsg``
-      - vector<ReadFunctor<:ref:`FuelTankMsgPayload`>>
+      - ReadFunctor<:ref:`FuelTankMsgPayload`>
       -
       - No
       - incoming fuel tank state msg, only connect one input message


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The documentation had a typo on the storage info input connectors.

## Verification
The documentation build process finished without error.

## Documentation
N/A

## Future work
N/A