### PR TITLE
Cancel workflow for invalidated branch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,10 @@ name: "Pull Request Test"
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-linux:
     name: Build Linux


### PR DESCRIPTION
* **Tickets addressed:** bsk-#572
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The `concurrency` directive is added to the `pull-request.yml` github action. It simply triggers on workflow name and branch ref.

## Verification
This is manually tested. I create this PR, the actions start. Then I update the branch, the current action is cancelled and a new one starts. This can be seen in the Action history where "Pull Request Test #950" was cancelled and then "Pull Request Test #951" ran to completion.

## Documentation
NA

## Future work
None
