### PR TITLE
Small fixes to MTB module

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -62,6 +62,8 @@ Version |release|
 - Created a new example scenario :ref:`scenarioDeployingSolarArrays` demonstrating how to simulate hub-relative
   multi-body prescribed motion.
 - Added support for Vizard 2.1.6.1
+- Updated :ref:`MtbEffector` to include missing swig interface file for a message definition and corrected
+  message table in the module documentation.
 
 
 Version 2.2.1 (Dec. 22, 2023)

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.i
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.i
@@ -40,7 +40,7 @@ struct MTBCmdMsg_C;
 struct MagneticFieldMsg_C;
 %include "architecture/msgPayloadDefC/MTBArrayConfigMsgPayload.h"
 struct MTBArrayConfigMsg_C;
-%include "architecture/msgPayloadDefC/MTBArrayConfigMsgPayload.h"
+%include "architecture/msgPayloadDefC/MTBMsgPayload.h"
 struct MTBMsg_C;
 
 %pythoncode %{

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.rst
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.rst
@@ -26,7 +26,7 @@ provides information on what this message is used for.
       - :ref:`MTBArrayConfigMsgPayload`
       - input msg for layout of magnetic torque bars
     * - mtbOutMsg
-      - :ref:`MagneticFieldMsgPayload`
+      - :ref:`MTBMsgPayload`
       - output message containing net torque produced by the torque bars in body frame `B` components
 
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The magnetic torque bar effector module swig interface was importing a message payload definition file
twice instead of importing another message definition file.  This is now corrected in this branch.

## Verification
Did a clean build and all unit tests pass.

## Documentation
Update the module documentation to show the correct message type of all input and output messages.

## Future work
None