### PR TITLE
Treat python version as string, rather than float, to accommodate python >=3.10

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -266,7 +266,7 @@ class BasiliskConan(ConanFile):
         cmake.definitions["BUILD_OPNAV"] = self.options.opNav
         cmake.definitions["BUILD_VIZINTERFACE"] = self.options.vizInterface
         cmake.definitions["EXTERNAL_MODULES_PATH"] = self.options.pathToExternalModules
-        cmake.definitions["PYTHON_VERSION"] = sys.version_info.major + 0.1*sys.version_info.minor
+        cmake.definitions["PYTHON_VERSION"] = f"{sys.version_info.major}.{sys.version_info.minor}"
         cmake.parallel = True
         print(statusColor + "Configuring cmake..." + endColor)
         cmake.configure()


### PR DESCRIPTION
* **Tickets addressed:** bsk-551 (#551)
* **Review:** by file
* **Merge strategy:** squash and merge

## Description
Updated handling of version numbers to treat them as a string, rather than a float. Per [PEP 440](https://peps.python.org/pep-0440/#public-version-identifiers), python version numbers conform to the following schema:

```
[N!]N(.N)*[{a|b|rc}N][.postN][.devN]
```
Because the schema supports multiple periods and the possibility of letters, the python version cannot be treated as a float. Additionally, because the minor version number is not constrained to the range 0-9, versions like 3.10 are not representable as a float (most implementations would display that as 3.1).

## Verification
Ran a clean build. Previously printing `print(cmake.definitions["PYTHON_VERSION"])` in `conanfile.py` yielded `4.0`. Now yields `3.10`.

AFAIK, there are no checks on this value in the code, so I didn't see anywhere that it made sense to add a test for this behavior. I don't see any CI checks which use python 3.10 (which is perhaps why the issue wasn't obvious) and it doesn't seem worth it to add them just for this change.

## Documentation
N/A

## Future work
N/A
