### PR TITLE
Feature/bsk 612 smooth rotational profiler

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -69,6 +69,11 @@ Version |release|
   simulation module
 - Added a new commanded linear force array :ref:`LinearTranslationRigidBodyMsgPayload`.
 - Added a new single-axis translating effector :ref:`linearTranslationOneDOFStateEffector`.
+- Added smoothed bang-bang and smoothed bang-coast-bang profiler options to the :ref:`prescribedRotation1DOF`
+  simulation module. Note that the optional module variable ``coastOptionRampDuration`` has been renamed to
+  ``coastOptionBangDuration``. The setter and getter methods for this variable are renamed to reflect this change as
+  ``setCoastOptionBangDuration()`` and  ``getCoastOptionBangDuration()``, respectively. See the module documentation
+  for the current usage of this parameter and these associated methods.
 
 
 Version 2.2.1 (Dec. 22, 2023)

--- a/examples/scenarioDeployingSolarArrays.py
+++ b/examples/scenarioDeployingSolarArrays.py
@@ -338,8 +338,8 @@ def run(show_plots):
         array2RotProfilerList.append(prescribedRotation1DOF.PrescribedRotation1DOF())
         array1RotProfilerList[i].ModelTag = "prescribedRotation1DOFArray1Element" + str(i + 1)
         array2RotProfilerList[i].ModelTag = "prescribedRotation1DOFArray2Element" + str(i + 1)
