### PR TITLE
Feature/rotation with coast profiler

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,6 +33,8 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Added optional facet articulation to the :ref:`facetSRPDynamicEffector` module.
+- Added a coast option to the :ref:`prescribedRot1DOF` module, where a period of zero acceleration is added between
+  the two acceleration segments.
 
 
 Version 2.2.1 (Dec. 22, 2023)

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.c
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.c
@@ -17,28 +17,22 @@
 
  */
 
-/* Import the module header file */
 #include "prescribedRot1DOF.h"
-
-/* Other required files to import */
-#include <stdbool.h>
-#include <math.h>
 #include "architecture/utilities/linearAlgebra.h"
-#include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/rigidBodyKinematics.h"
+#include <math.h>
+#include <stdbool.h>
 
 /*! This method initializes the output messages for this module.
  @return void
  @param configData The configuration data associated with this module
  @param moduleID The module identifier
  */
-void SelfInit_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, int64_t moduleID)
-{
-    // Initialize the output messages
+void SelfInit_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, int64_t moduleID) {
     PrescribedMotionMsg_C_init(&configData->prescribedMotionOutMsg);
     HingedRigidBodyMsg_C_init(&configData->spinningBodyOutMsg);
 }
-
 
 /*! This method performs a complete reset of the module. The input messages are checked to ensure they are linked.
  @return void
@@ -46,31 +40,31 @@ void SelfInit_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, int64_t mod
  @param callTime [ns] Time the method is called
  @param moduleID The module identifier
 */
