### PR TITLE
Feature/bsk 613 smooth translational profiler

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -64,6 +64,8 @@ Version |release|
 - Added support for Vizard 2.1.6.1
 - Updated :ref:`MtbEffector` to include missing swig interface file for a message definition and corrected
   message table in the module documentation.
+- Added smoothed bang-bang and smoothed bang-coast-bang profiler options to the :ref:`prescribedLinearTranslation`
+  simulation module
 
 
 Version 2.2.1 (Dec. 22, 2023)

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/_UnitTest/test_prescribedLinearTranslation.py
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/_UnitTest/test_prescribedLinearTranslation.py
@@ -41,14 +41,14 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 
-@pytest.mark.parametrize("coastOptionRampDuration", [0.0, 2.0, 5.0])  # [s]
+@pytest.mark.parametrize("coastOptionBangDuration", [0.0, 2.0, 5.0])  # [s]
 @pytest.mark.parametrize("transPosInit", [0, -0.75])  # [m]
 @pytest.mark.parametrize("transPosRef1", [0, -0.5])  # [m]
 @pytest.mark.parametrize("transPosRef2", [-0.75, 1.0])  # [m]
 @pytest.mark.parametrize("transAccelMax", [0.01, 0.005])  # [m/s^2]
 @pytest.mark.parametrize("accuracy", [1e-4])
 def test_prescribedLinearTranslation(show_plots,
-                                     coastOptionRampDuration,
+                                     coastOptionBangDuration,
                                      transPosInit,
                                      transPosRef1,
                                      transPosRef2,
@@ -71,7 +71,7 @@ def test_prescribedLinearTranslation(show_plots,
 
     Args:
         show_plots (bool): Variable for choosing whether plots should be displayed
-        coastOptionRampDuration: (double): [s] Ramp duration used for the coast option
+        coastOptionBangDuration: (double): [s] Ramp duration used for the coast option
         transPosInit (float): [m] Initial translational body position from M to F frame origin along transHat_M
         transPosRef1 (float): [m] First reference position from M to F frame origin along transHat_M
         transPosRef2 (float): [m] Second reference position from M to F frame origin along transHat_M
@@ -101,7 +101,7 @@ def test_prescribedLinearTranslation(show_plots,
     prescribedTrans = prescribedLinearTranslation.PrescribedLinearTranslation()
     prescribedTrans.ModelTag = "prescribedTrans"
     transHat_M = np.array([0.5, 0.0, 0.5 * np.sqrt(3)])
-    prescribedTrans.setCoastOptionRampDuration(coastOptionRampDuration)
+    prescribedTrans.setCoastOptionBangDuration(coastOptionBangDuration)
     prescribedTrans.setTransHat_M(transHat_M)
     prescribedTrans.setTransAccelMax(transAccelMax)  # [m/s^2]
     prescribedTrans.setTransPosInit(transPosInit)  # [m]
@@ -126,25 +126,25 @@ def test_prescribedLinearTranslation(show_plots,
     # Determine the required simulation time for the first translation
     transVelInit = 0.0  # [m/s]
     tCoast_1 = 0.0  # [s]
-    if coastOptionRampDuration > 0.0:
+    if coastOptionBangDuration > 0.0:
         # Determine the position and velocity at the end of the ramp segment/start of the coast segment
         if transPosInit < transPosRef1:
-            transPos_tr_1 = ((0.5 * transAccelMax * coastOptionRampDuration * coastOptionRampDuration)
-                             + (transVelInit * coastOptionRampDuration)
+            transPos_tr_1 = ((0.5 * transAccelMax * coastOptionBangDuration * coastOptionBangDuration)
+                             + (transVelInit * coastOptionBangDuration)
                              + transPosInit)  # [m]
-            transVel_tr_1 = transAccelMax * coastOptionRampDuration + transVelInit  # [m/s]
+            transVel_tr_1 = transAccelMax * coastOptionBangDuration + transVelInit  # [m/s]
         else:
-            transPos_tr_1 = (- ((0.5 * transAccelMax * coastOptionRampDuration * coastOptionRampDuration)
-                                + (transVelInit * coastOptionRampDuration))
+            transPos_tr_1 = (- ((0.5 * transAccelMax * coastOptionBangDuration * coastOptionBangDuration)
+                                + (transVelInit * coastOptionBangDuration))
                              + transPosInit)  # [m]
-            transVel_tr_1 = - transAccelMax * coastOptionRampDuration + transVelInit  # [m/s]
+            transVel_tr_1 = - transAccelMax * coastOptionBangDuration + transVelInit  # [m/s]
 
         # Determine the distance traveled during the coast period
         deltaPosCoast_1 = transPosRef1 - transPosInit - 2 * (transPos_tr_1 - transPosInit)  # [m]
 
         # Determine the time duration of the coast segment
         tCoast_1 = np.abs(deltaPosCoast_1) / np.abs(transVel_tr_1)  # [s]
-        translation1ReqTime = (2 * coastOptionRampDuration) + tCoast_1  # [s]
+        translation1ReqTime = (2 * coastOptionBangDuration) + tCoast_1  # [s]
     else:
         translation1ReqTime = np.sqrt(((0.5 * np.abs(transPosRef1 - transPosInit)) * 8) / transAccelMax) + 5  # [s]
 
@@ -163,25 +163,25 @@ def test_prescribedLinearTranslation(show_plots,
 
     # Determine the required simulation time for the second translation
     tCoast_2 = 0.0  # [s]
-    if coastOptionRampDuration > 0.0:
+    if coastOptionBangDuration > 0.0:
         # Determine the position and velocity at the end of the ramp segment/start of the coast segment
         if transPosRef1 < transPosRef2:
-            transPos_tr_2 = ((0.5 * transAccelMax * coastOptionRampDuration * coastOptionRampDuration)
-                             + (transVelInit * coastOptionRampDuration)
+            transPos_tr_2 = ((0.5 * transAccelMax * coastOptionBangDuration * coastOptionBangDuration)
+                             + (transVelInit * coastOptionBangDuration)
                              + transPosRef1)  # [m]
-            transVel_tr_2 = transAccelMax * coastOptionRampDuration + transVelInit  # [m/s]
+            transVel_tr_2 = transAccelMax * coastOptionBangDuration + transVelInit  # [m/s]
         else:
-            transPos_tr_2 = (- ((0.5 * transAccelMax * coastOptionRampDuration * coastOptionRampDuration)
-                             + (transVelInit * coastOptionRampDuration))
+            transPos_tr_2 = (- ((0.5 * transAccelMax * coastOptionBangDuration * coastOptionBangDuration)
+                             + (transVelInit * coastOptionBangDuration))
                              + transPosRef1)  # [m]
-            transVel_tr_2 = - transAccelMax * coastOptionRampDuration + transVelInit  # [m/s]
+            transVel_tr_2 = - transAccelMax * coastOptionBangDuration + transVelInit  # [m/s]
 
         # Determine the distance traveled during the coast period
         deltaPosCoast_2 = transPosRef2 - transPosRef1 - 2 * (transPos_tr_2 - transPosRef1)  # [m]
 
         # Determine the time duration of the coast segment
         tCoast_2 = np.abs(deltaPosCoast_2) / np.abs(transVel_tr_2)  # [s]
-        translation2ReqTime = (2 * coastOptionRampDuration) + tCoast_2  # [s]
+        translation2ReqTime = (2 * coastOptionBangDuration) + tCoast_2  # [s]
     else:
         translation2ReqTime = np.sqrt(((0.5 * np.abs(transPosRef2 - transPosRef1)) * 8) / transAccelMax) + 5  # [s]
 
@@ -202,11 +202,11 @@ def test_prescribedLinearTranslation(show_plots,
 
     # Unit test validation
     # Store the truth data used to validate the module in two lists
-    if coastOptionRampDuration > 0.0:
+    if coastOptionBangDuration > 0.0:
         # Compute tf for the first translation, and tInit tf for the second translation
-        tf_1 = 2 * coastOptionRampDuration + tCoast_1  # [s]
+        tf_1 = 2 * coastOptionBangDuration + tCoast_1  # [s]
         tInit_2 = translation1ReqTime + translation1ExtraTime  # [s]
-        tf_2 = tInit_2 + (2 * coastOptionRampDuration) + tCoast_2  # [s]
+        tf_2 = tInit_2 + (2 * coastOptionBangDuration) + tCoast_2  # [s]
 
         # Compute the timespan indices for each check
         tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -103,11 +103,11 @@ void PrescribedLinearTranslation::computeBangBangParametersNoSmoothing() {
     this->t_f = this->tInit + totalTransTime;
 
     // Determine the time halfway through the translation
-    this->t_s = this->tInit + (totalTransTime / 2);
+    this->t_b1 = this->tInit + (totalTransTime / 2);
 
     // Define the parabolic constants for the first and second half of the translation
-    this->a = 0.5 * (this->transPosRef - this->transPosInit) / ((this->t_s - this->tInit) * (this->t_s - this->tInit));
-    this->b = -0.5 * (this->transPosRef - this->transPosInit) / ((this->t_s - this->t_f) * (this->t_s - this->t_f));
+    this->a = 0.5 * (this->transPosRef - this->transPosInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
+    this->b = -0.5 * (this->transPosRef - this->transPosInit) / ((this->t_b1 - this->t_f) * (this->t_b1 - this->t_f));
 }
 
 /*! This method computes the required parameters for the translation with a coast period.
@@ -116,7 +116,7 @@ void PrescribedLinearTranslation::computeBangBangParametersNoSmoothing() {
 void PrescribedLinearTranslation::computeBangCoastBangParametersNoSmoothing() {
     if (this->transPosInit != this->transPosRef) {
         // Determine the time at the end of the first bang segment
-        this->t_r = this->tInit + this->coastOptionBangDuration;
+        this->t_b1 = this->tInit + this->coastOptionBangDuration;
 
         // Determine the position and velocity at the end of the bang segment/start of the coast segment
         if (this->transPosInit < this->transPosRef) {
@@ -137,7 +137,7 @@ void PrescribedLinearTranslation::computeBangCoastBangParametersNoSmoothing() {
         double tCoast = fabs(deltaPosCoast) / fabs(this->transVel_tr);
 
         // Determine the time at the end of the coast segment
-        this->t_c = this->t_r + tCoast;
+        this->t_c = this->t_b1 + tCoast;
 
         // Determine the position [m] at the end of the coast segment
         double transPos_tc = this->transPos_tr + deltaPosCoast;
@@ -146,7 +146,7 @@ void PrescribedLinearTranslation::computeBangCoastBangParametersNoSmoothing() {
         this->t_f = this->t_c + this->coastOptionBangDuration;
 
         // Define the parabolic constants for the first and second bang segments of the translation
-        this->a = (this->transPos_tr - this->transPosInit) / ((this->t_r - this->tInit) * (this->t_r - this->tInit));
+        this->a = (this->transPos_tr - this->transPosInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
         this->b = -(this->transPosRef - transPos_tc) / ((this->t_c - this->t_f) * (this->t_c - this->t_f));
     } else {
         // If the initial position equals the reference position, no translation is required.
@@ -184,7 +184,7 @@ void PrescribedLinearTranslation::computeCurrentState(double t) {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInFirstBangSegmentNoCoast(double t) const {
-    return (t <= this->t_s && this->t_f - this->tInit != 0);
+    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the first bang segment for the coast option.
@@ -192,7 +192,7 @@ bool PrescribedLinearTranslation::isInFirstBangSegmentNoCoast(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInFirstBangSegment(double t) const {
-    return (t <= this->t_r && this->t_f - this->tInit != 0);
+    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the no coast option.
@@ -200,7 +200,7 @@ bool PrescribedLinearTranslation::isInFirstBangSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInSecondBangSegmentNoCoast(double t) const {
-    return (t > this->t_s && t <= this->t_f && this->t_f - this->tInit != 0);
+    return (t > this->t_b1 && t <= this->t_f && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the coast option.
@@ -216,7 +216,7 @@ bool PrescribedLinearTranslation::isInSecondBangSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInCoastSegment(double t) const {
-    return (t > this->t_r && t <= this->t_c && this->t_f - this->tInit != 0);
+    return (t > this->t_b1 && t <= this->t_c && this->t_f - this->tInit != 0);
 }
 
 /*! This method computes the scalar translational states for the first bang segment. The acceleration during the first
@@ -258,7 +258,7 @@ void PrescribedLinearTranslation::computeSecondBangSegment(double t) {
 void PrescribedLinearTranslation::computeCoastSegment(double t) {
     this->transAccel = 0.0;
     this->transVel = this->transVel_tr;
-    this->transPos = this->transVel_tr * (t - this->t_r) + this->transPos_tr;
+    this->transPos = this->transVel_tr * (t - this->t_b1) + this->transPos_tr;
 }
 
 /*! This method computes the scalar translational states when the translation is complete.

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -87,28 +87,8 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime)
         }
     }
 
-    double t = callTime * NANO2SEC;
-
     // Compute the scalar translational states at the current simulation time
-    if (this->coastOptionBangDuration > 0.0) {
-        if (this->isInFirstBangSegment(t)) {
-            this->computeFirstBangSegment(t);
-        } else if (this->isInCoastSegment(t)) {
-            this->computeCoastSegment(t);
-        } else if (this->isInSecondBangSegment(t)) {
-            this->computeSecondBangSegment(t);
-        } else {
-            this->computeTranslationComplete();
-        }
-    } else {
-        if (this->isInFirstBangSegmentNoCoast(t)) {
-            this->computeFirstBangSegment(t);
-        } else if (this->isInSecondBangSegmentNoCoast(t)) {
-            this->computeSecondBangSegment(t);
-        } else {
-            this->computeTranslationComplete();
-        }
-    }
+    this->computeCurrentState(callTime * NANO2SEC);
 
     // Write the module output messages
     this->writeOutputMessages(callTime);
@@ -173,6 +153,31 @@ void PrescribedLinearTranslation::computeCoastParameters() {
     } else {
         // If the initial position equals the reference position, no translation is required.
         this->t_f = this->tInit;
+    }
+}
+
+/*! This intermediate method groups the calculation of the current translational states into a single method.
+ @return void
+*/
+void PrescribedLinearTranslation::computeCurrentState(double t) {
+    if (this->coastOptionBangDuration > 0.0) {
+        if (this->isInFirstBangSegment(t)) {
+            this->computeFirstBangSegment(t);
+        } else if (this->isInCoastSegment(t)) {
+            this->computeCoastSegment(t);
+        } else if (this->isInSecondBangSegment(t)) {
+            this->computeSecondBangSegment(t);
+        } else {
+            this->computeTranslationComplete();
+        }
+    } else {
+        if (this->isInFirstBangSegmentNoCoast(t)) {
+            this->computeFirstBangSegment(t);
+        } else if (this->isInSecondBangSegmentNoCoast(t)) {
+            this->computeSecondBangSegment(t);
+        } else {
+            this->computeTranslationComplete();
+        }
     }
 }
 

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -76,11 +76,7 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime) {
 
         // Set the parameters required to profile the translation
         if (this->transPosRef != this->transPosInit) {
-            if (this->coastOptionBangDuration > 0.0) {
-                this->computeBangCoastBangParametersNoSmoothing();
-            } else {
-                this->computeBangBangParametersNoSmoothing();
-            }
+            this->computeTranslationParameters();
         } else {
             this->t_f = this->tInit;
         }
@@ -94,6 +90,17 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime) {
 
     // Write the module output messages
     this->writeOutputMessages(callTime);
+}
+
+/*! This intermediate method groups the calculation of translation parameters into a single method.
+ @return void
+*/
+void PrescribedLinearTranslation::computeTranslationParameters() {
+    if (this->coastOptionBangDuration > 0.0) {
+        this->computeBangCoastBangParametersNoSmoothing();
+    } else {
+        this->computeBangBangParametersNoSmoothing();
+    }
 }
 
 /*! This method computes the required parameters for the translation with a non-smoothed bang-bang acceleration profile.

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -120,33 +120,34 @@ void PrescribedLinearTranslation::computeBangCoastBangParametersNoSmoothing() {
 
         // Determine the position and velocity at the end of the bang segment/start of the coast segment
         if (this->transPosInit < this->transPosRef) {
-            this->transPos_tr = (0.5 * this->transAccelMax * this->coastOptionBangDuration * this->coastOptionBangDuration)
+            this->transPos_tb1 = (0.5 * this->transAccelMax * this->coastOptionBangDuration * this->coastOptionBangDuration)
                                  + this->transPosInit;
-            this->transVel_tr = this->transAccelMax * this->coastOptionBangDuration;
+            this->transVel_tb1 = this->transAccelMax * this->coastOptionBangDuration;
         } else {
-            this->transPos_tr =
+            this->transPos_tb1 =
                     -((0.5 * this->transAccelMax * this->coastOptionBangDuration * this->coastOptionBangDuration))
                     + this->transPosInit;
-            this->transVel_tr = -this->transAccelMax * this->coastOptionBangDuration;
+            this->transVel_tb1 = -this->transAccelMax * this->coastOptionBangDuration;
         }
 
         // Determine the distance traveled during the coast period
-        double deltaPosCoast = this->transPosRef - this->transPosInit - 2 * (this->transPos_tr - this->transPosInit);
+        double deltaPosCoast = this->transPosRef - this->transPosInit - 2 * (this->transPos_tb1 - this->transPosInit);
 
         // Determine the time duration of the coast segment
-        double tCoast = fabs(deltaPosCoast) / fabs(this->transVel_tr);
+        double tCoast = fabs(deltaPosCoast) / fabs(this->transVel_tb1);
 
         // Determine the time at the end of the coast segment
         this->t_c = this->t_b1 + tCoast;
 
         // Determine the position [m] at the end of the coast segment
-        double transPos_tc = this->transPos_tr + deltaPosCoast;
+        double transPos_tc = this->transPos_tb1 + deltaPosCoast;
 
         // Determine the time at the end of the translation
         this->t_f = this->t_c + this->coastOptionBangDuration;
 
         // Define the parabolic constants for the first and second bang segments of the translation
-        this->a = (this->transPos_tr - this->transPosInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
+
+        this->a = (this->transPos_tb1 - this->transPosInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
         this->b = -(this->transPosRef - transPos_tc) / ((this->t_c - this->t_f) * (this->t_c - this->t_f));
     } else {
         // If the initial position equals the reference position, no translation is required.
@@ -257,8 +258,8 @@ void PrescribedLinearTranslation::computeSecondBangSegment(double t) {
 */
 void PrescribedLinearTranslation::computeCoastSegment(double t) {
     this->transAccel = 0.0;
-    this->transVel = this->transVel_tr;
-    this->transPos = this->transVel_tr * (t - this->t_b1) + this->transPos_tr;
+    this->transVel = this->transVel_tb1;
+    this->transPos = this->transVel_tb1 * (t - this->t_b1) + this->transPos_tb1;
 }
 
 /*! This method computes the scalar translational states when the translation is complete.

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -165,9 +165,9 @@ void PrescribedLinearTranslation::computeCurrentState(double t) {
             this->computeTranslationComplete();
         }
     } else {
-        if (this->isInFirstBangSegmentNoCoast(t)) {
+        if (this->isInFirstBangSegment(t)) {
             this->computeFirstBangSegment(t);
-        } else if (this->isInSecondBangSegmentNoCoast(t)) {
+        } else if (this->isInSecondBangSegment(t)) {
             this->computeSecondBangSegment(t);
         } else {
             this->computeTranslationComplete();
@@ -175,31 +175,15 @@ void PrescribedLinearTranslation::computeCurrentState(double t) {
     }
 }
 
-/*! This method determines if the current time is within the first bang segment for the no coast option.
- @return bool
- @param t [s] Current simulation time
-*/
-bool PrescribedLinearTranslation::isInFirstBangSegmentNoCoast(double t) const {
-    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
-}
-
-/*! This method determines if the current time is within the first bang segment for the coast option.
+/*! This method determines if the current time is within the first bang segment.
  @return bool
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInFirstBangSegment(double t) const {
-    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
+    return (t <= this->t_b1 && this->t_f - this->tInit != 0.0);
 }
 
-/*! This method determines if the current time is within the second bang segment for the no coast option.
- @return bool
- @param t [s] Current simulation time
-*/
-bool PrescribedLinearTranslation::isInSecondBangSegmentNoCoast(double t) const {
-    return (t > this->t_b1 && t <= this->t_f && this->t_f - this->tInit != 0);
-}
-
-/*! This method determines if the current time is within the second bang segment for the coast option.
+/*! This method determines if the current time is within the second bang segment.
  @return bool
  @param t [s] Current simulation time
 */

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -137,7 +137,7 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime)
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInFirstBangSegment(double t) const {
-    return (t <= this->tr && this->tf - this->tInit != 0);
+    return (t <= this->t_r && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the coast segment for the coast option.
@@ -145,7 +145,7 @@ bool PrescribedLinearTranslation::isInFirstBangSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInCoastSegment(double t) const {
-    return (t > this->tr && t <= this->tc && this->tf - this->tInit != 0);
+    return (t > this->t_r && t <= this->t_c && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the coast option.
@@ -153,7 +153,7 @@ bool PrescribedLinearTranslation::isInCoastSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInSecondBangSegment(double t) const {
-    return (t > this->tc && t <= this->tf && this->tf - this->tInit != 0);
+    return (t > this->t_c && t <= this->t_f && this->t_f - this->tInit != 0);
 }
 
 /*! This method computes the required parameters for the translation with a coast period.
@@ -162,7 +162,7 @@ bool PrescribedLinearTranslation::isInSecondBangSegment(double t) const {
 void PrescribedLinearTranslation::computeCoastParameters() {
     if (this->transPosInit != this->transPosRef) {
         // Determine the time at the end of the first bang segment
-        this->tr = this->tInit + this->coastOptionBangDuration;
+        this->t_r = this->tInit + this->coastOptionBangDuration;
 
         // Determine the position and velocity at the end of the bang segment/start of the coast segment
         if (this->transPosInit < this->transPosRef) {
@@ -183,20 +183,20 @@ void PrescribedLinearTranslation::computeCoastParameters() {
         double tCoast = fabs(deltaPosCoast) / fabs(this->transVel_tr);
 
         // Determine the time at the end of the coast segment
-        this->tc = this->tr + tCoast;
+        this->t_c = this->t_r + tCoast;
 
         // Determine the position [m] at the end of the coast segment
         double transPos_tc = this->transPos_tr + deltaPosCoast;
 
         // Determine the time at the end of the translation
-        this->tf = this->tc + this->coastOptionBangDuration;
+        this->t_f = this->t_c + this->coastOptionBangDuration;
 
         // Define the parabolic constants for the first and second bang segments of the translation
-        this->a = (this->transPos_tr - this->transPosInit) / ((this->tr - this->tInit) * (this->tr - this->tInit));
-        this->b = -(this->transPosRef - transPos_tc) / ((this->tc - this->tf) * (this->tc - this->tf));
+        this->a = (this->transPos_tr - this->transPosInit) / ((this->t_r - this->tInit) * (this->t_r - this->tInit));
+        this->b = -(this->transPosRef - transPos_tc) / ((this->t_c - this->t_f) * (this->t_c - this->t_f));
     } else {
         // If the initial position equals the reference position, no translation is required.
-        this->tf = this->tInit;
+        this->t_f = this->tInit;
     }
 }
 
@@ -207,7 +207,7 @@ void PrescribedLinearTranslation::computeCoastParameters() {
 void PrescribedLinearTranslation::computeCoastSegment(double t) {
     this->transAccel = 0.0;
     this->transVel = this->transVel_tr;
-    this->transPos = this->transVel_tr * (t - this->tr) + this->transPos_tr;
+    this->transPos = this->transVel_tr * (t - this->t_r) + this->transPos_tr;
 }
 
 /*! This method determines if the current time is within the first bang segment for the no coast option.
@@ -215,7 +215,7 @@ void PrescribedLinearTranslation::computeCoastSegment(double t) {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInFirstBangSegmentNoCoast(double t) const {
-    return (t <= this->ts && this->tf - this->tInit != 0);
+    return (t <= this->t_s && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the no coast option.
@@ -223,7 +223,7 @@ bool PrescribedLinearTranslation::isInFirstBangSegmentNoCoast(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedLinearTranslation::isInSecondBangSegmentNoCoast(double t) const {
-    return (t > this->ts && t <= this->tf && this->tf - this->tInit != 0);
+    return (t > this->t_s && t <= this->t_f && this->t_f - this->tInit != 0);
 }
 
 /*! This method computes the required parameters for the translation with no coast period.
@@ -234,14 +234,14 @@ void PrescribedLinearTranslation::computeParametersNoCoast() {
     double totalTransTime = sqrt(((0.5 * fabs(this->transPosRef - this->transPosInit)) * 8) / this->transAccelMax);
 
     // Determine the time at the end of the translation
-    this->tf = this->tInit + totalTransTime;
+    this->t_f = this->tInit + totalTransTime;
 
     // Determine the time halfway through the translation
-    this->ts = this->tInit + (totalTransTime / 2);
+    this->t_s = this->tInit + (totalTransTime / 2);
 
     // Define the parabolic constants for the first and second half of the translation
-    this->a = 0.5 * (this->transPosRef - this->transPosInit) / ((this->ts - this->tInit) * (this->ts - this->tInit));
-    this->b = -0.5 * (this->transPosRef - this->transPosInit) / ((this->ts - this->tf) * (this->ts - this->tf));
+    this->a = 0.5 * (this->transPosRef - this->transPosInit) / ((this->t_s - this->tInit) * (this->t_s - this->tInit));
+    this->b = -0.5 * (this->transPosRef - this->transPosInit) / ((this->t_s - this->t_f) * (this->t_s - this->t_f));
 }
 
 /*! This method computes the scalar translational states for the first bang segment. The acceleration during the first
@@ -272,8 +272,8 @@ void PrescribedLinearTranslation::computeSecondBangSegment(double t) {
     } else {
         this->transAccel = this->transAccelMax;
     }
-    this->transVel = this->transAccel * (t - this->tInit) - this->transAccel * (this->tf - this->tInit);
-    this->transPos = this->b * (t - this->tf) * (t - this->tf) + this->transPosRef;
+    this->transVel = this->transAccel * (t - this->tInit) - this->transAccel * (this->t_f - this->tInit);
+    this->transPos = this->b * (t - this->t_f) * (t - this->t_f) + this->transPosRef;
 }
 
 /*! This method computes the scalar translational states when the translation is complete.

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -76,9 +76,9 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime) {
 
         // Set the parameters required to profile the translation
         if (this->coastOptionBangDuration > 0.0) {
-            this->computeCoastParameters();
+            this->computeBangCoastBangParametersNoSmoothing();
         } else {
-            this->computeParametersNoCoast();
+            this->computeBangBangParametersNoSmoothing();
         }
 
         // Set the convergence to false until the translation is complete
@@ -95,7 +95,7 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime) {
 /*! This method computes the required parameters for the translation with no coast period.
  @return void
 */
-void PrescribedLinearTranslation::computeParametersNoCoast() {
+void PrescribedLinearTranslation::computeBangBangParametersNoSmoothing() {
     // Determine the total time required for the translation
     double totalTransTime = sqrt(((0.5 * fabs(this->transPosRef - this->transPosInit)) * 8) / this->transAccelMax);
 
@@ -113,7 +113,7 @@ void PrescribedLinearTranslation::computeParametersNoCoast() {
 /*! This method computes the required parameters for the translation with a coast period.
  @return void
 */
-void PrescribedLinearTranslation::computeCoastParameters() {
+void PrescribedLinearTranslation::computeBangCoastBangParametersNoSmoothing() {
     if (this->transPosInit != this->transPosRef) {
         // Determine the time at the end of the first bang segment
         this->t_r = this->tInit + this->coastOptionBangDuration;

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -92,22 +92,24 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime) {
     this->writeOutputMessages(callTime);
 }
 
-/*! This method computes the required parameters for the translation with no coast period.
+/*! This method computes the required parameters for the translation with a non-smoothed bang-bang acceleration profile.
  @return void
 */
 void PrescribedLinearTranslation::computeBangBangParametersNoSmoothing() {
     // Determine the total time required for the translation
-    double totalTransTime = sqrt(((0.5 * fabs(this->transPosRef - this->transPosInit)) * 8) / this->transAccelMax);
+    double totalTransTime = sqrt(((0.5 * fabs(this->transPosRef - this->transPosInit)) * 8.0) / this->transAccelMax);
 
-    // Determine the time at the end of the translation
+    // Determine the time when the translation is complete t_f
     this->t_f = this->tInit + totalTransTime;
 
     // Determine the time halfway through the translation
-    this->t_b1 = this->tInit + (totalTransTime / 2);
+    this->t_b1 = this->tInit + (totalTransTime / 2.0);
 
     // Define the parabolic constants for the first and second half of the translation
-    this->a = 0.5 * (this->transPosRef - this->transPosInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
-    this->b = -0.5 * (this->transPosRef - this->transPosInit) / ((this->t_b1 - this->t_f) * (this->t_b1 - this->t_f));
+    this->a = 0.5 * (this->transPosRef - this->transPosInit)
+              / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
+    this->b = -0.5 * (this->transPosRef - this->transPosInit)
+              / ((this->t_b1 - this->t_f) * (this->t_b1 - this->t_f));
 }
 
 /*! This method computes the required parameters for the translation with a coast period.

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -37,12 +37,12 @@ public:
     void SelfInit() override;                                               //!< Member function to initialize the C-wrapped output message
     void Reset(uint64_t CurrentSimNanos) override;                          //!< Reset member function
     void UpdateState(uint64_t CurrentSimNanos) override;                    //!< Update member function
-    void setCoastOptionRampDuration(double rampDuration);                   //!< Setter method for the coast option ramp duration
-    void setTransAccelMax(double transAccelMax);                            //!< Setter method for the ramp segment scalar linear acceleration
+    void setCoastOptionBangDuration(double bangDuration);                   //!< Setter method for the coast option bang duration
+    void setTransAccelMax(double transAccelMax);                            //!< Setter method for the bang segment scalar linear acceleration
     void setTransHat_M(const Eigen::Vector3d &transHat_M);                  //!< Setter method for the translating body axis of translation
     void setTransPosInit(double transPosInit);                              //!< Setter method for the initial translating body hub-relative position
-    double getCoastOptionRampDuration() const;                              //!< Getter method for the coast option ramp duration
-    double getTransAccelMax() const;                                        //!< Getter method for the ramp segment scalar linear acceleration
+    double getCoastOptionBangDuration() const;                              //!< Getter method for the coast option bang duration
+    double getTransAccelMax() const;                                        //!< Getter method for the bang segment scalar linear acceleration
     const Eigen::Vector3d &getTransHat_M() const;                           //!< Getter method for the translating body axis of translation
     double getTransPosInit() const;                                         //!< Getter method for the initial translating body position
     
@@ -55,31 +55,31 @@ public:
 private:
 
     /* Coast option member functions */
-    bool isInFirstRampSegment(double time) const;               //!< Method for determining if the current time is within the first ramp segment for the coast option
+    bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
     bool isInCoastSegment(double time) const;                   //!< Method for determining if the current time is within the coast segment for the coast option
-    bool isInSecondRampSegment(double time) const;              //!< Method for determining if the current time is within the second ramp segment for the coast option
+    bool isInSecondBangSegment(double time) const;              //!< Method for determining if the current time is within the second bang segment for the coast option
     void computeCoastParameters();                              //!< Method for computing the required parameters for the translation with a coast period
     void computeCoastSegment(double time);                      //!< Method for computing the scalar translational states for the coast option coast period
 
     /* Non-coast option member functions */
-    bool isInFirstRampSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first ramp segment for the no coast option
-    bool isInSecondRampSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second ramp segment for the no coast option
+    bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
+    bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option
     void computeParametersNoCoast();                            //!< Method for computing the required parameters for the translation with no coast period
 
     /* Shared member functions */
-    void computeFirstRampSegment(double time);                  //!< Method for computing the scalar translational states for the first ramp segment
-    void computeSecondRampSegment(double time);                 //!< Method for computing the scalar translational states for the second ramp segment
+    void computeFirstBangSegment(double time);                  //!< Method for computing the scalar translational states for the first bang segment
+    void computeSecondBangSegment(double time);                 //!< Method for computing the scalar translational states for the second bang segment
     void computeTranslationComplete();                          //!< Method for computing the scalar translational states when the translation is complete
 
     /* User-configurable variables */
-    double coastOptionRampDuration;                             //!< [s] Ramp time used for the coast option
+    double coastOptionBangDuration;                             //!< [s] Bang time used for the coast option
     double transAccelMax;                                       //!< [m/s^2] Maximum acceleration magnitude
     Eigen::Vector3d transHat_M;                                 //!< Axis along the direction of translation expressed in M frame components
 
     /* Coast option variables */
-    double transPos_tr;                                         //!< [m] Position at the end of the first ramp segment
-    double transVel_tr;                                         //!< [m/s] Velocity at the end of the first ramp segment
-    double tr;                                                  //!< [s] The simulation time at the end of the first ramp segment
+    double transPos_tr;                                         //!< [m] Position at the end of the first bang segment
+    double transVel_tr;                                         //!< [m/s] Velocity at the end of the first bang segment
+    double tr;                                                  //!< [s] The simulation time at the end of the first bang segment
     double tc;                                                  //!< [s] The simulation time at the end of the coast period
 
     /* Non-coast option variables */

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -81,8 +81,8 @@ private:
     double transPos;                                                            //!< [m] Current translational body position along transHat_M
     double transVel;                                                            //!< [m] Current translational body velocity along transHat_M
     double transAccel;                                                          //!< [m] Current translational body acceleration along transHat_M
-    double transPos_tr;                                                         //!< [m] Position at the end of the first bang segment
-    double transVel_tr;                                                         //!< [m/s] Velocity at the end of the first bang segment
+    double transPos_tb1;                                                        //!< [m] Position at the end of the first bang segment
+    double transVel_tb1;                                                        //!< [m/s] Velocity at the end of the first bang segment
 
     /* Temporal parameters */
     double tInit;                                                               //!< [s] Simulation time at the beginning of the translation

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -58,13 +58,11 @@ private:
 
     /* Methods for computing the current translational states */
     void computeCurrentState(double time);                                      //!< Intermediate method used to group the calculation of the current translational states into a single method
-    bool isInFirstBangSegmentNoCoast(double time) const;                        //!< Method for determining if the current time is within the first bang segment for the no coast option
-    bool isInFirstBangSegment(double time) const;                               //!< Method for determining if the current time is within the first bang segment for the coast option
-    bool isInSecondBangSegmentNoCoast(double time) const;                       //!< Method for determining if the current time is within the second bang segment for the no coast option
-    bool isInSecondBangSegment(double time) const;                              //!< Method for determining if the current time is within the second bang segment for the coast option
+    bool isInFirstBangSegment(double time) const;                               //!< Method for determining if the current time is within the first bang segment
+    bool isInSecondBangSegment(double time) const;                              //!< Method for determining if the current time is within the second bang segment
     bool isInCoastSegment(double time) const;                                   //!< Method for determining if the current time is within the coast segment for the coast option
-    void computeFirstBangSegment(double time);                                  //!< Method for computing the scalar translational states for the first bang segment
-    void computeSecondBangSegment(double time);                                 //!< Method for computing the scalar translational states for the second bang segment
+    void computeFirstBangSegment(double time);                                  //!< Method for computing the first bang segment scalar translational states
+    void computeSecondBangSegment(double time);                                 //!< Method for computing the second bang segment scalar translational states
     void computeCoastSegment(double time);                                      //!< Method for computing the scalar translational states for the coast option coast period
     void computeTranslationComplete();                                          //!< Method for computing the scalar translational states when the translation is complete
 

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -79,11 +79,11 @@ private:
     /* Coast option variables */
     double transPos_tr;                                         //!< [m] Position at the end of the first bang segment
     double transVel_tr;                                         //!< [m/s] Velocity at the end of the first bang segment
-    double tr;                                                  //!< [s] The simulation time at the end of the first bang segment
-    double tc;                                                  //!< [s] The simulation time at the end of the coast period
+    double t_r;                                                 //!< [s] The simulation time at the end of the first bang segment
+    double t_c;                                                 //!< [s] The simulation time at the end of the coast period
 
     /* Non-coast option variables */
-    double ts;                                                  //!< [s] The simulation time halfway through the translation
+    double t_s;                                                 //!< [s] The simulation time halfway through the translation
 
     /* Shared module variables */
     double transPos;                                            //!< [m] Current translational body position along transHat_M
@@ -93,7 +93,7 @@ private:
     double tInit;                                               //!< [s] Simulation time at the beginning of the translation
     double transPosInit;                                        //!< [m] Initial translational body position from M to F frame origin along transHat_M
     double transPosRef;                                         //!< [m] Reference translational body position from M to F frame origin along transHat_M
-    double tf;                                                  //!< [s] The simulation time when the translation is complete
+    double t_f;                                                 //!< [s] The simulation time when the translation is complete
     double a;                                                   //!< Parabolic constant for the first half of the translation
     double b;                                                   //!< Parabolic constant for the second half of the translation
 };

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -30,71 +30,70 @@
 /*! @brief Prescribed Linear Translation Profiler Class */
 class PrescribedLinearTranslation: public SysModel {
 public:
+    PrescribedLinearTranslation() = default;                                    //!< Constructor
+    ~PrescribedLinearTranslation() = default;                                   //!< Destructor
 
-    PrescribedLinearTranslation() = default;                                //!< Constructor
-    ~PrescribedLinearTranslation() = default;                               //!< Destructor
+    void SelfInit() override;                                                   //!< Member function to initialize the C-wrapped output message
+    void Reset(uint64_t CurrentSimNanos) override;                              //!< Reset member function
+    void UpdateState(uint64_t CurrentSimNanos) override;                        //!< Update member function
+    void setCoastOptionBangDuration(double bangDuration);                       //!< Setter method for the coast option bang duration
+    void setTransAccelMax(double transAccelMax);                                //!< Setter method for the bang segment scalar linear acceleration
+    void setTransHat_M(const Eigen::Vector3d &transHat_M);                      //!< Setter method for the translating body axis of translation
+    void setTransPosInit(double transPosInit);                                  //!< Setter method for the initial translating body hub-relative position
+    double getCoastOptionBangDuration() const;                                  //!< Getter method for the coast option bang duration
+    double getTransAccelMax() const;                                            //!< Getter method for the bang segment scalar linear acceleration
+    const Eigen::Vector3d &getTransHat_M() const;                               //!< Getter method for the translating body axis of translation
+    double getTransPosInit() const;                                             //!< Getter method for the initial translating body position
 
-    void SelfInit() override;                                               //!< Member function to initialize the C-wrapped output message
-    void Reset(uint64_t CurrentSimNanos) override;                          //!< Reset member function
-    void UpdateState(uint64_t CurrentSimNanos) override;                    //!< Update member function
-    void setCoastOptionBangDuration(double bangDuration);                   //!< Setter method for the coast option bang duration
-    void setTransAccelMax(double transAccelMax);                            //!< Setter method for the bang segment scalar linear acceleration
-    void setTransHat_M(const Eigen::Vector3d &transHat_M);                  //!< Setter method for the translating body axis of translation
-    void setTransPosInit(double transPosInit);                              //!< Setter method for the initial translating body hub-relative position
-    double getCoastOptionBangDuration() const;                              //!< Getter method for the coast option bang duration
-    double getTransAccelMax() const;                                        //!< Getter method for the bang segment scalar linear acceleration
-    const Eigen::Vector3d &getTransHat_M() const;                           //!< Getter method for the translating body axis of translation
-    double getTransPosInit() const;                                         //!< Getter method for the initial translating body position
-    
     ReadFunctor<LinearTranslationRigidBodyMsgPayload> linearTranslationRigidBodyInMsg;    //!< Input msg for the translational reference position and velocity
     Message<PrescribedTranslationMsgPayload> prescribedTranslationOutMsg;                 //!< Output msg for the translational body prescribed states
     PrescribedTranslationMsg_C prescribedTranslationOutMsgC = {};                         //!< C-wrapped Output msg for the translational body prescribed states
 
-    BSKLogger *bskLogger;                                                   //!< BSK Logging
+    BSKLogger *bskLogger;                                                       //!< BSK Logging
 
 private:
     /* Methods for computing the required translation parameters */
-    void computeParametersNoCoast();                                        //!< Method for computing the required parameters for the translation with no coast period
-    void computeCoastParameters();                                          //!< Method for computing the required parameters for the translation with a coast period
+    void computeParametersNoCoast();                                            //!< Method for computing the required parameters for the translation with no coast period
+    void computeCoastParameters();                                              //!< Method for computing the required parameters for the translation with a coast period
 
     /* Methods for computing the current translational states */
-    void computeCurrentState(double time);                                  //!< Intermediate method used to group the calculation of the current translational states into a single method
-    bool isInFirstBangSegmentNoCoast(double time) const;                    //!< Method for determining if the current time is within the first bang segment for the no coast option
-    bool isInFirstBangSegment(double time) const;                           //!< Method for determining if the current time is within the first bang segment for the coast option
-    bool isInSecondBangSegmentNoCoast(double time) const;                   //!< Method for determining if the current time is within the second bang segment for the no coast option
-    bool isInSecondBangSegment(double time) const;                          //!< Method for determining if the current time is within the second bang segment for the coast option
-    bool isInCoastSegment(double time) const;                               //!< Method for determining if the current time is within the coast segment for the coast option
-    void computeFirstBangSegment(double time);                              //!< Method for computing the scalar translational states for the first bang segment
-    void computeSecondBangSegment(double time);                             //!< Method for computing the scalar translational states for the second bang segment
-    void computeCoastSegment(double time);                                  //!< Method for computing the scalar translational states for the coast option coast period
-    void computeTranslationComplete();                                      //!< Method for computing the scalar translational states when the translation is complete
+    void computeCurrentState(double time);                                      //!< Intermediate method used to group the calculation of the current translational states into a single method
+    bool isInFirstBangSegmentNoCoast(double time) const;                        //!< Method for determining if the current time is within the first bang segment for the no coast option
+    bool isInFirstBangSegment(double time) const;                               //!< Method for determining if the current time is within the first bang segment for the coast option
+    bool isInSecondBangSegmentNoCoast(double time) const;                       //!< Method for determining if the current time is within the second bang segment for the no coast option
+    bool isInSecondBangSegment(double time) const;                              //!< Method for determining if the current time is within the second bang segment for the coast option
+    bool isInCoastSegment(double time) const;                                   //!< Method for determining if the current time is within the coast segment for the coast option
+    void computeFirstBangSegment(double time);                                  //!< Method for computing the scalar translational states for the first bang segment
+    void computeSecondBangSegment(double time);                                 //!< Method for computing the scalar translational states for the second bang segment
+    void computeCoastSegment(double time);                                      //!< Method for computing the scalar translational states for the coast option coast period
+    void computeTranslationComplete();                                          //!< Method for computing the scalar translational states when the translation is complete
 
-    void writeOutputMessages(uint64_t CurrentSimNanos);                     //!< Method for writing the module output messages and computing the output message data
+    void writeOutputMessages(uint64_t CurrentSimNanos);                         //!< Method for writing the module output messages and computing the output message data
 
     /* User-configurable variables */
-    double coastOptionBangDuration;                                         //!< [s] Bang time used for the coast option
-    double transAccelMax;                                                   //!< [m/s^2] Maximum acceleration magnitude
-    Eigen::Vector3d transHat_M;                                             //!< Axis along the direction of translation expressed in M frame components
+    double coastOptionBangDuration;                                             //!< [s] Time used for the coast option bang segment
+    double transAccelMax;                                                       //!< [m/s^2] Maximum acceleration magnitude
+    Eigen::Vector3d transHat_M;                                                 //!< Axis along the direction of translation expressed in M frame components
 
     /* Scalar translational states */
-    double transPosInit;                                                    //!< [m] Initial translational body position from M to F frame origin along transHat_M
-    double transPosRef;                                                     //!< [m] Reference translational body position from M to F frame origin along transHat_M
-    double transPos;                                                        //!< [m] Current translational body position along transHat_M
-    double transVel;                                                        //!< [m] Current translational body velocity along transHat_M
-    double transAccel;                                                      //!< [m] Current translational body acceleration along transHat_M
-    double transPos_tr;                                                     //!< [m] Position at the end of the first bang segment
-    double transVel_tr;                                                     //!< [m/s] Velocity at the end of the first bang segment
+    double transPosInit;                                                        //!< [m] Initial translational body position from M to F frame origin along transHat_M
+    double transPosRef;                                                         //!< [m] Reference translational body position from M to F frame origin along transHat_M
+    double transPos;                                                            //!< [m] Current translational body position along transHat_M
+    double transVel;                                                            //!< [m] Current translational body velocity along transHat_M
+    double transAccel;                                                          //!< [m] Current translational body acceleration along transHat_M
+    double transPos_tr;                                                         //!< [m] Position at the end of the first bang segment
+    double transVel_tr;                                                         //!< [m/s] Velocity at the end of the first bang segment
 
     /* Temporal parameters */
-    double tInit;                                                           //!< [s] Simulation time at the beginning of the translation
-    double t_r;                                                             //!< [s] The simulation time at the end of the first bang segment
-    double t_s;                                                             //!< [s] The simulation time halfway through the translation
-    double t_c;                                                             //!< [s] The simulation time at the end of the coast period
-    double t_f;                                                             //!< [s] The simulation time when the translation is complete
+    double tInit;                                                               //!< [s] Simulation time at the beginning of the translation
+    double t_r;                                                                 //!< [s] The simulation time at the end of the first bang segment
+    double t_s;                                                                 //!< [s] The simulation time halfway through the translation
+    double t_c;                                                                 //!< [s] Simulation time at the end of the coast segment
+    double t_f;                                                                 //!< [s] Simulation time when the translation is complete
 
-    bool convergence;                                                       //!< Boolean variable is true when the translation is complete
-    double a;                                                               //!< Parabolic constant for the first half of the translation
-    double b;                                                               //!< Parabolic constant for the second half of the translation
+    bool convergence;                                                           //!< Boolean variable is true when the translation is complete
+    double a;                                                                   //!< Parabolic constant for the first half of the bang-bang non-smoothed translation
+    double b;                                                                   //!< Parabolic constant for the second half of the bang-bang non-smoothed translation
 };
 
 #endif

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -37,10 +37,12 @@ public:
     void Reset(uint64_t CurrentSimNanos) override;                              //!< Reset member function
     void UpdateState(uint64_t CurrentSimNanos) override;                        //!< Update member function
     void setCoastOptionBangDuration(double bangDuration);                       //!< Setter method for the coast option bang duration
+    void setSmoothingDuration(double smoothingDuration);                        //!< Setter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
     void setTransAccelMax(double transAccelMax);                                //!< Setter method for the bang segment scalar linear acceleration
     void setTransHat_M(const Eigen::Vector3d &transHat_M);                      //!< Setter method for the translating body axis of translation
     void setTransPosInit(double transPosInit);                                  //!< Setter method for the initial translating body hub-relative position
     double getCoastOptionBangDuration() const;                                  //!< Getter method for the coast option bang duration
+    double getSmoothingDuration() const;                                        //!< Getter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
     double getTransAccelMax() const;                                            //!< Getter method for the bang segment scalar linear acceleration
     const Eigen::Vector3d &getTransHat_M() const;                               //!< Getter method for the translating body axis of translation
     double getTransPosInit() const;                                             //!< Getter method for the initial translating body position
@@ -56,21 +58,32 @@ private:
     void computeTranslationParameters();                                        //!< Intermediate method to group the calculation of translation parameters into a single method
     void computeBangBangParametersNoSmoothing();                                //!< Method for computing the required parameters for the non-smoothed bang-bang profiler option
     void computeBangCoastBangParametersNoSmoothing();                           //!< Method for computing the required parameters for the non-smoothed bang-coast-bang profiler option
+    void computeSmoothedBangBangParameters();                                   //!< Method for computing the required parameters for the translation with a smoothed bang-bang acceleration profile
+    void computeSmoothedBangCoastBangParameters();                              //!< Method for computing the required parameters for the smoothed bang-coast-bang option
 
     /* Methods for computing the current translational states */
     void computeCurrentState(double time);                                      //!< Intermediate method used to group the calculation of the current translational states into a single method
     bool isInFirstBangSegment(double time) const;                               //!< Method for determining if the current time is within the first bang segment
     bool isInSecondBangSegment(double time) const;                              //!< Method for determining if the current time is within the second bang segment
-    bool isInCoastSegment(double time) const;                                   //!< Method for determining if the current time is within the coast segment for the coast option
+    bool isInFirstSmoothedSegment(double time) const;                           //!< Method for determining if the current time is within the first smoothing segment for the smoothed profiler options
+    bool isInSecondSmoothedSegment(double time) const;                          //!< Method for determining if the current time is within the second smoothing segment for the smoothed profiler options
+    bool isInThirdSmoothedSegment(double time) const;                           //!< Method for determining if the current time is within the third smoothing segment for the smoothed profiler options
+    bool isInFourthSmoothedSegment(double time) const;                          //!< Method for determining if the current time is within the fourth smoothing segment for the smoothed bang-coast-bang option
+    bool isInCoastSegment(double time) const;                                   //!< Method for determining if the current time is within the coast segment
     void computeFirstBangSegment(double time);                                  //!< Method for computing the first bang segment scalar translational states
     void computeSecondBangSegment(double time);                                 //!< Method for computing the second bang segment scalar translational states
-    void computeCoastSegment(double time);                                      //!< Method for computing the scalar translational states for the coast option coast period
+    void computeFirstSmoothedSegment(double time);                              //!< Method for computing the first smoothing segment scalar translational states for the smoothed profiler options
+    void computeSecondSmoothedSegment(double time);                             //!< Method for computing the second smoothing segment scalar translational states for the smoothed profiler options
+    void computeThirdSmoothedSegment(double time);                              //!< Method for computing the third smoothing segment scalar translational states for the smoothed profiler options
+    void computeFourthSmoothedSegment(double time);                             //!< Method for computing the fourth smoothing segment scalar translational states for the smoothed bang-coast-bang option
+    void computeCoastSegment(double time);                                      //!< Method for computing the coast segment scalar translational states
     void computeTranslationComplete();                                          //!< Method for computing the scalar translational states when the translation is complete
 
     void writeOutputMessages(uint64_t CurrentSimNanos);                         //!< Method for writing the module output messages and computing the output message data
 
     /* User-configurable variables */
     double coastOptionBangDuration;                                             //!< [s] Time used for the coast option bang segment
+    double smoothingDuration;                                                   //!< [s] Time the acceleration is smoothed to the given maximum acceleration value
     double transAccelMax;                                                       //!< [m/s^2] Maximum acceleration magnitude
     Eigen::Vector3d transHat_M;                                                 //!< Axis along the direction of translation expressed in M frame components
 
@@ -82,10 +95,24 @@ private:
     double transAccel;                                                          //!< [m] Current translational body acceleration along transHat_M
     double transPos_tb1;                                                        //!< [m] Position at the end of the first bang segment
     double transVel_tb1;                                                        //!< [m/s] Velocity at the end of the first bang segment
+    double transPos_tb2;                                                        //!< [m] Position at the end of the second bang segment
+    double transVel_tb2;                                                        //!< [m/s] Velocity at the end of the second bang segment
+    double transPos_ts1;                                                        //!< [m] Position at the end of the first smoothed segment
+    double transVel_ts1;                                                        //!< [m/s] Velocity at the end of the first smoothed segment
+    double transPos_ts2;                                                        //!< [m] Position at the end of the second smoothed segment
+    double transVel_ts2;                                                        //!< [m/s] Velocity at the end of the second smoothed segment
+    double transPos_ts3;                                                        //!< [m] Position at the end of the third smoothed segment
+    double transVel_ts3;                                                        //!< [m/s] Velocity at the end of the third smoothed segment
+    double transPos_tc;                                                         //!< [m] Position at the end of the coast segment
+    double transVel_tc;                                                         //!< [m/s] Velocity at the end of the coast segment
 
     /* Temporal parameters */
     double tInit;                                                               //!< [s] Simulation time at the beginning of the translation
     double t_b1;                                                                //!< [s] Simulation time at the end of the first bang segment
+    double t_b2;                                                                //!< [s] Simulation time at the end of the second bang segment
+    double t_s1;                                                                //!< [s] Simulation time at the end of the first smoothed segment
+    double t_s2;                                                                //!< [s] Simulation time at the end of the second smoothed segment
+    double t_s3;                                                                //!< [s] Simulation time at the end of the third smoothed segment
     double t_c;                                                                 //!< [s] Simulation time at the end of the coast segment
     double t_f;                                                                 //!< [s] Simulation time when the translation is complete
 

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -53,6 +53,7 @@ public:
 
 private:
     /* Methods for computing the required translation parameters */
+    void computeTranslationParameters();                                        //!< Intermediate method to group the calculation of translation parameters into a single method
     void computeBangBangParametersNoSmoothing();                                //!< Method for computing the required parameters for the non-smoothed bang-bang profiler option
     void computeBangCoastBangParametersNoSmoothing();                           //!< Method for computing the required parameters for the non-smoothed bang-coast-bang profiler option
 

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -68,6 +68,8 @@ private:
     void computeCoastSegment(double time);                                  //!< Method for computing the scalar translational states for the coast option coast period
     void computeTranslationComplete();                                      //!< Method for computing the scalar translational states when the translation is complete
 
+    void writeOutputMessages(uint64_t CurrentSimNanos);                     //!< Method for writing the module output messages and computing the output message data
+
     /* User-configurable variables */
     double coastOptionBangDuration;                                         //!< [s] Bang time used for the coast option
     double transAccelMax;                                                   //!< [m/s^2] Maximum acceleration magnitude

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -53,49 +53,45 @@ public:
     BSKLogger *bskLogger;                                                   //!< BSK Logging
 
 private:
+    /* Methods for computing the required translation parameters */
+    void computeParametersNoCoast();                                        //!< Method for computing the required parameters for the translation with no coast period
+    void computeCoastParameters();                                          //!< Method for computing the required parameters for the translation with a coast period
 
-    /* Coast option member functions */
-    bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
-    bool isInCoastSegment(double time) const;                   //!< Method for determining if the current time is within the coast segment for the coast option
-    bool isInSecondBangSegment(double time) const;              //!< Method for determining if the current time is within the second bang segment for the coast option
-    void computeCoastParameters();                              //!< Method for computing the required parameters for the translation with a coast period
-    void computeCoastSegment(double time);                      //!< Method for computing the scalar translational states for the coast option coast period
-
-    /* Non-coast option member functions */
-    bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
-    bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option
-    void computeParametersNoCoast();                            //!< Method for computing the required parameters for the translation with no coast period
-
-    /* Shared member functions */
-    void computeFirstBangSegment(double time);                  //!< Method for computing the scalar translational states for the first bang segment
-    void computeSecondBangSegment(double time);                 //!< Method for computing the scalar translational states for the second bang segment
-    void computeTranslationComplete();                          //!< Method for computing the scalar translational states when the translation is complete
+    /* Methods for computing the current translational states */
+    bool isInFirstBangSegmentNoCoast(double time) const;                    //!< Method for determining if the current time is within the first bang segment for the no coast option
+    bool isInFirstBangSegment(double time) const;                           //!< Method for determining if the current time is within the first bang segment for the coast option
+    bool isInSecondBangSegmentNoCoast(double time) const;                   //!< Method for determining if the current time is within the second bang segment for the no coast option
+    bool isInSecondBangSegment(double time) const;                          //!< Method for determining if the current time is within the second bang segment for the coast option
+    bool isInCoastSegment(double time) const;                               //!< Method for determining if the current time is within the coast segment for the coast option
+    void computeFirstBangSegment(double time);                              //!< Method for computing the scalar translational states for the first bang segment
+    void computeSecondBangSegment(double time);                             //!< Method for computing the scalar translational states for the second bang segment
+    void computeCoastSegment(double time);                                  //!< Method for computing the scalar translational states for the coast option coast period
+    void computeTranslationComplete();                                      //!< Method for computing the scalar translational states when the translation is complete
 
     /* User-configurable variables */
-    double coastOptionBangDuration;                             //!< [s] Bang time used for the coast option
-    double transAccelMax;                                       //!< [m/s^2] Maximum acceleration magnitude
-    Eigen::Vector3d transHat_M;                                 //!< Axis along the direction of translation expressed in M frame components
+    double coastOptionBangDuration;                                         //!< [s] Bang time used for the coast option
+    double transAccelMax;                                                   //!< [m/s^2] Maximum acceleration magnitude
+    Eigen::Vector3d transHat_M;                                             //!< Axis along the direction of translation expressed in M frame components
 
-    /* Coast option variables */
-    double transPos_tr;                                         //!< [m] Position at the end of the first bang segment
-    double transVel_tr;                                         //!< [m/s] Velocity at the end of the first bang segment
-    double t_r;                                                 //!< [s] The simulation time at the end of the first bang segment
-    double t_c;                                                 //!< [s] The simulation time at the end of the coast period
+    /* Scalar translational states */
+    double transPosInit;                                                    //!< [m] Initial translational body position from M to F frame origin along transHat_M
+    double transPosRef;                                                     //!< [m] Reference translational body position from M to F frame origin along transHat_M
+    double transPos;                                                        //!< [m] Current translational body position along transHat_M
+    double transVel;                                                        //!< [m] Current translational body velocity along transHat_M
+    double transAccel;                                                      //!< [m] Current translational body acceleration along transHat_M
+    double transPos_tr;                                                     //!< [m] Position at the end of the first bang segment
+    double transVel_tr;                                                     //!< [m/s] Velocity at the end of the first bang segment
 
-    /* Non-coast option variables */
-    double t_s;                                                 //!< [s] The simulation time halfway through the translation
+    /* Temporal parameters */
+    double tInit;                                                           //!< [s] Simulation time at the beginning of the translation
+    double t_r;                                                             //!< [s] The simulation time at the end of the first bang segment
+    double t_s;                                                             //!< [s] The simulation time halfway through the translation
+    double t_c;                                                             //!< [s] The simulation time at the end of the coast period
+    double t_f;                                                             //!< [s] The simulation time when the translation is complete
 
-    /* Shared module variables */
-    double transPos;                                            //!< [m] Current translational body position along transHat_M
-    double transVel;                                            //!< [m] Current translational body velocity along transHat_M
-    double transAccel;                                          //!< [m] Current translational body acceleration along transHat_M
-    bool convergence;                                           //!< Boolean variable is true when the translation is complete
-    double tInit;                                               //!< [s] Simulation time at the beginning of the translation
-    double transPosInit;                                        //!< [m] Initial translational body position from M to F frame origin along transHat_M
-    double transPosRef;                                         //!< [m] Reference translational body position from M to F frame origin along transHat_M
-    double t_f;                                                 //!< [s] The simulation time when the translation is complete
-    double a;                                                   //!< Parabolic constant for the first half of the translation
-    double b;                                                   //!< Parabolic constant for the second half of the translation
+    bool convergence;                                                       //!< Boolean variable is true when the translation is complete
+    double a;                                                               //!< Parabolic constant for the first half of the translation
+    double b;                                                               //!< Parabolic constant for the second half of the translation
 };
 
 #endif

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -53,8 +53,8 @@ public:
 
 private:
     /* Methods for computing the required translation parameters */
-    void computeParametersNoCoast();                                            //!< Method for computing the required parameters for the translation with no coast period
-    void computeCoastParameters();                                              //!< Method for computing the required parameters for the translation with a coast period
+    void computeBangBangParametersNoSmoothing();                                //!< Method for computing the required parameters for the non-smoothed bang-bang profiler option
+    void computeBangCoastBangParametersNoSmoothing();                           //!< Method for computing the required parameters for the non-smoothed bang-coast-bang profiler option
 
     /* Methods for computing the current translational states */
     void computeCurrentState(double time);                                      //!< Intermediate method used to group the calculation of the current translational states into a single method

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -86,8 +86,7 @@ private:
 
     /* Temporal parameters */
     double tInit;                                                               //!< [s] Simulation time at the beginning of the translation
-    double t_r;                                                                 //!< [s] The simulation time at the end of the first bang segment
-    double t_s;                                                                 //!< [s] The simulation time halfway through the translation
+    double t_b1;                                                                //!< [s] Simulation time at the end of the first bang segment
     double t_c;                                                                 //!< [s] Simulation time at the end of the coast segment
     double t_f;                                                                 //!< [s] Simulation time when the translation is complete
 

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -58,6 +58,7 @@ private:
     void computeCoastParameters();                                          //!< Method for computing the required parameters for the translation with a coast period
 
     /* Methods for computing the current translational states */
+    void computeCurrentState(double time);                                  //!< Intermediate method used to group the calculation of the current translational states into a single method
     bool isInFirstBangSegmentNoCoast(double time) const;                    //!< Method for determining if the current time is within the first bang segment for the no coast option
     bool isInFirstBangSegment(double time) const;                           //!< Method for determining if the current time is within the first bang segment for the coast option
     bool isInSecondBangSegmentNoCoast(double time) const;                   //!< Method for determining if the current time is within the second bang segment for the no coast option

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.rst
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.rst
@@ -4,21 +4,29 @@ This module profiles linear translational motion for a rigid body connected to a
 the translating body is designated by the frame :math:`\mathcal{F}`. The states of the translating body are profiled
 relative to a hub-fixed frame :math:`\mathcal{M}`. The :ref:`PrescribedTranslationMsgPayload` message is used to output
 the prescribed translational states from the module. The prescribed states profiled in this module are: ``r_FM_M``,
-``rPrime_FM_M``, and ``rPrimePrime_FM_M``. This module has two options to profile the linear translation.
+``rPrime_FM_M``, and ``rPrimePrime_FM_M``. This module has four options to profile the linear translation.
 The first option is a bang-bang acceleration profile that minimizes the time required to complete the translation.
-The second option is a bang-off-bang acceleration profile that adds a coast period of zero acceleration between the
-acceleration ramp segments. The module defaults to the bang-bang option with no coast period. If the coast option is
-desired, the user must set the ramp time module variable ``coastOptionRampDuration`` to a nonzero value.
+The second option is a bang-coast-bang acceleration profile that adds a coast period of zero acceleration between the
+acceleration ramp segments. The third option is a smoothed bang-bang acceleration profile that uses cubic splines to
+construct a continuous acceleration profile across the entire translation. The fourth option is a smoothed
+bang-coast-bang acceleration profile.
+
+The module defaults to the non-smoothed bang-bang option with no coast period. If the coast option is desired, the
+user must set the module variable ``coastOptionBangDuration`` to a nonzero value. If smoothing is desired,
+the module variable ``smoothingDuration`` must be set to a nonzero value.
 
 .. important::
     Note that this module assumes the initial and final hub-relative translational rates of the translating body are zero.
 
 The general inputs to this module that must be set by the user are the translational axis expressed as a
-unit vector in Mount frame components ``transHat_M``, the initial translational body position relative to the Mount
-frame ``transPosInit``, the reference position relative to the Mount frame ``transPosRef``, the maximum scalar linear
-acceleration for the translation ``transAccelMax``, and the ramp time variable ``coastOptionRampDuration`` for specifying
-the time the acceleration ramp segments are applied if the coast option is desired. This variable is defaulted to zero,
-meaning that the module defaults to the bang-bang acceleration profile with no coast period.
+unit vector in mount frame components ``transHat_M``, the initial translational body position relative to the hub-fixed
+mount frame ``transPosInit``, the reference position relative to the mount frame ``transPosRef``, and the maximum scalar
+linear acceleration for the translation ``transAccelMax``. The optional inputs ``coastOptionBangDuration`` and
+``smoothingDuration`` can be set by the user to select the specific type of profiler that is desired. If these variables
+are not set by the user, the module defaults to the non-smoothed bang-bang profiler. If only the variable
+``coastOptionBangDuration`` is set to a nonzero value, the bang-coast-bang profiler is selected. If only the variable
+``smoothingDuration`` is set to a nonzero value, the smoothed bang-bang profiler is selected. If both variables are
+set to nonzero values, the smoothed bang-coast-bang profiler is selected.
 
 .. important::
     To use this module for prescribed motion, it must be connected to the :ref:`PrescribedMotionStateEffector`
@@ -53,8 +61,8 @@ provides information on what this message is used for.
 Detailed Module Description
 ---------------------------
 
-Profiler With No Coast Period
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Non-Smoothed Bang-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The first option to profile the linear translation is a pure bang-bang acceleration profile. If the given reference 
 position is greater than the given initial position, the user-specified maximum acceleration value
@@ -80,7 +88,7 @@ To profile this motion, the translational body's hub-relative scalar states :mat
 where
 
 .. math::
-    a = \frac{ \rho_{\text{ref}} - \rho_0}{2 (t_s - t_0)^2}
+    a = \frac{ \rho_{\text{ref}} - \rho_0}{2 (t_{b1} - t_0)^2}
 
 During the second half of the translation the states are:
 
@@ -96,25 +104,25 @@ During the second half of the translation the states are:
 where
 
 .. math::
-    b = - \frac{ \rho_{\text{ref}} - \rho_0}{2 (t_s - t_f)^2}
+    b = - \frac{ \rho_{\text{ref}} - \rho_0}{2 (t_{b1} - t_f)^2}
 
-The switch time :math:`t_s` is the simulation time halfway through the translation:
+The switch time :math:`t_{b1}` is the simulation time at the end of the first bang segment:
 
 .. math::
-    t_s = t_0 + \frac{\Delta t_{\text{tot}}}{2}
+    t_{b1} = t_0 + \frac{\Delta t_{\text{tot}}}{2}
 
 The total time required to complete the translation :math:`\Delta t_{\text{tot}}` is:
 
 .. math::
     \Delta t_{\text{tot}} = 2 \sqrt{ \frac{| \rho_{\text{ref}} - \rho_0 | }{\ddot{\rho}_{\text{max}}}} = t_f - t_0
 
-Profiler With Coast Period
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Non-Smoothed Bang-Coast-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The second option to profile the linear translation is a bang-coast-bang acceleration profile with an added coast
 period between the acceleration segments where the acceleration is zero. Similar to the previous profiler, if the
 reference position is greater than the given initial position, the maximum acceleration value is applied
-positively for the specified ramp time ``coastOptionRampDuration`` to the first segment of the translation and negatively
+positively for the specified ramp time ``coastOptionBangDuration`` to the first segment of the translation and negatively
 to the third segment of the translation. The second segment of the translation is the coast period. However, if the
 reference position is less than the initial position, the acceleration is instead applied negatively during the first
 segment of the translation and positively during the third segment of the translation. As a result of this acceleration
@@ -138,16 +146,17 @@ To profile this linear motion, the scalar translating body's hub-relative states
 where
 
 .. math::
-    a = \frac{ \rho(t_r) - \rho_0}{2 (t_r - t_0)^2}
+    a = \frac{ \rho(t_{b1}) - \rho_0}{2 (t_{b1} - t_0)^2}
 
-and :math:`\rho(t_r)` is the hub-relative position at the end of the first segment:
+and :math:`\rho(t_{b1})` is the hub-relative position at the end of the first bang segment:
 
 .. math::
-    \rho(t_r) = \pm \frac{1}{2} \ddot{\rho}_{\text{max}} t_{\text{ramp}}^2 + \dot{\rho}_0 t_{\text{ramp}} + \rho_0
+    \rho(t_{b1}) = \pm \frac{1}{2} \ddot{\rho}_{\text{max}} t_{\text{bang}}^2 + \dot{\rho}_0 t_{\text{bang}} + \rho_0
 
 .. important::
-    Note the distinction between :math:`t_r` and :math:`t_{\text{ramp}}`. :math:`t_{\text{ramp}}` is the time duration of the acceleration segment
-    and :math:`t_r` is the simulation time at the end of the first acceleration segment. :math:`t_r = t_0 + t_{\text{ramp}}`
+    Note the distinction between :math:`t_{b1}` and :math:`t_{\text{bang}}`. :math:`t_{\text{bang}}` is the time
+    duration of the acceleration segment and :math:`t_{b1}` is the simulation time at the end of the first acceleration
+    segment. :math:`t_{b1} = t_0 + t_{\text{bang}}`
 
 During the coast segment, the translational states are:
 
@@ -155,10 +164,10 @@ During the coast segment, the translational states are:
     \ddot{\rho}(t) = 0
 
 .. math::
-    \dot{\rho}(t) = \dot{\rho}(t_r) = \ddot{\rho}_{\text{max}} t_{\text{ramp}} + \dot{\rho}_0
+    \dot{\rho}(t) = \dot{\rho}(t_{b1}) = \ddot{\rho}_{\text{max}} t_{\text{bang}} + \dot{\rho}_0
 
 .. math::
-    \rho(t) = \dot{\rho}(t_r) (t - t_r) + \rho(t_r)
+    \rho(t) = \dot{\rho}(t_{b1}) (t - t_{b1}) + \rho(t_{b1})
 
 During the third segment, the translational states are
 
@@ -179,60 +188,274 @@ where
 Here :math:`\rho(t_c)` is the hub-relative position at the end of the coast segment:
 
 .. math::
-    \rho(t_c) = \rho(t_r) + \Delta \rho_{\text{coast}}
+    \rho(t_c) = \rho(t_{b1}) + \Delta \rho_{\text{coast}}
 
 and :math:`\Delta \rho_{\text{coast}}` is the distance traveled during the coast segment:
 
 .. math::
-    \Delta \rho_{\text{coast}} = (\rho_{\text{ref}} - \rho_0) - 2 (\rho(t_r) - \rho_0)
+    \Delta \rho_{\text{coast}} = (\rho_{\text{ref}} - \rho_0) - 2 (\rho(t_{b1}) - \rho_0)
 
 :math:`t_c` is the simulation time at the end of the coast segment:
 
 .. math::
-    t_c = t_r + \frac{\Delta \rho_{\text{coast}}}{\dot{\rho}(t_r)}
+    t_c = t_{b1} + \frac{\Delta \rho_{\text{coast}}}{\dot{\rho}(t_{b1})}
 
 Using the given translation axis ``transHat_M``, the scalar states are then transformed to the prescribed translational
 states ``r_FM_M``, ``rPrime_FM_M``, and ``rPrimePrime_FM_M``. The states are then written to the
 :ref:`PrescribedTranslationMsgPayload` module output message.
 
+Smoothed Bang-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The third option to profile the linear translation is a smoothed bang-bang acceleration profile. This option is selected
+by setting the module variable ``smoothingDuration`` to a nonzero value. This profiler uses cubic splines to construct
+a continuous acceleration profiler across the entire translation. Similar to the non-smoothed bang-bang profiler,
+this option smooths the acceleration between the given maximum acceleration values.
+To profile this motion, the translational body's hub-relative scalar states :math:`\rho`, :math:`\dot{\rho}`, and
+:math:`\ddot{\rho}` are prescribed as a function of time and the translational motion is split into five different
+segments.
+
+The first segment smooths the acceleration from zero to the user-specified maximum acceleration value in the given
+time ``smoothingDuration``. If the given reference position is greater than the given initial position, the
+acceleration is smoothed positively to the given maximum acceleration value. If the given reference position is less
+than the given initial position, the acceleration is smoothed from zero to the negative maximum acceleration value.
+During this phase, the scalar hub-relative states are:
+
+.. math::
+    \ddot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{3 (t - t_0)^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_0)^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{(t - t_0)^3}{t_{\text{smooth}}^2} - \frac{(t - t_0)^4}{2 t_{\text{smooth}}^3} \right)
+
+.. math::
+    \rho(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{(t - t_0)^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_0)^5}{10 t_{\text{smooth}}^3} \right)
+
+The second segment is the first bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \pm \ddot{\rho}_{\text{max}}
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} (t - t_{s1}) + \dot{\rho}(t_{s1})
+
+.. math::
+    \rho(t) = \pm \frac{\ddot{\rho}_{\text{max}} (t - t_{s1})^2}{2} + \dot{\rho}(t_{s1})(t - t_{s1}) + \rho(t_{s1})
+
+where :math:`t_{s1}` is the time at the end of the first smoothing segment:
+
+.. math::
+    t_{s1} = t_0 + t_{\text{smooth}}
+
+The third segment smooths the acceleration from the current maximum acceleration value to the opposite magnitude maximum
+acceleration value. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( 1 - \frac{3 (t - t_{b1})^2}{2 t_{\text{smooth}}^2} + \frac{(t - t_{b1})^3}{2 t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( (t - t_{b1}) - \frac{(t - t_{b1})^3}{2 t_{\text{smooth}}^2} + \frac{(t - t_{b1})^4}{8 t_{\text{smooth}}^3} \right) + \dot{\rho}(t_{b1})
+
+.. math::
+    \rho(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{(t - t_{b1})^2}{2} - \frac{(t - t_{b1})^4}{8 t_{\text{smooth}}^2} + \frac{(t - t_{b1})^5}{40 t_{\text{smooth}}^3} \right) + \dot{\rho}(t_{b1})(t - t_{b1}) + \rho(t_{b1})
+
+where :math:`t_{b1}` is the time at the end of the first bang segment:
+
+.. math::
+    t_{b1} = t_{s1} + t_{\text{bang}}
+
+The fourth segment is the second bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \mp \ddot{\rho}_{\text{max}}
+
+.. math::
+    \dot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} (t - t_{s2}) + \dot{\rho}(t_{s2})
+
+.. math::
+    \rho(t) = \mp \frac{\ddot{\rho}_{\text{max}} (t - t_{s2})^2}{2} + \dot{\rho}(t_{s2})(t - t_{s2}) + \rho(t_{s2})
+
+where :math:`t_{s2}` is the time at the end of the second smoothing segment:
+
+.. math::
+    t_{s2} = t_{b1} + t_{\text{smooth}}
+
+The fifth segment is the third and final smoothing segment where the acceleration returns to zero. The scalar
+hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} \left ( -1 + \frac{3(t - t_{b2})^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_{b2})^3}{t_{\text{smooth}}^3} \right )
+
+.. math::
+    \dot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} \left ( -(t - t_{b2}) + \frac{(t - t_{b2})^3}{t_{\text{smooth}}^2} - \frac{(t - t_{b2})^4}{2 t_{\text{smooth}}^3} \right ) + \dot{\rho}(t_{b2})
+
+.. math::
+    \rho(t) = \mp \ddot{\rho}_{\text{max}} \left ( \frac{(t - t_{b2})^2}{2} + \frac{(t - t_{b2})^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_{b2})^5}{10 t_{\text{smooth}}^3} \right ) + \dot{\rho}(t_{b2})(t - t_{b2}) + \rho(t_{b2})
+
+where :math:`t_{b2}` is the time at the end of the second bang segment:
+
+.. math::
+    t_{b2} = t_{s2} + t_{\text{bang}}
+
+Smoothed Bang-Coast-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The fourth option to profile the linear translation is a smoothed bang-coast-bang acceleration profile. This option is
+selected by setting the module variables ``coastOptionBangDuration`` and ``smoothingDuration`` to nonzero values.
+This profiler uses cubic splines to construct a continuous acceleration profiler across the entire translation.
+To profile this motion, the translational body's hub-relative scalar states :math:`\rho`, :math:`\dot{\rho}`, and
+:math:`\ddot{\rho}` are prescribed as a function of time and the translational motion is split into seven different
+segments.
+
+The first segment smooths the acceleration from zero to the user-specified maximum acceleration value in the given
+time ``smoothingDuration``. If the given reference position is greater than the given initial position, the
+acceleration is smoothed positively to the given maximum acceleration value. If the given reference position is less
+than the given initial position, the acceleration is smoothed from zero to the negative maximum acceleration value.
+During this phase, the scalar hub-relative states are:
+
+.. math::
+    \ddot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{3 (t - t_0)^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_0)^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{(t - t_0)^3}{t_{\text{smooth}}^2} - \frac{(t - t_0)^4}{2 t_{\text{smooth}}^3} \right)
+
+.. math::
+    \rho(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{(t - t_0)^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_0)^5}{10 t_{\text{smooth}}^3} \right)
+
+The second segment is the first bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \pm \ddot{\rho}_{\text{max}}
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} (t - t_{s1}) + \dot{\rho}(t_{s1})
+
+.. math::
+    \rho(t) = \pm \frac{\ddot{\rho}_{\text{max}} (t - t_{s1})^2}{2} + \dot{\rho}(t_{s1})(t - t_{s1}) + \rho(t_{s1})
+
+where :math:`t_{s1}` is the time at the end of the first smoothing segment.
+
+The third segment prior to the coast phase smooths the acceleration from the current maximum acceleration value to zero.
+The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( 1 - \frac{3 (t - t_{b1})^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_{b1})^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left( (t - t_{b1}) - \frac{(t - t_{b1})^3}{t_{\text{smooth}}^2} - \frac{(t - t_{b1})^4}{2 t_{\text{smooth}}^3} \right) + \dot{\rho}(t_{b1})
+
+.. math::
+    \rho(t) = \pm \ddot{\rho}_{\text{max}} \left( \frac{(t - t_{b1})^2}{2} - \frac{(t - t_{b1})^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_{b1})^5}{10 t_{\text{smooth}}^3} \right) + \dot{\rho}(t_{b1})(t - t_{b1}) + \rho(t_{b1})
+
+where :math:`t_{b1}` is the time at the end of the first bang segment.
+
+The fourth segment is the coast segment where the translational states are:
+
+.. math::
+    \ddot{\rho}(t) = 0
+
+.. math::
+    \dot{\rho}(t) = \dot{\rho}(t_{s2})
+
+.. math::
+    \rho(t) = \dot{\rho}(t_{s2}) (t - t_{s2}) + \rho(t_{s2})
+
+where :math:`t_{s2}` is the time at the end of the second smoothing segment.
+
+The fifth segment smooths the acceleration from zero to the maximum acceleration value prior to the second bang segment.
+The translational states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} \left( \frac{3 (t - t_c)^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_c)^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} \left( \frac{(t - t_c)^3}{t_{\text{smooth}}^2} - \frac{(t - t_c)^4}{2 t_{\text{smooth}}^3} \right) + \dot{\rho}(t_c)
+
+.. math::
+    \rho(t) = \mp \ddot{\rho}_{\text{max}} \left( \frac{(t - t_c)^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_c)^5}{10 t_{\text{smooth}}^3} \right) + \dot{\rho}(t_c) (t - t_c) + \rho(t_c)
+
+where :math:`t_c` is the time at the end of the coast segment.
+
+The sixth segment is the second bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \mp \ddot{\rho}_{\text{max}}
+
+.. math::
+    \dot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} (t - t_{s3}) + \dot{\rho}(t_{s3})
+
+.. math::
+    \rho(t) = \mp \frac{\ddot{\rho}_{\text{max}} (t - t_{s3})^2}{2} + \dot{\rho}(t_{s3})(t - t_{s3}) + \rho(t_{s3})
+
+where :math:`t_{s3}` is the time at the end of the third smoothing segment.
+
+The seventh segment is the fourth and final smoothing segment where the acceleration returns to zero. The scalar
+hub-relative states during this phase are:
+
+.. math::
+    \ddot{\rho}(t) = \mp \ddot{\rho}_{\text{max}} \left (\frac{3(t_f - t)^2}{t_{\text{smooth}}^2} - \frac{2 (t_f - t)^3}{t_{\text{smooth}}^3} \right )
+
+.. math::
+    \dot{\rho}(t) = \pm \ddot{\rho}_{\text{max}} \left (\frac{(t_f - t)^3}{t_{\text{smooth}}^2} - \frac{(t_f - t)^4}{2 t_{\text{smooth}}^3} \right )
+
+.. math::
+    \rho(t) = \mp \ddot{\rho}_{\text{max}} \left (\frac{(t_f - t)^4}{4 t_{\text{smooth}}^2} - \frac{(t_f - t)^5}{10 t_{\text{smooth}}^3} \right ) + \rho_{\text{ref}}
+
+where :math:`t_f` is the time at the end of the translation:
+
 Module Testing
 ^^^^^^^^^^^^^^
-The unit test for this module ensures that a profiled linear translation for a secondary rigid body connected to a
-spacecraft hub is properly computed for several different simulation configurations. The unit test profiles two
-successive translations to ensure the module is correctly configured. The body's initial scalar translational position
-relative to the spacecraft hub is varied, along with the two final reference positions and the maximum translational
-acceleration. The unit test also tests both methods of profiling the translation, where either a pure bang-bang
-acceleration profile can be selected for the translation, or a coast option can be selected where the accelerations
-are only applied for a specified ramp time and a coast segment with zero acceleration is applied between the two
-acceleration periods. To validate the module, the final hub-relative position at the end of each translation is
-checked to match the specified reference position.
+The unit test for this module ensures that the profiled linear translation for a secondary rigid body relative to
+the spacecraft hub is properly computed for several different simulation configurations. The unit test profiles
+two successive translations to ensure the module is correctly configured. The secondary body's initial scalar
+translational position relative to the spacecraft hub is varied, along with the two final reference positions
+and the maximum translational acceleration.
+
+The unit test also tests four different methods of profiling the translation. Two profilers prescribe a pure
+bang-bang or bang-coast-bang linear acceleration profile for the translation. The bang-bang option results in
+the fastest possible translation; while the bang-coast-bang option includes a coast period with zero acceleration
+between the acceleration segments. The other two profilers apply smoothing to the bang-bang and bang-coast-bang
+acceleration profiles so that the secondary body hub-relative rates start and end at zero.
+
+To verify the module functionality, the final position at the end of each translation segment is checked to match
+the specified reference positions. Additionally, for the smoothed profiler options, the numerical derivative of the
+profiled displacements and velocities is determined across the entire simulation. These numerical derivatives are
+checked with the module's acceleration and velocity profiles to ensure the profiled acceleration is correctly
+integrated in the module to obtain the displacements and velocities.
 
 User Guide
 ----------
 The general inputs to this module that must be set by the user are the translational axis expressed as a
-unit vector in Mount frame components ``transHat_M``, the initial translational body position relative to the Mount
-frame ``transPosInit``, the reference position relative to the Mount frame ``transPosRef``, the maximum scalar linear
-acceleration for the translation ``transAccelMax``, and the ramp time variable ``coastOptionRampDuration`` for specifying
-the time the acceleration ramp segments are applied if the coast option is desired. This variable is defaulted to zero,
-meaning that the module defaults to the bang-bang acceleration profile with no coast period.
+unit vector in mount frame components ``transHat_M``, the initial translational body position relative to the hub-fixed
+mount frame ``transPosInit``, the reference position relative to the mount frame ``transPosRef``, and the maximum scalar
+linear acceleration for the translation ``transAccelMax``. The optional inputs ``coastOptionBangDuration`` and
+``smoothingDuration`` can be set by the user to select the specific type of profiler that is desired. If these variables
+are not set by the user, the module defaults to the non-smoothed bang-bang profiler. If only the variable
+``coastOptionBangDuration`` is set to a nonzero value, the bang-coast-bang profiler is selected. If only the variable
+``smoothingDuration`` is set to a nonzero value, the smoothed bang-bang profiler is selected. If both variables are
+set to nonzero values, the smoothed bang-coast-bang profiler is selected.
 
 This section is to outline the steps needed to setup the prescribed linear translational module in python using Basilisk.
 
-#. Import the prescribedTranslation class::
+#. Import the prescribedLinearTranslation class::
 
-    from Basilisk.simulation import prescribedTranslation
+    from Basilisk.simulation import prescribedLinearTranslation
 
 #. Create an instantiation of the module::
 
     prescribedLinearTrans = prescribedLinearTranslation.PrescribedLinearTranslation()
 
-#. Define all of the configuration data associated with the module. For example, to configure the coast option::
+#. Define all of the configuration data associated with the module. For example, to configure the smoothed bang-coast-bang option::
 
     prescribedLinearTrans.ModelTag = "prescribedLinearTranslation"
     prescribedLinearTrans.setTransHat_M(np.array([0.5, 0.0, 0.5 * np.sqrt(3)]))
     prescribedLinearTrans.setTransAccelMax(0.01)  # [m/s^2]
     prescribedLinearTrans.setTransPosInit(0.5)  # [m]
     prescribedLinearTrans.setCoastRampDuration(1.0)  # [s]
+    prescribedLinearTrans.setSmoothingDuration(1.0)  # [s]
 
 #. Connect a :ref:`LinearTranslationRigidBodyMsgPayload` message for the translating body reference position to the module. For example, the user can create a stand-alone message to specify the reference position::
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-613
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
A smoothing option is added to the `prescribedLinearTranslation` module that smooths the bang-bang and bang-coast-bang options using cubic-spline acceleration profiles. This option is added to improve the verification of the prescribed motion state effector module and reduce the likelihood of exciting flexible modes of the spacecraft components. As a result of this update to the module, there are now four available options to configure the module: bang-bang, bang-coast-bang, smoothed bang-bang, and smoothed bang-coast-bang.

The first 13 commits of this PR are changes that are made to the existing profiler module to prepare and organize the module for the addition of the smoothing profilers. The following commits are changes made to add smoothing to the module.

## Verification
The module unit test is updated to check the smoothed profilers. In addition to checking that the translational positions converge to the reference values, the numerical derivative of the profiled displacements and velocities is determined across the entire simulation and then checked with the module's profiled acceleration and velocity to ensure the
profiled acceleration is correctly integrated in the module to obtain the displacements and velocities.

## Documentation
The module documentation is updated to discuss the mathematics for the smoothed profiler options.

## Future work
N/A
