### PR TITLE
Address compiler warnings

### DIFF
--- a/docs/source/Learn/makingModules/cppModules/cppModules-4.rst
+++ b/docs/source/Learn/makingModules/cppModules/cppModules-4.rst
@@ -59,7 +59,7 @@ The line ``%include "swig_conly_data.i"`` enables the python interface to read a
 If you have to interact with a standard vector of input or output messages, running ``python conanfile.py`` will
 auto-create the required python interfaces to vectors of output messages, vector of output message pointers,
 as well as vectors of input messages. Assume the message is of type ``SomeMsg``. After running
-``python conanfile.py`` the folling swig interfaces are defined:
+``python conanfile.py`` the following swig interfaces are defined:
 
 .. code:: cpp
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -41,6 +41,7 @@ Version |release|
   automatically increment the patch number. This allows users to reference/require specific versions of Basilisk 
   outside of the release cycle.
 - updated plotting of ``opNav`` example scenarios to work again with latest version of ``matplotlib``
+- fixed a slew of compiler warnings when compiling with Xcode 15
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------

--- a/src/simulation/dynamics/gravityEffector/polyhedralGravityModel.h
+++ b/src/simulation/dynamics/gravityEffector/polyhedralGravityModel.h
@@ -66,7 +66,7 @@ class PolyhedralGravityModel : public GravityModel {
      * The position is given relative to the body and in the inertial
      * reference frame.
      */
-    double computePotentialEnergy(const Eigen::Vector3d& positionWrtPlanet_N) const;
+    double computePotentialEnergy(const Eigen::Vector3d& positionWrtPlanet_N) const override;
 
   public:
     double muBody = 0;  /**< [m^3/s^2] Gravitation parameter for the planet */

--- a/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.cpp
+++ b/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 // Computes the term (2 - d_l), where d_l is the kronecker delta.
-inline double getK(const unsigned int degree)
+inline double getK(const size_t degree)
 {
     return (degree == 0) ? 1.0 : 2.0;
 }
@@ -92,7 +92,7 @@ SphericalHarmonicsGravityModel::computeField(const Eigen::Vector3d& position_pla
 
 Eigen::Vector3d
 SphericalHarmonicsGravityModel::computeField(const Eigen::Vector3d& position_planetFixed,
-                                             unsigned int degree, bool include_zero_degree) const
+                                             size_t degree, bool include_zero_degree) const
 {
     if (degree > this->maxDeg) {
         auto errorMsg =

--- a/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.h
+++ b/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.h
@@ -69,7 +69,7 @@ class SphericalHarmonicsGravityModel : public GravityModel {
      * If include_zero_degree is false the degree that corresponds to the spherical
      * term (point-mass) of the gravity is ignored.
      */
-    Eigen::Vector3d computeField(const Eigen::Vector3d& position_planetFixed, unsigned int degree,
+    Eigen::Vector3d computeField(const Eigen::Vector3d& position_planetFixed, size_t degree,
                                  bool include_zero_degree) const;
 
     /** Returns the gravitational potential energy at a position around this body.

--- a/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.h
+++ b/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.h
@@ -80,7 +80,7 @@ class SphericalHarmonicsGravityModel : public GravityModel {
      * The position is given relative to the body and in the inertial
      * reference frame.
      */
-    double computePotentialEnergy(const Eigen::Vector3d& positionWrtPlanet_N) const;
+    double computePotentialEnergy(const Eigen::Vector3d& positionWrtPlanet_N) const override;
 
   public:
     double radEquator = 0;  /**< [m] Reference radius for the planet */

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -216,7 +216,6 @@ void SpiceInterface::computeGPSData()
  */
 void SpiceInterface::writeOutputMessages(uint64_t CurrentClock)
 {
-    std::vector<Message<SpicePlanetStateMsgPayload>*>::iterator planMsgit;
     SpiceTimeMsgPayload OutputData;
 
     //! - Set the members of the time output message structure and write

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -52,7 +52,7 @@ SpiceInterface::SpiceInterface()
 
     //! - set default epoch time information
     char string[255];
-    sprintf(string, "%4d/%02d/%02d, %02d:%02d:%04.1f (UTC)", EPOCH_YEAR, EPOCH_MONTH, EPOCH_DAY, EPOCH_HOUR, EPOCH_MIN, EPOCH_SEC);
+    snprintf(string, 255, "%4d/%02d/%02d, %02d:%02d:%04.1f (UTC)", EPOCH_YEAR, EPOCH_MONTH, EPOCH_DAY, EPOCH_HOUR, EPOCH_MIN, EPOCH_SEC);
     this->UTCCalInit = string;
 
     return;
@@ -173,7 +173,7 @@ void SpiceInterface::initTimeData()
         } else {
             // Set the epoch information from the input message
             char string[255];
-            sprintf(string, "%4d/%02d/%02d, %02d:%02d:%04.1f (UTC)", epochMsg.year, epochMsg.month, epochMsg.day, epochMsg.hours, epochMsg.minutes, epochMsg.seconds);
+            snprintf(string, 255, "%4d/%02d/%02d, %02d:%02d:%04.1f (UTC)", epochMsg.year, epochMsg.month, epochMsg.day, epochMsg.hours, epochMsg.minutes, epochMsg.seconds);
             this->UTCCalInit = string;
         }
     }


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In Xcode 15.2 there are several compiler warnings that should be addressed.  This branch addresses the various warnings.

## Verification
Did a clean build and the associated warnings are gone now.

## Documentation
None

## Future work
None
