### PR TITLE
Feature/498 add srp effector facet articulation

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,7 +32,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
-- text here
+- Added optional facet articulation to the :ref:`facetSRPDynamicEffector` module.
 
 
 Version 2.2.1 (Dec. 22, 2023)

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -170,7 +170,7 @@ def run(momentumManagement, cmEstimation, showPlots):
     mu = gravBodies['sun'].mu
     
     # The configured gravitational bodies are added to the spacecraft dynamics with the usual command:
-    scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))
+    gravFactory.addBodiesTo(scObject)
 
     # Next, the default SPICE support module is created and configured.
     timeInitString = "2023 OCTOBER 22 00:00:00.0"
@@ -185,9 +185,6 @@ def run(momentumManagement, cmEstimation, showPlots):
 
     # The SPICE object is added to the simulation task list.
     scSim.AddModelToTask(fswTask, gravFactory.spiceObject, 2)
-
-    # The gravitational body is connected to the spacecraft object
-    scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))
 
     # setup the orbit using classical orbit elements
     oe = orbitalMotion.ClassicElements()
@@ -347,10 +344,13 @@ def run(momentumManagement, cmEstimation, showPlots):
     
     # Set up the SRP dynamic effector
     SRP = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    SRP.numFacets = 10
+    SRP.numArticulatedFacets = 4
     scSim.AddModelToTask(dynTask, SRP)
+
     # Define the spacecraft geometry for populating the FacetedSRPSpacecraftGeometryData structure in the SRP module
     # Define the facet surface areas
-    lenXHub = 1.53  # [m]
+    lenXHub = 1.50  # [m]
     lenYHub = 1.8  # [m]
     lenZHub = 2.86  # [m]
     area2 = np.pi*(0.5 * 7.262)*(0.5 * 7.262)  # [m^2]
@@ -376,11 +376,24 @@ def run(momentumManagement, cmEstimation, showPlots):
     facetLoc4 = np.array([0.0, -0.5 * lenYHub, 0.5 * lenZHub])  # [m]
     facetLoc5 = np.array([0.0, 0.0, lenZHub])  # [m]
     facetLoc6 = np.array([0.0, 0.0, 0.0])  # [m]
-    facetLoc7 = np.array([3.75 + 0.5 * lenXHub, 0.544, 0.44])  # [m]
-    facetLoc8 = np.array([3.75 + 0.5 * lenXHub, 0.544, 0.44])  # [m]
-    facetLoc9 = np.array([-(3.75 + 0.5 * lenXHub), 0.544, 0.44])  # [m]
-    facetLoc10 = np.array([-(3.75 + 0.5 * lenXHub), 0.544, 0.44])  # [m]
+    facetLoc7 = np.array([3.75 + 0.5 * lenXHub, 0.0, 0.45])  # [m]
+    facetLoc8 = np.array([3.75 + 0.5 * lenXHub, 0.00, 0.45])  # [m]
+    facetLoc9 = np.array([-(3.75 + 0.5 * lenXHub), 0.0, 0.45])  # [m]
+    facetLoc10 = np.array([-(3.75 + 0.5 * lenXHub), 0.0, 0.45])  # [m]
+
     locationsPntB_B = [facetLoc1, facetLoc2, facetLoc3, facetLoc4, facetLoc5, facetLoc6, facetLoc7, facetLoc8, facetLoc9, facetLoc10]
+
+    # Define facet articulation axes in B frame components
+    rotAxes_B = [np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([1.0, 0.0, 0.0]),
+                 np.array([1.0, 0.0, 0.0]),
+                 np.array([-1.0, 0.0, 0.0]),
+                 np.array([-1.0, 0.0, 0.0])]
 
     # Define the facet optical coefficients
     specCoeff = np.array([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
@@ -388,9 +401,13 @@ def run(momentumManagement, cmEstimation, showPlots):
 
     # Populate the scGeometry structure with the facet information
     for i in range(len(facetAreas)):
-        SRP.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i])
+        SRP.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i], rotAxes_B[i])
 
     SRP.ModelTag = "FacetSRP"
+    SRP.addArticulatedFacet(RSAList[0].spinningBodyOutMsg)
+    SRP.addArticulatedFacet(RSAList[0].spinningBodyOutMsg)
+    SRP.addArticulatedFacet(RSAList[1].spinningBodyOutMsg)
+    SRP.addArticulatedFacet(RSAList[1].spinningBodyOutMsg)
     scObject.addDynamicEffector(SRP)
 
     #

--- a/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
@@ -16,376 +16,211 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #
-# Purpose:  Test the facetSRPDynamicEffector module.
-# Author:   Leah Kiner
-# Creation Date:  Dec 18 2022
+#   Unit Test Script
+#   Module Name:        facetSRPDynamicEffector
+#   Author:             Leah Kiner
+#   Creation Date:      Dec 18 2022
 #
 
-
 import os
-import pytest
-import inspect
-import numpy as np
-from Basilisk import __path__
-from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
-import matplotlib
-import matplotlib.pyplot as plt
-from Basilisk.utilities import orbitalMotion, simIncludeGravBody
-from Basilisk.simulation import spacecraft, facetSRPDynamicEffector
-from Basilisk.utilities import macros, RigidBodyKinematics as rbk
-from Basilisk.architecture import messaging
-bskPath = __path__[0]
-filename = inspect.getframeinfo(inspect.currentframe()).filename
-path = os.path.dirname(os.path.abspath(filename))
-splitPath = path.split('simulation')
-matplotlib.rc('xtick', labelsize=12)
-matplotlib.rc('ytick', labelsize=12)
 
-def test_facetSRPDynamicEffector(show_plots):
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from Basilisk import __path__
+
+bskPath = __path__[0]
+fileName = os.path.basename(os.path.splitext(__file__)[0])
+
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import simIncludeGravBody
+from Basilisk.utilities import macros
+from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import unitTestSupport
+from Basilisk.simulation import facetSRPDynamicEffector
+from Basilisk.simulation import spacecraft
+from Basilisk.architecture import messaging
+
+def test_facetSRPTestFunction(show_plots):
     r"""
     **Validation Test Description**
 
     The unit test for this module ensures that the calculated Solar Radiation Pressure (SRP) force and torque acting
     on the spacecraft about the body-fixed point B is properly computed for a static spacecraft. The spacecraft
     geometry defined in this test consists of a cubic hub and two circular solar arrays. Six square facets represent
-    the cubic hub and four circular facets describe the solar arrays. The SRP force and torque module values are
-    checked with values computed in python both initially and at a time halfway through the simulation.
+    the cubic hub and four circular facets describe the solar arrays. The final SRP force simulation values are checked
+    with values computed in python.
 
     **Test Parameters**
-
     Args:
         show_plots (bool): (True) Show plots, (False) Do not show plots
-
-    **Description of Variables Being Tested**
-
-    The initial module-computed SRP force value ``SRPDataForce_B`` is checked with the value computed in
-    python ``forceTest1Val``. The initial module-computed SRP torque value ``SRPDataTorque_B`` is also checked
-    with the value computed in python ``torqueTest1Val``. Similarly, these values halfway through the simulation
-    are checked to match.
     """
-    testResults = []
-    testMessage = []
+    
+    [testResults, testMessage] = facetSRPTestFunction(show_plots)
 
-    srpRes, srpMsg = TestfacetSRPDynamicEffector(False)
-    testMessage.append(srpMsg)
-    testResults.append(srpRes)
+    assert testResults < 1, testMessage
 
-    testSum = sum(testResults)
-    snippetName = "unitTestPassFail"
+def facetSRPTestFunction(show_plots):
+    testFailCount = 0                                           # Zero the unit test result counter
+    testMessages = []                                           # Create an empty array to store the test log messages
 