-void Reset_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID)
-{
+void Reset_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID) {
     // Check if the required input message is linked
-    if (!HingedRigidBodyMsg_C_isLinked(&configData->spinningBodyInMsg))
-    {
+    if (!HingedRigidBodyMsg_C_isLinked(&configData->spinningBodyInMsg)) {
         _bskLog(configData->bskLogger, BSK_ERROR, "Error: prescribedRot1DOF.spinningBodyInMsg wasn't connected.");
     }
 
-    // Set the initial time
+    // Set the initial time to zero
     configData->tInit = 0.0;
 
-    // Set the initial convergence to true to enter the required loop in Update_prescribedRot1DOF() on the first pass
+    // Set the module variables to the initial states set by the user
+    configData->theta = configData->thetaInit;
+    configData->thetaDot = configData->thetaDotInit;
+
+    // Set the initial convergence to true to enter the if statement in the Update method on the first pass
     configData->convergence = true;
 }
 
-
-/*! This method profiles the prescribed trajectory and updates the prescribed states as a function of time.
-The prescribed states are then written to the output message.
+/*! This method profiles the spinning body rotation and updates the prescribed states as a function of time.
+The spinning body prescribed states are then written to the output message.
  @return void
  @param configData The configuration data associated with the module
  @param callTime [ns] Time the method is called
  @param moduleID The module identifier
 */
-void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID)
-{
+void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t callTime, int64_t moduleID) {
     // Create the buffer messages
     HingedRigidBodyMsgPayload spinningBodyIn;
     HingedRigidBodyMsgPayload spinningBodyOut;
@@ -82,38 +76,31 @@ void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t call
 
     // Read the input message
     spinningBodyIn = HingedRigidBodyMsg_C_zeroMsgPayload();
-    if (HingedRigidBodyMsg_C_isWritten(&configData->spinningBodyInMsg))
-    {
+    if (HingedRigidBodyMsg_C_isWritten(&configData->spinningBodyInMsg)) {
         spinningBodyIn = HingedRigidBodyMsg_C_read(&configData->spinningBodyInMsg);
     }
 
-    /* This loop is entered (a) initially and (b) when each attitude maneuver is complete. The reference angle is updated
-    even if a new message is not written */
-    if (HingedRigidBodyMsg_C_timeWritten(&configData->spinningBodyInMsg) <= callTime && configData->convergence)
-    {
-        // Store the initial time as the current simulation time
+    /* This loop is entered (a) initially and (b) when each rotation is complete. The parameters used to profile the
+    spinning body rotation are updated in this statement. */
+    if (HingedRigidBodyMsg_C_timeWritten(&configData->spinningBodyInMsg) <= callTime && configData->convergence) {
+        // Update the initial time as the current simulation time
         configData->tInit = callTime * NANO2SEC;
 
-        // Calculate the current ange and angle rate
-        double prv_FM_array[3];
-        MRP2PRV(configData->sigma_FM, prv_FM_array);
-        configData->thetaInit = v3Dot(prv_FM_array, configData->rotAxis_M);
-        configData->thetaDotInit = v3Norm(configData->omega_FM_F);
-
-        // Store the reference angle and reference angle rate
+        // Store the reference angle
         configData->thetaRef = spinningBodyIn.theta;
-        configData->thetaDotRef = spinningBodyIn.thetaDot;
 
         // Define temporal information for the maneuver
         double convTime = sqrt(((0.5 * fabs(configData->thetaRef - configData->thetaInit)) * 8) / configData->thetaDDotMax);
         configData->tf = configData->tInit + convTime;
         configData->ts = configData->tInit + convTime / 2;
+        // Update the initial spinning body angle
+        configData->thetaInit = configData->theta;
 
         // Define the parabolic constants for the first and second half of the maneuver
         configData->a = 0.5 * (configData->thetaRef - configData->thetaInit) / ((configData->ts - configData->tInit) * (configData->ts - configData->tInit));
         configData->b = -0.5 * (configData->thetaRef - configData->thetaInit) / ((configData->ts - configData->tf) * (configData->ts - configData->tf));
 
-        // Set the convergence to false until the attitude maneuver is complete
+        // Set the convergence to false until the rotation is complete
         configData->convergence = false;
     }
 
@@ -148,30 +135,30 @@ void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t call
 
     // Determine the prescribed parameters: omega_FM_F and omegaPrime_FM_F
     v3Normalize(configData->rotAxis_M, configData->rotAxis_M);
-    v3Scale(thetaDot, configData->rotAxis_M, configData->omega_FM_F);
-    v3Scale(thetaDDot, configData->rotAxis_M, configData->omegaPrime_FM_F);
+    v3Scale(configData->thetaDot, configData->rotAxis_M, configData->omega_FM_F);
+    v3Scale(configData->thetaDDot, configData->rotAxis_M, configData->omegaPrime_FM_F);
 
-    // Determine dcm_FF0
-    double dcm_FF0[3][3];
-    double prv_FF0_array[3];
-    double theta_FF0 = theta - configData->thetaInit;
-    v3Scale(theta_FF0, configData->rotAxis_M, prv_FF0_array);
-    PRV2C(prv_FF0_array, dcm_FF0);
-
-    // Determine dcm_F0M
+    // Determine the DCM dcm_F0M that describes the initial spinning body attitude relative to the hub-fixed mount frame
     double dcm_F0M[3][3];
     double prv_F0M_array[3];
     v3Scale(configData->thetaInit, configData->rotAxis_M, prv_F0M_array);
     PRV2C(prv_F0M_array, dcm_F0M);
 
-    // Determine dcm_FM
+    // Determine the DCM dcm_FF0 that describes the current spinning body attitude relative to the initial attitude
+    double dcm_FF0[3][3];
+    double prv_FF0_array[3];
+    double theta_FF0 = configData->theta - configData->thetaInit;
+    v3Scale(theta_FF0, configData->rotAxis_M, prv_FF0_array);
+    PRV2C(prv_FF0_array, dcm_FF0);
+
+    // Determine the DCM dcm_FM that describes the current spinning body attitude relative to the mount frame
     double dcm_FM[3][3];
     m33MultM33(dcm_FF0, dcm_F0M, dcm_FM);
 
-    // Determine the prescribed parameter: sigma_FM
+    // Determine the spinning body MRP attitude sigma_FM from the computed dcm_FM
     C2MRP(dcm_FM, configData->sigma_FM);
 
-    // Copy the module variables to the prescribedMotionOut output message
+    // Copy the required module variables to the prescribedMotionOut output message
     v3Copy(configData->r_FM_M, prescribedMotionOut.r_FM_M);
     v3Copy(configData->rPrime_FM_M, prescribedMotionOut.rPrime_FM_M);
     v3Copy(configData->rPrimePrime_FM_M, prescribedMotionOut.rPrimePrime_FM_M);
@@ -179,9 +166,9 @@ void Update_prescribedRot1DOF(PrescribedRot1DOFConfig *configData, uint64_t call
     v3Copy(configData->omegaPrime_FM_F, prescribedMotionOut.omegaPrime_FM_F);
     v3Copy(configData->sigma_FM, prescribedMotionOut.sigma_FM);
 
-    // Copy the local scalar variables to the spinningBodyOut output message
-    spinningBodyOut.theta = theta;
-    spinningBodyOut.thetaDot = thetaDot;
+    // Copy the required scalar variables to the spinningBodyOut output message
+    spinningBodyOut.theta = configData->theta;
+    spinningBodyOut.thetaDot = configData->thetaDot;
 
     // Write the output messages
     HingedRigidBodyMsg_C_write(&spinningBodyOut, &configData->spinningBodyOutMsg, moduleID, callTime);

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.h
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.h
@@ -29,6 +29,8 @@
 typedef struct {
 
     /* User-configurable module variables */
+    bool coastOption;                                           //!< Boolean variable used for selecting an optional coast period during the rotation
+    double tRamp;                                               //!< [s] Ramp time used for the coast option maneuver
     double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of the spinning body
     double rotAxis_M[3];                                        //!< Spinning body rotation axis expressed in M frame components
     double r_FM_M[3];                                           //!< [m] Spinning body position relative to the Mount frame expressed in M frame components (fixed)
@@ -38,20 +40,29 @@ typedef struct {
     double omegaPrime_FM_F[3];                                  //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components
     double sigma_FM[3];                                         //!< Spinning body MRP attitude with respect to frame M
 
-    /* Private variables */
-    bool convergence;                                           //!< Boolean variable is true when the maneuver is complete
-    double tInit;                                               //!< [s] Simulation time at the beginning of the maneuver
-    double thetaInit;                                           //!< [rad] Initial spinning body angle from frame M to frame F about rotAxis_M
-    double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate between frame M to frame F
-    double thetaRef;                                            //!< [rad] Reference angle from frame M to frame F about rotAxis_M
-    double ts;                                                  //!< [s] The simulation time halfway through the maneuver (switch time for ang accel)
-    double tf;                                                  //!< [s] Simulation time when the maneuver is finished
-    double a;                                                   //!< Parabolic constant for the first half of the maneuver
-    double b;                                                   //!< Parabolic constant for the second half of the maneuver
+    /* Coast option variables */
+    double theta_tr;                                            //!< [rad] Angle at the end of the first ramp segment
+    double theta_tc;                                            //!< [rad] Angle at the end of the coast segment
+    double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first ramp segment
+    double thetaDot_tc;                                         //!< [rad/s] Angle rate at the end of the coast segment
+    double tr;                                                  //!< [s] The simulation time at the end of the first ramp segment
+    double tc;                                                  //!< [s] The simulation time at the end of the coast period
 
+    /* Non-coast option variables */
+    double ts;                                                  //!< [s] The simulation time halfway through the rotation
+
+    /* Shared module variables */
+    bool convergence;                                           //!< Boolean variable is true when the rotation is complete
+    double tInit;                                               //!< [s] Simulation time at the beginning of the rotation
+    double thetaInit;                                           //!< [rad] Initial spinning body rotation angle from M to F frame about rotAxis_M
+    double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate
+    double thetaRef;                                            //!< [rad] Reference angle from frame M to frame F about rotAxis_M
     double theta;                                               //!< [rad] Current angle
     double thetaDot;                                            //!< [rad/s] Current angle rate
     double thetaDDot;                                           //!< [rad/s^2] Current angular acceleration
+    double tf;                                                  //!< [s] Simulation time when the rotation is finished
+    double a;                                                   //!< Parabolic constant for the first half of the rotation
+    double b;                                                   //!< Parabolic constant for the second half of the rotation
     BSKLogger *bskLogger;                                       //!< BSK Logging
 
     /* Messages */

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.h
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.h
@@ -28,15 +28,15 @@
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
 
-    /* User configurable variables */
-    double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of spinning body
-    double rotAxis_M[3];                                        //!< Rotation axis for the maneuver in M frame components
-    double r_FM_M[3];                                           //!< [m] Position of the F frame origin with respect to the M frame origin in M frame components (fixed)
-    double rPrime_FM_M[3];                                      //!< [m/s] B frame time derivative of r_FM_M in M frame components (fixed)
-    double rPrimePrime_FM_M[3];                                 //!< [m/s^2] B frame time derivative of rPrime_FM_M in M frame components (fixed)
-    double omega_FM_F[3];                                       //!< [rad/s] Angular velocity of frame F wrt frame M in F frame components
-    double omegaPrime_FM_F[3];                                  //!< [rad/s^2] B frame time derivative of omega_FM_F in F frame components
-    double sigma_FM[3];                                         //!< MRP attitude of frame F with respect to frame M
+    /* User-configurable module variables */
+    double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of the spinning body
+    double rotAxis_M[3];                                        //!< Spinning body rotation axis expressed in M frame components
+    double r_FM_M[3];                                           //!< [m] Spinning body position relative to the Mount frame expressed in M frame components (fixed)
+    double rPrime_FM_M[3];                                      //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components (fixed)
+    double rPrimePrime_FM_M[3];                                 //!< [m/s^2] B frame time derivative of rPrime_FM_M expressed in M frame components (fixed)
+    double omega_FM_F[3];                                       //!< [rad/s] Spinning body angular velocity relative to the Mount frame expressed in F frame components
+    double omegaPrime_FM_F[3];                                  //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components
+    double sigma_FM[3];                                         //!< Spinning body MRP attitude with respect to frame M
 
     /* Private variables */
     bool convergence;                                           //!< Boolean variable is true when the maneuver is complete
@@ -44,17 +44,19 @@ typedef struct {
     double thetaInit;                                           //!< [rad] Initial spinning body angle from frame M to frame F about rotAxis_M
     double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate between frame M to frame F
     double thetaRef;                                            //!< [rad] Reference angle from frame M to frame F about rotAxis_M
-    double thetaDotRef;                                         //!< [rad/s] Reference angle rate between frame M to frame F
     double ts;                                                  //!< [s] The simulation time halfway through the maneuver (switch time for ang accel)
     double tf;                                                  //!< [s] Simulation time when the maneuver is finished
     double a;                                                   //!< Parabolic constant for the first half of the maneuver
     double b;                                                   //!< Parabolic constant for the second half of the maneuver
 
+    double theta;                                               //!< [rad] Current angle
+    double thetaDot;                                            //!< [rad/s] Current angle rate
+    double thetaDDot;                                           //!< [rad/s^2] Current angular acceleration
     BSKLogger *bskLogger;                                       //!< BSK Logging
 
     /* Messages */
-    HingedRigidBodyMsg_C    spinningBodyInMsg;                  //!< Input msg for the spinning body reference angle and angle rate
-    HingedRigidBodyMsg_C    spinningBodyOutMsg;                 //!< Output msg for the spinning body angle and angle rate
+    HingedRigidBodyMsg_C spinningBodyInMsg;                     //!< Input msg for the spinning body reference angle and angle rate
+    HingedRigidBodyMsg_C spinningBodyOutMsg;                    //!< Output msg for the spinning body angle and angle rate
     PrescribedMotionMsg_C prescribedMotionOutMsg;               //!< Output msg for the spinning body prescribed states
 
 }PrescribedRot1DOFConfig;

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.rst
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot1DOF/prescribedRot1DOF.rst
@@ -1,31 +1,40 @@
 Executive Summary
 -----------------
-This module profiles a :ref:`PrescribedMotionMsgPayload` message for a specified 1 DOF rotational attitude maneuver
-for a secondary rigid body connected to a rigid spacecraft hub at a hub-fixed location, :math:`\mathcal{M}`. The body
-frame for the prescribed body is designated by the frame :math:`\mathcal{F}`. Accordingly, the prescribed states for the
-secondary body are written with respect to the mount frame, :math:`\mathcal{M}`. The prescribed states are: ``r_FM_M``,
-``rPrime_FM_M``, ``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. Because this is a
-purely rotational profiler, the translational states ``r_FM_M``, ``rPrime_FM_M``, and ``rPrimePrime_FM_M`` are held
-constant in this module.
+This module profiles a 1 DOF rotation for a spinning rigid body connected to a rigid spacecraft hub. The body frame
+of the spinning body is designated by the frame :math:`\mathcal{F}`. The spinning body states are profiled
+relative to a hub-fixed frame :math:`\mathcal{M}`. The :ref:`PrescribedMotionMsgPayload` message
+is used to output the prescribed states from the module. The prescribed states are: ``r_FM_M``, ``rPrime_FM_M``,
+``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. Because this module only profiles
+a rotation, the spinning body translational states ``r_FM_M``, ``rPrime_FM_M``, and ``rPrimePrime_FM_M`` are fixed
+in this module.
 
-To use this module for prescribed motion purposes, it must be connected to the :ref:`PrescribedMotionStateEffector`
-dynamics module in order to profile the states of the secondary body. The required maneuver is determined from the
-user-specified scalar maximum angular acceleration for the attitude maneuver :math:`\alpha_{\text{max}}`, prescribed
-body's initial attitude with respect to the mount frame as the Principal Rotation Vector ``prv_F0M``
-:math:`(\Phi_0, \hat{\textbf{{e}}}_0)`, and the prescribed body's reference attitude with respect to the mount frame as
-the Principal Rotation Vector ``prv_F1M`` :math:`(\Phi_1, \hat{\textbf{{e}}}_1)`.
+.. important::
+    Note that this module assumes the initial and final spinning body angular rates are zero.
 
-The maximum scalar angular acceleration is applied constant and positively for the first half of the maneuver and
-constant negatively for the second half of the maneuver. The resulting angular velocity of the prescribed body is
-linear, approaching a maximum magnitude halfway through the maneuver and ending with zero residual velocity.
-The corresponding angle the prescribed body moves through during the maneuver is parabolic in time.
+The general inputs to this module that must be set by the user are the spinning body translational states ``r_FM_M``,
+``rPrime_FM_M``, and ``rPrimePrime_FM_M``, the spinning body rotation axis expressed in Mount frame components
+``rotAxis_M``, the initial spinning body angle relative to the Mount frame ``thetaInit``, the reference spinning
+body angle relative to the Mount frame ``thetaRef``, the maximum angular acceleration for the rotation
+``thetaDDotMax``, and a boolean toggle variable ``coastOption`` for selecting which of two profiling options is
+desired. The first profiling option applies a bang-bang acceleration profile to the spinning body that
+results in the fastest possible rotation from a rest to rest state. This option is automatically selected by default
+upon module creation, where ``coastOption`` is set to ``False``. The second profiling option includes a coast
+segment between the two constant acceleration profiles and is toggled with ``coastOption`` set to ``True``.
+To use the coast option, the user is required to specify the additional module variable ``tRamp``.
+Defaulted as zero for the option with no coast period, this variable specifies how long each acceleration segment
+is applied before and after the coast segment. If the user does not set this variable, the module reverts to the
+profiler with no coast period.
+
+.. important::
+    To use this module for prescribed motion, it must be connected to the :ref:`PrescribedMotionStateEffector`
+    dynamics module. This ensures the spinning body states are correctly incorporated into the spacecraft hub dynamics.
 
 Message Connection Descriptions
 -------------------------------
 The following table lists all the module input and output messages.  
 The module msg connection is set by the user from python.  
 The msg type contains a link to the message structure definition, while the description 
-provides information on what this message is used for.
+provides information on what the message is used for.
 
 .. list-table:: Module I/O Messages
     :widths: 25 25 50
@@ -44,97 +53,176 @@ provides information on what this message is used for.
       - :ref:`PrescribedMotionMsgPayload`
       - output message with the prescribed spinning body states
 
-
-
 Detailed Module Description
 ---------------------------
-This 1 DOF rotational motion flight software module is written to profile spinning body motion with respect to a 
-body-fixed mount frame. The inputs to the profiler are the scalar maximum angular acceleration for the attitude maneuver 
-:math:`\alpha_{\text{max}}`, the prescribed body's initial attitude with respect to the mount frame as the Principal 
-Rotation Vector ``prv_F0M`` :math:`(\Phi_0, \hat{\textbf{{e}}}_0)`, and the prescribed body's reference attitude with respect to the
-mount frame as the Principal Rotation Vector ``prv_F1M`` :math:`(\Phi_1, \hat{\textbf{{e}}}_1)`. The prescribed body is
-assumed to be non-rotating at the beginning of the attitude maneuver.
-    
-Subtracting the initial principal rotation vector from the reference principal rotation vector gives the required 
-rotation angle and axis for the maneuver:
+
+Profiler With No Coast Period
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The first option to profile the spinning body rotation is a pure bang-bang acceleration profile. If the spinning
+body reference angle is greater than the given initial angle, the user-specified maximum angular acceleration value
+is applied positively to the first half of the rotation and negatively to the second half of the rotation.
+However, if the reference angle is less than the initial spinning body angle, the acceleration is instead applied
+negatively during the first half of the rotation and positively during the second half of the rotation. As a result
+of this acceleration profile, the spinning body's angle rate changes linearly with time and reaches a maximum
+in magnitude halfway through the rotation. Note that the angle rate is assumed to both start and end at zero
+in this module. The resulting spinning body angle trajectory for the rotation is
+parabolic in time.
+
+To profile this spinning body motion, the scalar spinning body states :math:`\theta`, :math:`\dot{\theta}`, and
+:math:`\ddot{\theta}` are prescribed as a function of time. During the first half of the rotation the states are:
 
 .. math::
-    \Phi_{\text{ref}} = 2 \cos^{-1} \left ( \cos \frac{\Phi_1}{2} \cos \frac{\Phi_0}{2} + \sin \frac{\Phi_1}{2} \sin \frac {\Phi_0}{2} \hat{\textbf{{e}}}_1 \cdot \hat{\textbf{{e}}}_0 \right )
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}}
 
 .. math::
-    \hat{\textbf{{e}}} = \frac{\cos \frac{\Phi_0}{2} \sin \frac{\Phi_1}{2} \hat{\textbf{{e}}}_1 - \cos \frac{\Phi_1}{2} \sin \frac{\Phi_0}{2} \hat{\textbf{{e}}}_0 + \sin \frac{\Phi_1}{2} \sin \frac{\Phi_0}{2} \hat{\textbf{{e}}}_1 \times \hat{\textbf{{e}}}_0 }{\sin \frac{\Phi_{\text{ref}}}{2}}
-
-During the first half of the attitude maneuver, the prescribed body is constantly accelerated with the given maximum 
-angular acceleration. The prescribed body's angular velocity increases linearly during the acceleration phase and 
-reaches a maximum magnitude halfway through the attitude maneuver. The switch time :math:`t_s` is the simulation time 
-halfway through the maneuver:
-    
-.. math::
-    t_s = t_0 + \frac{\Delta t}{2}
-
-where the time required for the maneuver :math:`\Delta t` is determined using the inputs to the profiler:
-    
-.. math::
-    \Delta t = t_f - t_0 = 2 \sqrt{ \Phi_{\text{ref}} / \ddot{\Phi}_{\text{max}}}
-
-The resulting trajectory of the angle :math:`\Phi` swept during the first half of the maneuver is parabolic. The profiled 
-motion is concave upwards if the reference angle :math:`\Phi_{\text{ref}}` is greater than zero. If the converse is true, 
-the profiled motion is instead concave downwards. The described motion during the first half of the attitude maneuver 
-is characterized by the expressions:
- 
-.. math::
-    \omega_{\mathcal{F} / \mathcal{M}}(t) = \alpha_{\text{max}}
+    \dot{\theta}(t) = \ddot{\theta} (t - t_0) + \dot{\theta}_0
 
 .. math::
-    \dot{\Phi}(t) = \alpha_{\text{max}} (t - t_0)
+    \theta(t) = a (t - t_0)^2 + \theta_0
+
+where
 
 .. math::
-    \Phi(t) = c_1 (t - t_0)^2
+    a = \frac{ \theta_{\text{ref}} - \theta_0}{2 (t_s - t_0)^2}
 
-where 
-
-.. math::
-    c_1 = \frac{\Phi_{\text{ref}}}{2(t_s - t_0)^2}
-
-Similarly, the second half of the attitude maneuver decelerates the prescribed body constantly until it reaches a 
-non-rotating state. The prescribed body angular velocity decreases linearly from its maximum magnitude back to zero. 
-The trajectory swept during the second half of the maneuver is quadratic and concave downwards if the reference angle 
-:math:`\Phi_{\text{ref}}` is positive. If :math:`\Phi_{\text{ref}}` is negative, the profiled motion is instead concave upwards. 
-The described motion during the second half of the attitude maneuver is characterized by the expressions:
-    
-.. math::
-    \ddot{\Phi}(t) = -\alpha_{\text{max}}
+During the second half of the rotation the states are:
 
 .. math::
-    \dot{\Phi}(t) = \alpha_{\text{max}} (t - t_f)
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}}
 
 .. math::
-    \Phi(t) = c_2 (t - t_f)^2  + \Phi_{\text{ref}}
-
- where 
+    \dot{\theta}(t) = \ddot{\theta} (t - t_f) + \dot{\theta}_0
 
 .. math::
-    c_2 = \frac{\Phi_{\text{ref}}}{2(t_s - t_f)^2}
+    \theta(t) = b (t - t_f)^2 + \theta_{\text{ref}}
+
+where
+
+.. math::
+    b = - \frac{ \theta_{\text{ref}} - \theta_0}{2 (t_s - t_f)^2}
+
+The switch time :math:`t_s` is the simulation time halfway through the maneuver:
+
+.. math::
+    t_s = t_0 + \frac{\Delta t_{\text{tot}}}{2}
+
+The total time required to complete the rotation :math:`\Delta t_{\text{tot}}` is:
+
+.. math::
+    \Delta t_{\text{tot}} = 2 \sqrt{ \frac{| \theta_{\text{ref}} - \theta_0 | }{\ddot{\theta}_{\text{max}}}} = t_f - t_0
+
+Profiler With Coast Period
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The second option to profile the spinning body rotation is a bang-bang acceleration profile with an added coast period
+between the acceleration segments where the acceleration is zero. Similarly to the previous profiler, if the spinning
+body reference angle is greater than the given initial angle, the maximum angular acceleration value is applied
+positively for the specified ramp time ``tRamp`` to the first segment of the rotation and negatively to the
+third segment of the rotation. The second segment of the rotation is the coast period. However, if the reference angle
+is less than the initial spinning body angle, the acceleration is instead applied negatively during the first segment
+of the rotation and positively during the third segment of the rotation. As a result of this acceleration
+profile, the spinning body's angle rate changes linearly with time and reaches a maximum in magnitude at the end of
+the first segment and is constant during the coast segment. The angle rate decreases back to zero during the third
+segment. The resulting spinning body angle trajectory for the rotation is parabolic during the first and third
+segments and linear during the coast segment.
+
+To profile this spinning body motion, the scalar spinning body states :math:`\theta`, :math:`\dot{\theta}`, and
+:math:`\ddot{\theta}` are prescribed as a function of time. During the first segment of the rotation the states are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}}
+
+.. math::
+    \dot{\theta}(t) = \ddot{\theta} (t - t_0) + \dot{\theta}_0
+
+.. math::
+    \theta(t) = a (t - t_0)^2 + \theta_0
+
+where
+
+.. math::
+    a = \frac{ \theta(t_r) - \theta_0}{2 (t_r - t_0)^2}
+
+and :math:`\theta(t_r)` is the spinning body angle at the end of the first segment:
+
+.. math::
+    \theta(t_r) = \pm \frac{1}{2} \ddot{\theta}_{\text{max}} t_{\text{ramp}}^2
+                                       + \dot{\theta}_0 t_{\text{ramp}} + \theta_0
+
+.. important::
+    Note the distinction between :math:`t_r` and :math:`t_{\text{ramp}}`. :math:`t_{\text{ramp}}` is the time duration of the acceleration segment
+    and :math:`t_r` is the simulation time at the end of the first acceleration segment.
+    :math:`t_r = t_0 + t_{\text{ramp}}`
+
+During the coast segment, the rotation states are:
+
+.. math::
+    \ddot{\theta}(t) = 0
+
+.. math::
+    \dot{\theta}(t) = \dot{\theta}(t_r) = \ddot{\theta}_{\text{max}} t_{\text{ramp}} + \dot{\theta}_0
+
+.. math::
+    \theta(t) = \dot{\theta}(t_r) (t - t_r) + \theta(t_r)
+
+During the third segment, the rotation states are
+
+.. math::
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}}
+
+.. math::
+    \dot{\theta}(t) = \ddot{\theta} (t - t_f) + \dot{\theta}_0
+
+.. math::
+    \theta(t) = b (t - t_f)^2 + \theta_{\text{ref}}
+
+where
+
+.. math::
+    b = - \frac{ \theta_{\text{ref}} - \theta(t_c) }{(t_c - t_f)^2}
+
+Here :math:`\theta(t_c)` is the spinning body angle at the end of the coast segment:
+
+.. math::
+    \theta(t_c) = \theta(t_r) + \Delta \theta_{\text{coast}}
+
+and :math:`\Delta \theta_{\text{coast}}` is the angle traveled during the coast segment:
+
+.. math::
+    \Delta \theta_{\text{coast}} = (\theta_{\text{ref}} - \theta_0) - 2 (\theta(t_r) - \theta_0)
+
+:math:`t_c` is the simulation time at the end of the coast segment:
+
+.. math::
+    t_c = t_r + \frac{\Delta \theta_{\text{coast}}}{\dot{\theta}(t_r)}
+
+Using the given rotation axis ``rotAxis_M``, the scalar states are then transformed to the spinning body
+rotational states ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. The states are then written to the
+:ref:`PrescribedMotionMsgPayload` module output message.
 
 Module Testing
 ^^^^^^^^^^^^^^