-        array1RotProfilerList[i].setCoastOptionRampDuration(ramp_duration)  # [s]
-        array2RotProfilerList[i].setCoastOptionRampDuration(ramp_duration)  # [s]
+        array1RotProfilerList[i].setCoastOptionBangDuration(ramp_duration)  # [s]
+        array2RotProfilerList[i].setCoastOptionBangDuration(ramp_duration)  # [s]
         array1RotProfilerList[i].setRotHat_M(rot_hat_M)
         array2RotProfilerList[i].setRotHat_M(rot_hat_M)
         array1RotProfilerList[i].setThetaDDotMax(array1MaxRotAccelList1[i])  # [rad/s^2]

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/_UnitTest/test_prescribedRotation1DOF.py
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/_UnitTest/test_prescribedRotation1DOF.py
@@ -42,14 +42,14 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 
-@pytest.mark.parametrize("coastOptionRampDuration", [0.0, 2.0, 5.0])  # [s]
+@pytest.mark.parametrize("coastOptionBangDuration", [0.0, 2.0, 5.0])  # [s]
 @pytest.mark.parametrize("thetaInit", [0.0, macros.D2R * -25.0])  # [rad]
 @pytest.mark.parametrize("thetaRef1", [0.0, macros.D2R * -15.0])  # [rad]
 @pytest.mark.parametrize("thetaRef2", [macros.D2R * -25.0, macros.D2R * 35.0])  # [rad]
 @pytest.mark.parametrize("thetaDDotMax", [macros.D2R * 0.4, macros.D2R * 1.0])  # [rad/s^2]
 @pytest.mark.parametrize("accuracy", [1e-4])
 def test_prescribedRotation1DOF(show_plots,
-                            coastOptionRampDuration,
+                            coastOptionBangDuration,
                             thetaInit,
                             thetaRef1,
                             thetaRef2,
@@ -64,14 +64,14 @@ def test_prescribedRotation1DOF(show_plots,
     along with the two final reference angles and the maximum angular acceleration for the rotation.
     The unit test also tests both methods of profiling the rotation, where either a pure bang-bang acceleration
     profile can be selected for the rotation, or a bang-off-bang option can be selected where a coast period with zero
-    acceleration is added between the acceleration ramp segments. To validate the module, the final spinning body angle
+    acceleration is added between the acceleration bang segments. To validate the module, the final spinning body angle
     at the end of each rotation are checked to match the specified reference angles.
 
     **Test Parameters**
 
     Args:
         show_plots (bool): Variable for choosing whether plots should be displayed
-        coastOptionRampDuration (double): [s] Ramp duration used for the coast option
+        coastOptionBangDuration (double): [s] Bang duration used for the coast option
         thetaInit (float): [rad] Initial spinning body angle relative to the mount frame
         thetaRef1 (float): [rad] First spinning body reference angle relative to the mount frame
         thetaRef2 (float): [rad] Second spinning body reference angle relative to the mount frame
@@ -104,7 +104,7 @@ def test_prescribedRotation1DOF(show_plots,
 
     # Initialize the prescribedRotation1DOF test module configuration data
     rotAxis_M = np.array([1.0, 0.0, 0.0])
-    prescribedRot1DOF.setCoastOptionRampDuration(coastOptionRampDuration)
+    prescribedRot1DOF.setCoastOptionBangDuration(coastOptionBangDuration)
     prescribedRot1DOF.setRotHat_M(rotAxis_M)
     prescribedRot1DOF.setThetaDDotMax(thetaDDotMax)
     prescribedRot1DOF.setThetaInit(thetaInit)
@@ -128,23 +128,23 @@ def test_prescribedRotation1DOF(show_plots,
     # Determine the required simulation time for the first rotation
     thetaDotInit = 0.0  # [rad/s]
     tCoast_1 = 0.0  # [s]
-    if (coastOptionRampDuration > 0.0):
-        # Determine the angle and angle rate at the end of the ramp segment/start of the coast segment
+    if (coastOptionBangDuration > 0.0):
+        # Determine the angle and angle rate at the end of the bang segment/start of the coast segment
         if (thetaInit < thetaRef1):
-            theta_tr_1 = ((0.5 * thetaDDotMax * coastOptionRampDuration * coastOptionRampDuration)
-                          + (thetaDotInit * coastOptionRampDuration) + thetaInit)  # [rad]
-            thetaDot_tr_1 = thetaDDotMax * coastOptionRampDuration + thetaDotInit  # [rad/s]
+            theta_tr_1 = ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
+                          + (thetaDotInit * coastOptionBangDuration) + thetaInit)  # [rad]
+            thetaDot_tr_1 = thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
         else:
-            theta_tr_1 = - ((0.5 * thetaDDotMax * coastOptionRampDuration * coastOptionRampDuration)
-                            + (thetaDotInit * coastOptionRampDuration)) + thetaInit  # [rad]
-            thetaDot_tr_1 = - thetaDDotMax * coastOptionRampDuration + thetaDotInit  # [rad/s]
+            theta_tr_1 = - ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
+                            + (thetaDotInit * coastOptionBangDuration)) + thetaInit  # [rad]
+            thetaDot_tr_1 = - thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
 
         # Determine the angle traveled during the coast period
         deltaThetaCoast_1 = thetaRef1 - thetaInit - 2 * (theta_tr_1 - thetaInit)  # [rad]
 
         # Determine the time duration of the coast segment
         tCoast_1 = np.abs(deltaThetaCoast_1) / np.abs(thetaDot_tr_1)  # [s]
-        rotation1ReqTime = (2 * coastOptionRampDuration) + tCoast_1  # [s]
+        rotation1ReqTime = (2 * coastOptionBangDuration) + tCoast_1  # [s]
     else:
         rotation1ReqTime = np.sqrt(((0.5 * np.abs(thetaRef1 - thetaInit)) * 8) / thetaDDotMax)  # [s]
 
@@ -163,23 +163,23 @@ def test_prescribedRotation1DOF(show_plots,
 
     # Determine the required simulation time for the second rotation
     tCoast_2 = 0.0  # [s]
-    if (coastOptionRampDuration > 0.0):
-        # Determine the angle and angle rate at the end of the ramp segment/start of the coast segment
+    if (coastOptionBangDuration > 0.0):
+        # Determine the angle and angle rate at the end of the bang segment/start of the coast segment
         if (thetaRef1 < thetaRef2):
-            theta_tr_2 = ((0.5 * thetaDDotMax * coastOptionRampDuration * coastOptionRampDuration)
-                          + (thetaDotInit * coastOptionRampDuration) + thetaRef1)  # [rad]
-            thetaDot_tr_2 = thetaDDotMax * coastOptionRampDuration + thetaDotInit  # [rad/s]
+            theta_tr_2 = ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
+                          + (thetaDotInit * coastOptionBangDuration) + thetaRef1)  # [rad]
+            thetaDot_tr_2 = thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
         else:
-            theta_tr_2 = - ((0.5 * thetaDDotMax * coastOptionRampDuration * coastOptionRampDuration)
-                            + (thetaDotInit * coastOptionRampDuration)) + thetaRef1  # [rad]
-            thetaDot_tr_2 = - thetaDDotMax * coastOptionRampDuration + thetaDotInit  # [rad/s]
+            theta_tr_2 = - ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
+                            + (thetaDotInit * coastOptionBangDuration)) + thetaRef1  # [rad]
+            thetaDot_tr_2 = - thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
 
         # Determine the angle traveled during the coast period
         deltaThetaCoast_2 = thetaRef2 - thetaRef1 - 2 * (theta_tr_2 - thetaRef1)  # [rad]
 
         # Determine the time duration of the coast segment
         tCoast_2 = np.abs(deltaThetaCoast_2) / np.abs(thetaDot_tr_2)  # [s]
-        rotation2ReqTime = (2 * coastOptionRampDuration) + tCoast_2  # [s]
+        rotation2ReqTime = (2 * coastOptionBangDuration) + tCoast_2  # [s]
     else:
         rotation2ReqTime = np.sqrt(((0.5 * np.abs(thetaRef2 - thetaRef1)) * 8) / thetaDDotMax)  # [s]
 
@@ -203,11 +203,11 @@ def test_prescribedRotation1DOF(show_plots,
 
     # Unit test validation
     # Store the truth data used to validate the module in two lists
-    if (coastOptionRampDuration > 0.0):
+    if (coastOptionBangDuration > 0.0):
         # Compute tf for the first rotation, and tInit tf for the second rotation
-        tf_1 = 2 * coastOptionRampDuration + tCoast_1  # [s]
+        tf_1 = 2 * coastOptionBangDuration + tCoast_1  # [s]
         tInit_2 = rotation1ReqTime + rotation1ExtraTime  # [s]
-        tf_2 = tInit_2 + (2 * coastOptionRampDuration) + tCoast_2  # [s]
+        tf_2 = tInit_2 + (2 * coastOptionBangDuration) + tCoast_2  # [s]
     
         # Compute the timespan indices for each check
         tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
@@ -327,7 +327,7 @@ def test_prescribedRotation1DOF(show_plots,
 if __name__ == "__main__":
     test_prescribedRotation1DOF(
         True,  # show_plots
-        5.0,  # [s] coastOptionRampDuration
+        5.0,  # [s] coastOptionBangDuration
         macros.D2R * -25.0,  # [rad] thetaInit
         macros.D2R * 15.0,  # [rad] thetaRef1
         macros.D2R * 55.0,  # [rad] thetaRef2

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/_UnitTest/test_prescribedRotation1DOF.py
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/_UnitTest/test_prescribedRotation1DOF.py
@@ -16,13 +16,11 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-
 #
 #   Unit Test Script
 #   Module Name:        PrescribedRotation1DOF
 #   Author:             Leah Kiner
-#   Creation Date:      Nov 14, 2022
-#   Last Updated:       Jan 26, 2024
+#   Last Updated:       March 28, 2024
 
 import inspect
 import os
@@ -30,6 +28,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+
 from Basilisk.architecture import bskLogging
 from Basilisk.architecture import messaging
 from Basilisk.simulation import prescribedRotation1DOF
@@ -41,37 +40,44 @@ path = os.path.dirname(os.path.abspath(filename))
 bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
-
-@pytest.mark.parametrize("coastOptionBangDuration", [0.0, 2.0, 5.0])  # [s]
-@pytest.mark.parametrize("thetaInit", [0.0, macros.D2R * -25.0])  # [rad]
-@pytest.mark.parametrize("thetaRef1", [0.0, macros.D2R * -15.0])  # [rad]
-@pytest.mark.parametrize("thetaRef2", [macros.D2R * -25.0, macros.D2R * 35.0])  # [rad]
-@pytest.mark.parametrize("thetaDDotMax", [macros.D2R * 0.4, macros.D2R * 1.0])  # [rad/s^2]
-@pytest.mark.parametrize("accuracy", [1e-4])
+@pytest.mark.parametrize("coastOptionBangDuration", [0.0, 2.0])  # [s]
+@pytest.mark.parametrize("smoothingDuration", [0.0, 2.0])  # [s]
+@pytest.mark.parametrize("thetaInit", [0.0, macros.D2R * -5.0])  # [rad]
+@pytest.mark.parametrize("thetaRef1", [0.0, macros.D2R * -10.0])  # [rad]
+@pytest.mark.parametrize("thetaRef2", [macros.D2R * 5.0])  # [rad]
+@pytest.mark.parametrize("thetaDDotMax", [macros.D2R * 0.05, macros.D2R * 0.1])  # [rad/s^2]
+@pytest.mark.parametrize("accuracy", [1e-8])
 def test_prescribedRotation1DOF(show_plots,
-                            coastOptionBangDuration,
-                            thetaInit,
-                            thetaRef1,
-                            thetaRef2,
-                            thetaDDotMax,
-                            accuracy):
+                                coastOptionBangDuration,
+                                smoothingDuration,
+                                thetaInit,
+                                thetaRef1,
+                                thetaRef2,
+                                thetaDDotMax,
+                                accuracy):
     r"""
     **Validation Test Description**
 
-    The unit test for this module ensures that the 1 DOF rotation is properly profiled for several different
-    simulation configurations. The unit test profiles two successive rotations for the spinning body to ensure the
-    module is correctly configured. The initial spinning body angle relative to the spacecraft hub is varied,
-    along with the two final reference angles and the maximum angular acceleration for the rotation.
-    The unit test also tests both methods of profiling the rotation, where either a pure bang-bang acceleration
-    profile can be selected for the rotation, or a bang-off-bang option can be selected where a coast period with zero
-    acceleration is added between the acceleration bang segments. To validate the module, the final spinning body angle
-    at the end of each rotation are checked to match the specified reference angles.
+    The unit test for this module ensures that the profiled 1 DOF rotation for a secondary rigid body relative to
+    the spacecraft hub is properly computed for several different simulation configurations. The unit test profiles
+    two successive rotations to ensure the module is correctly configured. The initial spinning body angle relative
+    to the spacecraft hub is varied, along with the two final reference angles and the maximum angular acceleration
+    for the rotation.
+
+    This unit test also tests four different methods of profiling the rotation. Two profilers prescribe a pure
+    bang-bang or bang-coast-bang angular acceleration profile for the rotation. The bang-bang option results in
+    the fastest possible rotation; while the bang-coast-bang option includes a coast period with zero acceleration
+    between the acceleration segments. The other two profilers apply smoothing to the bang-bang and bang-coast-bang
+    acceleration profiles so that the spinning body hub-relative rates start and end at zero.
 
     **Test Parameters**
 
     Args:
         show_plots (bool): Variable for choosing whether plots should be displayed
-        coastOptionBangDuration (double): [s] Bang duration used for the coast option
+        coastOptionBangDuration: (float): [s] Time the acceleration is applied during the bang segments
+        (Variable must be nonzero to select the bang-coast-bang option)
+        smoothingDuration (float) [s] Time the acceleration is smoothed to the given maximum acceleration value
+        (Variable must be nonzero to toggle the smoothed profiler options)
         thetaInit (float): [rad] Initial spinning body angle relative to the mount frame
         thetaRef1 (float): [rad] First spinning body reference angle relative to the mount frame
         thetaRef2 (float): [rad] Second spinning body reference angle relative to the mount frame
@@ -80,8 +86,11 @@ def test_prescribedRotation1DOF(show_plots,
 
     **Description of Variables Being Tested**
 
-    This unit test checks that the final spinning body angle at the end of each rotation converge to the specified
-    reference values ``thetaRef1`` and ``thetaRef2``.
+    To verify the module functionality, the final angle at the end of each rotation is checked to match the specified
+    reference angle (``thetaRef1`` and ``thetaRef2``). Additionally, for the smoothed profiler options,
+    the numerical derivative of the profiled angles and their rates is determined across the entire simulation in this
+    test script. These numerical derivatives are checked with the profiled angular accelerations and angle rates to
+    ensure the profiled acceleration is correctly integrated in the module to obtain the angles and their rates.
     """
 
     unitTaskName = "unitTask"
@@ -91,28 +100,26 @@ def test_prescribedRotation1DOF(show_plots,
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
-    testTimeStepSec = 0.01  # [s]
+    testTimeStepSec = 0.1  # [s]
     testProcessRate = macros.sec2nano(testTimeStepSec)
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
     # Create an instance of the prescribedRotation1DOF module to be tested
+    rotAxis_M = np.array([1.0, 0.0, 0.0])  # Spinning body rotation axis
     prescribedRot1DOF = prescribedRotation1DOF.PrescribedRotation1DOF()
     prescribedRot1DOF.ModelTag = "prescribedRotation1DOF"
-
-    unitTestSim.AddModelToTask(unitTaskName, prescribedRot1DOF)
-
-    # Initialize the prescribedRotation1DOF test module configuration data
-    rotAxis_M = np.array([1.0, 0.0, 0.0])
     prescribedRot1DOF.setCoastOptionBangDuration(coastOptionBangDuration)
     prescribedRot1DOF.setRotHat_M(rotAxis_M)
+    prescribedRot1DOF.setSmoothingDuration(smoothingDuration)
     prescribedRot1DOF.setThetaDDotMax(thetaDDotMax)
     prescribedRot1DOF.setThetaInit(thetaInit)
+    unitTestSim.AddModelToTask(unitTaskName, prescribedRot1DOF)
 
-    # Create the prescribedRotation1DOF input reference angle message for the first spinning body rotation
+    # Create the reference angle input message for the first rotation
     hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
-    hingedRigidBodyMessageData.theta = thetaRef1
-    hingedRigidBodyMessageData.thetaDot = 0.0
+    hingedRigidBodyMessageData.theta = thetaRef1  # [rad]
+    hingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
     hingedRigidBodyMessage = messaging.HingedRigidBodyMsg().write(hingedRigidBodyMessageData)
     prescribedRot1DOF.spinningBodyInMsg.subscribeTo(hingedRigidBodyMessage)
 
@@ -122,74 +129,21 @@ def test_prescribedRotation1DOF(show_plots,
     unitTestSim.AddModelToTask(unitTaskName, prescribedRotStatesDataLog)
     unitTestSim.AddModelToTask(unitTaskName, scalarAngleDataLog)
 
-    # Initialize the simulation
-    unitTestSim.InitializeSimulation()
-
-    # Determine the required simulation time for the first rotation
-    thetaDotInit = 0.0  # [rad/s]
-    tCoast_1 = 0.0  # [s]
-    if (coastOptionBangDuration > 0.0):
-        # Determine the angle and angle rate at the end of the bang segment/start of the coast segment
-        if (thetaInit < thetaRef1):
-            theta_tr_1 = ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
-                          + (thetaDotInit * coastOptionBangDuration) + thetaInit)  # [rad]
-            thetaDot_tr_1 = thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
-        else:
-            theta_tr_1 = - ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
-                            + (thetaDotInit * coastOptionBangDuration)) + thetaInit  # [rad]
-            thetaDot_tr_1 = - thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
-
-        # Determine the angle traveled during the coast period
-        deltaThetaCoast_1 = thetaRef1 - thetaInit - 2 * (theta_tr_1 - thetaInit)  # [rad]
-
-        # Determine the time duration of the coast segment
-        tCoast_1 = np.abs(deltaThetaCoast_1) / np.abs(thetaDot_tr_1)  # [s]
-        rotation1ReqTime = (2 * coastOptionBangDuration) + tCoast_1  # [s]
-    else:
-        rotation1ReqTime = np.sqrt(((0.5 * np.abs(thetaRef1 - thetaInit)) * 8) / thetaDDotMax)  # [s]
-
-    rotation1ExtraTime = 5  # [s]
-    unitTestSim.ConfigureStopTime(macros.sec2nano(rotation1ReqTime + rotation1ExtraTime))
-
     # Execute the first spinning body rotation
+    simTime = 5 * 60  # [s]
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(simTime))
     unitTestSim.ExecuteSimulation()
 
-    # Create the hingedRigidBody reference angle input message for the second rotation
+    # Create the reference angle input message for the second rotation
     hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
     hingedRigidBodyMessageData.theta = thetaRef2  # [rad]
     hingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
     hingedRigidBodyMessage = messaging.HingedRigidBodyMsg().write(hingedRigidBodyMessageData)
     prescribedRot1DOF.spinningBodyInMsg.subscribeTo(hingedRigidBodyMessage)
 
-    # Determine the required simulation time for the second rotation
-    tCoast_2 = 0.0  # [s]
-    if (coastOptionBangDuration > 0.0):
-        # Determine the angle and angle rate at the end of the bang segment/start of the coast segment
-        if (thetaRef1 < thetaRef2):
-            theta_tr_2 = ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
-                          + (thetaDotInit * coastOptionBangDuration) + thetaRef1)  # [rad]
-            thetaDot_tr_2 = thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
-        else:
-            theta_tr_2 = - ((0.5 * thetaDDotMax * coastOptionBangDuration * coastOptionBangDuration)
-                            + (thetaDotInit * coastOptionBangDuration)) + thetaRef1  # [rad]
-            thetaDot_tr_2 = - thetaDDotMax * coastOptionBangDuration + thetaDotInit  # [rad/s]
-
-        # Determine the angle traveled during the coast period
-        deltaThetaCoast_2 = thetaRef2 - thetaRef1 - 2 * (theta_tr_2 - thetaRef1)  # [rad]
-
-        # Determine the time duration of the coast segment
-        tCoast_2 = np.abs(deltaThetaCoast_2) / np.abs(thetaDot_tr_2)  # [s]
-        rotation2ReqTime = (2 * coastOptionBangDuration) + tCoast_2  # [s]
-    else:
-        rotation2ReqTime = np.sqrt(((0.5 * np.abs(thetaRef2 - thetaRef1)) * 8) / thetaDDotMax)  # [s]
-
-    rotation2ExtraTime = 5.0  # [s]
-    unitTestSim.ConfigureStopTime(macros.sec2nano(rotation1ReqTime
-                                                  + rotation1ExtraTime
-                                                  + rotation2ReqTime
-                                                  + rotation2ExtraTime))
-
     # Execute the second spinning body rotation
+    unitTestSim.ConfigureStopTime(macros.sec2nano(2 * simTime))
     unitTestSim.ExecuteSimulation()
 
     # Extract logged data
@@ -201,136 +155,133 @@ def test_prescribedRotation1DOF(show_plots,
     thetaDot = macros.R2D * scalarAngleDataLog.thetaDot  # [deg/s]
     thetaDDot = omegaPrime_FM_F.dot(rotAxis_M)  # [deg/s^2]
 
-    # Unit test validation
-    # Store the truth data used to validate the module in two lists
-    if (coastOptionBangDuration > 0.0):
-        # Compute tf for the first rotation, and tInit tf for the second rotation
-        tf_1 = 2 * coastOptionBangDuration + tCoast_1  # [s]
-        tInit_2 = rotation1ReqTime + rotation1ExtraTime  # [s]
-        tf_2 = tInit_2 + (2 * coastOptionBangDuration) + tCoast_2  # [s]
-    
-        # Compute the timespan indices for each check
-        tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
-        tInit_2_index = int(round(tInit_2 / testTimeStepSec)) + 1
-        tf_2_index = int(round(tf_2 / testTimeStepSec)) + 1
-    
-        # Store the timespan indices in a list
-        timeCheckIndicesList = [tf_1_index, tInit_2_index, tf_2_index]
-    
-        # Store the angles to check in a list
-        thetaCheckList = [macros.R2D * thetaRef1, macros.R2D * thetaRef1, macros.R2D * thetaRef2]  # [deg]
-    
-    else:
-        # Compute tf for the first rotation, and tInit tf for the second rotation
-        tf_1 = rotation1ReqTime  # [s]
-        tInit_2 = rotation1ReqTime + rotation1ExtraTime  # [s]
-        tf_2 = tInit_2 + rotation2ReqTime  # [s]
-    
-        # Compute the timespan indices for each check
-        tf_1_index = int(round(tf_1 / testTimeStepSec)) + 1
-        tInit_2_index = int(round(tInit_2 / testTimeStepSec)) + 1
-        tf_2_index = int(round(tf_2 / testTimeStepSec)) + 1
-    
-        # Store the timespan indices in a list
-        timeCheckIndicesList = [tf_1_index, tInit_2_index, tf_2_index]
-    
-        # Store the angles to check in a list
-        thetaCheckList = [macros.R2D * thetaRef1, macros.R2D * thetaRef1, macros.R2D * thetaRef2]  # [deg]
-
-    # Use the two truth data lists to compare with the module-extracted data
-    np.testing.assert_allclose(theta[timeCheckIndicesList],
-                               thetaCheckList,
+    # Unit test validation 1: Check that the profiler converges to the required final angles
+    tf_1_index = int(round(simTime / testTimeStepSec)) + 1
+    thetaFinal1 = theta[tf_1_index]
+    thetaFinal2 = theta[-1]
+    thetaFinalList = [thetaFinal1, thetaFinal2]  # [deg]
+    thetaRefList = [macros.R2D * thetaRef1, macros.R2D * thetaRef2]  # [deg]
+    np.testing.assert_allclose(thetaRefList,
+                               thetaFinalList,
                                atol=accuracy,
                                verbose=True)
 
-    # 1. Plot the scalar spinning body rotational states
-    # 1A. Plot theta
-    thetaInitPlotting = np.ones(len(timespan)) * macros.R2D * thetaInit  # [deg]
-    thetaRef1Plotting = np.ones(len(timespan)) * macros.R2D * thetaRef1  # [deg]
-    thetaRef2Plotting = np.ones(len(timespan)) * macros.R2D * thetaRef2  # [deg]
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan, theta, label=r"$\theta$")
-    plt.plot(timespan, thetaInitPlotting, '--', label=r'$\theta_{0}$')
-    plt.plot(timespan, thetaRef1Plotting, '--', label=r'$\theta_{Ref_1}$')
-    plt.plot(timespan, thetaRef2Plotting, '--', label=r'$\theta_{Ref_2}$')
-    plt.title(r'Spinning Body Angle $\theta_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
-    plt.ylabel('(deg)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
+    # Unit test validation 2: Numerically check that the profiled accelerations, angle rates, and angles are correct
+    if (smoothingDuration > 0.0):
+        thetaDDotNumerical = []
+        thetaDotNumerical = []
+        for i in range(len(timespan) - 1):
+            # First order forward difference
+            thetaDDotNumerical.append((thetaDot[i+1] - thetaDot[i]) / testTimeStepSec)
+            thetaDotNumerical.append((theta[i+1] - theta[i]) / testTimeStepSec)
 
-    # 1B. Plot thetaDot
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan, thetaDot, label=r"$\dot{\theta}$")
-    plt.title(r'Spinning Body Angle Rate $\dot{\theta}_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
-    plt.ylabel('(deg/s)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
-
-    # 1C. Plot thetaDDot
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan, thetaDDot, label=r"$\ddot{\theta}$")
-    plt.title(r'Spinning Body Angular Acceleration $\ddot{\theta}_{\mathcal{F}/\mathcal{M}}$ ', fontsize=14)
-    plt.ylabel('(deg/s$^2$)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 12})
-    plt.grid(True)
-
-    # 2. Plot the spinning body prescribed rotational states
-    # 2A. Plot PRV angle from sigma_FM
-    phi_FM = []
-    for i in range(len(timespan)):
-        phi_FM.append(macros.R2D * 4 * np.arctan(np.linalg.norm(sigma_FM[i, :])))  # [deg]
-
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan, phi_FM, label=r"$\Phi$")
-    plt.title(r'Spinning Body PRV Angle $\Phi_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
-    plt.ylabel('(deg)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='center right', prop={'size': 14})
-    plt.grid(True)
-
-    # 2B. Plot omega_FM_F
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan, omega_FM_F[:, 0], label=r'$\omega_{1}$')
-    plt.plot(timespan, omega_FM_F[:, 1], label=r'$\omega_{2}$')
-    plt.plot(timespan, omega_FM_F[:, 2], label=r'$\omega_{3}$')
-    plt.title(r'Spinning Body Angular Velocity ${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
-    plt.ylabel('(deg/s)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 14})
-    plt.grid(True)
-
-    # 2C. Plot omegaPrime_FM_F
-    plt.figure()
-    plt.clf()
-    plt.plot(timespan, omegaPrime_FM_F[:, 0], label=r'1')
-    plt.plot(timespan, omegaPrime_FM_F[:, 1], label=r'2')
-    plt.plot(timespan, omegaPrime_FM_F[:, 2], label=r'3')
-    plt.title(r'Spinning Body Angular Acceleration ${}^\mathcal{F} \omega$Prime$_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
-    plt.ylabel('(deg/s$^2$)', fontsize=14)
-    plt.xlabel('Time (s)', fontsize=14)
-    plt.legend(loc='upper right', prop={'size': 14})
-    plt.grid(True)
+        np.testing.assert_allclose(thetaDDot[0:-1],
+                                   thetaDDotNumerical,
+                                   atol=1e-2,
+                                   verbose=True)
+        np.testing.assert_allclose(thetaDot[0:-1],
+                                   thetaDotNumerical,
+                                   atol=1e-2,
+                                   verbose=True)
+        if show_plots:
+            # Plot the difference between the numerical and profiled results
+            plt.figure()
+            plt.clf()
+            plt.plot(timespan[0:-1], thetaDDotNumerical - thetaDDot[0:-1], label=r'$\ddot{\theta}$')
+            plt.plot(timespan[0:-1], thetaDotNumerical - thetaDot[0:-1], label=r"$\dot{\theta}$")
+            plt.title(r'Profiled vs Numerical Difference', fontsize=14)
+            plt.legend(loc='upper right', prop={'size': 12})
+            plt.grid(True)
 
     if show_plots:
+        # 1. Plot the scalar spinning body rotational states
+        # 1A. Plot theta
+        thetaInitPlotting = np.ones(len(timespan)) * macros.R2D * thetaInit  # [deg]
+        thetaRef1Plotting = np.ones(len(timespan)) * macros.R2D * thetaRef1  # [deg]
+        thetaRef2Plotting = np.ones(len(timespan)) * macros.R2D * thetaRef2  # [deg]
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan, theta, label=r"$\theta$")
+        plt.plot(timespan, thetaInitPlotting, '--', label=r'$\theta_{0}$')
+        plt.plot(timespan, thetaRef1Plotting, '--', label=r'$\theta_{Ref_1}$')
+        plt.plot(timespan, thetaRef2Plotting, '--', label=r'$\theta_{Ref_2}$')
+        plt.title(r'Profiled Angle $\theta_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+        plt.ylabel('(deg)', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=14)
+        plt.legend(loc='upper right', prop={'size': 12})
+        plt.grid(True)
+
+        # 1B. Plot thetaDot
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan, thetaDot, label=r"$\dot{\theta}$")
+        plt.title(r'Profiled Angle Rate $\dot{\theta}_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+        plt.ylabel('(deg/s)', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=14)
+        plt.legend(loc='upper right', prop={'size': 12})
+        plt.grid(True)
+
+        # 1C. Plot thetaDDot
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan, thetaDDot, label=r"$\ddot{\theta}$")
+        plt.title(r'Profiled Angular Acceleration $\ddot{\theta}_{\mathcal{F}/\mathcal{M}}$ ', fontsize=14)
+        plt.ylabel('(deg/s$^2$)', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=14)
+        plt.legend(loc='upper right', prop={'size': 12})
+        plt.grid(True)
+
+        # 2. Plot the spinning body prescribed rotational states
+        # 2A. Plot PRV angle from sigma_FM
+        phi_FM = []
+        for i in range(len(timespan)):
+            phi_FM.append(macros.R2D * 4 * np.arctan(np.linalg.norm(sigma_FM[i, :])))  # [deg]
+
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan, phi_FM, label=r"$\Phi$")
+        plt.title(r'Profiled PRV Angle $\Phi_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+        plt.ylabel('(deg)', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=14)
+        plt.legend(loc='center right', prop={'size': 14})
+        plt.grid(True)
+
+        # 2B. Plot omega_FM_F
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan, omega_FM_F[:, 0], label=r'$\omega_{1}$')
+        plt.plot(timespan, omega_FM_F[:, 1], label=r'$\omega_{2}$')
+        plt.plot(timespan, omega_FM_F[:, 2], label=r'$\omega_{3}$')
+        plt.title(r'Profiled Angular Velocity ${}^\mathcal{F} \omega_{\mathcal{F}/\mathcal{M}}$', fontsize=14)
+        plt.ylabel('(deg/s)', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=14)
+        plt.legend(loc='upper right', prop={'size': 14})
+        plt.grid(True)
+
+        # 2C. Plot omegaPrime_FM_F
+        plt.figure()
+        plt.clf()
+        plt.plot(timespan, omegaPrime_FM_F[:, 0], label=r'1')
+        plt.plot(timespan, omegaPrime_FM_F[:, 1], label=r'2')
+        plt.plot(timespan, omegaPrime_FM_F[:, 2], label=r'3')
+        plt.title(r'Profiled Angular Acceleration ${}^\mathcal{F} \omega$Prime$_{\mathcal{F}/\mathcal{M}}$',
+                  fontsize=14)
+        plt.ylabel('(deg/s$^2$)', fontsize=14)
+        plt.xlabel('Time (s)', fontsize=14)
+        plt.legend(loc='upper right', prop={'size': 14})
+        plt.grid(True)
+
         plt.show()
     plt.close("all")
-
 
 if __name__ == "__main__":
     test_prescribedRotation1DOF(
         True,  # show_plots
-        5.0,  # [s] coastOptionBangDuration
-        macros.D2R * -25.0,  # [rad] thetaInit
-        macros.D2R * 15.0,  # [rad] thetaRef1
-        macros.D2R * 55.0,  # [rad] thetaRef2
-        macros.D2R * 0.4,  # [rad/s^2] thetaDDotMax
-        1e-4  # accuracy
+        2.0,  # [s] coastOptionBangDuration
+        2.0,  # [s] smoothingDuration
+        macros.D2R * -5.0,  # [rad] thetaInit
+        macros.D2R * -10.0,  # [rad] thetaRef1
+        macros.D2R * 5.0,  # [rad] thetaRef2
+        macros.D2R * 0.1,  # [rad/s^2] thetaDDotMax
+        1e-8  # accuracy
     )

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -151,7 +151,7 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInFirstBangSegment(double t) const {
-    return (t <= this->tr && this->tf - this->tInit != 0);
+    return (t <= this->t_r && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the coast segment for the coast option.
@@ -159,7 +159,7 @@ bool PrescribedRotation1DOF::isInFirstBangSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInCoastSegment(double t) const {
-    return (t > this->tr && t <= this->tc && this->tf - this->tInit != 0);
+    return (t > this->t_r && t <= this->t_c && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the coast option.
@@ -167,7 +167,7 @@ bool PrescribedRotation1DOF::isInCoastSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInSecondBangSegment(double t) const {
-    return (t > this->tc && t <= this->tf && this->tf - this->tInit != 0);
+    return (t > this->t_c && t <= this->t_f && this->t_f - this->tInit != 0);
 }
 
 /*! This method computes the required parameters for the rotation with a coast period.
@@ -176,7 +176,7 @@ bool PrescribedRotation1DOF::isInSecondBangSegment(double t) const {
 void PrescribedRotation1DOF::computeCoastParameters() {
     if (this->thetaInit != this->thetaRef) {
         // Determine the time at the end of the first bang segment
-        this->tr = this->tInit + this->coastOptionBangDuration;
+        this->t_r = this->tInit + this->coastOptionBangDuration;
 
         // Determine the angle and angle rate at the end of the bang segment/start of the coast segment
         if (this->thetaInit < this->thetaRef) {
@@ -196,21 +196,21 @@ void PrescribedRotation1DOF::computeCoastParameters() {
         double tCoast = fabs(deltaThetaCoast) / fabs(this->thetaDot_tr);
 
         // Determine the time at the end of the coast segment
-        this->tc = this->tr + tCoast;
+        this->t_c = this->t_r + tCoast;
 
         // Determine the angle at the end of the coast segment
         this->theta_tc = this->theta_tr + deltaThetaCoast;
 
         // Determine the time at the end of the rotation
-        this->tf = this->tc + this->coastOptionBangDuration;
+        this->t_f = this->t_c + this->coastOptionBangDuration;
 
         // Define the parabolic constants for the first and second bang segments of the rotation
-        this->a = (this->theta_tr - this->thetaInit) / ((this->tr - this->tInit) * (this->tr - this->tInit));
-        this->b = - (this->thetaRef - this->theta_tc) / ((this->tc - this->tf) * (this->tc - this->tf));
+        this->a = (this->theta_tr - this->thetaInit) / ((this->t_r - this->tInit) * (this->t_r - this->tInit));
+        this->b = - (this->thetaRef - this->theta_tc) / ((this->t_c - this->t_f) * (this->t_c - this->t_f));
     } else { // If the initial angle equals the reference angle, no rotation is required. Setting the final time
         // equal to the initial time ensures the correct statement is entered when the rotational states are
         // profiled below
-        this->tf = this->tInit;
+        this->t_f = this->tInit;
     }
 }
 
@@ -221,7 +221,7 @@ void PrescribedRotation1DOF::computeCoastParameters() {
 void PrescribedRotation1DOF::computeCoastSegment(double t) {
     this->thetaDDot = 0.0;
     this->thetaDot = this->thetaDot_tr;
-    this->theta = this->thetaDot_tr * (t - this->tr) + this->theta_tr;
+    this->theta = this->thetaDot_tr * (t - this->t_r) + this->theta_tr;
 }
 
 /*! This method determines if the current time is within the first bang segment for the no coast option.
@@ -229,7 +229,7 @@ void PrescribedRotation1DOF::computeCoastSegment(double t) {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInFirstBangSegmentNoCoast(double t) const {
-    return (t <= this->ts && this->tf - this->tInit != 0);
+    return (t <= this->t_s && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the no coast option.
@@ -237,7 +237,7 @@ bool PrescribedRotation1DOF::isInFirstBangSegmentNoCoast(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInSecondBangSegmentNoCoast(double t) const {
-    return (t > this->ts && t <= this->tf && this->tf - this->tInit != 0);
+    return (t > this->t_s && t <= this->t_f && this->t_f - this->tInit != 0);
 }
 
 /*! This method computes the required parameters for the rotation with no coast period.
@@ -248,14 +248,14 @@ void PrescribedRotation1DOF::computeParametersNoCoast() {
     double totalRotTime = sqrt(((0.5 * fabs(this->thetaRef - this->thetaInit)) * 8) / this->thetaDDotMax);
 
     // Determine the time at the end of the rotation
-    this->tf = this->tInit + totalRotTime;
+    this->t_f = this->tInit + totalRotTime;
 
     // Determine the time halfway through the rotation
-    this->ts = this->tInit + (totalRotTime / 2);
+    this->t_s = this->tInit + (totalRotTime / 2);
 
     // Define the parabolic constants for the first and second half of the rotation
-    this->a = 0.5 * (this->thetaRef - this->thetaInit) / ((this->ts - this->tInit) * (this->ts - this->tInit));
-    this->b = -0.5 * (this->thetaRef - this->thetaInit) / ((this->ts - this->tf) * (this->ts - this->tf));
+    this->a = 0.5 * (this->thetaRef - this->thetaInit) / ((this->t_s - this->tInit) * (this->t_s - this->tInit));
+    this->b = -0.5 * (this->thetaRef - this->thetaInit) / ((this->t_s - this->t_f) * (this->t_s - this->t_f));
 }
 
 /*! This method computes the scalar rotational states for the first bang segment.
@@ -289,8 +289,8 @@ void PrescribedRotation1DOF::computeSecondBangSegment(double t) {
         this->thetaDDot = this->thetaDDotMax;
     }
     this->thetaDot = this->thetaDDot * (t - this->tInit) + this->thetaDotInit
-                     - this->thetaDDot * (this->tf - this->tInit);
-    this->theta = this->b * (t - this->tf) * (t - this->tf) + this->thetaRef;
+                     - this->thetaDDot * (this->t_f - this->tInit);
+    this->theta = this->b * (t - this->t_f) * (t - this->t_f) + this->thetaRef;
 }
 
 /*! This method computes the scalar rotational states when the rotation is complete.

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -698,7 +698,7 @@ Eigen::Vector3d PrescribedRotation1DOF::computeSigma_FM() {
  @return void
  @param bangDuration [s] Bang segment time duration
 */
-void PrescribedRotation1DOF::setCoastOptionBangDuration(double bangDuration) {
+void PrescribedRotation1DOF::setCoastOptionBangDuration(const double bangDuration) {
     this->coastOptionBangDuration = bangDuration;
 }
 
@@ -714,7 +714,7 @@ void PrescribedRotation1DOF::setRotHat_M(const Eigen::Vector3d &rotHat_M) {
  @return void
  @param smoothingDuration [s] Duration the acceleration is smoothed until reaching the given maximum acceleration value
 */
-void PrescribedRotation1DOF::setSmoothingDuration(double smoothingDuration) {
+void PrescribedRotation1DOF::setSmoothingDuration(const double smoothingDuration) {
     this->smoothingDuration = smoothingDuration;
 }
 
@@ -722,7 +722,7 @@ void PrescribedRotation1DOF::setSmoothingDuration(double smoothingDuration) {
  @return void
  @param thetaDDotMax [rad/s^2] Bang segment scalar angular acceleration
 */
-void PrescribedRotation1DOF::setThetaDDotMax(double thetaDDotMax) {
+void PrescribedRotation1DOF::setThetaDDotMax(const double thetaDDotMax) {
     this->thetaDDotMax = thetaDDotMax;
 }
 
@@ -730,7 +730,7 @@ void PrescribedRotation1DOF::setThetaDDotMax(double thetaDDotMax) {
  @return void
  @param thetaInit [rad] Initial spinning body angle
 */
-void PrescribedRotation1DOF::setThetaInit(double thetaInit) {
+void PrescribedRotation1DOF::setThetaInit(const double thetaInit) {
     this->thetaInit = thetaInit;
 }
 

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -119,32 +119,32 @@ void PrescribedRotation1DOF::computeBangCoastBangParametersNoSmoothing() {
 
         // Determine the angle and angle rate at the end of the bang segment/start of the coast segment
         if (this->thetaInit < this->thetaRef) {
-            this->theta_tr = (0.5 * this->thetaDDotMax * this->coastOptionBangDuration * this->coastOptionBangDuration)
+            this->theta_tb1 = (0.5 * this->thetaDDotMax * this->coastOptionBangDuration * this->coastOptionBangDuration)
                              + this->thetaInit;
-            this->thetaDot_tr = this->thetaDDotMax * this->coastOptionBangDuration;
+            this->thetaDot_tb1 = this->thetaDDotMax * this->coastOptionBangDuration;
         } else {
-            this->theta_tr = - (0.5 * this->thetaDDotMax * this->coastOptionBangDuration
+            this->theta_tb1 = - (0.5 * this->thetaDDotMax * this->coastOptionBangDuration
                              * this->coastOptionBangDuration) + this->thetaInit;
-            this->thetaDot_tr = - this->thetaDDotMax * this->coastOptionBangDuration;
+            this->thetaDot_tb1 = - this->thetaDDotMax * this->coastOptionBangDuration;
         }
 
         // Determine the angle traveled during the coast period
-        double deltaThetaCoast = this->thetaRef - this->thetaInit - 2 * (this->theta_tr - this->thetaInit);
+        double deltaThetaCoast = this->thetaRef - this->thetaInit - 2 * (this->theta_tb1 - this->thetaInit);
 
         // Determine the time duration of the coast segment
-        double tCoast = fabs(deltaThetaCoast) / fabs(this->thetaDot_tr);
+        double tCoast = fabs(deltaThetaCoast) / fabs(this->thetaDot_tb1);
 
         // Determine the time at the end of the coast segment
         this->t_c = this->t_b1 + tCoast;
 
         // Determine the angle at the end of the coast segment
-        this->theta_tc = this->theta_tr + deltaThetaCoast;
+        this->theta_tc = this->theta_tb1 + deltaThetaCoast;
 
         // Determine the time at the end of the rotation
         this->t_f = this->t_c + this->coastOptionBangDuration;
 
         // Define the parabolic constants for the first and second bang segments of the rotation
-        this->a = (this->theta_tr - this->thetaInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
+        this->a = (this->theta_tb1 - this->thetaInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
         this->b = - (this->thetaRef - this->theta_tc) / ((this->t_c - this->t_f) * (this->t_c - this->t_f));
     } else { // If the initial angle equals the reference angle, no rotation is required. Setting the final time
         // equal to the initial time ensures the correct statement is entered when the rotational states are
@@ -258,8 +258,8 @@ void PrescribedRotation1DOF::computeSecondBangSegment(double t) {
 */
 void PrescribedRotation1DOF::computeCoastSegment(double t) {
     this->thetaDDot = 0.0;
-    this->thetaDot = this->thetaDot_tr;
-    this->theta = this->thetaDot_tr * (t - this->t_b1) + this->theta_tr;
+    this->thetaDot = this->thetaDot_tb1;
+    this->theta = this->thetaDot_tb1 * (t - this->t_b1) + this->theta_tb1;
 }
 
 /*! This method computes the scalar rotational states when the rotation is complete.

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -75,11 +75,7 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
 
         // Set the parameters required to profile the rotation
         if (this->thetaInit != this->thetaRef) {
-            if (this->coastOptionBangDuration > 0.0) {
-                this->computeBangCoastBangParametersNoSmoothing();
-            } else {
-                this->computeBangBangParametersNoSmoothing();
-            }
+            this->computeRotationParameters();
         } else {
             this->t_f = this->tInit;
         }
@@ -93,6 +89,17 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
 
     // Write the module output messages
     this->writeOutputMessages(callTime);
+}
+
+/*! This intermediate method groups the calculation of rotation parameters into a single method.
+ @return void
+*/
+void PrescribedRotation1DOF::computeRotationParameters() {
+    if (this->coastOptionBangDuration > 0.0) {
+        this->computeBangCoastBangParametersNoSmoothing();
+    } else {
+        this->computeBangBangParametersNoSmoothing();
+    }
 }
 
 /*! This method computes the required parameters for the rotation with a non-smoothed bang-bang acceleration profile.

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -91,18 +91,18 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
     this->writeOutputMessages(callTime);
 }
 
-/*! This method computes the required parameters for the rotation with no coast period.
+/*! This method computes the required parameters for the rotation with a non-smoothed bang-bang acceleration profile.
  @return void
 */
 void PrescribedRotation1DOF::computeBangBangParametersNoSmoothing() {
     // Determine the total time required for the rotation
-    double totalRotTime = sqrt(((0.5 * fabs(this->thetaRef - this->thetaInit)) * 8) / this->thetaDDotMax);
+    double totalRotTime = sqrt(((0.5 * fabs(this->thetaRef - this->thetaInit)) * 8.0) / this->thetaDDotMax);
 
-    // Determine the time at the end of the rotation
+    // Determine the time when the rotation is complete t_f
     this->t_f = this->tInit + totalRotTime;
 
     // Determine the time halfway through the rotation
-    this->t_b1 = this->tInit + (totalRotTime / 2);
+    this->t_b1 = this->tInit + (totalRotTime / 2.0);
 
     // Define the parabolic constants for the first and second half of the rotation
     this->a = 0.5 * (this->thetaRef - this->thetaInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -162,9 +162,9 @@ void PrescribedRotation1DOF::computeCurrentState(double t) {
             this->computeRotationComplete();
         }
     } else {
-        if (this->isInFirstBangSegmentNoCoast(t)) {
+        if (this->isInFirstBangSegment(t)) {
             this->computeFirstBangSegment(t);
-        } else if (this->isInSecondBangSegmentNoCoast(t)) {
+        } else if (this->isInSecondBangSegment(t)) {
             this->computeSecondBangSegment(t);
         } else {
             this->computeRotationComplete();
@@ -172,15 +172,7 @@ void PrescribedRotation1DOF::computeCurrentState(double t) {
     }
 }
 
-/*! This method determines if the current time is within the first bang segment for the no coast option.
- @return bool
- @param t [s] Current simulation time
-*/
-bool PrescribedRotation1DOF::isInFirstBangSegmentNoCoast(double t) const {
-    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
-}
-
-/*! This method determines if the current time is within the first bang segment for the coast option.
+/*! This method determines if the current time is within the first bang segment.
  @return bool
  @param t [s] Current simulation time
 */
@@ -188,15 +180,7 @@ bool PrescribedRotation1DOF::isInFirstBangSegment(double t) const {
     return (t <= this->t_b1 && this->t_f - this->tInit != 0);
 }
 
-/*! This method determines if the current time is within the second bang segment for the no coast option.
- @return bool
- @param t [s] Current simulation time
-*/
-bool PrescribedRotation1DOF::isInSecondBangSegmentNoCoast(double t) const {
-    return (t > this->t_b1 && t <= this->t_f && this->t_f - this->tInit != 0);
-}
-
-/*! This method determines if the current time is within the second bang segment for the coast option.
+/*! This method determines if the current time is within the second bang segment.
  @return bool
  @param t [s] Current simulation time
 */

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -102,11 +102,11 @@ void PrescribedRotation1DOF::computeBangBangParametersNoSmoothing() {
     this->t_f = this->tInit + totalRotTime;
 
     // Determine the time halfway through the rotation
-    this->t_s = this->tInit + (totalRotTime / 2);
+    this->t_b1 = this->tInit + (totalRotTime / 2);
 
     // Define the parabolic constants for the first and second half of the rotation
-    this->a = 0.5 * (this->thetaRef - this->thetaInit) / ((this->t_s - this->tInit) * (this->t_s - this->tInit));
-    this->b = -0.5 * (this->thetaRef - this->thetaInit) / ((this->t_s - this->t_f) * (this->t_s - this->t_f));
+    this->a = 0.5 * (this->thetaRef - this->thetaInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
+    this->b = -0.5 * (this->thetaRef - this->thetaInit) / ((this->t_b1 - this->t_f) * (this->t_b1 - this->t_f));
 }
 
 /*! This method computes the required parameters for the rotation with a coast period.
@@ -115,7 +115,7 @@ void PrescribedRotation1DOF::computeBangBangParametersNoSmoothing() {
 void PrescribedRotation1DOF::computeBangCoastBangParametersNoSmoothing() {
     if (this->thetaInit != this->thetaRef) {
         // Determine the time at the end of the first bang segment
-        this->t_r = this->tInit + this->coastOptionBangDuration;
+        this->t_b1 = this->tInit + this->coastOptionBangDuration;
 
         // Determine the angle and angle rate at the end of the bang segment/start of the coast segment
         if (this->thetaInit < this->thetaRef) {
@@ -135,7 +135,7 @@ void PrescribedRotation1DOF::computeBangCoastBangParametersNoSmoothing() {
         double tCoast = fabs(deltaThetaCoast) / fabs(this->thetaDot_tr);
 
         // Determine the time at the end of the coast segment
-        this->t_c = this->t_r + tCoast;
+        this->t_c = this->t_b1 + tCoast;
 
         // Determine the angle at the end of the coast segment
         this->theta_tc = this->theta_tr + deltaThetaCoast;
@@ -144,7 +144,7 @@ void PrescribedRotation1DOF::computeBangCoastBangParametersNoSmoothing() {
         this->t_f = this->t_c + this->coastOptionBangDuration;
 
         // Define the parabolic constants for the first and second bang segments of the rotation
-        this->a = (this->theta_tr - this->thetaInit) / ((this->t_r - this->tInit) * (this->t_r - this->tInit));
+        this->a = (this->theta_tr - this->thetaInit) / ((this->t_b1 - this->tInit) * (this->t_b1 - this->tInit));
         this->b = - (this->thetaRef - this->theta_tc) / ((this->t_c - this->t_f) * (this->t_c - this->t_f));
     } else { // If the initial angle equals the reference angle, no rotation is required. Setting the final time
         // equal to the initial time ensures the correct statement is entered when the rotational states are
@@ -183,7 +183,7 @@ void PrescribedRotation1DOF::computeCurrentState(double t) {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInFirstBangSegmentNoCoast(double t) const {
-    return (t <= this->t_s && this->t_f - this->tInit != 0);
+    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the first bang segment for the coast option.
@@ -191,7 +191,7 @@ bool PrescribedRotation1DOF::isInFirstBangSegmentNoCoast(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInFirstBangSegment(double t) const {
-    return (t <= this->t_r && this->t_f - this->tInit != 0);
+    return (t <= this->t_b1 && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the no coast option.
@@ -199,7 +199,7 @@ bool PrescribedRotation1DOF::isInFirstBangSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInSecondBangSegmentNoCoast(double t) const {
-    return (t > this->t_s && t <= this->t_f && this->t_f - this->tInit != 0);
+    return (t > this->t_b1 && t <= this->t_f && this->t_f - this->tInit != 0);
 }
 
 /*! This method determines if the current time is within the second bang segment for the coast option.
@@ -215,7 +215,7 @@ bool PrescribedRotation1DOF::isInSecondBangSegment(double t) const {
  @param t [s] Current simulation time
 */
 bool PrescribedRotation1DOF::isInCoastSegment(double t) const {
-    return (t > this->t_r && t <= this->t_c && this->t_f - this->tInit != 0);
+    return (t > this->t_b1 && t <= this->t_c && this->t_f - this->tInit != 0);
 }
 
 /*! This method computes the scalar rotational states for the first bang segment.
@@ -259,7 +259,7 @@ void PrescribedRotation1DOF::computeSecondBangSegment(double t) {
 void PrescribedRotation1DOF::computeCoastSegment(double t) {
     this->thetaDDot = 0.0;
     this->thetaDot = this->thetaDot_tr;
-    this->theta = this->thetaDot_tr * (t - this->t_r) + this->theta_tr;
+    this->theta = this->thetaDot_tr * (t - this->t_b1) + this->theta_tr;
 }
 
 /*! This method computes the scalar rotational states when the rotation is complete.

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -27,8 +27,7 @@
 /*! This method self initializes the C-wrapped output messages.
  @return void
 */
-void PrescribedRotation1DOF::SelfInit()
-{
+void PrescribedRotation1DOF::SelfInit() {
     HingedRigidBodyMsg_C_init(&this->spinningBodyOutMsgC);
     PrescribedRotationMsg_C_init(&this->prescribedRotationOutMsgC);
 }
@@ -38,9 +37,8 @@ void PrescribedRotation1DOF::SelfInit()
  @param callTime [ns] Time the method is called
 */
 void PrescribedRotation1DOF::Reset(uint64_t callTime) {
-    // Check if the required input message is linked
     if (!this->spinningBodyInMsg.isLinked()) {
-        _bskLog(this->bskLogger, BSK_ERROR, "Error: prescribedRot.spinningBodyInMsg wasn't connected.");
+        _bskLog(this->bskLogger, BSK_ERROR, "Error: prescribedRotation1DOF.spinningBodyInMsg wasn't connected.");
     }
 
     this->tInit = 0.0;
@@ -59,16 +57,14 @@ void PrescribedRotation1DOF::Reset(uint64_t callTime) {
 */
 void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
     // Read the input message
-    HingedRigidBodyMsgPayload spinningBodyIn;
-    spinningBodyIn = HingedRigidBodyMsgPayload();
+    HingedRigidBodyMsgPayload spinningBodyIn = HingedRigidBodyMsgPayload();
     if (this->spinningBodyInMsg.isWritten()) {
         spinningBodyIn = this->spinningBodyInMsg();
     }
 
     /* This loop is entered (a) initially and (b) when each rotation is complete. The parameters used to profile the
     spinning body rotation are updated in this statement. */
-    if (this->spinningBodyInMsg.timeWritten() <= callTime && this->convergence)
-    {
+    if (this->spinningBodyInMsg.timeWritten() <= callTime && this->convergence) {
         // Update the initial time as the current simulation time
         this->tInit = callTime * NANO2SEC;
 
@@ -78,15 +74,15 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
         // Store the reference angle
         this->thetaRef = spinningBodyIn.theta;
 
-        // Set the convergence to false until the rotation is complete
-        this->convergence = false;
-
         // Set the parameters required to profile the rotation
         if (this->coastOptionBangDuration > 0.0) {
             this->computeCoastParameters();
         } else {
             this->computeParametersNoCoast();
         }
+
+        // Set the convergence to false until the rotation is complete
+        this->convergence = false;
     }
 
     // Compute the scalar rotational states at the current simulation time

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -75,9 +75,9 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
 
         // Set the parameters required to profile the rotation
         if (this->coastOptionBangDuration > 0.0) {
-            this->computeCoastParameters();
+            this->computeBangCoastBangParametersNoSmoothing();
         } else {
-            this->computeParametersNoCoast();
+            this->computeBangBangParametersNoSmoothing();
         }
 
         // Set the convergence to false until the rotation is complete
@@ -94,7 +94,7 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
 /*! This method computes the required parameters for the rotation with no coast period.
  @return void
 */
-void PrescribedRotation1DOF::computeParametersNoCoast() {
+void PrescribedRotation1DOF::computeBangBangParametersNoSmoothing() {
     // Determine the total time required for the rotation
     double totalRotTime = sqrt(((0.5 * fabs(this->thetaRef - this->thetaInit)) * 8) / this->thetaDDotMax);
 
@@ -112,7 +112,7 @@ void PrescribedRotation1DOF::computeParametersNoCoast() {
 /*! This method computes the required parameters for the rotation with a coast period.
  @return void
 */
-void PrescribedRotation1DOF::computeCoastParameters() {
+void PrescribedRotation1DOF::computeBangCoastBangParametersNoSmoothing() {
     if (this->thetaInit != this->thetaRef) {
         // Determine the time at the end of the first bang segment
         this->t_r = this->tInit + this->coastOptionBangDuration;

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -43,7 +43,6 @@ void PrescribedRotation1DOF::Reset(uint64_t callTime) {
 
     this->tInit = 0.0;
     this->theta = this->thetaInit;
-    this->thetaDotInit = 0.0;
     this->thetaDot = 0.0;
 
     // Set the initial convergence to true to enter the required loop in Update() method on the first pass
@@ -121,12 +120,12 @@ void PrescribedRotation1DOF::computeCoastParameters() {
         // Determine the angle and angle rate at the end of the bang segment/start of the coast segment
         if (this->thetaInit < this->thetaRef) {
             this->theta_tr = (0.5 * this->thetaDDotMax * this->coastOptionBangDuration * this->coastOptionBangDuration)
-                             + (this->thetaDotInit * this->coastOptionBangDuration) + this->thetaInit;
-            this->thetaDot_tr = this->thetaDDotMax * this->coastOptionBangDuration + this->thetaDotInit;
+                             + this->thetaInit;
+            this->thetaDot_tr = this->thetaDDotMax * this->coastOptionBangDuration;
         } else {
-            this->theta_tr = - ((0.5 * this->thetaDDotMax * this->coastOptionBangDuration * this->coastOptionBangDuration)
-                                + (this->thetaDotInit * this->coastOptionBangDuration)) + this->thetaInit;
-            this->thetaDot_tr = - this->thetaDDotMax * this->coastOptionBangDuration + this->thetaDotInit;
+            this->theta_tr = - (0.5 * this->thetaDDotMax * this->coastOptionBangDuration
+                             * this->coastOptionBangDuration) + this->thetaInit;
+            this->thetaDot_tr = - this->thetaDDotMax * this->coastOptionBangDuration;
         }
 
         // Determine the angle traveled during the coast period
@@ -232,7 +231,7 @@ void PrescribedRotation1DOF::computeFirstBangSegment(double t) {
     } else {
         this->thetaDDot = - this->thetaDDotMax;
     }
-    this->thetaDot = this->thetaDDot * (t - this->tInit) + this->thetaDotInit;
+    this->thetaDot = this->thetaDDot * (t - this->tInit);
     this->theta = this->a * (t - this->tInit) * (t - this->tInit) + this->thetaInit;
 }
 
@@ -249,8 +248,7 @@ void PrescribedRotation1DOF::computeSecondBangSegment(double t) {
     } else {
         this->thetaDDot = this->thetaDDotMax;
     }
-    this->thetaDot = this->thetaDDot * (t - this->tInit) + this->thetaDotInit
-                     - this->thetaDDot * (this->t_f - this->tInit);
+    this->thetaDot = this->thetaDDot * (t - this->tInit) - this->thetaDDot * (this->t_f - this->tInit);
     this->theta = this->b * (t - this->t_f) * (t - this->t_f) + this->thetaRef;
 }
 

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -38,7 +38,7 @@ void PrescribedRotation1DOF::SelfInit() {
 */
 void PrescribedRotation1DOF::Reset(uint64_t callTime) {
     if (!this->spinningBodyInMsg.isLinked()) {
-        _bskLog(this->bskLogger, BSK_ERROR, "Error: prescribedRotation1DOF.spinningBodyInMsg wasn't connected.");
+        _bskLog(this->bskLogger, BSK_ERROR, "prescribedRotation1DOF.spinningBodyInMsg wasn't connected.");
     }
 
     this->tInit = 0.0;

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -89,29 +89,8 @@ void PrescribedRotation1DOF::UpdateState(uint64_t callTime) {
         }
     }
 
-    // Store the current simulation time
-    double t = callTime * NANO2SEC;
-
     // Compute the scalar rotational states at the current simulation time
-    if (this->coastOptionBangDuration > 0.0) {
-        if (this->isInFirstBangSegment(t)) {
-            this->computeFirstBangSegment(t);
-        } else if (this->isInCoastSegment(t)) {
-            this->computeCoastSegment(t);
-        } else if (this->isInSecondBangSegment(t)) {
-            this->computeSecondBangSegment(t);
-        } else {
-            this->computeRotationComplete();
-        }
-    } else {
-        if (this->isInFirstBangSegmentNoCoast(t)) {
-            this->computeFirstBangSegment(t);
-        } else if (this->isInSecondBangSegmentNoCoast(t)) {
-            this->computeSecondBangSegment(t);
-        } else {
-            this->computeRotationComplete();
-        }
-    }
+    this->computeCurrentState(callTime * NANO2SEC);
 
     // Write the module output messages
     this->writeOutputMessages(callTime);
@@ -176,6 +155,31 @@ void PrescribedRotation1DOF::computeCoastParameters() {
         // equal to the initial time ensures the correct statement is entered when the rotational states are
         // profiled below
         this->t_f = this->tInit;
+    }
+}
+
+/*! This intermediate method groups the calculation of the current rotational states into a single method.
+ @return void
+*/
+void PrescribedRotation1DOF::computeCurrentState(double t) {
+    if (this->coastOptionBangDuration > 0.0) {
+        if (this->isInFirstBangSegment(t)) {
+            this->computeFirstBangSegment(t);
+        } else if (this->isInCoastSegment(t)) {
+            this->computeCoastSegment(t);
+        } else if (this->isInSecondBangSegment(t)) {
+            this->computeSecondBangSegment(t);
+        } else {
+            this->computeRotationComplete();
+        }
+    } else {
+        if (this->isInFirstBangSegmentNoCoast(t)) {
+            this->computeFirstBangSegment(t);
+        } else if (this->isInSecondBangSegmentNoCoast(t)) {
+            this->computeSecondBangSegment(t);
+        } else {
+            this->computeRotationComplete();
+        }
     }
 }
 

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -84,9 +84,9 @@ private:
     double theta;                                                          //!< [rad] Current angle
     double thetaDot;                                                       //!< [rad/s] Current angle rate
     double thetaDDot;                                                      //!< [rad/s^2] Current angular acceleration
-    double theta_tr;                                                       //!< [rad] Angle at the end of the first bang segment
+    double theta_tb1;                                                      //!< [rad] Angle at the end of the first bang segment
     double theta_tc;                                                       //!< [rad] Angle at the end of the coast segment
-    double thetaDot_tr;                                                    //!< [rad/s] Angle rate at the end of the first bang segment
+    double thetaDot_tb1;                                                   //!< [rad/s] Angle rate at the end of the first bang segment
 
     /* Temporal parameters */
     double tInit;                                                          //!< [s] Simulation time at the beginning of the rotation

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -68,6 +68,8 @@ private:
     void computeSecondBangSegment(double time);                 //!< Method for computing the scalar rotational states for the second bang segment
     void computeCoastSegment(double time);                      //!< Method for computing the scalar rotational states for the coast option coast period
     void computeRotationComplete();                             //!< Method for computing the scalar rotational states when the rotation is complete
+
+    void writeOutputMessages(uint64_t CurrentSimNanos);         //!< Method for writing the module output messages and computing the output message data
     Eigen::Vector3d computeSigma_FM();                          //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_FM
 
     /* User-configurable variables */

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -80,7 +80,6 @@ private:
 
     /* Scalar rotational states */
     double thetaInit;                                                      //!< [rad] Initial spinning body angle from frame M to frame F about rotHat_M
-    double thetaDotInit;                                                   //!< [rad/s] Initial spinning body angle rate between frame M to frame F
     double thetaRef;                                                       //!< [rad] Spinning body reference angle from frame M to frame F about rotHat_M
     double theta;                                                          //!< [rad] Current angle
     double thetaDot;                                                       //!< [rad/s] Current angle rate

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -90,8 +90,7 @@ private:
 
     /* Temporal parameters */
     double tInit;                                                          //!< [s] Simulation time at the beginning of the rotation
-    double t_r;                                                            //!< [s] The simulation time at the end of the first bang segment
-    double t_s;                                                            //!< [s] The simulation time halfway through the rotation
+    double t_b1;                                                           //!< [s] The simulation time at the end of the first bang segment
     double t_c;                                                            //!< [s] The simulation time at the end of the coast period
     double t_f;                                                            //!< [s] The simulation time when the rotation is complete
 

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -55,6 +55,7 @@ public:
 
 private:
     /* Methods for computing the required rotational parameters */
+    void computeRotationParameters();                                      //!< Intermediate method to group the calculation of rotation parameters into a single method
     void computeBangBangParametersNoSmoothing();                           //!< Method for computing the required parameters for the non-smoothed bang-bang profiler option
     void computeBangCoastBangParametersNoSmoothing();                      //!< Method for computing the required parameters for the non-smoothed bang-coast-bang profiler option
 

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -59,6 +59,7 @@ private:
     void computeCoastParameters();                              //!< Method for computing the required parameters for the rotation with a coast period
 
     /* Methods for computing the current rotational states */
+    void computeCurrentState(double time);                      //!< Intermediate method used to group the calculation of the current rotational states into a single method
     bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
     bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
     bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -54,22 +54,19 @@ public:
     BSKLogger *bskLogger;                                                  //!< BSK Logging
 
 private:
-
-    /* Coast option member functions */
-    bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
-    bool isInCoastSegment(double time) const;                   //!< Method for determining if the current time is within the coast segment for the coast option
-    bool isInSecondBangSegment(double time) const;              //!< Method for determining if the current time is within the second bang segment for the coast option
-    void computeCoastParameters();                              //!< Method for computing the required parameters for the rotation with a coast period
-    void computeCoastSegment(double time);                      //!< Method for computing the scalar rotational states for the coast option coast period
-
-    /* Non-coast option member functions */
-    bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
-    bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option
+    /* Methods for computing the required rotational parameters */
     void computeParametersNoCoast();                            //!< Method for computing the required parameters for the rotation with no coast period
+    void computeCoastParameters();                              //!< Method for computing the required parameters for the rotation with a coast period
 
-    /* Shared member functions */
+    /* Methods for computing the current rotational states */
+    bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
+    bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
+    bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option
+    bool isInSecondBangSegment(double time) const;              //!< Method for determining if the current time is within the second bang segment for the coast option
+    bool isInCoastSegment(double time) const;                   //!< Method for determining if the current time is within the coast segment for the coast option
     void computeFirstBangSegment(double time);                  //!< Method for computing the scalar rotational states for the first bang segment
     void computeSecondBangSegment(double time);                 //!< Method for computing the scalar rotational states for the second bang segment
+    void computeCoastSegment(double time);                      //!< Method for computing the scalar rotational states for the coast option coast period
     void computeRotationComplete();                             //!< Method for computing the scalar rotational states when the rotation is complete
     Eigen::Vector3d computeSigma_FM();                          //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_FM
 
@@ -78,29 +75,27 @@ private:
     double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of spinning body used in the bang segments
     Eigen::Vector3d rotHat_M;                                   //!< Spinning body rotation axis in M frame components
 
-    /* Coast option variables */
-    double theta_tr;                                            //!< [rad] Angle at the end of the first bang segment
-    double theta_tc;                                            //!< [rad] Angle at the end of the coast segment
-    double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first bang segment
-    double t_r;                                                 //!< [s] The simulation time at the end of the first bang segment
-    double t_c;                                                 //!< [s] The simulation time at the end of the coast period
-
-    /* Non-coast option variables */
-    double t_s;                                                 //!< [s] The simulation time halfway through the rotation
-
-    /* Shared module variables */
-    double theta;                                               //!< [rad] Current angle
-    double thetaDot;                                            //!< [rad/s] Current angle rate
-    double thetaDDot;                                           //!< [rad/s^2] Current angular acceleration
-    bool convergence;                                           //!< Boolean variable is true when the rotation is complete
-    double tInit;                                               //!< [s] Simulation time at the beginning of the rotation
+    /* Scalar rotational states */
     double thetaInit;                                           //!< [rad] Initial spinning body angle from frame M to frame F about rotHat_M
     double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate between frame M to frame F
     double thetaRef;                                            //!< [rad] Spinning body reference angle from frame M to frame F about rotHat_M
+    double theta;                                               //!< [rad] Current angle
+    double thetaDot;                                            //!< [rad/s] Current angle rate
+    double thetaDDot;                                           //!< [rad/s^2] Current angular acceleration
+    double theta_tr;                                            //!< [rad] Angle at the end of the first bang segment
+    double theta_tc;                                            //!< [rad] Angle at the end of the coast segment
+    double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first bang segment
+
+    /* Temporal parameters */
+    double tInit;                                               //!< [s] Simulation time at the beginning of the rotation
+    double t_r;                                                 //!< [s] The simulation time at the end of the first bang segment
+    double t_s;                                                 //!< [s] The simulation time halfway through the rotation
+    double t_c;                                                 //!< [s] The simulation time at the end of the coast period
     double t_f;                                                 //!< [s] Simulation time when the rotation is complete
+
+    bool convergence;                                           //!< Boolean variable is true when the rotation is complete
     double a;                                                   //!< Parabolic constant for the first acceleration segment
     double b;                                                   //!< Parabolic constant for the second acceleration segment
-
 };
 
 #endif

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -38,10 +38,12 @@ public:
     void UpdateState(uint64_t CurrentSimNanos) override;                   //!< Update member function
     void setCoastOptionBangDuration(double bangDuration);                  //!< Setter for the coast option bang duration
     void setRotHat_M(const Eigen::Vector3d &rotHat_M);                     //!< Setter for the spinning body rotation axis
+    void setSmoothingDuration(double smoothingDuration);                   //!< Setter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
     void setThetaDDotMax(double thetaDDotMax);                             //!< Setter for the bang segment scalar angular acceleration
     void setThetaInit(double thetaInit);                                   //!< Setter for the initial spinning body angle
     double getCoastOptionBangDuration() const;                             //!< Getter for the coast option bang duration
     const Eigen::Vector3d &getRotHat_M() const;                            //!< Getter for the spinning body rotation axis
+    double getSmoothingDuration() const;                                   //!< Getter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
     double getThetaDDotMax() const;                                        //!< Getter for the bang segment scalar angular acceleration
     double getThetaInit() const;                                           //!< Getter for the initial spinning body angle
 
@@ -58,15 +60,25 @@ private:
     void computeRotationParameters();                                      //!< Intermediate method to group the calculation of rotation parameters into a single method
     void computeBangBangParametersNoSmoothing();                           //!< Method for computing the required parameters for the non-smoothed bang-bang profiler option
     void computeBangCoastBangParametersNoSmoothing();                      //!< Method for computing the required parameters for the non-smoothed bang-coast-bang profiler option
+    void computeSmoothedBangBangParameters();                              //!< Method for computing the required parameters for the smoothed bang-bang profiler option
+    void computeSmoothedBangCoastBangParameters();                         //!< Method for computing the required parameters for the smoothed bang-coast-bang profiler option
 
     /* Methods for computing the current rotational states */
     void computeCurrentState(double time);                                 //!< Intermediate method used to group the calculation of the current rotational states into a single method
     bool isInFirstBangSegment(double time) const;                          //!< Method for determining if the current time is within the first bang segment
     bool isInSecondBangSegment(double time) const;                         //!< Method for determining if the current time is within the second bang segment
-    bool isInCoastSegment(double time) const;                              //!< Method for determining if the current time is within the coast segment for the coast option
-    void computeFirstBangSegment(double time);                             //!< Method for computing the scalar rotational states for the first bang segment
-    void computeSecondBangSegment(double time);                            //!< Method for computing the scalar rotational states for the second bang segment
-    void computeCoastSegment(double time);                                 //!< Method for computing the scalar rotational states for the coast option coast period
+    bool isInFirstSmoothedSegment(double time) const;                      //!< Method for determining if the current time is within the first smoothing segment for the smoothed profiler options
+    bool isInSecondSmoothedSegment(double time) const;                     //!< Method for determining if the current time is within the second smoothing segment for the smoothed profiler options
+    bool isInThirdSmoothedSegment(double time) const;                      //!< Method for determining if the current time is within the third smoothing segment for the smoothed profiler options
+    bool isInFourthSmoothedSegment(double time) const;                     //!< Method for determining if the current time is within the fourth smoothing segment for the smoothed bang-coast-bang option
+    bool isInCoastSegment(double time) const;                              //!< Method for determining if the current time is within the coast segment
+    void computeFirstBangSegment(double time);                             //!< Method for computing the first bang segment scalar rotational states
+    void computeSecondBangSegment(double time);                            //!< Method for computing the second bang segment scalar rotational states
+    void computeFirstSmoothedSegment(double time);                         //!< Method for computing the first smoothing segment scalar rotational states for the smoothed profiler options
+    void computeSecondSmoothedSegment(double time);                        //!< Method for computing the second smoothing segment scalar rotational states for the smoothed profiler options
+    void computeThirdSmoothedSegment(double time);                         //!< Method for computing the third smoothing segment scalar rotational states for the smoothed profiler options
+    void computeFourthSmoothedSegment(double time);                        //!< Method for computing the fourth smoothing segment scalar rotational states for the smoothed bang-coast-bang option
+    void computeCoastSegment(double time);                                 //!< Method for computing the coast segment scalar rotational states
     void computeRotationComplete();                                        //!< Method for computing the scalar rotational states when the rotation is complete
 
     void writeOutputMessages(uint64_t CurrentSimNanos);                    //!< Method for writing the module output messages and computing the output message data
@@ -74,6 +86,7 @@ private:
 
     /* User-configurable variables */
     double coastOptionBangDuration;                                        //!< [s] Time used for the coast option bang segment
+    double smoothingDuration;                                              //!< [s] Time the acceleration is smoothed to the given maximum acceleration value
     double thetaDDotMax;                                                   //!< [rad/s^2] Maximum angular acceleration of spinning body used in the bang segments
     Eigen::Vector3d rotHat_M;                                              //!< Spinning body rotation axis in M frame components
 
@@ -84,14 +97,27 @@ private:
     double thetaDot;                                                       //!< [rad/s] Current angle rate
     double thetaDDot;                                                      //!< [rad/s^2] Current angular acceleration
     double theta_tb1;                                                      //!< [rad] Angle at the end of the first bang segment
-    double theta_tc;                                                       //!< [rad] Angle at the end of the coast segment
     double thetaDot_tb1;                                                   //!< [rad/s] Angle rate at the end of the first bang segment
+    double theta_tb2;                                                      //!< [rad] Angle at the end of the second bang segment
+    double thetaDot_tb2;                                                   //!< [rad/s] Angle rate at the end of the second bang segment
+    double theta_ts1;                                                      //!< [rad] Angle at the end of the first smoothed segment
+    double thetaDot_ts1;                                                   //!< [rad/s] Angle rate at the end of the first smoothed segment
+    double theta_ts2;                                                      //!< [rad] Angle at the end of the second smoothed segment
+    double thetaDot_ts2;                                                   //!< [rad/s] Angle rate at the end of the second smoothed segment
+    double theta_ts3;                                                      //!< [rad] Angle at the end of the third smoothed segment
+    double thetaDot_ts3;                                                   //!< [rad/s] Angle rate at the end of the third smoothed segment
+    double theta_tc;                                                       //!< [rad] Angle at the end of the coast segment
+    double thetaDot_tc;                                                    //!< [rad/s] Angle rate at the end of the coast segment
 
     /* Temporal parameters */
     double tInit;                                                          //!< [s] Simulation time at the beginning of the rotation
-    double t_b1;                                                           //!< [s] The simulation time at the end of the first bang segment
-    double t_c;                                                            //!< [s] The simulation time at the end of the coast period
-    double t_f;                                                            //!< [s] The simulation time when the rotation is complete
+    double t_b1;                                                           //!< [s] Simulation time at the end of the first bang segment
+    double t_b2;                                                           //!< [s] Simulation time at the end of the second bang segment
+    double t_s1;                                                           //!< [s] Simulation time at the end of the first smoothed segment
+    double t_s2;                                                           //!< [s] Simulation time at the end of the second smoothed segment
+    double t_s3;                                                           //!< [s] Simulation time at the end of the third smoothed segment
+    double t_c;                                                            //!< [s] Simulation time at the end of the coast segment
+    double t_f;                                                            //!< [s] Simulation time when the rotation is complete
 
     bool convergence;                                                      //!< Boolean variable is true when the rotation is complete
     double a;                                                              //!< Parabolic constant for the first half of the bang-bang non-smoothed rotation

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -36,11 +36,11 @@ public:
     void SelfInit() override;                                              //!< Member function to initialize the C-wrapped output message
     void Reset(uint64_t CurrentSimNanos) override;                         //!< Reset member function
     void UpdateState(uint64_t CurrentSimNanos) override;                   //!< Update member function
-    void setCoastOptionBangDuration(double bangDuration);                  //!< Setter for the coast option bang duration
+    void setCoastOptionBangDuration(const double bangDuration);            //!< Setter for the coast option bang duration
     void setRotHat_M(const Eigen::Vector3d &rotHat_M);                     //!< Setter for the spinning body rotation axis
-    void setSmoothingDuration(double smoothingDuration);                   //!< Setter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
-    void setThetaDDotMax(double thetaDDotMax);                             //!< Setter for the bang segment scalar angular acceleration
-    void setThetaInit(double thetaInit);                                   //!< Setter for the initial spinning body angle
+    void setSmoothingDuration(const double smoothingDuration);             //!< Setter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
+    void setThetaDDotMax(const double thetaDDotMax);                       //!< Setter for the bang segment scalar angular acceleration
+    void setThetaInit(const double thetaInit);                             //!< Setter for the initial spinning body angle
     double getCoastOptionBangDuration() const;                             //!< Getter for the coast option bang duration
     const Eigen::Vector3d &getRotHat_M() const;                            //!< Getter for the spinning body rotation axis
     double getSmoothingDuration() const;                                   //!< Getter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -36,13 +36,13 @@ public:
     void SelfInit() override;                                               //!< Member function to initialize the C-wrapped output message
     void Reset(uint64_t CurrentSimNanos) override;                         //!< Reset member function
     void UpdateState(uint64_t CurrentSimNanos) override;                   //!< Update member function
-    void setCoastOptionRampDuration(double rampDuration);                  //!< Setter for the coast option ramp duration
+    void setCoastOptionBangDuration(double bangDuration);                  //!< Setter for the coast option bang duration
     void setRotHat_M(const Eigen::Vector3d &rotHat_M);                     //!< Setter for the spinning body rotation axis
-    void setThetaDDotMax(double thetaDDotMax);                             //!< Setter for the ramp segment scalar angular acceleration
+    void setThetaDDotMax(double thetaDDotMax);                             //!< Setter for the bang segment scalar angular acceleration
     void setThetaInit(double thetaInit);                                   //!< Setter for the initial spinning body angle
-    double getCoastOptionRampDuration() const;                             //!< Getter for the coast option ramp duration
+    double getCoastOptionBangDuration() const;                             //!< Getter for the coast option bang duration
     const Eigen::Vector3d &getRotHat_M() const;                            //!< Getter for the spinning body rotation axis
-    double getThetaDDotMax() const;                                        //!< Getter for the ramp segment scalar angular acceleration
+    double getThetaDDotMax() const;                                        //!< Getter for the bang segment scalar angular acceleration
     double getThetaInit() const;                                           //!< Getter for the initial spinning body angle
 
     ReadFunctor<HingedRigidBodyMsgPayload> spinningBodyInMsg;              //!< Input msg for the spinning body reference angle and angle rate
@@ -56,33 +56,33 @@ public:
 private:
 
     /* Coast option member functions */
-    bool isInFirstRampSegment(double time) const;               //!< Method for determining if the current time is within the first ramp segment for the coast option
+    bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
     bool isInCoastSegment(double time) const;                   //!< Method for determining if the current time is within the coast segment for the coast option
-    bool isInSecondRampSegment(double time) const;              //!< Method for determining if the current time is within the second ramp segment for the coast option
+    bool isInSecondBangSegment(double time) const;              //!< Method for determining if the current time is within the second bang segment for the coast option
     void computeCoastParameters();                              //!< Method for computing the required parameters for the rotation with a coast period
     void computeCoastSegment(double time);                      //!< Method for computing the scalar rotational states for the coast option coast period
 
     /* Non-coast option member functions */
-    bool isInFirstRampSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first ramp segment for the no coast option
-    bool isInSecondRampSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second ramp segment for the no coast option
+    bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
+    bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option
     void computeParametersNoCoast();                            //!< Method for computing the required parameters for the rotation with no coast period
 
     /* Shared member functions */
-    void computeFirstRampSegment(double time);                  //!< Method for computing the scalar rotational states for the first ramp segment
-    void computeSecondRampSegment(double time);                 //!< Method for computing the scalar rotational states for the second ramp segment
+    void computeFirstBangSegment(double time);                  //!< Method for computing the scalar rotational states for the first bang segment
+    void computeSecondBangSegment(double time);                 //!< Method for computing the scalar rotational states for the second bang segment
     void computeRotationComplete();                             //!< Method for computing the scalar rotational states when the rotation is complete
     Eigen::Vector3d computeSigma_FM();                          //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_FM
 
     /* User-configurable variables */
-    double coastOptionRampDuration;                             //!< [s] Ramp time used for the coast option
-    double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of spinning body used in the ramp segments
+    double coastOptionBangDuration;                             //!< [s] Bang time used for the coast option
+    double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of spinning body used in the bang segments
     Eigen::Vector3d rotHat_M;                                   //!< Spinning body rotation axis in M frame components
 
     /* Coast option variables */
-    double theta_tr;                                            //!< [rad] Angle at the end of the first ramp segment
+    double theta_tr;                                            //!< [rad] Angle at the end of the first bang segment
     double theta_tc;                                            //!< [rad] Angle at the end of the coast segment
-    double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first ramp segment
-    double tr;                                                  //!< [s] The simulation time at the end of the first ramp segment
+    double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first bang segment
+    double tr;                                                  //!< [s] The simulation time at the end of the first bang segment
     double tc;                                                  //!< [s] The simulation time at the end of the coast period
 
     /* Non-coast option variables */

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -55,8 +55,8 @@ public:
 
 private:
     /* Methods for computing the required rotational parameters */
-    void computeParametersNoCoast();                                       //!< Method for computing the required parameters for the rotation with no coast period
-    void computeCoastParameters();                                         //!< Method for computing the required parameters for the rotation with a coast period
+    void computeBangBangParametersNoSmoothing();                           //!< Method for computing the required parameters for the non-smoothed bang-bang profiler option
+    void computeBangCoastBangParametersNoSmoothing();                      //!< Method for computing the required parameters for the non-smoothed bang-coast-bang profiler option
 
     /* Methods for computing the current rotational states */
     void computeCurrentState(double time);                                 //!< Intermediate method used to group the calculation of the current rotational states into a single method

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -60,10 +60,8 @@ private:
 
     /* Methods for computing the current rotational states */
     void computeCurrentState(double time);                                 //!< Intermediate method used to group the calculation of the current rotational states into a single method
-    bool isInFirstBangSegmentNoCoast(double time) const;                   //!< Method for determining if the current time is within the first bang segment for the no coast option
-    bool isInFirstBangSegment(double time) const;                          //!< Method for determining if the current time is within the first bang segment for the coast option
-    bool isInSecondBangSegmentNoCoast(double time) const;                  //!< Method for determining if the current time is within the second bang segment for the no coast option
-    bool isInSecondBangSegment(double time) const;                         //!< Method for determining if the current time is within the second bang segment for the coast option
+    bool isInFirstBangSegment(double time) const;                          //!< Method for determining if the current time is within the first bang segment
+    bool isInSecondBangSegment(double time) const;                         //!< Method for determining if the current time is within the second bang segment
     bool isInCoastSegment(double time) const;                              //!< Method for determining if the current time is within the coast segment for the coast option
     void computeFirstBangSegment(double time);                             //!< Method for computing the scalar rotational states for the first bang segment
     void computeSecondBangSegment(double time);                            //!< Method for computing the scalar rotational states for the second bang segment

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -82,11 +82,11 @@ private:
     double theta_tr;                                            //!< [rad] Angle at the end of the first bang segment
     double theta_tc;                                            //!< [rad] Angle at the end of the coast segment
     double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first bang segment
-    double tr;                                                  //!< [s] The simulation time at the end of the first bang segment
-    double tc;                                                  //!< [s] The simulation time at the end of the coast period
+    double t_r;                                                 //!< [s] The simulation time at the end of the first bang segment
+    double t_c;                                                 //!< [s] The simulation time at the end of the coast period
 
     /* Non-coast option variables */
-    double ts;                                                  //!< [s] The simulation time halfway through the rotation
+    double t_s;                                                 //!< [s] The simulation time halfway through the rotation
 
     /* Shared module variables */
     double theta;                                               //!< [rad] Current angle
@@ -97,7 +97,7 @@ private:
     double thetaInit;                                           //!< [rad] Initial spinning body angle from frame M to frame F about rotHat_M
     double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate between frame M to frame F
     double thetaRef;                                            //!< [rad] Spinning body reference angle from frame M to frame F about rotHat_M
-    double tf;                                                  //!< [s] Simulation time when the rotation is complete
+    double t_f;                                                 //!< [s] Simulation time when the rotation is complete
     double a;                                                   //!< Parabolic constant for the first acceleration segment
     double b;                                                   //!< Parabolic constant for the second acceleration segment
 

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -33,7 +33,7 @@ public:
     PrescribedRotation1DOF() = default;                                    //!< Constructor
     ~PrescribedRotation1DOF() = default;                                   //!< Destructor
 
-    void SelfInit() override;                                               //!< Member function to initialize the C-wrapped output message
+    void SelfInit() override;                                              //!< Member function to initialize the C-wrapped output message
     void Reset(uint64_t CurrentSimNanos) override;                         //!< Reset member function
     void UpdateState(uint64_t CurrentSimNanos) override;                   //!< Update member function
     void setCoastOptionBangDuration(double bangDuration);                  //!< Setter for the coast option bang duration
@@ -55,50 +55,50 @@ public:
 
 private:
     /* Methods for computing the required rotational parameters */
-    void computeParametersNoCoast();                            //!< Method for computing the required parameters for the rotation with no coast period
-    void computeCoastParameters();                              //!< Method for computing the required parameters for the rotation with a coast period
+    void computeParametersNoCoast();                                       //!< Method for computing the required parameters for the rotation with no coast period
+    void computeCoastParameters();                                         //!< Method for computing the required parameters for the rotation with a coast period
 
     /* Methods for computing the current rotational states */
-    void computeCurrentState(double time);                      //!< Intermediate method used to group the calculation of the current rotational states into a single method
-    bool isInFirstBangSegmentNoCoast(double time) const;        //!< Method for determining if the current time is within the first bang segment for the no coast option
-    bool isInFirstBangSegment(double time) const;               //!< Method for determining if the current time is within the first bang segment for the coast option
-    bool isInSecondBangSegmentNoCoast(double time) const;       //!< Method for determining if the current time is within the second bang segment for the no coast option
-    bool isInSecondBangSegment(double time) const;              //!< Method for determining if the current time is within the second bang segment for the coast option
-    bool isInCoastSegment(double time) const;                   //!< Method for determining if the current time is within the coast segment for the coast option
-    void computeFirstBangSegment(double time);                  //!< Method for computing the scalar rotational states for the first bang segment
-    void computeSecondBangSegment(double time);                 //!< Method for computing the scalar rotational states for the second bang segment
-    void computeCoastSegment(double time);                      //!< Method for computing the scalar rotational states for the coast option coast period
-    void computeRotationComplete();                             //!< Method for computing the scalar rotational states when the rotation is complete
+    void computeCurrentState(double time);                                 //!< Intermediate method used to group the calculation of the current rotational states into a single method
+    bool isInFirstBangSegmentNoCoast(double time) const;                   //!< Method for determining if the current time is within the first bang segment for the no coast option
+    bool isInFirstBangSegment(double time) const;                          //!< Method for determining if the current time is within the first bang segment for the coast option
+    bool isInSecondBangSegmentNoCoast(double time) const;                  //!< Method for determining if the current time is within the second bang segment for the no coast option
+    bool isInSecondBangSegment(double time) const;                         //!< Method for determining if the current time is within the second bang segment for the coast option
+    bool isInCoastSegment(double time) const;                              //!< Method for determining if the current time is within the coast segment for the coast option
+    void computeFirstBangSegment(double time);                             //!< Method for computing the scalar rotational states for the first bang segment
+    void computeSecondBangSegment(double time);                            //!< Method for computing the scalar rotational states for the second bang segment
+    void computeCoastSegment(double time);                                 //!< Method for computing the scalar rotational states for the coast option coast period
+    void computeRotationComplete();                                        //!< Method for computing the scalar rotational states when the rotation is complete
 
-    void writeOutputMessages(uint64_t CurrentSimNanos);         //!< Method for writing the module output messages and computing the output message data
-    Eigen::Vector3d computeSigma_FM();                          //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_FM
+    void writeOutputMessages(uint64_t CurrentSimNanos);                    //!< Method for writing the module output messages and computing the output message data
+    Eigen::Vector3d computeSigma_FM();                                     //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_FM
 
     /* User-configurable variables */
-    double coastOptionBangDuration;                             //!< [s] Bang time used for the coast option
-    double thetaDDotMax;                                        //!< [rad/s^2] Maximum angular acceleration of spinning body used in the bang segments
-    Eigen::Vector3d rotHat_M;                                   //!< Spinning body rotation axis in M frame components
+    double coastOptionBangDuration;                                        //!< [s] Time used for the coast option bang segment
+    double thetaDDotMax;                                                   //!< [rad/s^2] Maximum angular acceleration of spinning body used in the bang segments
+    Eigen::Vector3d rotHat_M;                                              //!< Spinning body rotation axis in M frame components
 
     /* Scalar rotational states */
-    double thetaInit;                                           //!< [rad] Initial spinning body angle from frame M to frame F about rotHat_M
-    double thetaDotInit;                                        //!< [rad/s] Initial spinning body angle rate between frame M to frame F
-    double thetaRef;                                            //!< [rad] Spinning body reference angle from frame M to frame F about rotHat_M
-    double theta;                                               //!< [rad] Current angle
-    double thetaDot;                                            //!< [rad/s] Current angle rate
-    double thetaDDot;                                           //!< [rad/s^2] Current angular acceleration
-    double theta_tr;                                            //!< [rad] Angle at the end of the first bang segment
-    double theta_tc;                                            //!< [rad] Angle at the end of the coast segment
-    double thetaDot_tr;                                         //!< [rad/s] Angle rate at the end of the first bang segment
+    double thetaInit;                                                      //!< [rad] Initial spinning body angle from frame M to frame F about rotHat_M
+    double thetaDotInit;                                                   //!< [rad/s] Initial spinning body angle rate between frame M to frame F
+    double thetaRef;                                                       //!< [rad] Spinning body reference angle from frame M to frame F about rotHat_M
+    double theta;                                                          //!< [rad] Current angle
+    double thetaDot;                                                       //!< [rad/s] Current angle rate
+    double thetaDDot;                                                      //!< [rad/s^2] Current angular acceleration
+    double theta_tr;                                                       //!< [rad] Angle at the end of the first bang segment
+    double theta_tc;                                                       //!< [rad] Angle at the end of the coast segment
+    double thetaDot_tr;                                                    //!< [rad/s] Angle rate at the end of the first bang segment
 
     /* Temporal parameters */
-    double tInit;                                               //!< [s] Simulation time at the beginning of the rotation
-    double t_r;                                                 //!< [s] The simulation time at the end of the first bang segment
-    double t_s;                                                 //!< [s] The simulation time halfway through the rotation
-    double t_c;                                                 //!< [s] The simulation time at the end of the coast period
-    double t_f;                                                 //!< [s] Simulation time when the rotation is complete
+    double tInit;                                                          //!< [s] Simulation time at the beginning of the rotation
+    double t_r;                                                            //!< [s] The simulation time at the end of the first bang segment
+    double t_s;                                                            //!< [s] The simulation time halfway through the rotation
+    double t_c;                                                            //!< [s] The simulation time at the end of the coast period
+    double t_f;                                                            //!< [s] The simulation time when the rotation is complete
 
-    bool convergence;                                           //!< Boolean variable is true when the rotation is complete
-    double a;                                                   //!< Parabolic constant for the first acceleration segment
-    double b;                                                   //!< Parabolic constant for the second acceleration segment
+    bool convergence;                                                      //!< Boolean variable is true when the rotation is complete
+    double a;                                                              //!< Parabolic constant for the first half of the bang-bang non-smoothed rotation
+    double b;                                                              //!< Parabolic constant for the second half of the bang-bang non-smoothed rotation
 };
 
 #endif

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.rst
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.rst
@@ -4,21 +4,29 @@ This module profiles a 1 DOF rotation for a spinning rigid body connected to a r
 of the spinning body is designated by the frame :math:`\mathcal{F}`. The spinning body's states are profiled
 relative to a hub-fixed frame :math:`\mathcal{M}`. The :ref:`PrescribedRotationMsgPayload` message
 is used to output the prescribed rotational states from the module. The prescribed states profiled in this module
-are: ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. This module has two options to profile the spinning body
+are: ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. This module has four options to profile the spinning body
 rotation. The first option is a bang-bang acceleration profile that minimizes the time required for the rotation.
-The second option is a bang-off-bang acceleration profile that adds a coast period of zero acceleration between the
-acceleration ramp segments. The module defaults to the bang-bang option with no coast period. If the coast option is
-desired, the user must set the ramp time module variable ``coastOptionRampDuration`` to a nonzero value.
+The second option is a bang-coast-bang acceleration profile that adds a coast period of zero acceleration between the
+acceleration ramp segments. The third option is a smoothed bang-bang acceleration profile that uses cubic splines to
+construct a continuous acceleration profile across the entire rotation. The fourth option is a smoothed
+bang-coast-bang acceleration profile.
+
+The module defaults to the non-smoothed bang-bang option with no coast period. If the coast option is desired, the
+user must set the module variable ``coastOptionBangDuration`` to a nonzero value. If smoothing is desired,
+the module variable ``smoothingDuration`` must be set to a nonzero value.
 
 .. important::
     Note that this module assumes the initial and final spinning body hub-relative angular rates are zero.
 
 The general inputs to this module that must be set by the user are the spinning body rotation axis expressed as a
-unit vector in Mount frame components ``rotHat_M``, the initial spinning body angle relative to the Mount frame
-``thetaInit``, the reference spinning body angle relative to the Mount frame ``thetaRef``, the maximum scalar angular
-acceleration for the rotation ``thetaDDotMax``, and the ramp time variable ``coastOptionRampDuration`` for specifying
-the time the acceleration ramp segments are applied if the coast option is desired. This variable is defaulted to zero,
-meaning that the module defaults to the bang-bang acceleration profile with no coast period.
+unit vector in mount frame components ``rotHat_M``, the initial spinning body angle relative to the hub-fixed
+mount frame ``thetaInit``, the reference angle relative to the mount frame ``thetaRef``, and the maximum scalar angular
+acceleration for the rotation ``thetaDDotMax``. The optional inputs ``coastOptionBangDuration`` and
+``smoothingDuration`` can be set by the user to select the specific type of profiler that is desired. If these variables
+are not set by the user, the module defaults to the non-smoothed bang-bang profiler. If only the variable
+``coastOptionBangDuration`` is set to a nonzero value, the bang-coast-bang profiler is selected. If only the variable
+``smoothingDuration`` is set to a nonzero value, the smoothed bang-bang profiler is selected. If both variables are
+set to nonzero values, the smoothed bang-coast-bang profiler is selected.
 
 .. important::
     To use this module for prescribed motion, it must be connected to the :ref:`PrescribedMotionStateEffector`
@@ -59,8 +67,8 @@ provides information on what the message is used for.
 Detailed Module Description
 ---------------------------
 
-Profiler With No Coast Period
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Non-Smoothed Bang-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The first option to profile the spinning body rotation is a pure bang-bang acceleration profile. If the spinning
 body reference angle is greater than the given initial angle, the user-specified maximum angular acceleration value
@@ -87,7 +95,7 @@ rotation the states are:
 where
 
 .. math::
-    a = \frac{ \theta_{\text{ref}} - \theta_0}{2 (t_s - t_0)^2}
+    a = \frac{ \theta_{\text{ref}} - \theta_0}{2 (t_{b1} - t_0)^2}
 
 During the second half of the rotation the states are:
 
@@ -103,25 +111,25 @@ During the second half of the rotation the states are:
 where
 
 .. math::
-    b = - \frac{ \theta_{\text{ref}} - \theta_0}{2 (t_s - t_f)^2}
+    b = - \frac{ \theta_{\text{ref}} - \theta_0}{2 (t_{b1} - t_f)^2}
 
-The switch time :math:`t_s` is the simulation time halfway through the rotation:
+The switch time :math:`t_{b1}` is the simulation time at the end of the first bang segment:
 
 .. math::
-    t_s = t_0 + \frac{\Delta t_{\text{tot}}}{2}
+    t_{b1} = t_0 + \frac{\Delta t_{\text{tot}}}{2}
 
 The total time required to complete the rotation :math:`\Delta t_{\text{tot}}` is:
 
 .. math::
     \Delta t_{\text{tot}} = 2 \sqrt{ \frac{| \theta_{\text{ref}} - \theta_0 | }{\ddot{\theta}_{\text{max}}}} = t_f - t_0
 
-Profiler With Coast Period
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Non-Smoothed Bang-Coast-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The second option to profile the spinning body rotation is a bang-coast-bang acceleration profile with an added coast
 period between the acceleration segments where the acceleration is zero. Similar to the previous profiler, if the
 spinning body reference angle is greater than the given initial angle, the maximum angular acceleration value is applied
-positively for the specified ramp time ``coastOptionRampDuration`` to the first segment of the rotation and negatively
+positively for the specified ramp time ``coastOptionBangDuration`` to the first segment of the rotation and negatively
 to the third segment of the rotation. The second segment of the rotation is the coast period. However, if the reference
 angle is less than the initial spinning body angle, the acceleration is instead applied negatively during the first
 segment of the rotation and positively during the third segment of the rotation. As a result of this acceleration
@@ -146,18 +154,19 @@ rotation the states are:
 where
 
 .. math::
-    a = \frac{ \theta(t_r) - \theta_0}{2 (t_r - t_0)^2}
+    a = \frac{ \theta(t_{b1}) - \theta_0}{2 (t_{b1} - t_0)^2}
 
-and :math:`\theta(t_r)` is the spinning body angle at the end of the first segment:
+and :math:`\theta(t_{b1})` is the spinning body angle at the end of the first bang segment:
 
 .. math::
-    \theta(t_r) = \pm \frac{1}{2} \ddot{\theta}_{\text{max}} t_{\text{ramp}}^2
-                                       + \dot{\theta}_0 t_{\text{ramp}} + \theta_0
+    \theta(t_{b1}) = \pm \frac{1}{2} \ddot{\theta}_{\text{max}} t_{\text{bang}}^2
+                                       + \dot{\theta}_0 t_{\text{bang}} + \theta_0
 
 .. important::
-    Note the distinction between :math:`t_r` and :math:`t_{\text{ramp}}`. :math:`t_{\text{ramp}}` is the time duration
-    of the acceleration segment configured by the user as the module variable ``coastOptionRampDuration``.
-    :math:`t_r` is the simulation time at the end of the first acceleration segment. :math:`t_r = t_0 + t_{\text{ramp}}`
+    Note the distinction between :math:`t_{b1}` and :math:`t_{\text{bang}}`. :math:`t_{\text{bang}}` is the time
+    duration of the acceleration segment configured by the user as the module variable ``coastOptionBangDuration``.
+    :math:`t_{b1}` is the simulation time at the end of the first acceleration segment.
+    :math:`t_{b1} = t_0 + t_{\text{bang}}`
 
 During the coast segment, the rotation states are:
 
@@ -165,10 +174,10 @@ During the coast segment, the rotation states are:
     \ddot{\theta}(t) = 0
 
 .. math::
-    \dot{\theta}(t) = \dot{\theta}(t_r) = \ddot{\theta}_{\text{max}} t_{\text{ramp}} + \dot{\theta}_0
+    \dot{\theta}(t) = \dot{\theta}(t_{b1}) = \ddot{\theta}_{\text{max}} t_{\text{bang}} + \dot{\theta}_0
 
 .. math::
-    \theta(t) = \dot{\theta}(t_r) (t - t_r) + \theta(t_r)
+    \theta(t) = \dot{\theta}(t_{b1}) (t - t_{b1}) + \theta(t_{b1})
 
 During the third segment, the rotation states are
 
@@ -189,59 +198,274 @@ where
 Here :math:`\theta(t_c)` is the spinning body angle at the end of the coast segment:
 
 .. math::
-    \theta(t_c) = \theta(t_r) + \Delta \theta_{\text{coast}}
+    \theta(t_c) = \theta(t_{b1}) + \Delta \theta_{\text{coast}}
 
 and :math:`\Delta \theta_{\text{coast}}` is the angle traveled during the coast segment:
 
 .. math::
-    \Delta \theta_{\text{coast}} = (\theta_{\text{ref}} - \theta_0) - 2 (\theta(t_r) - \theta_0)
+    \Delta \theta_{\text{coast}} = (\theta_{\text{ref}} - \theta_0) - 2 (\theta(t_{b1}) - \theta_0)
 
 :math:`t_c` is the simulation time at the end of the coast segment:
 
 .. math::
-    t_c = t_r + \frac{\Delta \theta_{\text{coast}}}{\dot{\theta}(t_r)}
+    t_c = t_{b1} + \frac{\Delta \theta_{\text{coast}}}{\dot{\theta}(t_{b1})}
 
 Using the given rotation axis ``rotHat_M``, the scalar states are then transformed to the spinning body
 rotational states ``omega_FM_F``, ``omegaPrime_FM_F``, and ``sigma_FM``. The states are then written to the
 :ref:`PrescribedRotationMsgPayload` module output message.
 
+Smoothed Bang-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The third option to profile the rotation is a smoothed bang-bang acceleration profile. This option is selected
+by setting the module variable ``smoothingDuration`` to a nonzero value. This profiler uses cubic splines to construct
+a continuous acceleration profiler across the entire rotation. Similar to the non-smoothed bang-bang profiler,
+this option smooths the acceleration between the given maximum acceleration values.
+To profile this motion, the spinning body's hub-relative scalar states :math:`\theta`, :math:`\dot{\theta}`, and
+:math:`\ddot{\theta}` are prescribed as a function of time and the rotational motion is split into five different
+segments.
+
+The first segment smooths the acceleration from zero to the user-specified maximum acceleration value in the given
+time ``smoothingDuration``. If the given reference angle is greater than the given initial angle, the
+acceleration is smoothed positively to the given maximum acceleration value. If the given reference angle is less
+than the given initial angle, the acceleration is smoothed from zero to the negative maximum acceleration value.
+During this phase, the scalar hub-relative states are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{3 (t - t_0)^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_0)^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{(t - t_0)^3}{t_{\text{smooth}}^2} - \frac{(t - t_0)^4}{2 t_{\text{smooth}}^3} \right)
+
+.. math::
+    \theta(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{(t - t_0)^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_0)^5}{10 t_{\text{smooth}}^3} \right) + \theta_0
+
+The second segment is the first bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}}
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} (t - t_{s1}) + \dot{\theta}(t_{s1})
+
+.. math::
+    \theta(t) = \pm \frac{\ddot{\theta}_{\text{max}} (t - t_{s1})^2}{2} + \dot{\theta}(t_{s1})(t - t_{s1}) + \theta(t_{s1})
+
+where :math:`t_{s1}` is the time at the end of the first smoothing segment:
+
+.. math::
+    t_{s1} = t_0 + t_{\text{smooth}}
+
+The third segment smooths the acceleration from the current maximum acceleration value to the opposite magnitude maximum
+acceleration value. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( 1 - \frac{3 (t - t_{b1})^2}{2 t_{\text{smooth}}^2} + \frac{(t - t_{b1})^3}{2 t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( (t - t_{b1}) - \frac{(t - t_{b1})^3}{2 t_{\text{smooth}}^2} + \frac{(t - t_{b1})^4}{8 t_{\text{smooth}}^3} \right) + \dot{\theta}(t_{b1})
+
+.. math::
+    \theta(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{(t - t_{b1})^2}{2} - \frac{(t - t_{b1})^4}{8 t_{\text{smooth}}^2} + \frac{(t - t_{b1})^5}{40 t_{\text{smooth}}^3} \right) + \dot{\theta}(t_{b1})(t - t_{b1}) + \theta(t_{b1})
+
+where :math:`t_{b1}` is the time at the end of the first bang segment:
+
+.. math::
+    t_{b1} = t_{s1} + t_{\text{bang}}
+
+The fourth segment is the second bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}}
+
+.. math::
+    \dot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} (t - t_{s2}) + \dot{\theta}(t_{s2})
+
+.. math::
+    \theta(t) = \mp \frac{\ddot{\theta}_{\text{max}} (t - t_{s2})^2}{2} + \dot{\theta}(t_{s2})(t - t_{s2}) + \theta(t_{s2})
+
+where :math:`t_{s2}` is the time at the end of the second smoothing segment:
+
+.. math::
+    t_{s2} = t_{b1} + t_{\text{smooth}}
+
+The fifth segment is the third and final smoothing segment where the acceleration returns to zero. The scalar
+hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} \left ( -1 + \frac{3(t - t_{b2})^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_{b2})^3}{t_{\text{smooth}}^3} \right )
+
+.. math::
+    \dot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} \left ( -(t - t_{b2}) + \frac{(t - t_{b2})^3}{t_{\text{smooth}}^2} - \frac{(t - t_{b2})^4}{2 t_{\text{smooth}}^3} \right ) + \dot{\theta}(t_{b2})
+
+.. math::
+    \theta(t) = \mp \ddot{\theta}_{\text{max}} \left ( \frac{(t - t_{b2})^2}{2} + \frac{(t - t_{b2})^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_{b2})^5}{10 t_{\text{smooth}}^3} \right ) + \dot{\theta}(t_{b2})(t - t_{b2}) + \theta(t_{b2})
+
+where :math:`t_{b2}` is the time at the end of the second bang segment:
+
+.. math::
+    t_{b2} = t_{s2} + t_{\text{bang}}
+
+Smoothed Bang-Coast-Bang Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The fourth option to profile the rotation is a smoothed bang-coast-bang acceleration profile. This option is
+selected by setting the module variables ``coastOptionBangDuration`` and ``smoothingDuration`` to nonzero values.
+This profiler uses cubic splines to construct a continuous acceleration profiler across the entire rotation.
+To profile this motion, the spinning body's hub-relative scalar states :math:`\theta`, :math:`\dot{\theta}`, and
+:math:`\ddot{\theta}` are prescribed as a function of time and the rotational motion is split into seven different
+segments.
+
+The first segment smooths the acceleration from zero to the user-specified maximum acceleration value in the given
+time ``smoothingDuration``. If the given reference angle is greater than the given initial angle, the
+acceleration is smoothed positively to the given maximum acceleration value. If the given reference angle is less
+than the given initial angle, the acceleration is smoothed from zero to the negative maximum acceleration value.
+During this phase, the scalar hub-relative states are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{3 (t - t_0)^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_0)^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{(t - t_0)^3}{t_{\text{smooth}}^2} - \frac{(t - t_0)^4}{2 t_{\text{smooth}}^3} \right)
+
+.. math::
+    \theta(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{(t - t_0)^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_0)^5}{10 t_{\text{smooth}}^3} \right) + \theta_0
+
+The second segment is the first bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}}
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} (t - t_{s1}) + \dot{\theta}(t_{s1})
+
+.. math::
+    \theta(t) = \pm \frac{\ddot{\theta}_{\text{max}} (t - t_{s1})^2}{2} + \dot{\theta}(t_{s1})(t - t_{s1}) + \theta(t_{s1})
+
+where :math:`t_{s1}` is the time at the end of the first smoothing segment.
+
+The third segment prior to the coast phase smooths the acceleration from the current maximum acceleration value to zero.
+The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( 1 - \frac{3 (t - t_{b1})^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_{b1})^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left( (t - t_{b1}) - \frac{(t - t_{b1})^3}{t_{\text{smooth}}^2} - \frac{(t - t_{b1})^4}{2 t_{\text{smooth}}^3} \right) + \dot{\theta}(t_{b1})
+
+.. math::
+    \theta(t) = \pm \ddot{\theta}_{\text{max}} \left( \frac{(t - t_{b1})^2}{2} - \frac{(t - t_{b1})^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_{b1})^5}{10 t_{\text{smooth}}^3} \right) + \dot{\theta}(t_{b1})(t - t_{b1}) + \theta(t_{b1})
+
+where :math:`t_{b1}` is the time at the end of the first bang segment.
+
+The fourth segment is the coast segment where the rotational states are:
+
+.. math::
+    \ddot{\theta}(t) = 0
+
+.. math::
+    \dot{\theta}(t) = \dot{\theta}(t_{s2})
+
+.. math::
+    \theta(t) = \dot{\theta}(t_{s2}) (t - t_{s2}) + \theta(t_{s2})
+
+where :math:`t_{s2}` is the time at the end of the second smoothing segment.
+
+The fifth segment smooths the acceleration from zero to the maximum acceleration value prior to the second bang segment.
+The rotational states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} \left( \frac{3 (t - t_c)^2}{t_{\text{smooth}}^2} - \frac{2 (t - t_c)^3}{t_{\text{smooth}}^3} \right)
+
+.. math::
+    \dot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} \left( \frac{(t - t_c)^3}{t_{\text{smooth}}^2} - \frac{(t - t_c)^4}{2 t_{\text{smooth}}^3} \right) + \dot{\theta}(t_c)
+
+.. math::
+    \theta(t) = \mp \ddot{\theta}_{\text{max}} \left( \frac{(t - t_c)^4}{4 t_{\text{smooth}}^2} - \frac{(t - t_c)^5}{10 t_{\text{smooth}}^3} \right) + \dot{\theta}(t_c) (t - t_c) + \theta(t_c)
+
+where :math:`t_c` is the time at the end of the coast segment.
+
+The sixth segment is the second bang segment where the maximum acceleration value is applied either positively or
+negatively as discussed previously. The scalar hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}}
+
+.. math::
+    \dot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} (t - t_{s3}) + \dot{\theta}(t_{s3})
+
+.. math::
+    \theta(t) = \mp \frac{\ddot{\theta}_{\text{max}} (t - t_{s3})^2}{2} + \dot{\theta}(t_{s3})(t - t_{s3}) + \theta(t_{s3})
+
+where :math:`t_{s3}` is the time at the end of the third smoothing segment.
+
+The seventh segment is the fourth and final smoothing segment where the acceleration returns to zero. The scalar
+hub-relative states during this phase are:
+
+.. math::
+    \ddot{\theta}(t) = \mp \ddot{\theta}_{\text{max}} \left (\frac{3(t_f - t)^2}{t_{\text{smooth}}^2} - \frac{2 (t_f - t)^3}{t_{\text{smooth}}^3} \right )
+
+.. math::
+    \dot{\theta}(t) = \pm \ddot{\theta}_{\text{max}} \left (\frac{(t_f - t)^3}{t_{\text{smooth}}^2} - \frac{(t_f - t)^4}{2 t_{\text{smooth}}^3} \right )
+
+.. math::
+    \theta(t) = \mp \ddot{\theta}_{\text{max}} \left (\frac{(t_f - t)^4}{4 t_{\text{smooth}}^2} - \frac{(t_f - t)^5}{10 t_{\text{smooth}}^3} \right ) + \theta_{\text{ref}}
+
+where :math:`t_f` is the time at the end of the rotation:
+
 Module Testing
 ^^^^^^^^^^^^^^
-The unit test for this module ensures that the 1 DOF rotation is properly profiled for several different
-simulation configurations. The unit test profiles two successive rotations for the spinning body to ensure the
-module is correctly configured. The initial spinning body angle relative to the spacecraft hub is varied,
-along with the two final reference angles and the maximum angular acceleration for the rotation.
-The unit test also tests both methods of profiling the rotation, where either a pure bang-bang acceleration
-profile can be selected for the rotation, or a bang-off-bang option can be selected where a coast period with zero
-acceleration is added between the acceleration ramp segments. To validate the module, the final spinning body angle
-at the end of each rotation are checked to match the specified reference angles.
+The unit test for this module ensures that the profiled 1 DOF rotation for a secondary rigid body relative to
+the spacecraft hub is properly computed for several different simulation configurations. The unit test profiles
+two successive rotations to ensure the module is correctly configured. The initial spinning body angle relative
+to the spacecraft hub is varied, along with the two final reference angles and the maximum angular acceleration
+for the rotation.
+
+The unit test also tests four different methods of profiling the rotation. Two profilers prescribe a pure
+bang-bang or bang-coast-bang angular acceleration profile for the rotation. The bang-bang option results in
+the fastest possible rotation; while the bang-coast-bang option includes a coast period with zero acceleration
+between the acceleration segments. The other two profilers apply smoothing to the bang-bang and bang-coast-bang
+acceleration profiles so that the spinning body hub-relative rates start and end at zero.
+
+To verify the module functionality, the final angle at the end of each rotation is checked to match the specified
+reference angle. Additionally, for the smoothed profiler options, the numerical derivative of the profiled angles
+and their rates is determined across the entire simulation. These numerical derivatives are checked with the module's
+acceleration and rate profiles to ensure the profiled acceleration is correctly integrated in the module to obtain
+the angles and their rates.
 
 User Guide
 ----------
 The general inputs to this module that must be set by the user are the spinning body rotation axis expressed as a
-unit vector in Mount frame components ``rotHat_M``, the initial spinning body angle relative to the Mount frame
-``thetaInit``, the reference spinning body angle relative to the Mount frame ``thetaRef``, the maximum scalar angular
-acceleration for the rotation ``thetaDDotMax``, and the ramp time variable ``coastOptionRampDuration`` for specifying
-the time the acceleration ramp segments are applied if the coast option is desired. This variable is defaulted to zero,
-meaning that the module defaults to the bang-bang acceleration profile with no coast period.
+unit vector in mount frame components ``rotHat_M``, the initial spinning body angle relative to the hub-fixed
+mount frame ``thetaInit``, the reference angle relative to the mount frame ``thetaRef``, and the maximum scalar angular
+acceleration for the rotation ``thetaDDotMax``. The optional inputs ``coastOptionBangDuration`` and
+``smoothingDuration`` can be set by the user to select the specific type of profiler that is desired. If these variables
+are not set by the user, the module defaults to the non-smoothed bang-bang profiler. If only the variable
+``coastOptionBangDuration`` is set to a nonzero value, the bang-coast-bang profiler is selected. If only the variable
+``smoothingDuration`` is set to a nonzero value, the smoothed bang-bang profiler is selected. If both variables are
+set to nonzero values, the smoothed bang-coast-bang profiler is selected.
 
 This section is to outline the steps needed to set up the prescribed rotational 1 DOF module in python using Basilisk.
 
-#. Import the prescribedRot1DOF class::
+#. Import the prescribedRotation1DOF class::
 
     from Basilisk.simulation import prescribedRotation1DOF
 
 #. Create an instantiation of the module::
 
-    prescribedRot1DOF = prescribedRotation1DOF.prescribedRotation1DOF()
+    prescribedRot1DOF = prescribedRotation1DOF.PrescribedRotation1DOF()
 
-#. Define all of the configuration data associated with the module. For example, to configure the coast option::
+#. Define all of the configuration data associated with the module. For example, to configure the smoothed bang-coast-bang option::
 
     prescribedRot1DOF.ModelTag = "prescribedRotation1DOF"
-    prescribedRot1DOF.setCoastOptionRampDuration(3.0)  # [s]
     prescribedRot1DOF.setRotHat_M(np.array([0.0, 1.0, 0.0]))
     prescribedRot1DOF.setThetaDDotMax(macros.D2R * 1.0)  # [rad/s^2]
     prescribedRot1DOF.setThetaInit(macros.D2R * 10.0)  # [rad]
+    prescribedRot1DOF.setCoastOptionBangDuration(3.0)  # [s]
+    prescribedRot1DOF.setSmoothingDuration(1.0)  # [s]
 
 #. Connect a :ref:`HingedRigidBodyMsgPayload` message for the spinning body reference angle to the module. For example, the user can create a stand-alone message to specify the reference angle::
 
@@ -257,4 +481,3 @@ This section is to outline the steps needed to set up the prescribed rotational 
 #. Add the module to the task list::
 
     unitTestSim.AddModelToTask(unitTaskName, prescribedRot1DOF)
-


### PR DESCRIPTION
* **Tickets addressed:** bsk-612
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
A smoothing option is added to the `prescribedRotation1DOF` module that smooths the bang-bang and bang-coast-bang options using cubic-spline acceleration profiles. This option is added to improve the verification of the prescribed motion state effector module and reduce the likelihood of exciting flexible modes of the spacecraft components. As a result of this update to the module, there are now four available options to configure the module: bang-bang, bang-coast-bang, smoothed bang-bang, and smoothed bang-coast-bang.

The first 14 commits of this PR are changes that are made to the existing profiler module to prepare and organize the module for the addition of the smoothing profilers. The following commits are changes made to add smoothing to the module.

## Verification
The module unit test is updated to check the smoothed profilers. In addition to checking that the angles converge to the reference values, the numerical derivative of the profiled angles and their rates is determined across the entire simulation and then checked with the module's profiled accelerations and angle rates to ensure the
profiled acceleration is correctly integrated in the module to obtain the angles and rates.

## Documentation
The module documentation is updated to discuss the mathematics for the smoothed profiler options.

## Future work
N/A