### PR TITLE
Fix Windows BSK build with opNav flag

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -206,7 +206,7 @@ class BasiliskConan(ConanFile):
             # Issue link: https://github.com/conan-community/community/issues/341
             #TODO Remove this once they fix this issue.
             if self.settings.os == "Windows":
-                self.options['opencv'].freetype = False
+                self.options['opencv'].contrib_freetype = False
 
         if self.options.generator == "":
             # Select default generator supplied to cmake based on os

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -19,6 +19,8 @@ Version |release|
   had an issue that is now corrected in the current build.
 - ``swig`` 4.2 was causing run-time errors with Basilisk.  The latest version of Basilisk now added
   support for this version of swig.
+- Basilisk no longer builds on Windows with the ``opNav`` flag turned on.  The ``opencv`` related
+  ``conan`` settings are updated in the current release to address this.
 
 
 Version 2.2.1

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -49,6 +49,8 @@ Version |release|
 - Deprecated the :ref:`prescribedMotionMsgPayload` message and replaced with two separate
   :ref:`prescribedTranslationMsgPayload` and :ref:`prescribedRotationMsgPayload` messages.
 - added support for the new ``swig`` 4.2 version
+- updated the Windows build to compile properly with ``opNav`` flag set to true.  A
+  ``opencv`` related flag had to be updated.
 
 >>>>>>> c996337e2 (update release notes and known issues)
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -52,7 +52,6 @@ Version |release|
 - updated the Windows build to compile properly with ``opNav`` flag set to true.  A
   ``opencv`` related flag had to be updated.
 
->>>>>>> c996337e2 (update release notes and known issues)
 
 Version 2.2.1 (Dec. 22, 2023)
 -----------------------------


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Basilisk stopped compiling on Windows if the ``opNav`` flag was included.  One of the ``opencv`` settings,
only used on Windows, had to be updated.

## Verification
Did a clean build on Windows and the opNav scenarios run again.

## Documentation
Updated the release notes and the known issues document.

## Future work
None