-The unit test for this module ensures that the profiled 1 DOF rotational attitude maneuver is properly computed for a series of
-initial and reference PRV angles and maximum angular accelerations. The final prescribed angle ``theta_FM_Final``
-and angular velocity magnitude ``thetaDot_Final`` are compared with the reference values ``theta_Ref`` and
-``thetaDot_Ref``, respectively.
+The unit test for this module ensures that the 1 DOF rotation is properly profiled for several different
+simulation configurations. The unit test profiles two successive rotations for the spinning body to ensure the
+module is correctly configured. The initial spinning body angle relative to the spacecraft hub is varied,
+along with the two final reference angles and the maximum angular acceleration for the rotation.
+The unit test also tests both methods of profiling the rotation, where either a pure bang-bang acceleration
+profile can be selected for the rotation, or a coast option can be selected where the accelerations are only
+applied for a specified ramp time and a coast segment with zero acceleration is applied between the two
+acceleration periods. To validate the module, the final spinning body angles at the end of each rotation are
+checked to match the specified reference angles.
 
 User Guide
 ----------
-The user-configurable inputs to the profiler are the scalar maximum angular acceleration for the attitude maneuver
-:math:`\alpha_{\text{max}}`, the prescribed body's initial attitude with respect to the mount frame as the Principal
-Rotation Vector ``prv_F0M`` :math:`(\Phi_0, \hat{\textbf{{e}}}_0)`, and the prescribed body's reference attitude with
-respect to the mount frame as the Principal Rotation Vector ``prv_F1M`` :math:`(\Phi_1, \hat{\textbf{{e}}}_1)`.
-
-This module provides two output messages in the form of :ref:`HingedRigidBodyMsgPayload` and
-:ref:`PrescribedMotionMsgPayload`. The first guidance message, describing the spinning body's scalar states relative to
-the body-fixed mount frame can be directly connected to an attitude feedback control module. The second prescribed
-motion output message can be connected to the :ref:`PrescribedMotionStateEffector` dynamics module to directly profile
-a state effector's rotational motion.
+The general inputs to this module that must be set by the user are the spinning body translational states ``r_FM_M``,
+``rPrime_FM_M``, and ``rPrimePrime_FM_M``, the spinning body rotation axis expressed in Mount frame components
+``rotAxis_M``, the initial spinning body angle relative to the Mount frame ``thetaInit``, the reference spinning
+body angle relative to the Mount frame ``thetaRef``, the maximum angular acceleration for the rotation
+``thetaDDotMax``, and the boolean toggle variable ``coastOption`` for selecting which profiling options is
+desired. To use the coast option, the user sets ``coastOption`` to True and must specify the variable ``tRamp``.
+This variable specifies how long each acceleration segment is applied before and after the coast segment.
+If the user does not set this variable, the module reverts to the profiler with no coast period.
 
 This section is to outline the steps needed to setup a prescribed 1 DOF rotational module in python using Basilisk.
 
