### PR TITLE
Feature/translation with coast profiler

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,6 +33,8 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Added optional facet articulation to the :ref:`facetSRPDynamicEffector` module.
+- Added a coast option to the :ref:`prescribedTrans` module, where a period of zero acceleration is added between
+  the two acceleration segments.
 
 
 Version 2.2.1 (Dec. 22, 2023)

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/_UnitTest/test_prescribedTrans.py
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/_UnitTest/test_prescribedTrans.py
@@ -42,12 +42,16 @@ path = os.path.dirname(os.path.abspath(filename))
 bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
+@pytest.mark.parametrize("coastOption", [True, False])
+@pytest.mark.parametrize("tRamp", [0.0, 2.0, 5.0])  # [s]
 @pytest.mark.parametrize("transPosInit", [0, -0.75])  # [m]
 @pytest.mark.parametrize("transPosRef1", [0, -0.5])  # [m]
 @pytest.mark.parametrize("transPosRef2", [-0.75, 1.0])  # [m]
 @pytest.mark.parametrize("transAccelMax", [0.01, 0.005])  # [m/s^2]
-@pytest.mark.parametrize("accuracy", [1e-12])
+@pytest.mark.parametrize("accuracy", [1e-4])
 def test_prescribedTransTestFunction(show_plots,
+                                     coastOption,
+                                     tRamp,
                                      transPosInit,
                                      transPosRef1,
                                      transPosRef2,
@@ -60,12 +64,17 @@ def test_prescribedTransTestFunction(show_plots,
     is properly computed for several different simulation configurations. This unit test profiles two successive
     translations to ensure the module is correctly configured. The body's initial scalar translational position
     relative to the spacecraft hub is varied, along with the two final reference positions and the maximum translational
-    acceleration. A pure bang-bang acceleration profile is used for profiling the translation. To validate the module,
-    the final position at the end of each translation is checked to match the specified reference position.
+    acceleration. This unit test also tests both methods of profiling the translation, where either a pure bang-bang
+    acceleration profile can be selected for the translation, or a coast option can be selected where the accelerations
+    are only applied for a specified ramp time and a coast segment with zero acceleration is applied between the two
+    acceleration periods. To validate the module, the final position at the end of each translation is checked to match
+    the specified reference position.
 
     **Test Parameters**
 
     Args:
+        coastOption (bool): Boolean variable used for selecting an optional coast period during the translation
+        tRamp (double): [s] Ramp time used for the coast option
         transPosInit (float): [m] Initial translational body position from M to F frame origin along transAxis_M
         transPosRef1 (float): [m] First reference position from M to F frame origin along transAxis_M
         transPosRef2 (float): [m] Second reference position from M to F frame origin along transAxis_M
@@ -78,6 +87,8 @@ def test_prescribedTransTestFunction(show_plots,
     specified reference values ``transPosRef1`` and ``transPosRef2``.
     """
     [testResults, testMessage] = prescribedTransTestFunction(show_plots,
+                                                             coastOption,
+                                                             tRamp,
                                                              transPosInit,
                                                              transPosRef1,
                                                              transPosRef2,
@@ -88,6 +99,8 @@ def test_prescribedTransTestFunction(show_plots,
 
 
 def prescribedTransTestFunction(show_plots,
+                                coastOption,
+                                tRamp,
                                 transPosInit,
                                 transPosRef1,
                                 transPosRef2,
@@ -113,20 +126,24 @@ def prescribedTransTestFunction(show_plots,
     PrescribedTrans = prescribedTrans.prescribedTrans()
     PrescribedTrans.ModelTag = "prescribedTrans"
     transAxis_M = np.array([0.5, 0.0, 0.5 * np.sqrt(3)])
+    PrescribedTrans.coastOption = coastOption
     PrescribedTrans.transAxis_M = transAxis_M
     PrescribedTrans.transAccelMax = transAccelMax  # [m/s^2]
     PrescribedTrans.omega_FM_F = np.array([0.0, 0.0, 0.0])  # [rad/s]
     PrescribedTrans.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])  # [rad/s^2]
     PrescribedTrans.sigma_FM = np.array([0.0, 0.0, 0.0])
     PrescribedTrans.transPosInit = transPosInit  # [m]
+    PrescribedTrans.tRamp = 0.0  # [s]
+    if coastOption:
+        PrescribedTrans.tRamp = tRamp  # [s]
 
     # Add the prescribedTrans test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, PrescribedTrans)
 
     # Create the prescribedTrans input reference position message for the first translation
     PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
-    PrescribedTransMessageData.scalarPos = transPosRef1
-    PrescribedTransMessageData.scalarVel = 0.0
+    PrescribedTransMessageData.scalarPos = transPosRef1  # [m]
+    PrescribedTransMessageData.scalarVel = 0.0  # [m/s]
     PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
     PrescribedTrans.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
 
@@ -143,8 +160,30 @@ def prescribedTransTestFunction(show_plots,
     # Initialize the simulation
     unitTestSim.InitializeSimulation()
 
-    # Determine the required simulation time for the first rotation
-    translation1ReqTime = np.sqrt(((0.5 * np.abs(transPosRef1 - transPosInit)) * 8) / transAccelMax) + 5  # [s]
+    # Set the coast option to false if the ramp time is zero
+    if tRamp == 0.0:
+        coastOption = False
+
+    # Determine the required simulation time for the first translation
+    transVelInit = 0.0  # [m/s]
+    tCoast_1 = 0.0  # [s]
+    if coastOption:
+        # Determine the position and velocity at the end of the ramp segment/start of the coast segment
+        if (transPosInit < transPosRef1):
+            transPos_tr_1 = (0.5 * transAccelMax * tRamp * tRamp) + (transVelInit * tRamp) + transPosInit  # [m]
+            transVel_tr_1 = transAccelMax * tRamp + transVelInit  # [m/s]
+        else:
+            transPos_tr_1 = - ((0.5 * transAccelMax * tRamp * tRamp) + (transVelInit * tRamp)) + transPosInit  # [m]
+            transVel_tr_1 = - transAccelMax * tRamp + transVelInit  # [m/s]
+
+        # Determine the distance traveled during the coast period
+        deltaPosCoast_1 = transPosRef1 - transPosInit - 2 * (transPos_tr_1 - transPosInit)  # [m]
+
+        # Determine the time duration of the coast segment
+        tCoast_1 = np.abs(deltaPosCoast_1) / np.abs(transVel_tr_1)  # [s]
+        translation1ReqTime = (2 * tRamp) + tCoast_1  # [s]
+    else:
+        translation1ReqTime = np.sqrt(((0.5 * np.abs(transPosRef1 - transPosInit)) * 8) / transAccelMax) + 5  # [s]
 
     translation1ExtraTime = 5  # [s]
     unitTestSim.ConfigureStopTime(macros.sec2nano(translation1ReqTime + translation1ExtraTime))
@@ -154,13 +193,30 @@ def prescribedTransTestFunction(show_plots,
 
     # Create the prescribedTrans input reference position message for the second translation
     PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
-    PrescribedTransMessageData.scalarPos = transPosRef2
-    PrescribedTransMessageData.scalarVel = 0.0
+    PrescribedTransMessageData.scalarPos = transPosRef2  # [m]
+    PrescribedTransMessageData.scalarVel = 0.0  # [m/s]
     PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
     PrescribedTrans.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
 
-    # Determine the required simulation time for the second rotation
-    translation2ReqTime = np.sqrt(((0.5 * np.abs(transPosRef2 - transPosRef1)) * 8) / transAccelMax) + 5  # [s]
+    # Determine the required simulation time for the second translation
+    tCoast_2 = 0.0  # [s]
+    if coastOption:
+        # Determine the position and velocity at the end of the ramp segment/start of the coast segment
+        if (transPosRef1 < transPosRef2):
+            transPos_tr_2 = (0.5 * transAccelMax * tRamp * tRamp) + (transVelInit * tRamp) + transPosRef1  # [m]
+            transVel_tr_2 = transAccelMax * tRamp + transVelInit  # [m/s]
+        else:
+            transPos_tr_2 = - ((0.5 * transAccelMax * tRamp * tRamp) + (transVelInit * tRamp)) + transPosRef1  # [m]
+            transVel_tr_2 = - transAccelMax * tRamp + transVelInit  # [m/s]
+
+        # Determine the distance traveled during the coast period
+        deltaPosCoast_2 = transPosRef2 - transPosRef1 - 2 * (transPos_tr_2 - transPosRef1)  # [m]
+
+        # Determine the time duration of the coast segment
+        tCoast_2 = np.abs(deltaPosCoast_2) / np.abs(transVel_tr_2)  # [s]
+        translation2ReqTime = (2 * tRamp) + tCoast_2  # [s]
+    else:
+        translation2ReqTime = np.sqrt(((0.5 * np.abs(transPosRef2 - transPosRef1)) * 8) / transAccelMax) + 5  # [s]
 
     translation2ExtraTime = 5  # [s]
     unitTestSim.ConfigureStopTime(macros.sec2nano(translation1ReqTime
@@ -182,23 +238,43 @@ def prescribedTransTestFunction(show_plots,
 
     # Unit test validation
     # Store the truth data used to validate the module in two lists
-    # Compute tf for the first translation, and tInit tf for the second translation
-    tf_1 = translation1ReqTime
-    tInit_2 = translation1ReqTime + translation1ExtraTime
-    tf_2 = tInit_2 + translation2ReqTime
+    if coastOption:
+        # Compute tf for the first translation, and tInit tf for the second translation
+        tf_1 = 2 * tRamp + tCoast_1  # [s]
+        tInit_2 = translation1ReqTime + translation1ExtraTime  # [s]
+        tf_2 = tInit_2 + (2 * tRamp) + tCoast_2  # [s]
 
-    # Compute the timespan indices for each check
-    tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
-    tInit_2_index = int(round(tInit_2 / testTimeStepSec)) + 1
-    tf_2_index = int(round(tf_2 / testTimeStepSec)) + 1
+        # Compute the timespan indices for each check
+        tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
+        tInit_2_index = int(round(tInit_2 / testTimeStepSec)) + 1
+        tf_2_index = int(round(tf_2 / testTimeStepSec)) + 1
 
-    # Store the timespan indices in a list
-    timeCheckIndicesList = [tf_1_index,
-                            tInit_2_index,
-                            tf_2_index]
+        # Store the timespan indices in a list
+        timeCheckIndicesList = [tf_1_index,
+                                tInit_2_index,
+                                tf_2_index]
 
-    # Store the positions to check in a list
-    transPosCheckList = [transPosRef1, transPosRef1, transPosRef2]
+        # Store the positions to check in a list
+        transPosCheckList = [transPosRef1, transPosRef1, transPosRef2]
+
+    else:
+        # Compute tf for the first translation, and tInit tf for the second translation
+        tf_1 = translation1ReqTime  # [s]
+        tInit_2 = translation1ReqTime + translation1ExtraTime  # [s]
+        tf_2 = tInit_2 + translation2ReqTime  # [s]
+
+        # Compute the timespan indices for each check
+        tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
+        tInit_2_index = int(round(tInit_2 / testTimeStepSec)) + 1
+        tf_2_index = int(round(tf_2 / testTimeStepSec)) + 1
+
+        # Store the timespan indices in a list
+        timeCheckIndicesList = [tf_1_index,
+                                tInit_2_index,
+                                tf_2_index]
+
+        # Store the positions to check in a list
+        transPosCheckList = [transPosRef1, transPosRef1, transPosRef2]
 
     # Use the two truth data lists to compare with the module-extracted data
     for i in range(len(timeCheckIndicesList)):
@@ -302,9 +378,11 @@ def prescribedTransTestFunction(show_plots,
 if __name__ == "__main__":
     prescribedTransTestFunction(
         True,       # show_plots
-        0.0,        # [m] transPosInit
-        -0.5,                  # [m] transPosRef1
-        -0.75,                 # [m] transPosRef2
+        True,      # coastOption
+        2.0,           # [s] tRamp
+        0.0,       # [m] transPosInit
+        -0.5,                 # [m] transPosRef1
+        1.0,      # [m] transPosRef2
         0.01,    # [m/s^2] transAccelMax
-        1e-12        # accuracy
+        1e-4         # accuracy
     )

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/_UnitTest/test_prescribedTrans.py
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/_UnitTest/test_prescribedTrans.py
@@ -16,177 +16,284 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-
 #
 #   Unit Test Script
 #   Module Name:        prescribedTrans
 #   Author:             Leah Kiner
 #   Creation Date:      Jan 2, 2023
-#
+#   Last Updated:       Jan 6, 2024
 
 import inspect
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
-import os
 import pytest
+
 from Basilisk.architecture import bskLogging
-from Basilisk.architecture import messaging  # import the message definitions
+from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import prescribedTrans  # import the module that is to be tested
-from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import unitTestSupport
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
-
-# Vary the initial angle, reference angle, and maximum angular acceleration for pytest
-@pytest.mark.parametrize("scalarPosInit", [0, 2*np.pi/3])
-@pytest.mark.parametrize("scalarPosRef", [0, 2*np.pi/3])
-@pytest.mark.parametrize("scalarAccelMax", [0.0005, 0.002])
+@pytest.mark.parametrize("transPosInit", [0, -0.75])  # [m]
+@pytest.mark.parametrize("transPosRef1", [0, -0.5])  # [m]
+@pytest.mark.parametrize("transPosRef2", [-0.75, 1.0])  # [m]
+@pytest.mark.parametrize("transAccelMax", [0.01, 0.005])  # [m/s^2]
 @pytest.mark.parametrize("accuracy", [1e-12])
-# update "module" in this function name to reflect the module name
-def test_prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarAccelMax, accuracy):
+def test_prescribedTransTestFunction(show_plots,
+                                     transPosInit,
+                                     transPosRef1,
+                                     transPosRef2,
+                                     transAccelMax,
+                                     accuracy):
     r"""
     **Validation Test Description**
 
-    This unit test ensures that the profiled translational maneuver for a secondary rigid body connected
-    to the spacecraft hub is properly computed for a series of initial and reference positions and maximum
-    accelerations. The final prescribed position and velocity magnitudes are compared with the reference values.
+    This unit test ensures that a profiled 1 DOF translation for a secondary rigid body connected to a spacecraft hub
+    is properly computed for several different simulation configurations. This unit test profiles two successive
+    translations to ensure the module is correctly configured. The body's initial scalar translational position
+    relative to the spacecraft hub is varied, along with the two final reference positions and the maximum translational
+    acceleration. A pure bang-bang acceleration profile is used for profiling the translation. To validate the module,
+    the final position at the end of each translation is checked to match the specified reference position.
 
     **Test Parameters**
 
     Args:
-        scalarPosInit (float): [m] Initial scalar position of the F frame with respect to the M frame
-        scalarPosRef (float): [m] Reference scalar position of the F frame with respect to the M frame
-        scalarAccelMax (float): [m/s^2] Maximum acceleration for the translational maneuver
-        accuracy (float): absolute accuracy value used in the validation tests
+        transPosInit (float): [m] Initial translational body position from M to F frame origin along transAxis_M
+        transPosRef1 (float): [m] First reference position from M to F frame origin along transAxis_M
+        transPosRef2 (float): [m] Second reference position from M to F frame origin along transAxis_M
+        transAccelMax (float): [m/s^2] Maximum translational acceleration
+        accuracy (float): Absolute accuracy value used in the validation tests
 
     **Description of Variables Being Tested**
 
-    This unit test ensures that the profiled translational maneuver is properly computed for a series of initial and
-    reference positions and maximum accelerations. The final prescribed position magnitude ``r_FM_M_Final`` and
-    velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values ``r_FM_M_Ref`` and
-    ``rPrime_FM_M_Ref``, respectively.
+    This unit test checks that the final translational body position at the end of each translation converge to the
+    specified reference values ``transPosRef1`` and ``transPosRef2``.
     """
-
-    [testResults, testMessage] = prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarAccelMax, accuracy)
+    [testResults, testMessage] = prescribedTransTestFunction(show_plots,
+                                                             transPosInit,
+                                                             transPosRef1,
+                                                             transPosRef2,
+                                                             transAccelMax,
+                                                             accuracy)
 
     assert testResults < 1, testMessage
 
 
-def prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarAccelMax, accuracy):
+def prescribedTransTestFunction(show_plots,
+                                transPosInit,
+                                transPosRef1,
+                                transPosRef2,
+                                transAccelMax,
+                                accuracy):
     """Call this routine directly to run the unit test."""
-    testFailCount = 0                                        # zero unit test result counter
-    testMessages = []                                        # create empty array to store test log messages
-    unitTaskName = "unitTask"                                # arbitrary name (don't change)
-    unitProcessName = "TestProcess"                          # arbitrary name (don't change)
+    testFailCount = 0                                        # Zero unit test result counter
+    testMessages = []                                        # Create an empty array to store the test log messages
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
     bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
-    # Create test thread
-    testProcessRate = macros.sec2nano(0.1)     # update process rate update time
+    # Create the test thread
+    testTimeStepSec = 0.01  # [s]
+    testProcessRate = macros.sec2nano(testTimeStepSec)
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
-    # Construct algorithm and associated C++ container
+    # Create an instance of the prescribedTrans module to be tested
     PrescribedTrans = prescribedTrans.prescribedTrans()
-    PrescribedTrans.ModelTag = "prescribedTrans"                                 # update python name of test module
-
-    # Add test module to runtime call list
-    unitTestSim.AddModelToTask(unitTaskName, PrescribedTrans)
-
-    # Initialize the test module configuration data
+    PrescribedTrans.ModelTag = "prescribedTrans"
     transAxis_M = np.array([0.5, 0.0, 0.5 * np.sqrt(3)])
     PrescribedTrans.transAxis_M = transAxis_M
-    PrescribedTrans.scalarAccelMax = scalarAccelMax  # [rad/s^2]
-    PrescribedTrans.r_FM_M = scalarPosInit * transAxis_M
-    PrescribedTrans.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.omega_FM_F = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedTrans.transAccelMax = transAccelMax  # [m/s^2]
+    PrescribedTrans.omega_FM_F = np.array([0.0, 0.0, 0.0])  # [rad/s]
+    PrescribedTrans.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])  # [rad/s^2]
     PrescribedTrans.sigma_FM = np.array([0.0, 0.0, 0.0])
+    PrescribedTrans.transPosInit = transPosInit  # [m]
 
-    # Create input message
-    scalarVelRef = 0.0  # [m/s]
+    # Add the prescribedTrans test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, PrescribedTrans)
+
+    # Create the prescribedTrans input reference position message for the first translation
     PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
-    PrescribedTransMessageData.scalarPos = scalarPosRef
-    PrescribedTransMessageData.scalarVel = scalarVelRef
+    PrescribedTransMessageData.scalarPos = transPosRef1
+    PrescribedTransMessageData.scalarVel = 0.0
     PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
     PrescribedTrans.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
 
-    # Setup logging on the test module output message so that we get all the writes to it
-    dataLog = PrescribedTrans.prescribedMotionOutMsg.recorder()
-    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    # Log module data for module unit test validation
+    prescribedStatesDataLog = PrescribedTrans.prescribedMotionOutMsg.recorder()
+    transPosLog = PrescribedTrans.logger("transPos", testProcessRate)
+    transVelLog = PrescribedTrans.logger("transVel", testProcessRate)
+    transAccelLog = PrescribedTrans.logger("transAccel", testProcessRate)
+    unitTestSim.AddModelToTask(unitTaskName, prescribedStatesDataLog)
+    unitTestSim.AddModelToTask(unitTaskName, transPosLog)
+    unitTestSim.AddModelToTask(unitTaskName, transVelLog)
+    unitTestSim.AddModelToTask(unitTaskName, transAccelLog)
 
-    # Need to call the self-init and cross-init methods
+    # Initialize the simulation
     unitTestSim.InitializeSimulation()
 
-    # Set the simulation time
-    simTime = np.sqrt(((0.5 * np.abs(scalarPosRef - scalarPosInit)) * 8) / scalarAccelMax) + 5
-    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
+    # Determine the required simulation time for the first rotation
+    translation1ReqTime = np.sqrt(((0.5 * np.abs(transPosRef1 - transPosInit)) * 8) / transAccelMax) + 5  # [s]
 
-    # Begin the simulation time run set above
+    translation1ExtraTime = 5  # [s]
+    unitTestSim.ConfigureStopTime(macros.sec2nano(translation1ReqTime + translation1ExtraTime))
+
+    # Execute the first translation
     unitTestSim.ExecuteSimulation()
 
-    # Extract logged data
-    r_FM_M = dataLog.r_FM_M
-    rPrime_FM_M = dataLog.rPrime_FM_M
-    timespan = dataLog.times()
+    # Create the prescribedTrans input reference position message for the second translation
+    PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
+    PrescribedTransMessageData.scalarPos = transPosRef2
+    PrescribedTransMessageData.scalarVel = 0.0
+    PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
+    PrescribedTrans.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
 
-    scalarVel_Final = np.linalg.norm(rPrime_FM_M[-1, :])
-    scalarPos_Final = np.linalg.norm(r_FM_M[-1, :])
+    # Determine the required simulation time for the second rotation
+    translation2ReqTime = np.sqrt(((0.5 * np.abs(transPosRef2 - transPosRef1)) * 8) / transAccelMax) + 5  # [s]
 
-    # Plot r_FM_F
-    r_FM_M_Ref = scalarPosRef * transAxis_M
-    r_FM_M_1_Ref = np.ones(len(timespan)) * r_FM_M_Ref[0]
-    r_FM_M_2_Ref = np.ones(len(timespan)) * r_FM_M_Ref[1]
-    r_FM_M_3_Ref = np.ones(len(timespan)) * r_FM_M_Ref[2]
+    translation2ExtraTime = 5  # [s]
+    unitTestSim.ConfigureStopTime(macros.sec2nano(translation1ReqTime
+                                                  + translation1ExtraTime
+                                                  + translation2ReqTime
+                                                  + translation2ExtraTime))
 
+    # Execute the second translation
+    unitTestSim.ExecuteSimulation()
+
+    # Extract the logged data for plotting and data comparison
+    timespan = macros.NANO2SEC * prescribedStatesDataLog.times()  # [s]
+    transPos = transPosLog.transPos  # [m]
+    transVel = transVelLog.transVel  # [m/s]
+    transAccel = transAccelLog.transAccel  # [m/s^2]
+    r_FM_M = prescribedStatesDataLog.r_FM_M  # [m]
+    rPrime_FM_M = prescribedStatesDataLog.rPrime_FM_M  # [m/s]
+    rPrimePrime_FM_M = prescribedStatesDataLog.rPrimePrime_FM_M  # [m/s^2]
+
+    # Unit test validation
+    # Store the truth data used to validate the module in two lists
+    # Compute tf for the first translation, and tInit tf for the second translation
+    tf_1 = translation1ReqTime
+    tInit_2 = translation1ReqTime + translation1ExtraTime
+    tf_2 = tInit_2 + translation2ReqTime
+
+    # Compute the timespan indices for each check
+    tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
+    tInit_2_index = int(round(tInit_2 / testTimeStepSec)) + 1
+    tf_2_index = int(round(tf_2 / testTimeStepSec)) + 1
+
+    # Store the timespan indices in a list
+    timeCheckIndicesList = [tf_1_index,
+                            tInit_2_index,
+                            tf_2_index]
+
+    # Store the positions to check in a list
+    transPosCheckList = [transPosRef1, transPosRef1, transPosRef2]
+
+    # Use the two truth data lists to compare with the module-extracted data
+    for i in range(len(timeCheckIndicesList)):
+        index = timeCheckIndicesList[i]
+        if not unitTestSupport.isDoubleEqual(transPos[index], transPosCheckList[i], accuracy):
+            testFailCount += 1
+            testMessages.append("FAILED: " + PrescribedTrans.ModelTag + " TRANSLATING BODY POSITION CHECK FAILED")
+            print("\nAt Simulation Time [s]: ")
+            print(timespan[index])
+            print("Module Computed Position [m]: ")
+            print(transPos[index])
+            print("Python Computed TRUTH Position [m]: ")
+            print(transPosCheckList[i])
+
+    # 1. Plot the scalar translational states
+    # 1A. Plot transPos
+    transPosInit_plotting = np.ones(len(timespan)) * transPosInit
+    transPosRef1_plotting = np.ones(len(timespan)) * transPosRef1
+    transPosRef2_plotting = np.ones(len(timespan)) * transPosRef2
     plt.figure()
     plt.clf()
-    plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 0], label=r'$r_{1}$')
-    plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 1], label=r'$r_{2}$')
-    plt.plot(timespan * macros.NANO2SEC, r_FM_M[:, 2], label=r'$r_{3}$')
-    plt.plot(timespan * macros.NANO2SEC, r_FM_M_1_Ref, '--', label=r'$r_{1 Ref}$')
-    plt.plot(timespan * macros.NANO2SEC, r_FM_M_2_Ref, '--', label=r'$r_{2 Ref}$')
-    plt.plot(timespan * macros.NANO2SEC, r_FM_M_3_Ref, '--', label=r'$r_{3 Ref}$')
+    plt.plot(timespan, transPos, label=r"$l$")
+    plt.plot(timespan, transPosInit_plotting, '--', label=r'$l_{0}$')
+    plt.plot(timespan, transPosRef1_plotting, '--', label=r'$l_{Ref_1}$')
+    plt.plot(timespan, transPosRef2_plotting, '--', label=r'$l_{Ref_2}$')
+    plt.title(r'Translational Position $l_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+    plt.ylabel('(m)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # 1B. Plot transVel
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, transVel, label=r"$\dot{l}$")
+    plt.title(r'Translational Velocity $\dot{l}_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+    plt.ylabel('(m/s)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # 1C. Plot transAccel
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, transAccel, label=r"$\ddot{l}$")
+    plt.title(r'Translational Acceleration $\ddot{l}_{\mathcal{F}/\mathcal{M}}$ ', fontsize=14)
+    plt.ylabel('(m/s$^2$)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper right', prop={'size': 12})
+    plt.grid(True)
+
+    # 2. Plot the prescribed translational states
+    # 2A. Plot r_FM_M
+    r_FM_M_Ref1 = transPosRef1 * transAxis_M
+    r_FM_M_1_Ref1 = np.ones(len(timespan[0:timeCheckIndicesList[0]])) * r_FM_M_Ref1[0]
+    r_FM_M_2_Ref1 = np.ones(len(timespan[0:timeCheckIndicesList[0]])) * r_FM_M_Ref1[1]
+    r_FM_M_3_Ref1 = np.ones(len(timespan[0:timeCheckIndicesList[0]])) * r_FM_M_Ref1[2]
+    r_FM_M_Ref2 = transPosRef2 * transAxis_M
+    r_FM_M_1_Ref2 = np.ones(len(timespan[timeCheckIndicesList[0]:-1])) * r_FM_M_Ref2[0]
+    r_FM_M_2_Ref2 = np.ones(len(timespan[timeCheckIndicesList[0]:-1])) * r_FM_M_Ref2[1]
+    r_FM_M_3_Ref2 = np.ones(len(timespan[timeCheckIndicesList[0]:-1])) * r_FM_M_Ref2[2]
+    plt.figure()
+    plt.clf()
+    plt.plot(timespan, r_FM_M[:, 0], label=r'$r_{1}$')
+    plt.plot(timespan, r_FM_M[:, 1], label=r'$r_{2}$')
+    plt.plot(timespan, r_FM_M[:, 2], label=r'$r_{3}$')
+    plt.plot(timespan[0:timeCheckIndicesList[0]], r_FM_M_1_Ref1, '--', label=r'$r_{1 Ref_{1}}$')
+    plt.plot(timespan[0:timeCheckIndicesList[0]], r_FM_M_2_Ref1, '--', label=r'$r_{2 Ref_{1}}$')
+    plt.plot(timespan[0:timeCheckIndicesList[0]], r_FM_M_3_Ref1, '--', label=r'$r_{3 Ref_{1}}$')
+    plt.plot(timespan[timeCheckIndicesList[0]:-1], r_FM_M_1_Ref2, '--', label=r'$r_{1 Ref_{2}}$')
+    plt.plot(timespan[timeCheckIndicesList[0]:-1], r_FM_M_2_Ref2, '--', label=r'$r_{2 Ref_{2}}$')
+    plt.plot(timespan[timeCheckIndicesList[0]:-1], r_FM_M_3_Ref2, '--', label=r'$r_{3 Ref_{2}}$')
     plt.title(r'${}^\mathcal{M} r_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
-    plt.ylabel('(m)', fontsize=16)
-    plt.xlabel('Time (s)', fontsize=16)
-    plt.legend(loc='center left', prop={'size': 16})
+    plt.ylabel('(m)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='center left', prop={'size': 12})
+    plt.grid(True)
 
     # Plot rPrime_FM_F
     plt.figure()
     plt.clf()
-    plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 0], label='$r\'_{1}$')
-    plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 1], label='$r\'_{2}$')
-    plt.plot(timespan * macros.NANO2SEC, rPrime_FM_M[:, 2], label='$r\'_{3}$')
-    plt.title(r'${}^\mathcal{M} r\'_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
-    plt.ylabel('(m/s)', fontsize=16)
-    plt.xlabel('Time (s)', fontsize=16)
-    plt.legend(loc='upper left', prop={'size': 16})
+    plt.plot(timespan, rPrime_FM_M[:, 0], label='1')
+    plt.plot(timespan, rPrime_FM_M[:, 1], label='2')
+    plt.plot(timespan, rPrime_FM_M[:, 2], label='3')
+    plt.title(r'${}^\mathcal{M} r$Prime$_{\mathcal{F}/\mathcal{M}}$ Profiled Trajectory', fontsize=14)
+    plt.ylabel('(m/s)', fontsize=14)
+    plt.xlabel('Time (s)', fontsize=14)
+    plt.legend(loc='upper left', prop={'size': 12})
+    plt.grid(True)
 
     if show_plots:
         plt.show()
     plt.close("all")
 
-    # set the filtered output truth states
-    if not unitTestSupport.isDoubleEqual(scalarVel_Final, scalarVelRef, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED: " + PrescribedTrans.ModelTag + "scalarVel_Final and scalarVelRef do not match")
-
-    if not unitTestSupport.isDoubleEqual(scalarPos_Final, scalarPosRef, accuracy):
-        testFailCount += 1
-        testMessages.append("FAILED: " + PrescribedTrans.ModelTag + "scalarPos_Final and scalarPosRef do not match")
-
     return [testFailCount, ''.join(testMessages)]
-
 
 #
 # This statement below ensures that the unitTestScript can be run as a
@@ -194,9 +301,10 @@ def prescribedTransTestFunction(show_plots, scalarPosInit, scalarPosRef, scalarA
 #
 if __name__ == "__main__":
     prescribedTransTestFunction(
-                 True,
-                 0.0,         # scalarPosInit
-                 0.25,        # scalarPosRef
-                 0.001,       # scalarAccelMax
-                 1e-12        # accuracy
-               )
+        True,       # show_plots
+        0.0,        # [m] transPosInit
+        -0.5,                  # [m] transPosRef1
+        -0.75,                 # [m] transPosRef2
+        0.01,    # [m/s^2] transAccelMax
+        1e-12        # accuracy
+    )

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.h
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.h
@@ -29,6 +29,8 @@
 typedef struct {
 
     /* User-configurable module variables */
+    bool coastOption;                                           //!< Boolean variable used for selecting an optional coast period during the translation
+    double tRamp;                                               //!< [s] Ramp time used for the coast option
     double transAccelMax;                                       //!< [m/s^2] Maximum translational acceleration
     double transAxis_M[3];                                      //!< Axis along the direction of translation expressed in M frame components
     double r_FM_M[3];                                           //!< [m] Translational body position relative to the Mount frame expressed in M frame components
@@ -37,6 +39,17 @@ typedef struct {
     double omega_FM_F[3];                                       //!< [rad/s] Translational body angular velocity relative to the Mount frame expressed in F frame components (fixed)
     double omegaPrime_FM_F[3];                                  //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components (fixed)
     double sigma_FM[3];                                         //!< Translational body MRP attitude with respect to frame M
+
+    /* Coast option variables */
+    double transPos_tr;                                         //!< [m] Position at the end of the first ramp segment
+    double transPos_tc;                                         //!< [m] Position at the end of the coast segment
+    double transVel_tr;                                         //!< [m/s] Velocity at the end of the first ramp segment
+    double transVel_tc;                                         //!< [m/s] Velocity at the end of the coast segment
+    double tr;                                                  //!< [s] The simulation time at the end of the first ramp segment
+    double tc;                                                  //!< [s] The simulation time at the end of the coast period
+
+    /* Non-coast option variables */
+    double ts;                                                  //!< [s] The simulation time halfway through the translation
 
     /* Private variables */
     bool convergence;                                           //!< Boolean variable is true when the rotation is complete
@@ -47,7 +60,6 @@ typedef struct {
     double transPos;                                            //!< [m] Current translational body position along transAxis_M
     double transVel;                                            //!< [m] Current translational body velocity along transAxis_M
     double transAccel;                                          //!< [m] Current translational body acceleration along transAxis_M
-    double ts;                                                  //!< [s] The simulation time halfway through the translation
     double tf;                                                  //!< [s] The simulation time when the rotation is complete
     double a;                                                   //!< Parabolic constant for the first half of the translation
     double b;                                                   //!< Parabolic constant for the second half of the translation

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.h
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.h
@@ -28,42 +28,43 @@
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {
 
-    /* User configurable variables */
-    double scalarAccelMax;                                          //!< [m/s^2] Maximum acceleration mag
-    double transAxis_M[3];                                          //!< Axis along the direction of translation
-    double r_FM_M[3];                                               //!< [m] Position of the frame F origin with respect to the M frame origin expressed in M frame components
-    double rPrime_FM_M[3];                                          //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
-    double rPrimePrime_FM_M[3];                                     //!< [m/s^] B frame time derivative of rPrime_FM_M expressed in M frame components
-    double omega_FM_F[3];                                           //!< [rad/s] Angular velocity of frame F with respect to frame M expressed in F frame components
-    double omegaPrime_FM_F[3];                                      //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components
-    double sigma_FM[3];                                             //!< MRP attitude of frame F with respect to frame M
+    /* User-configurable module variables */
+    double transAccelMax;                                       //!< [m/s^2] Maximum translational acceleration
+    double transAxis_M[3];                                      //!< Axis along the direction of translation expressed in M frame components
+    double r_FM_M[3];                                           //!< [m] Translational body position relative to the Mount frame expressed in M frame components
+    double rPrime_FM_M[3];                                      //!< [m/s] B frame time derivative of r_FM_M expressed in M frame components
+    double rPrimePrime_FM_M[3];                                 //!< [m/s^2] B frame time derivative of rPrime_FM_M expressed in M frame components
+    double omega_FM_F[3];                                       //!< [rad/s] Translational body angular velocity relative to the Mount frame expressed in F frame components (fixed)
+    double omegaPrime_FM_F[3];                                  //!< [rad/s^2] B frame time derivative of omega_FM_F expressed in F frame components (fixed)
+    double sigma_FM[3];                                         //!< Translational body MRP attitude with respect to frame M
 
     /* Private variables */
-    bool convergence;                                               //!< Boolean variable is true when the maneuver is complete
-    double tInit;                                                   //!< [s] Simulation time at the start of the maneuver
-    double scalarPosInit;                                           //!< [m] Initial distance between the frame F and frame M origin
-    double scalarVelInit;                                           //!< [m/s] Initial velocity between the frame F and frame M origin
-    double scalarPosRef;                                            //!< [m] Magnitude of the reference position vector
-    double scalarVelRef;                                            //!< [m/s] Magnitude of the reference velocity vector
-    double ts;                                                      //!< [s] Simulation time halfway through the maneuver
-    double tf;                                                      //!< [s] Simulation time at the time the maneuver is complete
-    double a;                                                       //!< Parabolic constant for the first half of the maneuver
-    double b;                                                       //!< Parabolic constant for the second half of the maneuver
+    bool convergence;                                           //!< Boolean variable is true when the rotation is complete
+    double tInit;                                               //!< [s] Simulation time at the beginning of the translation
+    double transPosInit;                                        //!< [m] Initial translational body position from M to F frame origin along transAxis_M
+    double transVelInit;                                        //!< [m/s] Initial translational body velocity
+    double transPosRef;                                         //!< [m] Reference translational body position from M to F frame origin along transAxis_M
+    double transPos;                                            //!< [m] Current translational body position along transAxis_M
+    double transVel;                                            //!< [m] Current translational body velocity along transAxis_M
+    double transAccel;                                          //!< [m] Current translational body acceleration along transAxis_M
+    double ts;                                                  //!< [s] The simulation time halfway through the translation
+    double tf;                                                  //!< [s] The simulation time when the rotation is complete
+    double a;                                                   //!< Parabolic constant for the first half of the translation
+    double b;                                                   //!< Parabolic constant for the second half of the translation
+    BSKLogger *bskLogger;                                       //!< BSK Logging
 
-    // Messages
-    PrescribedTransMsg_C prescribedTransInMsg;                      //!< Input message for the reference states
-    PrescribedMotionMsg_C prescribedMotionOutMsg;                   //!< Output message for the prescribed states
-
-    BSKLogger *bskLogger;                                           //!< BSK Logging
+    /* Messages */
+    PrescribedTransMsg_C prescribedTransInMsg;                  //!< Input msg for the translational reference position and velocity
+    PrescribedMotionMsg_C prescribedMotionOutMsg;               //!< Output msg for the translational body prescribed states
 
 }PrescribedTransConfig;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-    void SelfInit_prescribedTrans(PrescribedTransConfig *configData, int64_t moduleID);
-    void Reset_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID);
-    void Update_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID);
+    void SelfInit_prescribedTrans(PrescribedTransConfig *configData, int64_t moduleID);                     //!< Method for module initialization
+    void Reset_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID);     //!< Method for module reset
+    void Update_prescribedTrans(PrescribedTransConfig *configData, uint64_t callTime, int64_t moduleID);    //!< Method for module time update
 #ifdef __cplusplus
 }
 #endif

--- a/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.rst
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedTrans/prescribedTrans.rst
@@ -1,32 +1,39 @@
 Executive Summary
 -----------------
-This module profiles a :ref:`PrescribedMotionMsgPayload` message for a specified translational maneuver
-for a secondary rigid body connected to a rigid spacecraft hub at a hub-fixed location, :math:`\mathcal{M}`. The body
-frame for the prescribed body is designated by the frame :math:`\mathcal{F}`. Accordingly, the prescribed states for the
-secondary body are written with respect to the mount frame, :math:`\mathcal{M}`. The prescribed states are: ``r_FM_M``,
-``rPrime_FM_M``, ``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. Because this is a
-purely translational profiler, the states ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM`` are held
-constant in this module.
+This module profiles a 1 DOF translation for a rigid body connected to a rigid spacecraft hub. The body frame
+of the secondary body is designated by the frame :math:`\mathcal{F}`. The secondary body states are profiled
+relative to a hub-fixed frame :math:`\mathcal{M}`. The :ref:`PrescribedMotionMsgPayload` message
+is used to output the prescribed states from the module. The prescribed states are: ``r_FM_M``, ``rPrime_FM_M``,
+``rPrimePrime_FM_M``, ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. Because this module only profiles
+a translation, the secondary body rotational states ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM`` are fixed
+in this module.
 
-To use this module for prescribed motion purposes, it must be connected to the :ref:`PrescribedMotionStateEffector`
-dynamics module in order to profile the states of the secondary body. The required maneuver is determined from the
-user-specified scalar maximum acceleration :math:`a_{\text{max}}`, the mount frame axis for the translational motion,
-the prescribed body's initial position vector with respect to the mount frame :math:`\boldsymbol{r}_{F/M}(t_0)`, and
-the reference position vector or the prescribed body with respect to the mount frame
-:math:`\boldsymbol{r}_{F/M} (\text{ref})`.
+.. important::
+    Note that this module assumes the initial and final secondary body translational rates are zero.
 
-The maximum scalar acceleration is applied constant and positively for the first half of the maneuver and
-constant negatively for the second half of the maneuver. The resulting velocity of the prescribed body is
-linear, approaching a maximum magnitude halfway through the maneuver and ending with zero residual velocity.
-The corresponding translational trajectory the prescribed body moves through during the maneuver is parabolic in time.
+The general inputs to this module that must be set by the user are the secondary body rotational states ``omega_FM_F``,
+``omegaPrime_FM_F``, and ``sigma_FM``, the secondary body translational axis expressed in Mount frame components
+``transAxis_M``, the initial scalar position of the secondary body relative to the Mount frame ``transPosInit``,
+the reference position relative to the Mount frame ``transPosRef``, the maximum translational acceleration for the
+translation ``transAccelMax``, and a boolean toggle variable ``coastOption`` for selecting which of two profiling
+options is desired. The first profiling option applies a bang-bang acceleration profile to the secondary body that
+results in the fastest possible translation from a rest to rest state. This option is selected when ``coastOption`` is
+set to ``False``. The second profiling option includes a coast segment between the two constant acceleration profiles
+and is toggled with ``coastOption`` set to ``True``. To use the coast option, the user is required to specify the
+additional module variable ``tRamp``. Defaulted as zero for the option with no coast period, this variable
+specifies how long each acceleration segment is applied before and after the coast segment. If the user does not set
+this variable, the module reverts to the profiler with no coast period.
 
+.. important::
+    To use this module for prescribed motion, it must be connected to the :ref:`PrescribedMotionStateEffector`
+    dynamics module. This ensures the secondary body states are correctly incorporated into the spacecraft hub dynamics.
 
 Message Connection Descriptions
 -------------------------------
-The following table lists all the module input and output messages.  
-The module msg connection is set by the user from python.  
-The msg type contains a link to the message structure definition, while the description 
-provides information on what this message is used for.
+The following table lists all the module input and output messages.
+The module msg connection is set by the user from python.
+The msg type contains a link to the message structure definition, while the description
+provides information on what the message is used for.
 
 .. list-table:: Module I/O Messages
     :widths: 25 25 50
@@ -37,132 +44,213 @@ provides information on what this message is used for.
       - Description
     * - prescribedTransInMsg
       - :ref:`PrescribedTransMsgPayload`
-      - input msg with the prescribed body reference states
-    * - prescribedTransOutMsg
-      - :ref:`PrescribedTransMsgPayload`
-      - output message with the scalar prescribed body states
+      - input msg with the secondary body reference states
     * - prescribedMotionOutMsg
       - :ref:`PrescribedMotionMsgPayload`
-      - output message with the prescribed body states
-
-
+      - output message with the prescribed secondary body states
 
 Detailed Module Description
 ---------------------------
-This translational motion flight software module is written to profile a rigid body's motion with respect to a hub-fixed
-mount frame. The inputs to the profiler are the scalar maximum acceleration for the maneuver :math:`a_{\text{max}}`,
-the mount frame axis for the translational motion, the prescribed body's initial position vector with respect to
-the mount frame :math:`\boldsymbol{r}_{F/M}(t_0)`, and the reference position vector or the prescribed body with respect
-to the mount frame :math:`\boldsymbol{r}_{F/M} (\text{ref})`. The magnitudes of the initial and final position vectors
-are denoted :math:`r_0` and :math:`r_{\text{ref}}`, respectively. The prescribed body is assumed to be at rest at the
-beginning of the attitude maneuver.
 
-Subtracting the initial position from the reference position vector gives the required relative position vector in the
-direction of translation:
+Profiler With No Coast Period
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. math::
-    \Delta \boldsymbol{r} = \boldsymbol{r}_{F/M}(\text{ref}) - \boldsymbol{r}_{F/M}(t_0)
+The first option to profile the secondary body translation is a pure bang-bang acceleration profile. If the secondary
+body reference position is greater than the given initial position, the user-specified maximum acceleration value
+is applied positively to the first half of the translation and negatively to the second half of the translation.
+However, if the reference position is less than the initial secondary body position, the acceleration is instead applied
+negatively during the first half of the translation and positively during the second half of the translation. As a 
+result of this acceleration profile, the secondary body's velocity changes linearly with time and reaches a maximum
+in magnitude halfway through the translation. Note that the velocity is assumed to both start and end at zero
+in this module. The resulting secondary body position is parabolic in time.
 
-The magnitude of the determined relative position vector gives the required translational distance :math:`\Delta r`.
-During the first half of the maneuver, the prescribed body is constantly accelerated with the given maximum acceleration.
-The prescribed body's velocity increases linearly during the acceleration phase and reaches a maximum magnitude halfway
-through the maneuver.
-
-The switch time, :math:`t_s` is the simulation time halfway through the maneuver:
+To profile this motion, the scalar secondary body states :math:`l`, :math:`\dot{l}`, and
+:math:`\ddot{l}` are prescribed as a function of time. During the first half of the translation the states are:
 
 .. math::
-    t_s = t_0 + \frac{\Delta t}{2}
-
-The time required for the maneuver :math:`\Delta t` is determined using the inputs to the profiler:
+    \ddot{l}(t) = \pm \ddot{l}_{\text{max}}
 
 .. math::
-    \Delta t = \sqrt{\frac{4 r_{\text{ref}} - 8 r_0}{\ddot{a}_{\text{max}}}}
-
-The resulting trajectory of the position vector :math:`r = || \boldsymbol{r}_{F/M} ||_2` magnitude during the first half of the
-maneuver is parabolic. The profiled motion is concave upwards if the reference position magnitude :math:`r_{\text{ref}}`
-is greater than the initial position magnitude :math:`r_0`. If the converse is true, the profiled motion is instead concave
-downwards. The described motion during the first half of the maneuver is characterized by the expressions:
+    \dot{l}(t) = \ddot{l} (t - t_0) + \dot{l}_0
 
 .. math::
-    r^{''}_{F / M}(t) = a_{\text{max}}
-
-.. math::
-    r^{'}_{F / M}(t) = a_{\text{max}} (t - t_0)
-
-.. math::
-    r_{F / M}(t) = c_1 (t - t_0)^2  + r_0
+    l(t) = a (t - t_0)^2 + l_0
 
 where
 
 .. math::
-    c_1 = \frac{r_{\text{ref}} - r_0}{2(t_s - t_0)^2}
+    a = \frac{ l_{\text{ref}} - l_0}{2 (t_s - t_0)^2}
 
-
-Similarly, the second half of the maneuver decelerates the prescribed body constantly until it reaches the desired
-position with zero velocity. The prescribed body velocity decreases linearly from its maximum magnitude back to zero.
-The trajectory during the second half of the maneuver is quadratic and concave downwards if the reference position
-magnitude is greater than the initial position magnitude. If the converse is true, the profiled motion is instead
-concave upwards. The described motion during the second half of the maneuver is characterized by the expressions:
+During the second half of the translation the states are:
 
 .. math::
-    r^{''}_{F / M}(t) = -a_{\text{max}}
+    \ddot{l}(t) = \mp \ddot{l}_{\text{max}}
 
 .. math::
-    r^{'}_{F / M}(t) = a_{\text{max}} (t - t_f)
+    \dot{l}(t) = \ddot{l} (t - t_f) + \dot{l}_0
 
 .. math::
-    r_{F / M}(t) = c_2 (t - t_f)^2  + r_{\text{ref}}
+    l(t) = b (t - t_f)^2 + l_{\text{ref}}
 
 where
 
 .. math::
-    c_2 = \frac{r_{\text{ref}} - r_0}{2 (t_s - t_f)^2}
+    b = - \frac{ l_{\text{ref}} - l_0}{2 (t_s - t_f)^2}
+
+The switch time :math:`t_s` is the simulation time halfway through the translation:
+
+.. math::
+    t_s = t_0 + \frac{\Delta t_{\text{tot}}}{2}
+
+The total time required to complete the translation :math:`\Delta t_{\text{tot}}` is:
+
+.. math::
+    \Delta t_{\text{tot}} = 2 \sqrt{ \frac{| l_{\text{ref}} - l_0 | }{\ddot{l}_{\text{max}}}} = t_f - t_0
+
+Profiler With Coast Period
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The second option to profile the secondary body translation is a bang-bang acceleration profile with an added coast
+period between the acceleration segments where the acceleration is zero. Similarly to the previous profiler, if the
+secondary body reference position is greater than the given initial position, the maximum translational acceleration
+value is applied positively for the specified ramp time ``tRamp`` to the first segment of the translation and
+negatively to the third segment of the translation. The second segment of the translation is the coast period. However,
+if the reference position is less than the initial secondary body position, the acceleration is instead applied
+negatively during the first segment of the translation and positively during the third segment of the translation.
+As a result of this acceleration profile, the secondary body's velocity changes linearly with time and reaches a
+maximum in magnitude at the end of the first segment and is constant during the coast segment. The velocity decreases
+back to zero during the third segment. The resulting secondary body position is parabolic during the first and third
+segments and linear during the coast segment.
+
+To profile this motion, the scalar secondary body states :math:`l`, :math:`\dot{l}`, and
+:math:`\ddot{l}` are prescribed as a function of time. During the first segment of the translation the states are:
+
+.. math::
+    \ddot{l}(t) = \pm \ddot{l}_{\text{max}}
+
+.. math::
+    \dot{l}(t) = \ddot{l} (t - t_0) + \dot{l}_0
+
+.. math::
+    l(t) = a (t - t_0)^2 + l_0
+
+where
+
+.. math::
+    a = \frac{ l(t_r) - l_0}{2 (t_r - t_0)^2}
+
+and :math:`l(t_r)` is the secondary body position at the end of the first segment:
+
+.. math::
+    l(t_r) = \pm \frac{1}{2} \ddot{l}_{\text{max}} t_{\text{ramp}}^2
+                                       + \dot{l}_0 t_{\text{ramp}} + l_0
+
+.. important::
+    Note the distinction between :math:`t_r` and :math:`t_{\text{ramp}}`. :math:`t_{\text{ramp}}` is the time duration of the acceleration segment
+    and :math:`t_r` is the simulation time at the end of the first acceleration segment.
+    :math:`t_r = t_0 + t_{\text{ramp}}`
+
+During the coast segment, the translation states are:
+
+.. math::
+    \ddot{l}(t) = 0
+
+.. math::
+    \dot{l}(t) = \dot{l}(t_r) = \ddot{l}_{\text{max}} t_{\text{ramp}} + \dot{l}_0
+
+.. math::
+    l(t) = \dot{l}(t_r) (t - t_r) + l(t_r)
+
+During the third segment, the translational states are
+
+.. math::
+    \ddot{l}(t) = \mp \ddot{l}_{\text{max}}
+
+.. math::
+    \dot{l}(t) = \ddot{l} (t - t_f) + \dot{l}_0
+
+.. math::
+    l(t) = b (t - t_f)^2 + l_{\text{ref}}
+
+where
+
+.. math::
+    b = - \frac{ l_{\text{ref}} - l(t_c) }{(t_c - t_f)^2}
+
+Here :math:`l(t_c)` is the secondary body position at the end of the coast segment:
+
+.. math::
+    l(t_c) = l(t_r) + \Delta l_{\text{coast}}
+
+and :math:`\Delta l_{\text{coast}}` is the distance traveled during the coast segment:
+
+.. math::
+    \Delta l_{\text{coast}} = (l_{\text{ref}} - l_0) - 2 (l(t_r) - l_0)
+
+:math:`t_c` is the simulation time at the end of the coast segment:
+
+.. math::
+    t_c = t_r + \frac{\Delta l_{\text{coast}}}{\dot{l}(t_r)}
+
+Using the given translation axis ``transAxis_M``, the scalar states are then transformed to the secondary body
+translational states ``r_FM_M``, ``rPrime_FM_M``, and ``rPrimePrime_FM_M``. The states are then written to the
+:ref:`PrescribedMotionMsgPayload` module output message.
 
 Module Testing
 ^^^^^^^^^^^^^^
-This unit test for this module ensures that the profiled translational maneuver is properly computed for a series of
-initial and reference positions and maximum accelerations. The final prescribed position magnitude ``r_FM_M_Final`` and
-velocity magnitude ``rPrime_FM_M_Final`` are compared with the reference values ``r_FM_M_Ref`` and
-``rPrime_FM_M_Ref``, respectively.
+The unit test for this module ensures that a profiled 1 DOF translation for a secondary rigid body connected to a
+spacecraft hub is properly computed for several different simulation configurations. The unit test profiles two
+successive translations to ensure the module is correctly configured. The body's initial scalar translational position
+relative to the spacecraft hub is varied, along with the two final reference positions and the maximum translational
+acceleration. The unit test also tests both methods of profiling the translation, where either a pure bang-bang
+acceleration profile can be selected for the translation, or a coast option can be selected where the accelerations
+are only applied for a specified ramp time and a coast segment with zero acceleration is applied between the two
+acceleration periods. To validate the module, the final position at the end of each translation is checked to match
+the specified reference position.
 
 User Guide
 ----------
-The user-configurable inputs to the profiler are the scalar maximum acceleration for the maneuver :math:`a_{\text{max}}`,
-the mount frame axis for the translational motion, the prescribed body's initial position vector with respect to
-the mount frame :math:`\boldsymbol{r}_{F/M}(t_0)`, and the reference position vector of the prescribed body with respect
-to the mount frame :math:`\boldsymbol{r}_{F/M} (\text{ref})`.
+The general inputs to this module that must be set by the user are the secondary body rotational states ``omega_FM_F``,
+``omegaPrime_FM_F``, and ``sigma_FM``, the secondary body translational axis expressed in Mount frame components
+``transAxis_M``, the initial scalar position of the secondary body relative to the Mount frame ``transPosInit``,
+the reference position relative to the Mount frame ``transPosRef``, the maximum translational acceleration for the
+translation ``transAccelMax``, and the boolean toggle variable ``coastOption`` for selecting which profiling options is
+desired. To use the coast option, the user sets ``coastOption`` to True and must specify the variable ``tRamp``.
+This variable specifies how long each acceleration segment is applied before and after the coast segment.
+If the user does not set this variable, the module reverts to the profiler with no coast period.
 
-This module provides two output messages in the form of :ref:`PrescribedTransMsgPayload` and
-:ref:`PrescribedMotionMsgPayload`. The first guidance message, describing the prescribed body's scalar states relative to
-the hub-fixed mount frame can be directly connected to a feedback control module. The second prescribed
-motion output message can be connected to the :ref:`PrescribedMotionStateEffector` dynamics module to directly profile
-a state effector's translational motion.
-
-This section is to outline the steps needed to setup a prescribed translational module in python using Basilisk.
+This section is to outline the steps needed to setup a prescribed 1 DOF translational module in python using Basilisk.
 
 #. Import the prescribedTrans class::
 
     from Basilisk.fswAlgorithms import prescribedTrans
 
-#. Create an instantiation of a prescribed translational C module and the associated C++ container::
+#. Create an instantiation of the module::
 
     PrescribedTrans = prescribedTrans.prescribedTrans()
-    PrescribedTrans.ModelTag = "prescribedTrans"
 
-#. Define all of the configuration data associated with the module. For example::
+#. Define all of the configuration data associated with the module. For example, to configure the coast option::
 
-    PrescribedTrans.transAxis_M = np.array([1.0, 0.0, 0.0])
-    PrescribedTrans.scalarAccelMax = 0.01  # [m/s^2]
-    PrescribedTrans.r_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.omega_FM_F = np.array([0.0, 0.0, 0.0])
-    PrescribedTrans.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
+    PrescribedTrans.ModelTag = "PrescribedTrans"
+    PrescribedTrans.coastOption = True
+    PrescribedTrans.tRamp = 3.0  # [s]
+    PrescribedTrans.transAxis_M = np.array([0.5, 0.0, 0.5 * np.sqrt(3)])
+    PrescribedTrans.transAccelMax = 0.01  # [m/s^2]
+    PrescribedTrans.omega_FM_F = np.array([0.0, 0.0, 0.0])  # [rad/s]
+    PrescribedTrans.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])  # [rad/s^2]
     PrescribedTrans.sigma_FM = np.array([0.0, 0.0, 0.0])
+    PrescribedTrans.transPosInit = 0.5  # [m]
 
-The user is required to set the above configuration data parameters, as they are not initialized in the module.
+#. Connect a :ref:`PrescribedTransMsgPayload` message for the secondary body reference position to the module. For example, the user can create a stand-alone message to specify the reference position::
 
-#. Make sure to connect the required messages for this module.
+    PrescribedTransMessageData = messaging.PrescribedTransMsgPayload()
+    PrescribedTransMessageData.scalarPos = 1.0  # [m]
+    PrescribedTransMessageData.scalarVel = 0.0  # [m/s]
+    PrescribedTransMessage = messaging.PrescribedTransMsg().write(PrescribedTransMessageData)
+
+#. Subscribe the secondary body reference message to the prescribedRot1DOF module input message::
+
+    PrescribedTrans.prescribedTransInMsg.subscribeTo(PrescribedTransMessage)
 
 #. Add the module to the task list::
 

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffector.py
@@ -414,11 +414,11 @@ def PrescribedMotionTestFunction(show_plots, rotTest, thetaInit, theta_Ref, posI
 
         # Initialize the prescribedTrans test module configuration data
         accelMax = 0.005  # [m/s^2]
-        PrescribedTrans.r_FM_M = r_FM_M
-        PrescribedTrans.rPrime_FM_M = np.array([0.0, 0.0, 0.0])
-        PrescribedTrans.rPrimePrime_FM_M = np.array([0.0, 0.0, 0.0])
+        PrescribedTrans.coastOption = False
         PrescribedTrans.transAxis_M = transAxis_M
-        PrescribedTrans.scalarAccelMax = accelMax
+        PrescribedTrans.transAccelMax = accelMax
+        PrescribedTrans.transPosInit = posInit  # [m]
+        PrescribedTrans.tRamp = 0.0  # [s]
         PrescribedTrans.omega_FM_F = np.array([0.0, 0.0, 0.0])
         PrescribedTrans.omegaPrime_FM_F = np.array([0.0, 0.0, 0.0])
         PrescribedTrans.sigma_FM = sigma_FM


### PR DESCRIPTION
* **Tickets addressed:** bsk-564
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR adds a coast option to the `prescribedTrans` module. A period of zero acceleration is added between the two acceleration segments when the user selects this option.

## Verification
The unit test for this module is updated to check that the final secondary body position relative to the Mount frame converges for this option.

## Documentation
The module documentation is updated to add a description of the coast option.

## Future work
N/A
