### PR TITLE
suppress depreciation warning of legacy code testing

### DIFF
--- a/src/utilities/tests/test_legacyVariableLogging.py
+++ b/src/utilities/tests/test_legacyVariableLogging.py
@@ -19,10 +19,13 @@ from numpy.testing import assert_array_equal
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-
+import warnings
+from Basilisk.utilities import deprecated
 
 def test_legacy_variable_logging(show_plots):
     __tracebackhide__ = True
+
+    warnings.filterwarnings("ignore", category=deprecated.BSKDeprecationWarning)
 
     simulation = SimulationBaseClass.SimBaseClass()
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The test file `src/utilities/tests/test_legacyVariableLogging.py` is testing legacy behavior of logging a 
module variable. However, this is creating deprecation warnings when running `pytest` even though this 
is expected behavior.  The regular depreciation warnings should be ignored in this case.  This way
running all BSK `pytest` scripts yields a clear result, without depreciation warnings.  After the depreciation
due date an urgent depreciation warning is shown.  This is not silenced and should be shown as it is time
to remove this legacy code from the BSK repo.

## Verification
Running the `test_legacyVariableLogging.py` script with `pytest` no longer yields a depreciation warning
unless the current date is past the depreciation date.

## Documentation
None

## Future work
None