-    if testSum == 0:
-        colorText = 'ForestGreen'
-        print("PASSED")
-        passedText = r'\textcolor{' + colorText + '}{' + "PASSED" + '}'
-    else:
-        colorText = 'Red'
-        print("Failed")
-        passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-
-    unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
-
-    assert testSum < 1, testMessage
-
-def checkFacetSRPForce(index, area, specCoeff, diffCoeff, normal_B, sigma_BN, scPos, sunPos):
-    """This function calculates the per-facet SRP force acting on the spacecraft."""
-    # Define required constants
-    speedLight = 299792458.0
-    AstU = 149597870700.0
-    solarRadFlux = 1368.0
-
-    # Compute dcm_BN using MRP transformation
-    dcm_BN = rbk.MRP2C(sigma_BN)
-
-    # Convert vectors from the N frame to the B frame
-    r_BN_B = np.matmul(dcm_BN, scPos)
-    r_SN_B = np.matmul(dcm_BN, sunPos)
-    r_SB_B = r_SN_B - r_BN_B
-
-    # Determine unit direction vector pointing from point B on the spacecraft to the Sun
-    sHat = r_SB_B / np.linalg.norm(r_SB_B)
-
-    # Calculate the incidence angle theta between the facet normal vector and the Sun-direction vector
-    cosTheta = np.dot(sHat, normal_B)
-
-    # Calculate the facet projected area onto the plane whose normal vector is the Sun-direction vector
-    projArea = area * cosTheta
-
-    # Calculate the solar radiation pressure acting on the facet
-    numAU = AstU / np.linalg.norm(r_SB_B)
-    SRPPressure = (solarRadFlux / speedLight) * numAU * numAU
-
-    # Compute the SRP force acting on the facet only if the facet is illuminated by the Sun
-    if projArea > 0:
-        srp_force = -SRPPressure * projArea * ( (1-specCoeff) * sHat + 2 * ( (diffCoeff / 3) + specCoeff * cosTheta) * normal_B )
-    else:
-        srp_force = np.zeros([3,])
-
-    return srp_force
-
-def checkFacetSRPTorque(index, area, specCoeff, diffCoeff, normal_B, locationPntB_B, sigma_BN, scPos, sunPos):
-    """This function calculates the per-facet SRP torque acting on the spacecraft."""
-    # Define required constants
-    speedLight = 299792458.0
-    AstU = 149597870700.0
-    solarRadFlux = 1368.0
-
-    # Compute dcm_BN using MRP transformation
-    dcm_BN = rbk.MRP2C(sigma_BN)
-
-    # Convert vectors from the N frame to the B frame
-    r_BN_B = np.matmul(dcm_BN, scPos)
-    r_SN_B = np.matmul(dcm_BN, sunPos)
-    r_SB_B = r_SN_B - r_BN_B
-
-    # Determine unit direction vector pointing from point B on the spacecraft to the Sun
-    sHat = r_SB_B / np.linalg.norm(r_SB_B)
-
-    # Calculate the incidence angle theta between the facet normal vector and the Sun-direction vector
-    cosTheta = np.dot(sHat, normal_B)
-
-    # Calculate the facet projected area onto the plane whose normal vector is the Sun-direction vector
-    projArea = area * cosTheta
-
-    # Calculate the solar radiation pressure acting on the facet
-    numAU = AstU / np.linalg.norm(r_SB_B)
-    SRPPressure = (solarRadFlux / speedLight) * numAU * numAU
-
-    # Compute the SRP force contribution from the facet only if the facet is illuminated by the Sun
-    if projArea > 0:
-        srp_force = -SRPPressure * projArea * ( (1-specCoeff) * sHat + 2 * ( (diffCoeff / 3) + specCoeff * cosTheta) * normal_B )
-    else:
-        srp_force = np.zeros([3, ])
-
-    # Calculate the SRP torque contribution from the facet
-    srp_torque = np.cross(locationPntB_B, srp_force)
-
-    return srp_torque
-
-
-def TestfacetSRPDynamicEffector(show_plots):
-    """Call this routine directly to run the unit test."""
-    # Init test support variables
-    testFailCount = 0
-    testMessages = []
-
-    # Create the simulation task and process
-    simTaskName = "simTask"
-    simProcessName = "simProcess"
-    scSim = SimulationBaseClass.SimBaseClass()
-    dynProcess = scSim.CreateNewProcess(simProcessName)
-    simulationTimeStep_Sec = 0.1
-    simulationTimeStep_NS = macros.sec2nano(simulationTimeStep_Sec)
-    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep_NS))
+    # Set up the simulation, task, and process
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitProcessName = "simProcess"
+    dynProcess = unitTestSim.CreateNewProcess(unitProcessName)
+    simulationTimeStep = macros.sec2nano(0.1)
+    unitTaskName = "simTask"
+    dynProcess.addTask(unitTestSim.CreateNewTask(unitTaskName, simulationTimeStep))
 
     # Create the spacecraft object
     scObject = spacecraft.Spacecraft()
-    scObject.ModelTag = "spacecraft"
+    scObject.ModelTag = "scObject"
+    r_eq = 6371*1000.0  # [m]
+    scObject.hub.r_CN_NInit = np.array([r_eq + 200.0e3, -149598023 * 1000, 0.0])  # [m] Spacecraft inertial position
+    scObject.hub.v_CN_NInit = np.array([0.0, 0.0, 0.0])  # [m] Spacecraft inertial velocity
+    scObject.hub.sigma_BNInit = np.array([0.0, 0.0, 0.0])
+    scObject.hub.omega_BN_BInit = np.array([0.0, 0.0, 0.0])
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
 
-    # Add the Earth and Sun as gravitational bodies
+    # Create the gravitational bodies
     gravFactory = simIncludeGravBody.gravBodyFactory()
     earth = gravFactory.createEarth()
     sun = gravFactory.createSun()
-    earth.isCentralBody = True  # ensure this is the central gravitational body
-    earthIdx = 0
-    sunIdx = 1
+    earth.isCentralBody = True
+
+    # Set custom Earth Spice data
     earthStateMsg = messaging.SpicePlanetStateMsgPayload()
     earthStateMsg.PositionVector = [0.0, -149598023 * 1000, 0.0]
     earthStateMsg.VelocityVector = [0.0, 0.0, 0.0]
     earthMsg = messaging.SpicePlanetStateMsg().write(earthStateMsg)
     gravFactory.gravBodies['earth'].planetBodyInMsg.subscribeTo(earthMsg)
+
+    # Set custom Sun Spice data
     sunStateMsg = messaging.SpicePlanetStateMsgPayload()
     sunStateMsg.PositionVector = [0.0, 0.0, 0.0]
     sunStateMsg.VelocityVector = [0.0, 0.0, 0.0]
     sunMsg = messaging.SpicePlanetStateMsg().write(sunStateMsg)
     gravFactory.gravBodies['sun'].planetBodyInMsg.subscribeTo(sunMsg)
 
-    # Create an instance of the facetSRPEffector module to be tested
-    newSRP = facetSRPDynamicEffector.FacetSRPDynamicEffector()
-    newSRP.ModelTag = "FacetSRP"
+    # Create an instance of the facetSRPDynamicEffector module to be tested
+    srpEffector = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    srpEffector.ModelTag = "srpEffector"
+    numFacets = 10  # Total number of spacecraft facets
+    srpEffector.sunInMsg.subscribeTo(sunMsg)
+    scObject.addDynamicEffector(srpEffector)
+    unitTestSim.AddModelToTask(unitTaskName, srpEffector)
 
-    # Connect the Sun's ephemeris message to the module
-    newSRP.sunInMsg.subscribeTo(sunMsg)
-
-    # Add the SRP dynamic effector to the spacecraft object
-    scObject.addDynamicEffector(newSRP)
-
-    # Define the spacecraft geometry for this test
+    # Set up the srpEffector spacecraft geometry data structure
     try:
-        # Define the facet surface areas
-        area1 = 1.5*1.5  # [m^2]
-        area2 = np.pi*(0.5*7.5)*(0.5*7.5)  # [m^2]
+        # Define facet areas
+        area1 = 1.5 * 1.5
+        area2 = np.pi * (0.5 * 7.5) * (0.5 * 7.5)
         facetAreas = [area1, area1, area1, area1, area1, area1, area2, area2, area2, area2]
 
