### PR TITLE
Implement hardstops for spinningBodiesOneDOF

### DIFF
--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
@@ -310,8 +310,8 @@ def test_spinning_body_enforces_limits(max_lim, min_lim):
     spinningBody.theta_max = np.deg2rad(max_lim)
     spinningBody.theta_min = np.deg2rad(min_lim)
 
-    with pytest.raises(ValueError):
-        spinningBody.Reset(0)
+    # with pytest.raises(ValueError) as exc:
+    spinningBody.Reset(0)
 
 
 @pytest.mark.parametrize(

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
@@ -310,8 +310,8 @@ def test_spinning_body_enforces_limits(max_lim, min_lim):
     spinningBody.theta_max = np.deg2rad(max_lim)
     spinningBody.theta_min = np.deg2rad(min_lim)
 
-    # with pytest.raises(ValueError) as exc:
-    spinningBody.Reset(0)
+    with pytest.raises(ValueError) as exc:
+        spinningBody.Reset(0)
 
 
 @pytest.mark.parametrize(

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -70,13 +70,14 @@ void SpinningBodyOneDOFStateEffector::Reset(uint64_t CurrentClock)
     }
     // Ensure user specified valid angular limits
     if (this->theta_max < this->theta_min) {
-        bskLogger.bskLog(
-            BSK_ERROR, "theta_max (%f) must be greater than theta_min (%f).", this->theta_max, this->theta_min);
+        throw std::invalid_argument("theta_max (" + std::to_string(this->theta_max)
+            + ") must be greater than theta_min (" + std::to_string(this->theta_min) + ").");
     }
     // Ensure that user specified valid initial angle
     if ((this->thetaInit > this->theta_max) || (this->thetaInit < this->theta_min)) {
-        bskLogger.bskLog(BSK_ERROR, "Initial angle (%f) must be inside of body angle bounds (%f, %f).",
-            this->thetaInit, this->theta_min, this->theta_max);
+        throw std::invalid_argument("Initial angle (" + std::to_string(this->thetaInit)
+            + ") must be inside of body angle bounds (" + std::to_string(this->theta_min) + ", "
+            + std::to_string(this->theta_max) + ").");
     }
 }
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
@@ -43,6 +43,8 @@ public:
     double c = 0.0;                                                  //!< [N-m-s/rad] rotational damping coefficient
     double thetaInit = 0.0;                                          //!< [rad] initial spinning body angle
     double thetaDotInit = 0.0;                                       //!< [rad/s] initial spinning body angle rate
+    double theta_max = std::numeric_limits<double>::infinity();      //!< [rad] Maximum allowed angle
+    double theta_min = -std::numeric_limits<double>::infinity();     //!< [rad] Minimum allowed angle
     std::string nameOfThetaState;                                    //!< -- identifier for the theta state data container
     std::string nameOfThetaDotState;                                 //!< -- identifier for the thetaDot state data container
     Eigen::Vector3d r_SB_B{0.0, 0.0, 0.0};                  //!< [m] vector pointing from body frame B origin to spinning frame S origin in B frame components
@@ -75,6 +77,8 @@ public:
     void computeSpinningBodyInertialStates();               //!< Method for computing the SB's states
 
 private:
+    bool isMovingBeyondLimits(double theta, double thetaDot);
+
     static uint64_t effectorID;         //!< [] ID number of this panel
     double u = 0.0;                     //!< [N-m] optional motor torque
     int lockFlag = 0;                   //!< [] flag for locking the rotation axis

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
@@ -16,7 +16,17 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
+#include <stdexcept>
 
+%exception { 
+    try {
+        $action
+    } catch (std::invalid_argument &e) {
+        std::string s("spinningBodyOneDOF error: "), s2(e.what());
+        s = s + s2;
+        SWIG_exception(SWIG_ValueError, s.c_str());
+   }
+}
 
 %module spinningBodyOneDOFStateEffector
 %{

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
@@ -107,6 +107,11 @@ This section is to outline the steps needed to setup a Spinning Body State Effec
     angleRefMsg = messaging.HingedRigidBodyMsg().write(angleRef)
     spinningBody.spinningBodyRefInMsg.subscribeTo(angleRefMsg)
 
+#. (Optional) Specify angular limits for the body's rotation::
+
+    spinningBody.theta_max = 90.0 * macros.D2R
+    spinningBody.theta_min = -90.0 * macros.D2R
+
 #. The angular states of the body are created using an output message ``spinningBodyOutMsg``.
 
 #. The spinning body config log state output message is ``spinningBodyConfigLogOutMsg``.


### PR DESCRIPTION
* **Tickets addressed:** bsk-#637 (partially)
* **Review:** by file
* **Merge strategy:** squash and merge

## Description
It is not uncommon for realistic actuators have a non-finite range of motion (ie, if they don't use slip-rings and have cable bundles running through them which cannot rotate, or if there would be mechanical interferences with other parts of the structure at certain angles). Modeling these limits can be important to the practical use of these actuators and associated bodies.

To increase the fidelity of the `spinningBodyOneDOF`, this PR adds (optional) angular limits to the model. Once `theta` reaches these locations, the `spinningBodyOneDOF` will not move further than the boundary.

These limits are set to +/-Inf by default, so that they have no effect unless the caller explicitly sets them to a smaller range.

## Verification
Added unit tests verifying that the model respects various configurations of the limits. Existing tests verify that not specifying the limits does not impact default behavior of model.

## Documentation
Updated rst file associated with model to document the existence/example usage of these limits.

## Future work
Its not of interest for my work, but for high fidelity dynamics simulation it would be possible to model the interaction of the spinningBody with the hardstop (by specifying the mechanical stiffness/damping of the angular limit).

Also, it seems that raising an exception (to stop the program) is the proper response for an invalid configuration (rather than just logging an exception, which the user might ignore (either intentionally or accidentally) and get invalid results). I implemented the ability to propagate a C++ exception to python in the SWIG wrapper for this function. Perhaps it would make sense to generalize this exception handling to make it more widely available to other basilisk modules.