### PR TITLE
Legacy variable logging not selecting correct task

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,7 +10,11 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
-- text here
+- A bug was introduced at 2.2.1 (2dc0a35) to the :ref:`SimulationBaseClass` `AddModelToTask` function when it was
+  refactored to use the updated module variable logging. The bug manifests as no data being logged for a variable when
+  there are more than one task, a module in each task, and the variable being logged is from a module assigned to a
+  task added to a process after the first task has been added to a process.
+
 
 Version 2.2.1
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,7 +33,8 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Added optional facet articulation to the :ref:`facetSRPDynamicEffector` module.
-
+- Fixed a bug where the legacy variable logging API would either, not log at all or log at a rate different to the
+  requested rate.
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -424,6 +424,7 @@ class SimBaseClass:
         for model, modelData, task in self.allModels:
             if model.ModelTag == modelTag:
                 modelOrConfig = modelData or model
+                break
 
         if task is None or modelOrConfig is None:
             raise ValueError(f"Could not find model with tag {modelTag}")

--- a/src/utilities/tests/test_legacyVariableLogging.py
+++ b/src/utilities/tests/test_legacyVariableLogging.py
@@ -1,0 +1,60 @@
+# ISC License
+#
+# Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from numpy.testing import assert_array_equal
+
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+
+
+def test_legacy_variable_logging(show_plots):
+    __tracebackhide__ = True
+
+    simulation = SimulationBaseClass.SimBaseClass()
+
+    process = simulation.CreateNewProcess("testProcess")
+
+    task1Name = "task1"
+    process.addTask(simulation.CreateNewTask(task1Name, macros.sec2nano(1.0)))
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.r_CN_NInit = [0.0, 0.0, 0.0]
+    scObject.hub.v_CN_NInit = [1.0, 0.0, 0.0]
+    simulation.AddModelToTask(task1Name, scObject)
+
+    # Adding this second task and module are necessary for creating a runtime task/module graph that requires
+    # the AddVariableForLogging function to find the correct module and task for the variable being logged.
+    # The task is then disabled to ensure that the underlying logger does not execute on the second task
+    # which masks the fact that the function has not found the correct task and module.
+    task2Name = "task2"
+    process.addTask(simulation.CreateNewTask(task2Name, macros.sec2nano(1.0)))
+    scObject1 = spacecraft.Spacecraft()
+    scObject1.ModelTag = "spacecraftBody1"
+    simulation.AddModelToTask(task2Name, scObject1)
+    simulation.disableTask(task2Name)
+
+    # Log a single variable via both the legacy and current mechanism
+    simulation.AddVariableForLogging("spacecraftBody.totOrbEnergy")
+
+    scObjectLogger = scObject.logger(["totOrbEnergy"])
+    simulation.AddModelToTask(task1Name, scObjectLogger)
+
+    simulation.InitializeSimulation()
+    simulation.ConfigureStopTime(macros.sec2nano(2.0))
+    simulation.ExecuteSimulation()
+
+    assert_array_equal(scObjectLogger.totOrbEnergy, simulation.GetLogVariableData('spacecraftBody.totOrbEnergy')[:, 1])


### PR DESCRIPTION
* **Tickets addressed:** bsk-#569
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Even after finding the correct module, the loop continues and then overwrites the task variable. A simple `break` is added so that the loop exits once the module (and therefore task) are found.  A regression test has been added. 

## Verification
Regression test added where the logged data/behavior must be the same whether using legacy or current logging mechanism. 

## Documentation
Updated release notes.

## Future work
None
