### PR TITLE
Resolve memory leak in spiceInterface

### DIFF
--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -480,6 +480,8 @@ int SpiceInterface::unloadSpiceKernel(char *kernelName, const char *dataPath)
     strcpy(fileName, dataPath);
     strcat(fileName, kernelName);
     unload_c(fileName);
+    delete[] fileName;
+    delete[] name;
     if(failed_c()) {
         return 1;
     }


### PR DESCRIPTION
* **Tickets addressed:** bsk-440 (#440)
* **Review:** By commit 
* **Merge strategy:**  squash and merge

## Description
[SpiceInterface::unloadSpiceKernel](https://github.com/AVSLab/basilisk/blob/12e321ad431980855d3ef8be9d2e38ac992053a9/src/simulation/environment/spiceInterface/spiceInterface.cpp#L471) calls new on two string arrays, but never frees them. This ends up leaking memory. 

## Verification
Validated by inspection/comparison to other methods (like [SpiceInterface::loadSpiceKernel](https://github.com/AVSLab/basilisk/blob/12e321ad431980855d3ef8be9d2e38ac992053a9/src/simulation/environment/spiceInterface/spiceInterface.cpp#L439C5-L439C36) has a similar structure and calls delete on its pointers).

No automated tests to check for memory leaks exist, so none could be updated.

## Documentation
N/A

## Future work
N/A