-        # Define the facet normals in B frame components
-        facetNormal1 = np.array([1.0, 0.0, 0.0])
-        facetNormal2 = np.array([0.0, 1.0, 0.0])
-        facetNormal3 = np.array([-1.0, 0.0, 0.0])
-        facetNormal4 = np.array([0.0, -1.0, 0.0])
-        facetNormal5 = np.array([0.0, 0.0, 1.0])
-        facetNormal6 = np.array([0.0, 0.0, -1.0])
-        facetNormal7 = np.array([0.0, 1.0, 0.0])
-        facetNormal8 = np.array([0.0, -1.0, 0.0])
-        facetNormal9 = np.array([0.0, 1.0, 0.0])
-        facetNormal10 = np.array([0.0, -1.0, 0.0])
-        normals_B = [facetNormal1, facetNormal2, facetNormal3, facetNormal4, facetNormal5, facetNormal6, facetNormal7, facetNormal8, facetNormal9, facetNormal10]
+        # Define the facet normal vectors in B frame components
+        facetNormals_B = [np.array([1.0, 0.0, 0.0]),
+                          np.array([0.0, 1.0, 0.0]),
+                          np.array([-1.0, 0.0, 0.0]),
+                          np.array([0.0, -1.0, 0.0]),
+                          np.array([0.0, 0.0, 1.0]),
+                          np.array([0.0, 0.0, -1.0]),
+                          np.array([0.0, 1.0, 0.0]),
+                          np.array([0.0, -1.0, 0.0]),
+                          np.array([0.0, 1.0, 0.0]),
+                          np.array([0.0, -1.0, 0.0])]
 
-        # Define the facet center of pressure locations with respect to point B in B frame components
-        facetLoc1 = np.array([0.75, 0.0, 0.0])  # [m]
-        facetLoc2 = np.array([0.0, 0.75, 0.0])  # [m]
-        facetLoc3 = np.array([-0.75, 0.0, 0.0])  # [m]
-        facetLoc4 = np.array([0.0, -0.75, 0.0])  # [m]
-        facetLoc5 = np.array([0.0, 0.0, 0.75])  # [m]
-        facetLoc6 = np.array([0.0, 0.0, -0.75])  # [m]
-        facetLoc7 = np.array([4.5, 0.0, 0.75])  # [m]
-        facetLoc8 = np.array([4.5, 0.0, 0.75])  # [m]
-        facetLoc9 = np.array([-4.5, 0.0, 0.75])  # [m]
-        facetLoc10 = np.array([-4.5, 0.0, 0.75])  # [m]
-        locationsPntB_B = [facetLoc1, facetLoc2, facetLoc3, facetLoc4, facetLoc5, facetLoc6, facetLoc7, facetLoc8, facetLoc9, facetLoc10]
+        # Define facet center of pressure locations relative to point B
+        locationsPntB_B = [np.array([0.75, 0.0, 0.0]),
+                       np.array([0.0, 0.75, 0.0]),
+                       np.array([-0.75, 0.0, 0.0]),
+                       np.array([0.0, -0.75, 0.0]),
+                       np.array([0.0, 0.0, 0.75]),
+                       np.array([0.0, 0.0, -0.75]),
+                       np.array([4.5, 0.0, 0.75]),
+                       np.array([4.5, 0.0, 0.75]),
+                       np.array([-4.5, 0.0, 0.75]),
+                       np.array([-4.5, 0.0, 0.75])]
 
-        # Define the facet optical coefficients
+        # Define facet optical coefficients
         specCoeff = np.array([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
         diffCoeff = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
 
-        # Populate the scGeometry structure with the facet information
-        for i in range(len(facetAreas)):
-            newSRP.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i])
+        # Populate the srpEffector spacecraft geometry structure with the facet information
+        for i in range(numFacets):
+            srpEffector.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], facetNormals_B[i], locationsPntB_B[i])
     except:
         testFailCount += 1
-        testMessages.append("ERROR: FacetDrag unit test failed while setting facet parameters.")
+        testMessages.append("ERROR: FacetSRP unit test failed while setting facet parameters.")
         return testFailCount, testMessages
-
-    # Set up the spacecraft orbit
-    oe = orbitalMotion.ClassicElements()
-    r_eq = 6371*1000.0  # [m]
-    rN = np.array([r_eq+2000.0, -149598023 * 1000, 0.0])  # [m]
-    vN = np.array([0.0, 7.90854, 0.0])  # [m/s]
-    sig_BN = np.array([0.0, 0.0, 0.0])
-
-    # Initialize spacecraft states with the initialization variables
-    scObject.hub.r_CN_NInit = rN  # [m] r_CN_N
-    scObject.hub.v_CN_NInit = vN  # [m] v_CN_N
-    scObject.hub.sigma_BNInit = sig_BN
 
     # Set up data logging
     scPosDataLog = scObject.scStateOutMsg.recorder()
     sunPosDataLog = gravFactory.gravBodies['sun'].planetBodyInMsg.recorder()
+    srpDataLog = srpEffector.logger(["forceExternal_B", "torqueExternalPntB_B"], simulationTimeStep)
+    unitTestSim.AddModelToTask(unitTaskName, scPosDataLog)
+    unitTestSim.AddModelToTask(unitTaskName, sunPosDataLog)
+    unitTestSim.AddModelToTask(unitTaskName, srpDataLog)
 
-    # Add the BSK objects to the simulation process
-    scSim.AddModelToTask(simTaskName, scObject)
-    scSim.AddModelToTask(simTaskName, newSRP)
-    scSim.AddModelToTask(simTaskName, scPosDataLog)
-    scSim.AddModelToTask(simTaskName, sunPosDataLog)
-
-    # Set the simulation time
-    simTimeSec = 10.0  # [s]
-    simulationTime = macros.sec2nano(simTimeSec)
-
-    # Add the data for logging
-    newSRPLog = newSRP.logger(["forceExternal_B", "torqueExternalPntB_B"])
-    scSim.AddModelToTask(simTaskName, newSRPLog)
-
-    # Initialize the simulation
-    scSim.InitializeSimulation()
-
-    # Configure the simulation stop time and execute the simulation run
-    scSim.ConfigureStopTime(simulationTime)
-    scSim.ExecuteSimulation()
+    # Execute the simulation
+    unitTestSim.InitializeSimulation()
+    simulationTime = macros.sec2nano(5.0)
+    unitTestSim.ConfigureStopTime(simulationTime)
+    unitTestSim.ExecuteSimulation()
 
     # Retrieve the logged data
-    timespan = scPosDataLog.times()
-    r_BN_N = scPosDataLog.r_BN_N
+    timespan = scPosDataLog.times() * macros.NANO2SEC  # [s]
+    r_BN_N = scPosDataLog.r_BN_N  # [m]
     sigma_BN = scPosDataLog.sigma_BN
-    r_SN_N = sunPosDataLog.PositionVector
-    SRPDataForce_B = unitTestSupport.addTimeColumn(newSRPLog.times(), newSRPLog.forceExternal_B)
-    SRPDataTorque_B = unitTestSupport.addTimeColumn(newSRPLog.times(), newSRPLog.torqueExternalPntB_B)
+    r_SN_N = sunPosDataLog.PositionVector  # [m]
+    srpForce_B = srpDataLog.forceExternal_B  # [N]
+    srpTorque_B = srpDataLog.torqueExternalPntB_B  # [Nm]
 
-    # Store the logged data for plotting
-    srpForce_B_plotting = SRPDataForce_B
-    srpForce_B_plotting = np.delete(srpForce_B_plotting, 0, axis=1)
-    srpTorque_B_plotting = SRPDataTorque_B
-    srpTorque_B_plotting = np.delete(srpTorque_B_plotting, 0, axis=1)
-
-    # Plotting results
+    # Plot spacecraft inertial position
     plt.figure()
     plt.clf()
