### PR TITLE
Feature/swig 4 2

### DIFF
--- a/docs/source/Install/installOnLinux.rst
+++ b/docs/source/Install/installOnLinux.rst
@@ -18,7 +18,7 @@ In order to run Basilisk, the following software will be necessary. This documen
 
    - .. include:: ../bskPkgRequired.txt
 
--  `SWIG <http://www.swig.org/>`__ (version 3 or 4)
+-  `SWIG <http://www.swig.org/>`__ (version 4.x)
 -  `GCC <https://gcc.gnu.org/>`__
 -  (Optional) Get the `GitKraken <https://www.gitkraken.com>`__
    application to be able to pull and manage a copy of Basilisk

--- a/docs/source/Install/installOnMacOS.rst
+++ b/docs/source/Install/installOnMacOS.rst
@@ -56,7 +56,7 @@ Install HomeBrew Support Packages
 #. Install `HomeBrew <http://brew.sh>`__ using a Terminal window and
    pasting the install script from the HomeBrew web site.
 
-#. The new SWIG version 4 is compatible with Basilisk. Install the SWIG software package using::
+#. SWIG version 4.X is compatible with Basilisk. Install the SWIG software package using::
 
    $ brew install swig
 
@@ -65,7 +65,6 @@ Install HomeBrew Support Packages
    $ brew install cmake
    $ brew link cmake
 
-   You need at least version 3.14 or higher.
 
 Setting up the Python Environment
 ---------------------------------

--- a/docs/source/Install/installOnWindows.rst
+++ b/docs/source/Install/installOnWindows.rst
@@ -18,7 +18,7 @@ In order to run Basilisk, the following software will be necessary:
 -  `Python <https://www.python.org/downloads/windows/>`__ 3.8.x or greater
 -  `pip <https://pip.pypa.io/en/stable/installing/>`__
 -  Visual Studios 15 2017 or greater
--  `Swig <http://www.swig.org/download.html>`__ version 3 or 4
+-  `Swig <http://www.swig.org/download.html>`__ version 4.X
 -  (Optional) A GiT GUI application such as `GitKraken <https://www.gitkraken.com>`__
    to manage your copy of the Basilisk repository
 
@@ -53,7 +53,7 @@ required to place accurate breakpoints/attach a debugger to C/C++ code.
 
 Install Swig
 ~~~~~~~~~~~~
-The standard windows swig version 3 or 4 is suitable for Basilisk (see `Configuration
+The standard windows swig version 4 is suitable for Basilisk (see `Configuration
 Instructions <http://www.swig.org/Doc1.3/Windows.html#Windows_swig_exe>`__).
 Download the swig zip file, which includes ``swig.exe`` file, and unzip it into somewhere like ``C:/Program Files/Swig``
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -17,6 +17,8 @@ Version |release|
 - Doing a clean build on Windows appeared to complete, but when running python simulation scripts,
   errors came up about not finding Basilisk packages.  The python version number checking on Windows
   had an issue that is now corrected in the current build.
+- ``swig`` 4.2 was causing run-time errors with Basilisk.  The latest version of Basilisk now added
+  support for this version of swig.
 
 
 Version 2.2.1

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -48,6 +48,9 @@ Version |release|
   ``rho`` and ``rhoDot``
 - Deprecated the :ref:`prescribedMotionMsgPayload` message and replaced with two separate
   :ref:`prescribedTranslationMsgPayload` and :ref:`prescribedRotationMsgPayload` messages.
+- added support for the new ``swig`` 4.2 version
+
+>>>>>>> c996337e2 (update release notes and known issues)
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------

--- a/src/architecture/_GeneralModuleFiles/swig_common_model.i
+++ b/src/architecture/_GeneralModuleFiles/swig_common_model.i
@@ -29,12 +29,12 @@
 
 // Instantiate templates used by example
 namespace std {
-   %template(IntVector) vector<int>;
-   %template(DoubleVector) vector<double>;
-   %template(StringVector) vector<string>;
+   %template(IntVector) vector<int, allocator<int> >;
+   %template(DoubleVector) vector<double, allocator<double> >;
+   %template(StringVector) vector<string, allocator<string> >;
    %template(StringSet) set<string>;
    %template(intSet) set<unsigned long>;
-   %template(ConstCharVector) vector<const char*>;
+   %template(ConstCharVector) vector<const char*, allocator<const char*> >;
    %template(MultiArray) vector < vector <double> >;
    %template(MultiArray3d) vector < vector < vector <double> > >;
 }

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -19,9 +19,9 @@
 %include "_GeneralModuleFiles/swig_eigen.i"
 %include "_GeneralModuleFiles/swig_conly_data.i"
 %include "stdint.i"
-%template(TimeVector) std::vector<unsigned long long>;
-%template(DoubleVector) std::vector<double>;
-%template(StringVector) std::vector<std::string>;
+%template(TimeVector) std::vector<unsigned long long, std::allocator<unsigned long long>>;
+%template(DoubleVector) std::vector<double, std::allocator<double>>;
+%template(StringVector) std::vector<std::string, std::allocator<std::string>>;
 
 %include "architecture/utilities/macroDefinitions.h"
 %include "fswAlgorithms/fswUtilities/fswDefinitions.h"
@@ -52,8 +52,7 @@ import numpy as np
 %}};
 %include "{baseDir}/{type}Payload.h"
 INSTANTIATE_TEMPLATES({type}, {type}Payload, {baseDir})