@@ -142,28 +230,32 @@ This section is to outline the steps needed to setup a prescribed 1 DOF rotation
 
     from Basilisk.fswAlgorithms import prescribedRot1DOF
 
-#. Create an instantiation of a prescribed rotational 1 DOF C module and the associated C++ container::
+#. Create an instantiation of the module::
 
     PrescribedRot1DOF = prescribedRot1DOF.prescribedRot1DOF()
+
+#. Define all of the configuration data associated with the module. For example, to configure the coast option::
+
     PrescribedRot1DOF.ModelTag = "prescribedRot1DOF"
+    PrescribedRot1DOF.coastOption = True
+    PrescribedRot1DOF.tRamp = 3.0  # [s]
+    PrescribedRot1DOF.rotAxis_M = np.array([0.0, 1.0, 0.0])
+    PrescribedRot1DOF.thetaDDotMax = macros.D2R * 1.0  # [rad/s^2]
+    PrescribedRot1DOF.thetaInit = macros.D2R * 10.0  # [rad]
+    PrescribedRot1DOF.r_FM_M = np.array([1.0, 0.0, 0.0])  # [m]
+    PrescribedRot1DOF.rPrime_FM_M = np.array([0.0, 0.0, 0.0])  # [m/s]
+    PrescribedRot1DOF.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])  # [m/s^2]
 