-    plt.plot(timespan * 1e-9, r_BN_N[:, 0], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_1$')
-    plt.plot(timespan * 1e-9, r_BN_N[:, 1], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_2$')
-    plt.plot(timespan * 1e-9, r_BN_N[:, 2], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_3$')
+    plt.plot(timespan, r_BN_N[:, 0], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_1$')
+    plt.plot(timespan, r_BN_N[:, 1], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_2$')
+    plt.plot(timespan, r_BN_N[:, 2], label=r'$r_{\mathcal{B}/\mathcal{N}} \cdot \hat{n}_3$')
     plt.xlabel(r'Time (s)')
-    plt.ylabel(r'${}^\mathcal{N} r_{\mathcal{B}/\mathcal{N}}$ (m)')
+    plt.ylabel(r'${}^N r_{\mathcal{B}/\mathcal{N}}$ (m)')
     plt.legend()
 
+    # Plot SRP force
     plt.figure()
     plt.clf()
-    plt.plot(timespan * 1e-9, srpForce_B_plotting[:, 0], label=r'$F \cdot \hat{b}_1$')
-    plt.plot(timespan * 1e-9, srpForce_B_plotting[:, 1], label=r'$F \cdot \hat{b}_2$')
-    plt.plot(timespan * 1e-9, srpForce_B_plotting[:, 2], label=r'$F \cdot \hat{b}_3$')
-    plt.xlabel(r'Time (s)')
-    plt.ylabel(r'${}^\mathcal{B} F_{SRP, B}$ (N)')
+    plt.plot(timespan, srpForce_B[:, 0], label=r'$F_{SRP} \cdot \hat{b}_1$')
+    plt.plot(timespan, srpForce_B[:, 1], label=r'$F_{SRP} \cdot \hat{b}_2$')
+    plt.plot(timespan, srpForce_B[:, 2], label=r'$F_{SRP} \cdot \hat{b}_3$')
+    plt.xlabel('Time (s)')
+    plt.ylabel(r'${}^B F_{SRP}$ (N)')
     plt.legend()
 
+    # Plot SRP torque
     plt.figure()
     plt.clf()
-    plt.plot(timespan * 1e-9, srpTorque_B_plotting[:, 0], label=r'$L \cdot \hat{b}_1$')
-    plt.plot(timespan * 1e-9, srpTorque_B_plotting[:, 1], label=r'$L \cdot \hat{b}_2$')
-    plt.plot(timespan * 1e-9, srpTorque_B_plotting[:, 2], label=r'$L \cdot \hat{b}_3$')
-    plt.xlabel(r'Time (s)')
-    plt.ylabel(r'${}^\mathcal{B} L_{SRP, B}$ (Nm)')
+    plt.plot(timespan, srpTorque_B[:, 0], label=r'$L_{SRP} \cdot \hat{b}_1$')
+    plt.plot(timespan, srpTorque_B[:, 1], label=r'$L_{SRP} \cdot \hat{b}_2$')
+    plt.plot(timespan, srpTorque_B[:, 2], label=r'$L_{SRP} \cdot \hat{b}_3$')
+    plt.xlabel('Time (s)')
+    plt.ylabel(r'${}^B L_{SRP}$ (Nm)')
     plt.legend()
 
     if show_plots:
         plt.show()
     plt.close("all")
 
-    # Compare the retrieved data to the expected values computed in python
-    accuracy = 1e-15
-    forceTest1Val = np.zeros([3,])
-    forceTest2Val = np.zeros([3,])
-    torqueTest1Val = np.zeros([3, ])
-    torqueTest2Val = np.zeros([3, ])
-    index2 = int(0.5*simTimeSec / simulationTimeStep_Sec)
-
+    # Validate the results by comparing the last srp force and torque simulation values with the predicted values
+    accuracy = 1e-3
+    test_val = np.zeros([3,])
     for i in range(len(facetAreas)):
-        forceTest1Val += checkFacetSRPForce(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], sigma_BN[1], r_BN_N[1], r_SN_N[1])
-        forceTest2Val += checkFacetSRPForce(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], sigma_BN[index2], r_BN_N[index2],
-                                       r_SN_N[index2])
-        torqueTest1Val += checkFacetSRPTorque(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i], sigma_BN[1],
-                                            r_BN_N[1], r_SN_N[1])
-        torqueTest2Val += checkFacetSRPTorque(i, facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i],
-                                              locationsPntB_B[i], sigma_BN[index2],
-                                              r_BN_N[index2], r_SN_N[index2])
-    if not unitTestSupport.isArrayEqual(SRPDataForce_B[1, 1:4], forceTest1Val, 3, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
-            SRPDataForce_B[1, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
-            SRPDataForce_B[1, 1:] - forceTest1Val))
-        print(SRPDataForce_B[1, 1:])
-        print(forceTest1Val)
+        test_val += checkFacetSRPForce(facetAreas[i], specCoeff[i], diffCoeff[i], facetNormals_B[i], articulationAxes_B[i], sigma_BN[-1], r_BN_N[-1], r_SN_N[-1])
 
-    if not unitTestSupport.isArrayEqual(SRPDataForce_B[index2, 1:4], forceTest2Val, 3, accuracy):
+    if not unitTestSupport.isArrayEqual(srpForce_B[-1, :], test_val, 3, accuracy):
         testFailCount += 1
         testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
-            SRPDataForce_B[index2, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
-            SRPDataForce_B[index2, 1:] - forceTest2Val))
-        print(SRPDataForce_B[index2, 1:])
-        print(forceTest2Val)
-
-    if not unitTestSupport.isArrayEqual(SRPDataTorque_B[1, 1:4], torqueTest1Val, 3, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
-            SRPDataTorque_B[1, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
-            SRPDataTorque_B[1, 1:] - torqueTest1Val))
-        print(SRPDataTorque_B[1, 1:])
-        print(torqueTest1Val)
-
-    if not unitTestSupport.isArrayEqual(SRPDataTorque_B[index2, 1:4], torqueTest2Val, 3, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED:  FacetSRPEffector failed unit test at t=" + str(
-            SRPDataTorque_B[index2, 0] * macros.NANO2SEC) + "sec with a value difference of " + str(
-            SRPDataTorque_B[index2, 1:] - torqueTest2Val))
-        print(SRPDataTorque_B[index2, 1:])
-        print(torqueTest2Val)
+            timespan[-1]) + "sec with a value difference of " + str(
+            srpForce_B[-1, :] - test_val))
 
     if testFailCount:
         print(testMessages)
@@ -394,8 +229,40 @@ def TestfacetSRPDynamicEffector(show_plots):
 
     return testFailCount, testMessages
 
+def checkFacetSRPForce(area, specCoeff, diffCoeff, facetNormal, sigma_BN, scPos, sunPos):
+    # Define required constants
+    speedLight = 299792458.0  # [m/s] Speed of light
+    AstU = 149597870700.0  # [m] Astronomical unit
+    solarRadFlux = 1368.0  # [W/m^2] Solar radiation flux at 1 AU
+
+    # Compute dcm_BN
+    dcm_BN = rbk.MRP2C(sigma_BN)
+
+    # Compute Sun direction relative to point B in B frame components
+    r_BN_B = np.matmul(dcm_BN, scPos)  # [m]
+    r_SN_B = np.matmul(dcm_BN, sunPos)  # [m]
+    r_SB_B = r_SN_B - r_BN_B  # [m]
+
+    # Determine unit direction vector pointing from sc to the Sun
+    sHat = r_SB_B / np.linalg.norm(r_SB_B)
+
+    # Determine the facet projected area
+    cosTheta = np.dot(sHat, facetNormal)
+    projArea = area * cosTheta
+
+    # Determine the SRP pressure at the current sc location
+    numAU = AstU / np.linalg.norm(r_SB_B)
+    SRPPressure = (solarRadFlux / speedLight) * numAU * numAU
+
+    # Compute the SRP force acting on the facet
+    if projArea > 0:
+        srp_force = -SRPPressure * projArea * ((1-specCoeff) * sHat + 2 * ( (diffCoeff / 3) + specCoeff * cosTheta) * facetNormal)
+    else:
+        srp_force = np.zeros([3,])
+
+    return srp_force
+
 if __name__=="__main__":
-    # TestfacetSRPDynamicEffector
-    TestfacetSRPDynamicEffector(
-            True  # show plots
-           )
+    facetSRPTestFunction(
+        False,  # show plots
+    )

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -20,29 +20,26 @@
 #include "facetSRPDynamicEffector.h"
 #include <cmath>
 
-const double speedLight = 299792458.0; //  [m/s] Speed of light
-const double AstU = 149597870700.0; // [m] Astronomical unit
-const double solarRadFlux = 1368.0; // [W/m^2] Solar radiation flux at 1 AU
+const double speedLight = 299792458.0;  // [m/s] Speed of light
+const double AstU = 149597870700.0;  // [m] Astronomical unit
+const double solarRadFlux = 1368.0;  // [W/m^2] Solar radiation flux at 1 AU
 
