### PR TITLE
Fix version comparison operator

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -14,6 +14,9 @@ Version |release|
   refactored to use the updated module variable logging. The bug manifests as no data being logged for a variable when
   there are more than one task, a module in each task, and the variable being logged is from a module assigned to a
   task added to a process after the first task has been added to a process.
+- Doing a clean build on Windows appeared to complete, but when running python simulation scripts,
+  errors came up about not finding Basilisk packages.  The python version number checking on Windows
+  had an issue that is now corrected in the current build.
 
 
 Version 2.2.1

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -35,6 +35,7 @@ Version |release|
 - Added optional facet articulation to the :ref:`facetSRPDynamicEffector` module.
 - Fixed a bug where the legacy variable logging API would either, not log at all or log at a rate different to the
   requested rate.
+- Fixed a python version checking bug that prevented Basilisk from compiling on Windows
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -588,7 +588,7 @@ file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Basilisk/architecture")
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Basilisk/simulation")
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Basilisk/fswAlgorithms")
 
-if(WIN32 AND (PYTHON_VERSION GREATER 3.8))
+if(WIN32 AND (PYTHON_VERSION VERSION_GREATER 3.8))
   file(WRITE "${CMAKE_BINARY_DIR}/Basilisk/__init__.py"
        "#init file written by the build\n" "import sys, os\n" "from Basilisk import __path__\n"
        "bskPath = __path__[0]\n" "os.add_dll_directory(bskPath)\n")


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
7edb46013a6cc63f93f83cefa8837c78c6221ff5 updated the definition of `PYTHON_VERSION` in CMake from a double to a string. This caused problems in Windows, since we were not adding the proper calls to `os.add_dll_directory` because CMake failed to recognize we were in python >3.8. This is because this conditional:
```
if(WIN32 AND (PYTHON_VERSION GREATER 3.8))
```
expects `PYTHON_VERSION` to be a simple number, so that it can get compared to the simple number 3.8 with the `GREATER` operator. Since `PYTHON_VERSION` is now a proper version string, we need to use the proper operator `VERSION_GREATER`.

## Verification
Built it in my Windows laptop, no longer getting the DLL errors.