-#. Define all of the configuration data associated with the module. For example::
+#. Connect a :ref:`HingedRigidBodyMsgPayload` message for the spinning body reference angle to the module. For example, the user can create a stand-alone message to specify the reference angle::
 
-    thetaInit = 0.0  # [rad]
-    rotAxis_M = np.array([1.0, 0.0, 0.0])
-    prvInit_FM = thetaInit * rotAxisM
-    PrescribedRot1DOF.r_FM_M = np.array([1.0, 0.0, 0.0])
-    PrescribedRot1DOF.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedRot1DOF.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedRot1DOF.rotAxis_M = rotAxis_M
-    PrescribedRot1DOF.thetaDDotMax = 0.01  # [rad/s^2]
-    PrescribedRot1DOF.omega_FM_F = np.array([0.0, 0.0, 0.0])
-    PrescribedRot1DOF.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
-    PrescribedRot1DOF.sigma_FM = rbk.PRV2MRP(prvInit_FM)
+    HingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
+    HingedRigidBodyMessageData.theta = macros.D2R * 90.0  # [rad]
+    HingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
+    HingedRigidBodyMessage = messaging.HingedRigidBodyMsg().write(HingedRigidBodyMessageData)
 
-The user is required to set the above configuration data parameters, as they are not initialized in the module.
+#. Subscribe the spinning body reference message to the prescribedRot1DOF module input message::
 