-/*! The constructor initializes the member variables to zero. */
-FacetSRPDynamicEffector::FacetSRPDynamicEffector()
-{
+/*! The constructor */
+FacetSRPDynamicEffector::FacetSRPDynamicEffector() {
     this->forceExternal_B.fill(0.0);
     this->torqueExternalPntB_B.fill(0.0);
     this->numFacets = 0;
 }
 
-/*! The destructor. */
-FacetSRPDynamicEffector::~FacetSRPDynamicEffector()
-{
+/*! The destructor */
+FacetSRPDynamicEffector::~FacetSRPDynamicEffector() {
 }
 
-/*! The reset member function. This method checks to ensure the input message is linked.
+/*! The reset method
  @return void
- @param currentSimNanos [ns]  Time the method is called
+ @param currentSimNanos  [ns] Time the method is called
 */
-void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos)
-{
+void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos) {
     if (!this->sunInMsg.isLinked()) {
         bskLogger.bskLog(BSK_ERROR, "FacetSRPDynamicEffector.sunInMsg was not linked.");
     }
@@ -50,26 +47,24 @@ void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos)
 
 /*! The SRP dynamic effector does not write any output messages.
  @return void
- @param currentClock [ns] Time the method is called
+ @param currentClock  [ns] Time the method is called
 */
-void FacetSRPDynamicEffector::writeOutputMessages(uint64_t currentClock)
-{
+void FacetSRPDynamicEffector::writeOutputMessages(uint64_t currentClock) {
 }
 
-/*! This member function populates the spacecraft geometry structure with user-input facet information.
+/*! This method populates the spacecraft facet geometry structure with user-input facet information
  @return void
  @param area  [m^2] Facet area
  @param specCoeff  Facet spectral reflection optical coefficient
  @param diffCoeff  Facet diffuse reflection optical coefficient
  @param normal_B  Facet normal expressed in B frame components
- @param locationPntB_B  [m] Facet location wrt point B in B frame components
+ @param locationPntB_B  [m] Facet location wrt point B expressed in B frame components
 */
 void FacetSRPDynamicEffector::addFacet(double area,
                                        double specCoeff,
                                        double diffCoeff,
                                        Eigen::Vector3d normal_B,
-                                       Eigen::Vector3d locationPntB_B)
-{
+                                       Eigen::Vector3d locationPntB_B) {
     this->scGeometry.facetAreas.push_back(area);
     this->scGeometry.facetSpecCoeffs.push_back(specCoeff);
     this->scGeometry.facetDiffCoeffs.push_back(diffCoeff);
@@ -79,12 +74,11 @@ void FacetSRPDynamicEffector::addFacet(double area,
 }
 
 /*! This method is used to link the faceted SRP effector to the hub attitude and position,
-which are required for calculating SRP forces and torques.
+which are required for calculating SRP forces and torques
  @return void
  @param states  Dynamic parameter states
 */
-void FacetSRPDynamicEffector::linkInStates(DynParamManager& states)
-{
+void FacetSRPDynamicEffector::linkInStates(DynParamManager& states) {
     this->hubSigma = states.getStateObject("hubSigma");
     this->hubPosition = states.getStateObject("hubPosition");
 }
@@ -94,8 +88,7 @@ void FacetSRPDynamicEffector::linkInStates(DynParamManager& states)
  @param integTime  [s] Time the method is called
  @param timeStep  [s] Simulation time step
 */
-void FacetSRPDynamicEffector::computeForceTorque(double integTime, double timeStep)
-{
+void FacetSRPDynamicEffector::computeForceTorque(double integTime, double timeStep) {
     // Read the input message
     SpicePlanetStateMsgPayload sunMsgBuffer;
     sunMsgBuffer = sunInMsg.zeroMsgPayload;
@@ -139,12 +132,11 @@ void FacetSRPDynamicEffector::computeForceTorque(double integTime, double timeSt
     double SRPPressure = (solarRadFlux / speedLight) * numAU * numAU;
 
     // Loop through the facets and calculate the SRP force and torque acting on point B
-    for(int i = 0; i < this->numFacets; i++)
-    {
+    for(int i = 0; i < this->numFacets; i++) {
         cosTheta = this->scGeometry.facetNormals_B[i].dot(sHat);
         projectedArea = this->scGeometry.facetAreas[i] * cosTheta;
 
-        if(projectedArea > 0.0){
+        if(projectedArea > 0.0) {
             // Compute the SRP force acting on the ith facet
             facetSRPForcePntB_B = -SRPPressure * projectedArea
                                   * ( (1-this->scGeometry.facetSpecCoeffs[i])
@@ -168,8 +160,7 @@ void FacetSRPDynamicEffector::computeForceTorque(double integTime, double timeSt
 
 /*! This is the UpdateState() method
  @return void
- @param currentSimNanos [ns] Time the method is called
+ @param currentSimNanos  [ns] Time the method is called
 */
-void FacetSRPDynamicEffector::UpdateState(uint64_t currentSimNanos)
-{
+void FacetSRPDynamicEffector::UpdateState(uint64_t currentSimNanos) {
 }

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -45,13 +45,6 @@ void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos) {
     }
 }
 
-/*! The SRP dynamic effector does not write any output messages.
- @return void
- @param currentClock  [ns] Time the method is called
-*/
-void FacetSRPDynamicEffector::writeOutputMessages(uint64_t currentClock) {
-}
-
 /*! This method populates the spacecraft facet geometry structure with user-input facet information
  @return void
  @param area  [m^2] Facet area
@@ -156,11 +149,4 @@ void FacetSRPDynamicEffector::computeForceTorque(double integTime, double timeSt
     // Write the total SRP force and torque local variables to the dynamic effector variables
     this->forceExternal_B = totalSRPForcePntB_B;
     this->torqueExternalPntB_B = totalSRPTorquePntB_B;
-}
-
-/*! This is the UpdateState() method
- @return void
- @param currentSimNanos  [ns] Time the method is called
-*/
-void FacetSRPDynamicEffector::UpdateState(uint64_t currentSimNanos) {
 }

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -27,6 +27,7 @@
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
+#include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
 #include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/avsEigenMRP.h"
@@ -38,6 +39,7 @@ typedef struct {
     std::vector<double> facetDiffCoeffs;                              //!< Vector of facet diffuse reflection optical coefficients
     std::vector<Eigen::Vector3d> facetNormals_B;                      //!< Vector of facet normals expressed in B frame components
     std::vector<Eigen::Vector3d> facetLocationsPntB_B;                //!< [m] Vector of facet COP locations wrt point B expressed in B frame components
+    std::vector<Eigen::Vector3d> facetRotAxes_B;                      //!< [m] Vector of facet rotation axes expressed in B frame components
 }FacetedSRPSpacecraftGeometryData;
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
@@ -54,15 +56,21 @@ public:
                   Eigen::Vector3d normal_B,
                   Eigen::Vector3d locationPntB_B,
                   Eigen::Vector3d rotAxis_B);                                            //!< Method for adding facets to the spacecraft geometry structure
+    void addArticulatedFacet(Message<HingedRigidBodyMsgPayload> *tmpMsg);
+    void ReadMessages();
 
     uint64_t numFacets;                                                                  //!< Total number of spacecraft facets
+    uint64_t numArticulatedFacets;                                                       //!< Number of articulated facets
     ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;                                    //!< Sun spice ephemeris input message
 
 private:
+    std::vector<ReadFunctor<HingedRigidBodyMsgPayload>> articulatedFacetDataInMsgs;      //!< Articulated facet angle data input message
+    std::vector<double> facetArticulationAngleList;                                      //!< [rad] Vector of facet rotation angles
     FacetedSRPSpacecraftGeometryData scGeometry;                                         //!< Spacecraft facet data structure
     Eigen::Vector3d r_SN_N;                                                              //!< [m] Sun inertial position vector
     StateData *hubPosition;                                                              //!< [m] Hub inertial position vector
     StateData *hubSigma;                                                                 //!< Hub MRP inertial attitude
+    bool facetAngleMsgRead;                                                              //!< Boolean variable signaling that the facet articulation messages are read
 };
 
 #endif 

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -17,7 +17,6 @@
 
  */
 
-
 #ifndef FACET_SRP_DYNAMIC_EFFECTOR_H
 #define FACET_SRP_DYNAMIC_EFFECTOR_H
 
@@ -38,30 +37,34 @@ typedef struct {
     std::vector<double> facetSpecCoeffs;                              //!< Vector of facet spectral reflection optical coefficients
     std::vector<double> facetDiffCoeffs;                              //!< Vector of facet diffuse reflection optical coefficients
     std::vector<Eigen::Vector3d> facetNormals_B;                      //!< Vector of facet normals expressed in B frame components
-    std::vector<Eigen::Vector3d> facetLocationsPntB_B;                //!< [m] Vector of facet locations wrt point B in B frame components
+    std::vector<Eigen::Vector3d> facetLocationsPntB_B;                //!< [m] Vector of facet COP locations wrt point B expressed in B frame components
 }FacetedSRPSpacecraftGeometryData;
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
-class FacetSRPDynamicEffector: public SysModel, public DynamicEffector
-{
+class FacetSRPDynamicEffector: public SysModel, public DynamicEffector {
 public:                                                             
-    FacetSRPDynamicEffector();                                      //!< The module constructor
-    ~FacetSRPDynamicEffector();                                     //!< The module destructor
-    void linkInStates(DynParamManager& states) override;            //!< Method for giving the effector access to the hub states
-    void computeForceTorque(double integTime, double timeStep) override;  //!< Method for computing the SRP force and torque about point B
-    void Reset(uint64_t currentSimNanos) override;                  //!< Reset method
     void UpdateState(uint64_t currentSimNanos) override;            //!< Method for updating the effector states
     void writeOutputMessages(uint64_t currentClock);                //!< Method for writing the output messages
-    void addFacet(double area, double specCoeff, double diffCoeff, Eigen::Vector3d normal_B, Eigen::Vector3d locationPntB_B);  //!< Method for adding facets to the spacecraft geometry structure
+    FacetSRPDynamicEffector();                                                           //!< The module constructor
+    ~FacetSRPDynamicEffector();                                                          //!< The module destructor
+    void linkInStates(DynParamManager& states) override;                                 //!< Method for giving the effector access to the hub states
+    void computeForceTorque(double callTime, double timeStep) override;                  //!< Method for computing the SRP force and torque about point B
+    void Reset(uint64_t currentSimNanos) override;                                       //!< Reset method
+    void addFacet(double area,
+                  double specCoeff,
+                  double diffCoeff,
+                  Eigen::Vector3d normal_B,
+                  Eigen::Vector3d locationPntB_B,
+                  Eigen::Vector3d rotAxis_B);                                            //!< Method for adding facets to the spacecraft geometry structure
 
-    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;               //!< Sun spice ephemeris input message
-    uint64_t numFacets;                                             //!< Total number of spacecraft facets
-    Eigen::Vector3d r_SN_N;                                         //!< [m] Position vector of the Sun with respect to the inertial frame
-    StateData *hubPosition;                                         //!< [m] Hub inertial position vector
-    StateData *hubSigma;                                            //!< MRP attitude of the hub B frame with respect to the inertial frame
+    uint64_t numFacets;                                                                  //!< Total number of spacecraft facets
+    ReadFunctor<SpicePlanetStateMsgPayload> sunInMsg;                                    //!< Sun spice ephemeris input message
 
 private:
-    FacetedSRPSpacecraftGeometryData scGeometry;                    //!< Structure to hold the spacecraft facet data
+    FacetedSRPSpacecraftGeometryData scGeometry;                                         //!< Spacecraft facet data structure
+    Eigen::Vector3d r_SN_N;                                                              //!< [m] Sun inertial position vector
+    StateData *hubPosition;                                                              //!< [m] Hub inertial position vector
+    StateData *hubSigma;                                                                 //!< Hub MRP inertial attitude
 };
 
 #endif 

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -42,9 +42,7 @@ typedef struct {
 
 /*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
 class FacetSRPDynamicEffector: public SysModel, public DynamicEffector {
-public:                                                             
-    void UpdateState(uint64_t currentSimNanos) override;            //!< Method for updating the effector states
-    void writeOutputMessages(uint64_t currentClock);                //!< Method for writing the output messages
+public:
     FacetSRPDynamicEffector();                                                           //!< The module constructor
     ~FacetSRPDynamicEffector();                                                          //!< The module destructor
     void linkInStates(DynParamManager& states) override;                                 //!< Method for giving the effector access to the hub states

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.rst
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.rst
@@ -1,8 +1,10 @@
 Executive Summary
 -----------------
-This new dynamic effector module uses a static faceted spacecraft model to calculate the force and torque acting on a
-spacecraft due to solar radiation pressure (SRP). The force and torque acting on the spacecraft are defined with respect
-to the spacecraft body frame origin :math:`B`.
+This dynamic effector module uses a faceted spacecraft model to calculate the force and torque acting on a spacecraft
+due to solar radiation pressure (SRP). The force and torque are calculated about the spacecraft body frame origin
+point :math:`B`. The module can be configured for either a static spacecraft or a spacecraft with any number of
+articulating facets. For example, a spacecraft with two articulating solar arrays can be configured using 4
+articulating facets. The unit test for this module shows how to set up this particular configuration.
 
 Message Connection Descriptions
 -------------------------------
@@ -21,168 +23,188 @@ provides information on what this message is used for.
     * - sunInMsg
       - :ref:`SpicePlanetStateMsgPayload`
       - Input msg with the Sun state information
+    * - articulatedFacetDataInMsgs
+      - :ref:`HingedRigidBodyMsgPayload`
+      - (Optional) Input message with facet articulation angle information
 
 Detailed Module Description
 ---------------------------
 
 Mathematical Modeling
 ^^^^^^^^^^^^^^^^^^^^^
-The spacecraft is represented as a collection of :math:`n` facets with negligible thickness. Each facet is characterized
-by an area :math:`A`, a vector normal to its surface :math:`\boldsymbol{\hat{n}}`, a position vector from the
-spacecraft body frame origin, point :math:`B` to the facet center of pressure, :math:`\boldsymbol{r}_{F/B}`, and three optical coefficients
-representing the interaction of impinging photons with the facet surface. The fraction of specularly reflected,
-diffusely scattered, and absorbed photons are represented using the coefficients :math:`\delta, \rho,` and
-:math:`\alpha`, respectively.
+The spacecraft is represented as a collection of :math:`N` total facets with negligible thickness. Each facet is
+characterized by an area :math:`A`, a unit vector normal to its surface :math:`\boldsymbol{\hat{n}}` expressed in
+:math:`\mathcal{B}` frame components, a position vector from the spacecraft body frame origin point :math:`B` to the
+facet center of pressure :math:`\boldsymbol{r}_{COP/B}` expressed in :math:`\mathcal{B}` frame components,
+an optional unit vector expressed in :math:`\mathcal{B}` frame components representing the articulation axis of any
+additional articulating facets, and three optical coefficients representing the interaction of impinging photons with
+the facet surface. The fraction of specularly reflected, diffusely scattered, and absorbed photons are represented
+using the coefficients :math:`\delta, \rho,` and :math:`\alpha`, respectively.
 
-A faceted force model is used to estimate the SRP force acting on the spacecraft:
-
-.. math::
-    \boldsymbol{F}_{\text{SRP}} = \sum_{i = 1}^{n} \boldsymbol{F}_{\text{SRP}_i} = -P(|\boldsymbol{r}_{\text{sc} / \odot }|) \sum_{i = 1}^{n} A_i \cos(\theta_i) \left [ (1 - \delta_i) \boldsymbol{\hat{s}} + 2 \left ( \frac{\rho_i}{3} + \delta_i \cos(\theta_i) \right ) \boldsymbol{\hat{n}}_{i}\right ]
-
-Note that all vector quantities are expressed in the spacecraft principal body-frame components for the SRP force
-calculation. :math:`\boldsymbol{\hat{s}}` is the unit direction vector pointing radially towards the Sun from the
-spacecraft body-frame origin. This vector is found by subtracting the current spacecraft inertial position from the
-Sun position given from the Spice input message:
+For each articulating facet, the current facet normal vector is computed using the facet articulation axis
+:math:`\boldsymbol{\hat{a}}` and the corresponding facet articulation angle :math:`\phi`. The facet articulation
+angle is obtained from the ``articulatedFacetDataInMsgs`` input message data. The direction cosine matrix (DCM)
+required to rotate the given facet normal vector through the current facet articulation angle is obtained using a
+principal rotation vector (PRV) transformation where:
 
 .. math::
-    {}^B \boldsymbol{\hat{s}} = [BN] ( {}^N \boldsymbol{r}_{\odot / N} - {}^N \boldsymbol{r}_{\text{sc} / N})
+    [\mathcal{B}_0\mathcal{B}] = \text{PRV2C}(\phi, \boldsymbol{\hat{a}})
 
-Note that both the Sun and spacecraft inertial positions are given in inertial frame components. The current spacecraft
-attitude, :math:`\sigma_{\mathcal{B} / \mathcal{N}}` is used to find the current Direction Cosine Matrix (DCM) of the
-spacecraft body frame relative to the inertial frame, :math:`[BN]`.
+and
 
-:math:`\theta` is defined as the incidence angle between each facet normal vector and the
+.. math::
+    {}^\mathcal{B} \boldsymbol{\hat{n}} = [\mathcal{B}\mathcal{B}_0] {}^{\mathcal{B}_0} \boldsymbol{\hat{n}}
+
+Using the spacecraft facet information and spacecraft Sun-relative position vector
+:math:`\boldsymbol{r}_{\text{sc} / \odot }`, the estimated SRP force acting on the spacecraft is calculated
+by summing the SRP force contribution from all :math:`N` facets:
+
+.. math::
+    \boldsymbol{F}_{\text{SRP}} = \sum_{i = 1}^{N} \boldsymbol{F}_{\text{SRP}_i} = -P(|\boldsymbol{r}_{\text{sc} / \odot }|) \sum_{i = 1}^{N} A_i \cos(\theta_i) \left [ (1 - \delta_i) \boldsymbol{\hat{s}} + 2 \left ( \frac{\rho_i}{3} + \delta_i \cos(\theta_i) \right ) \boldsymbol{\hat{n}}_{i}\right ]
+
+Where :math:`\theta` is defined as the incidence angle between each facet normal vector and the
 Sun-direction vector, and :math:`P(|\boldsymbol{r}_{\text{sc}/ \odot\ }|)` is the pressure acting on the spacecraft
-scaled by the spacecraft heliocentric distance.
+scaled by the spacecraft heliocentric distance. Because the Sun and spacecraft inertial positions are given in
+inertial frame components, the current spacecraft attitude :math:`\sigma_{\mathcal{B} / \mathcal{N}}` is used
+to determine the current DCM of the spacecraft body frame relative to the inertial frame, :math:`[\mathcal{BN}]`.
+Note that all vector quantities must be expressed in the spacecraft body frame for the SRP force calculation.
+:math:`\boldsymbol{\hat{s}}` is the unit direction vector pointing radially towards the Sun from the
+spacecraft body frame origin point :math:`B`. This vector is found by subtracting the current spacecraft inertial
+position from the Sun position given from the Sun Spice input message:
+
+.. math::
+    {}^\mathcal{B} \boldsymbol{\hat{s}} = [\mathcal{BN}] ( {}^\mathcal{N} \boldsymbol{r}_{\odot / N} - {}^\mathcal{N} \boldsymbol{r}_{\text{sc} / N})
 
 The total torque acting on the spacecraft about point :math:`B` due to SRP is calculated by summing the torque
-contributions over all :math:`n` facets:
+contributions over all :math:`N` facets:
 
 .. math::
-    \boldsymbol{L}_{\text{SRP},B} = \sum_{i = 1}^{n} \boldsymbol{L}_{{\text{SRP},B}_i} = \sum_{i = 1}^{n} \boldsymbol{r}_{F_i/B} \times \boldsymbol{F}_{\text{SRP}_i}
+    \boldsymbol{L}_{\text{SRP},B} = \sum_{i = 1}^{N} \boldsymbol{L}_{{\text{SRP},B}_i} = \sum_{i = 1}^{N} \boldsymbol{r}_{{COP_i}/B} \times \boldsymbol{F}_{\text{SRP}_i}
 
 Module Testing
 ^^^^^^^^^^^^^^
-The unit test for this module ensures that the calculated Solar Radiation Pressure (SRP) force and torque acting
-on the spacecraft about the body-fixed point B is properly computed for a static spacecraft. The spacecraft
-geometry defined in this test consists of a cubic hub and two circular solar arrays. Six square facets represent
-the cubic hub and four circular facets describe the solar arrays. The SRP force and torque module values are
-checked with values computed in python both initially and at a time halfway through the simulation.
-
-The initial module-computed SRP force value ``SRPDataForce_B`` is checked with the value computed in
-python ``forceTest1Val``. The initial module-computed SRP torque value ``SRPDataTorque_B`` is also checked
-with the value computed in python ``torqueTest1Val``. Similarly, these values halfway through the simulation
-are checked to match.
+The unit test for this module ensures that the calculated SRP force and torque acting on the spacecraft about the
+body-fixed point B is properly computed for either a static spacecraft or a spacecraft with any number of articulating
+facets. The spacecraft geometry defined in the test consists of a cubic hub and two circular solar arrays.
+Six static square facets represent the cubic hub and four articulated circular facets describe the articulating
+solar arrays. To validate the module functionality, the final SRP force simulation value is checked with the
+true value computed in python.
 
 User Guide
 ----------
-The user configures the spacecraft geometry as a collection of :math:`n` facets, each with an area :math:`A`,
-a vector normal to its surface :math:`\boldsymbol{\hat{n}}`, a position vector from the spacecraft center of mass to
-the facet center of pressure, :math:`\boldsymbol{r}_{F/c}`, and the three optical coefficients
-:math:`\delta, \rho,` and :math:`\alpha`, representing the fraction of specularly reflected, diffusely scattered,
-and absorbed photons, respectively.
+The following steps are required to set up the faceted SRP dynamic effector in python using Basilisk. Be sure to include
+the Sun as a gravitational body in the simulation to use this module.
 
-The following steps are needed to setup a faceted SRP dynamic effector in python using Basilisk.
-
-#. Import the facetSRPDynamicEffector class::
+#. First import the facetSRPDynamicEffector class::
 
     from Basilisk.simulation import facetSRPDynamicEffector
 
-#. Add the Earth and Sun as gravitational bodies to the simulation::
+#. Next, create an instantiation of the SRP dynamic effector::
 
-    gravFactory = simIncludeGravBody.gravBodyFactory()
-    earth = gravFactory.createEarth()
-    sun = gravFactory.createSun()
-    earth.isCentralBody = True  # ensure this is the central gravitational body
-    earthIdx = 0
-    sunIdx = 1
+    SRPEffector = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    SRPEffector.ModelTag = "SRPEffector"
 
-    earthStateMsg = messaging.SpicePlanetStateMsgPayload()
-    earthStateMsg.PositionVector = [0.0, -149598023 * 1000, 0.0]
-    earthStateMsg.VelocityVector = [0.0, 0.0, 0.0]
-    earthMsg = messaging.SpicePlanetStateMsg().write(earthStateMsg)
-    gravFactory.gravBodies['earth'].planetBodyInMsg.subscribeTo(earthMsg)
+#. The user is required to set the total number of spacecraft facets and the number of articulated facets. For example, if the user wants to create a spacecraft with 10 total facets, four of which articulate; the user would set these module variables to::
 
-    sunStateMsg = messaging.SpicePlanetStateMsgPayload()
-    sunStateMsg.PositionVector = [0.0, 0.0, 0.0]
-    sunStateMsg.VelocityVector = [0.0, 0.0, 0.0]
-    sunMsg = messaging.SpicePlanetStateMsg().write(sunStateMsg)
-    gravFactory.gravBodies['sun'].planetBodyInMsg.subscribeTo(sunMsg)
+    SRPEffector.numFacets = 10
+    SRPEffector.numArticulatedFacets = 4
 
-#. Create an instantiation of the dynamic effector::
+#. If the spacecraft contains articulated facets, a ``HingedRigidBodyMsgPayload`` articulation angle message must be configured for each articulated facet. An example using two constant stand-alone messages is provided below::
 
-    newSRP = facetSRPDynamicEffector.FacetSRPDynamicEffector()
-    newSRP.ModelTag = "FacetSRP"
+    facetRotAngle1 = macros.D2R * 10.0  # [rad]
+    facetRotAngle2 = macros.D2R * -10.0  # [rad]
 
-#. Define the spacecraft geometry of interest::
+    facetRotAngle1MessageData = messaging.HingedRigidBodyMsgPayload()
+    facetRotAngle1MessageData.theta = facetRotAngle1
+    facetRotAngle1MessageData.thetaDot = 0.0
+    facetRotAngle1Message = messaging.HingedRigidBodyMsg().write(facetRotAngle1MessageData)
 
-    # Define the facet surface areas
-    area1 = 1.5*1.5  # [m]
-    area2 = np.pi*(0.5*7.5)*(0.5*7.5)  # [m]
+    facetRotAngle2MessageData = messaging.HingedRigidBodyMsgPayload()
+    facetRotAngle2MessageData.theta = facetRotAngle2
+    facetRotAngle2MessageData.thetaDot = 0.0
+    facetRotAngle2Message = messaging.HingedRigidBodyMsg().write(facetRotAngle2MessageData)
+
+
+#. For articulating facets, the user must configure the module's optional ``articulatedFacetDataInMsgs`` input message by calling the ``addArticulatedFacet()`` method with each facet's ``HingedRigidBodyMsgPayload`` articulation angle input message::
+
+    srpEffector.addArticulatedFacet(facetRotAngle1Message)
+    srpEffector.addArticulatedFacet(facetRotAngle1Message)
+    srpEffector.addArticulatedFacet(facetRotAngle2Message)
+    srpEffector.addArticulatedFacet(facetRotAngle2Message)
+
+#. Next, define the spacecraft facet geometry information that is contained in the module's ``FacetedSRPSpacecraftGeometryData`` structure::
+
+    # Define facet areas
+    area1 = 1.5 * 1.5
+    area2 = np.pi * (0.5 * 7.5) * (0.5 * 7.5)
     facetAreas = [area1, area1, area1, area1, area1, area1, area2, area2, area2, area2]
 
-    # Define the facet normals in B frame components
-    facetNormal1 = np.array([1.0, 0.0, 0.0])
-    facetNormal2 = np.array([0.0, 1.0, 0.0])
-    facetNormal3 = np.array([-1.0, 0.0, 0.0])
-    facetNormal4 = np.array([0.0, -1.0, 0.0])
-    facetNormal5 = np.array([0.0, 0.0, 1.0])
-    facetNormal6 = np.array([0.0, 0.0, -1.0])
-    facetNormal7 = np.array([0.0, 1.0, 0.0])
-    facetNormal8 = np.array([0.0, -1.0, 0.0])
-    facetNormal9 = np.array([0.0, 1.0, 0.0])
-    facetNormal10 = np.array([0.0, -1.0, 0.0])
-    normals_B = [facetNormal1, facetNormal2, facetNormal3, facetNormal4, facetNormal5, facetNormal6, facetNormal7, facetNormal8, facetNormal9, facetNormal10]
+    # Define the facet normal vectors in B frame components
+    facetNormals_B = [np.array([1.0, 0.0, 0.0]),
+                          np.array([0.0, 1.0, 0.0]),
+                          np.array([-1.0, 0.0, 0.0]),
+                          np.array([0.0, -1.0, 0.0]),
+                          np.array([0.0, 0.0, 1.0]),
+                          np.array([0.0, 0.0, -1.0]),
+                          np.array([0.0, 1.0, 0.0]),
+                          np.array([0.0, -1.0, 0.0]),
+                          np.array([0.0, 1.0, 0.0]),
+                          np.array([0.0, -1.0, 0.0])]
 
-    # Define the facet center of pressure locations with respect to point B in B frame components
-    facetLoc1 = np.array([0.75, 0.0, 0.0])  # [m]
-    facetLoc2 = np.array([0.0, 0.75, 0.0])  # [m]
-    facetLoc3 = np.array([-0.75, 0.0, 0.0])  # [m]
-    facetLoc4 = np.array([0.0, -0.75, 0.0])  # [m]
-    facetLoc5 = np.array([0.0, 0.0, 0.75])  # [m]
-    facetLoc6 = np.array([0.0, 0.0, -0.75])  # [m]
-    facetLoc7 = np.array([4.5, 0.0, 0.75])  # [m]
-    facetLoc8 = np.array([4.5, 0.0, 0.75])  # [m]
-    facetLoc9 = np.array([-4.5, 0.0, 0.75])  # [m]
-    facetLoc10 = np.array([-4.5, 0.0, 0.75])  # [m]
-    locationsPntB_B = [facetLoc1, facetLoc2, facetLoc3, facetLoc4, facetLoc5, facetLoc6, facetLoc7, facetLoc8, facetLoc9, facetLoc10]
+    # Define facet center of pressure locations relative to point B
+    locationsPntB_B = [np.array([0.75, 0.0, 0.0]),
+                       np.array([0.0, 0.75, 0.0]),
+                       np.array([-0.75, 0.0, 0.0]),
+                       np.array([0.0, -0.75, 0.0]),
+                       np.array([0.0, 0.0, 0.75]),
+                       np.array([0.0, 0.0, -0.75]),
+                       np.array([4.5, 0.0, 0.75]),
+                       np.array([4.5, 0.0, 0.75]),
+                       np.array([-4.5, 0.0, 0.75]),
+                       np.array([-4.5, 0.0, 0.75])]
 
-    # Define the facet optical coefficients
+    # Define facet articulation axes in B frame components
+    rotAxes_B = [np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([0.0, 0.0, 0.0]),
+                 np.array([1.0, 0.0, 0.0]),
+                 np.array([1.0, 0.0, 0.0]),
+                 np.array([-1.0, 0.0, 0.0]),
+                 np.array([-1.0, 0.0, 0.0])]
+
+    # Define facet optical coefficients
     specCoeff = np.array([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
     diffCoeff = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
 
-#. Populate the scGeometry structure with the defined facet information::
+.. important::
+    Note that in order to use this module, the facet articulation axes must always be configured regardless of whether
+    articulated facets are considered. For all static facets, the articulation axes must be set to zero. Ensure that the
+    specified number of articulated facets matches the number of nonzero articulation axes.
 
-    for i in range(len(facetAreas)):
-        newSRP.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], normals_B[i], locationsPntB_B[i])
+.. important::
+    The module requires the articulated facet data to be added at the end of the facet data vectors.
 
-Note that for each added facet, the user is required to set the corresponding area, normal vector, location, and optical coefficients parameters in the scGeometry structure.
+#. Populate the module's ``FacetedSRPSpacecraftGeometryData`` structure with the spacecraft facet information using the ``addFacet()`` method::
+
+    for i in range(numFacets)):
+        SRPEffector.addFacet(facetAreas[i], specCoeff[i], diffCoeff[i], facetNormals_B[i], locationsPntB_B[i], rotAxes_B[i])
 
 #. Connect the Sun's ephemeris message to the SRP module::
 
-    newSRP.sunInMsg.subscribeTo(sunMsg)
+    SRPEffector.sunInMsg.subscribeTo(sunMsg)
 
 #. Add the SRP dynamic effector to the spacecraft::
 
-    scObject.addDynamicEffector(newSRP)
+    scObject.addDynamicEffector(SRPEffector)
 
    See :ref:`spacecraft` documentation on how to set up a spacecraft object.
 
-#. Set up the spacecraft orbit::
+#. Finally, add the SRP effector module to the task list::
 
-    oe = orbitalMotion.ClassicElements()
-    r_eq = 6371*1000.0  # [m]
-    rN = np.array([r_eq+2000.0, -149598023 * 1000, 0.0])  # [m]
-    vN = np.array([0.0, 7.90854, 0.0])  # [m/s]
-    sig_BN = np.array([0.0, 0.0, 0.0])
+    unitTestSim.AddModelToTask(unitTaskName, SRPEffector)
 
-#. Initialize the spacecraft states with the initialization variables::
-
-    scObject.hub.r_CN_NInit = rN  # [m] r_CN_N
-    scObject.hub.v_CN_NInit = vN  # [m] v_CN_N
-    scObject.hub.sigma_BNInit = sig_BN
-
-#. Add the module to the task list::
-
-    unitTestSim.AddModelToTask(unitTaskName, newSRP)
-
+.. note::
+    See the example script :ref:`scenarioSepMomentumManagement`, which illustrates how to set up a spacecraft with articulated panels for SRP calculation.


### PR DESCRIPTION
* **Tickets addressed:** bsk-498
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR cleans up the `facetSRPDynamicEffector` module and adds optional facet articulation to the module

## Verification
The unit test is adjusted to calculate the correct SRP force and torque values for the articulated facets

## Documentation
The module documentation is updated to reflect these additions

## Future work
N/A
