### PR TITLE
Feature/fix opnav plotting

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -40,6 +40,7 @@ Version |release|
   ``MAJOR.MINOR.PATCH``. Releases will increment the minor version number, while pull requests into develop will 
   automatically increment the patch number. This allows users to reference/require specific versions of Basilisk 
   outside of the release cycle.
+- updated plotting of ``opNav`` example scenarios to work again with latest version of ``matplotlib``
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------

--- a/examples/OpNavScenarios/plottingOpNav/OpNav_Plotting.py
+++ b/examples/OpNavScenarios/plottingOpNav/OpNav_Plotting.py
@@ -743,7 +743,6 @@ def imgProcVsExp(true, centers, radii, size):
         pass
     plt.ylabel('X (px)')
     plt.xlabel('Time (min)')
-    plt.grid(b=None, which='major', axis='y')
     #plt.savefig('Xpix.pdf')
 
     plt.figure(302, figsize=(2.7, 1.6), facecolor='w', edgecolor='k')
@@ -758,7 +757,6 @@ def imgProcVsExp(true, centers, radii, size):
         pass
     plt.ylabel('Y (px)')
     plt.xlabel('Time (min)')
-    plt.grid(b=None, which='major', axis='y')
     #plt.savefig('Ypix.pdf')
 
     plt.figure(312, figsize=(2.7, 1.6), facecolor='w', edgecolor='k')
@@ -768,7 +766,6 @@ def imgProcVsExp(true, centers, radii, size):
     plt.legend(loc='best')
     plt.ylabel(r'$\rho$ (px)')
     plt.xlabel('Time (min)')
-    plt.grid(b=None, which='minor', axis='y')
     #plt.savefig('Rhopix.pdf')
 
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Running the `opNav` example scenarios created Matplotlib errors.  The `grid` command was using arguments that are no longer present in latest version of `Matplotlib`.  The plotting commands have been updated to work again.

## Verification
Running the example scripts leads to the expected `matplotlib` plots again.

## Documentation
added release notes bullet about this fix

## Future work
None