### PR TITLE
correct import statement in bskLogger documentation

### DIFF
--- a/src/architecture/utilities/bskLogging.rst
+++ b/src/architecture/utilities/bskLogging.rst
@@ -37,7 +37,7 @@ The default verbosity is set to the lowest level ``BSK_DEBUG`` such that any ``b
 
 If the verbosity level is to be changed for a particular Basilisk script, then the following instructions explain how this can be done.  At the top of the Basilisk python scrip be sure to include the ``bskLogging`` support package::
 
-    from Basilisk.simulation import bskLogging
+    from Basilisk.architecture import bskLogging
 
 Setting Verbosity Globally for all BSK Modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The RST documention for the logging functionality had an import module typo in it.

## Verification
No code changes here, so no changes to the unit tests.

## Documentation
All documentation builds without issue.

## Future work
None