-%template({type}OutMsgsVector) std::vector<Message<{type}Payload>>;
-%template({type}OutMsgsPtrVector) std::vector<Message<{type}Payload>*>;
-%template({type}InMsgsVector) std::vector<ReadFunctor<{type}Payload>>;
-
+%template({type}OutMsgsVector) std::vector<Message<{type}Payload>, std::allocator<Message<{type}Payload>> >;
+%template({type}OutMsgsPtrVector) std::vector<Message<{type}Payload>*, std::allocator<Message<{type}Payload>*> >;
+%template({type}InMsgsVector) std::vector<ReadFunctor<{type}Payload>, std::allocator<ReadFunctor<{type}Payload>> >;
 

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -151,8 +151,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 typedef struct messageType;
 
-%template(messageType ## PayloadVector) std::vector<messageType ## Payload>;
-%extend std::vector<messageType ## Payload>{
+%template(messageType ## PayloadVector) std::vector<messageType ## Payload, std::allocator<messageType ## Payload>>;
+%extend std::vector<messageType ## Payload, std::allocator<messageType ## Payload>>{
     %pythoncode %{
         # This __getattr__ is written in message.i.
         # It lets us return message struct attribute record as lists for plotting, etc.

--- a/src/architecture/system_model/sim_model.i
+++ b/src/architecture/system_model/sim_model.i
@@ -40,21 +40,21 @@
 
 // Instantiate templates used by example
 namespace std {
-   %template(IntVector) vector<int>;
-   %template(DoubleVector) vector<double>;
+   %template(IntVector) vector<int, allocator<int> >;
+   %template(DoubleVector) vector<double, allocator<double> >;
    %template(MultiArray) vector<vector<double>>;
-   %template(StringVector) vector<string>;
+   %template(StringVector) vector<string, allocator<string> >;
    %template(StringSet) set<string>;
    %template(intSet) set<unsigned long>;
    %template(int64Set) set<long int>;
-   %template(ConstCharVector) vector<const char*>;
+   %template(ConstCharVector) vector<const char*, allocator<const char*> >;
    %template() std::pair<long int, long int>;
    %template() std::pair<long long int, long long int>;
    %template() std::pair<int64_t, int64_t>;
-   %template(exchangeSet) std::set<std::pair<long int, long int>>;
-   %template(modelPriPair) std::vector<ModelPriorityPair>;
-   %template(procSchedList) std::vector<ModelScheduleEntry>;
-   %template(simProcList) std::vector<SysProcess *>;
+   %template(exchangeSet) set<pair<long int, long int>>;
+   %template(modelPriPair) vector<ModelPriorityPair, allocator<ModelPriorityPair> >;
+   %template(procSchedList) vector<ModelScheduleEntry, allocator<ModelScheduleEntry> >;
+   %template(simProcList) vector<SysProcess *, allocator<SysProcess *> >;
 }
 
 %inline %{

--- a/src/architecture/system_model/sys_model_task.i
+++ b/src/architecture/system_model/sys_model_task.i
@@ -27,10 +27,10 @@
 
 // Instantiate templates used by example
 namespace std {
-   %template(IntVector) vector<int>;
-   %template(DoubleVector) vector<double>;
-   %template(StringVector) vector<string>;
-   %template(ConstCharVector) vector<const char*>;
+   %template(IntVector) vector<int, allocator<int> >;
+   %template(DoubleVector) vector<double, allocator<double> >;
+   %template(StringVector) vector<string, allocator<string> >;
+   %template(ConstCharVector) vector<const char*, allocator<const char*> >;
 }
 %include "sys_model.h"
 %include "sys_model_task.h"

--- a/src/architecture/utilities/bskUtilities.i
+++ b/src/architecture/utilities/bskUtilities.i
@@ -34,7 +34,7 @@
 %include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 %include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
 
-%template(Eigen3dVector) std::vector<Eigen::Vector3d>;
+%template(Eigen3dVector) std::vector<Eigen::Vector3d, std::allocator<Eigen::Vector3d>>;
 
 %pythoncode %{
 import sys

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
@@ -33,8 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 // Instantiate templates used by example
 %include "std_vector.i"
 namespace std {
-    %template(ThrusterTimeVector) vector<THRTimePair>;
-    %template(ThrusterConfigVector) vector<THRSimConfig>;
+    %template(ThrusterTimeVector) vector<THRTimePair, std::allocator<THRTimePair>>;
+    %template(ThrusterConfigVector) vector<THRSimConfig, std::allocator<THRSimConfig>>;
 }
 
 %include "sys_model.i"

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
@@ -50,7 +50,7 @@ struct ArrayMotorTorqueMsg_C;
 
 %include "std_vector.i"
 namespace std {
-    %template(RWConfigPointerVector) vector<RWConfigMsgPayload *>;
+    %template(RWConfigPointerVector) vector<RWConfigMsgPayload *, allocator<RWConfigMsgPayload *> >;
 }
 
 %pythoncode %{

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.i
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.i
@@ -45,7 +45,7 @@ struct CSSArraySensorMsg_C;
 %include "architecture/msgPayloadDefCpp/CSSConfigLogMsgPayload.h"
 
 namespace std {
-    %template(CSSVector) vector<CoarseSunSensor *>;
+    %template(CSSVector) vector<CoarseSunSensor *, allocator<CoarseSunSensor *> >;
 }
 
 %pythoncode %{

--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.i
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.i
@@ -42,16 +42,16 @@ struct RWConfigLogMsg_C;
 
 // Instantiate templates used by example
 namespace std {
-    %template(VizThrConfig) vector<ThrClusterMap>;
-    %template(ThrClusterMapVectorVector) std::vector <std::vector <ThrClusterMap>>;
-    %template(THROutputMsgOutMsgsVector) std::vector<Message<THROutputMsgPayload>>;
-    %template(THROutputMsgOutMsgsPtrVector) std::vector<Message<THROutputMsgPayload>*>;
-    %template(THROutputMsgInMsgsVector) std::vector<ReadFunctor<THROutputMsgPayload>>;
-    %template(THROutputOutMsgsVectorVector) std::vector <std::vector <Message<THROutputMsgPayload>*>>;
-    %template(RWConfigLogMsgOutMsgsVector) std::vector<Message<RWConfigLogMsgPayload>>;
-    %template(RWConfigLogMsgOutMsgsPtrVector) std::vector<Message<RWConfigLogMsgPayload>*>;
-    %template(RWConfigLogMsgInMsgsVector) std::vector<ReadFunctor<RWConfigLogMsgPayload>>;
-    %template(RWConfigLogMsgInMsgsVectorVector) std::vector <std::vector <Message<RWConfigLogMsgPayload>*>>;
+    %template(VizThrConfig) vector<ThrClusterMap, std::allocator<ThrClusterMap> >;
+    %template(ThrClusterMapVectorVector) vector <vector <ThrClusterMap, allocator<ThrClusterMap> >, allocator<vector<ThrClusterMap>> >;
+    %template(THROutputMsgOutMsgsVector) vector<Message<THROutputMsgPayload>, allocator<Message<THROutputMsgPayload>> >;
+    %template(THROutputMsgOutMsgsPtrVector) vector<Message<THROutputMsgPayload>*, allocator<Message<THROutputMsgPayload>*> >;
+    %template(THROutputMsgInMsgsVector) vector<ReadFunctor<THROutputMsgPayload>, allocator<ReadFunctor<THROutputMsgPayload>> >;
+    %template(THROutputOutMsgsVectorVector) vector <vector <Message<THROutputMsgPayload>*, allocator<Message<THROutputMsgPayload>*> >, allocator<vector <Message<THROutputMsgPayload>*>> >;
+    %template(RWConfigLogMsgOutMsgsVector) vector<Message<RWConfigLogMsgPayload>, allocator<Message<RWConfigLogMsgPayload>> >;
+    %template(RWConfigLogMsgOutMsgsPtrVector) vector<Message<RWConfigLogMsgPayload>*, allocator<Message<RWConfigLogMsgPayload>*> >;
+    %template(RWConfigLogMsgInMsgsVector) vector<ReadFunctor<RWConfigLogMsgPayload>, allocator<ReadFunctor<RWConfigLogMsgPayload>> >;
+    %template(RWConfigLogMsgInMsgsVectorVector) vector <vector <Message<RWConfigLogMsgPayload>*, allocator<Message<RWConfigLogMsgPayload>*> >, allocator<vector <Message<RWConfigLogMsgPayload>*>> >;
 
 }
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-579
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When `swig` upgraded from 4.1.X to 4.2.0 Basilisk still compiled without issues, but at run time some errors appeared.
The swig interface of `std::vector` of types of messages needed to be updated to work with `swig` 4.2.

## Verification
Did a clean build with `swig` 4.1.1 and 4.2.0 and in both cases all unit tests pass again.

## Documentation
Updated the install documentation to say we are using `swig` 4.X version, removing mention
of being compatible with `swig` 3.x. We stopped testing against 3.x versions a while back.

## Future work
None
