### PR TITLE
Fix circular import in sysModel

### DIFF
--- a/src/architecture/_GeneralModuleFiles/sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/sys_model.i
@@ -15,7 +15,6 @@ from Basilisk.architecture.swig_common_model import *
 
 %pythonbegin %{
 from typing import Union, Iterable
-from Basilisk.utilities import pythonVariableLogger
 %}
 
 %extend SysModel
@@ -37,6 +36,7 @@ from Basilisk.utilities import pythonVariableLogger
                     raise ValueError(f"Cannot log {variable_name} as it is not a "
                                     f"variable of {type(self).__name__}")
 
+            from Basilisk.utilities import pythonVariableLogger
             return pythonVariableLogger.PythonVariableLogger(logging_functions, recordingTime)
     %}
 }


### PR DESCRIPTION
* **Tickets addressed:** #609 
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

I used the "Import When Needed" style of fixing the circular dependency. I think this makes sense, as it shouldn't mysteriously ImportError at runtime, and as the function is used only when setting stuff up, is not a hot path and should not cause threading related issues.

## Verification

I removed our workaround and confirmed that the tests that required the workaround were still passing, both locally and on our internal CI.

## Documentation

None

## Future work

None