-#. Make sure to connect the required messages for this module.
+    PrescribedRot1DOF.spinningBodyInMsg.subscribeTo(HingedRigidBodyMessage)
 
 #. Add the module to the task list::
 

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -179,14 +179,13 @@ def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posI
         # Initialize the prescribedRot1DOF test module configuration data
         accelMax = 0.01  # [rad/s^2]
         #accelMax = np.pi / 180  # [rad/s^2]
+        PrescribedRot1DOF.coastOption = False
+        PrescribedRot1DOF.rotAxis_M = rotAxis_M
+        PrescribedRot1DOF.thetaDDotMax = accelMax
+        PrescribedRot1DOF.thetaInit = thetaInit
         PrescribedRot1DOF.r_FM_M = r_FM_M
         PrescribedRot1DOF.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
         PrescribedRot1DOF.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
-        PrescribedRot1DOF.rotAxis_M = rotAxis_M
-        PrescribedRot1DOF.thetaDDotMax = accelMax
-        PrescribedRot1DOF.omega_FM_F = np.array([0.0, 0.0, 0.0])
-        PrescribedRot1DOF.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
-        PrescribedRot1DOF.sigma_FM = sigma_FM
 
         # Create the prescribedRot1DOF input message
         thetaDot_Ref = 0.0  # [rad/s]


### PR DESCRIPTION
* **Tickets addressed:** bsk-554
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description
This PR adds a coast option to the `prescribedRot1DOF` module. A period of zero acceleration is added between the two acceleration segments when the user selects this option.

## Verification
The unit test for this module is updated to check that the final spinning body angles converge for this option.

## Documentation
The module documentation is updated to add a description of the coast option.

## Future work
N/A
