### PR TITLE
Refactor/bsk 656 tweak prescribed linear translation

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -66,7 +66,10 @@ Version |release|
 - Updated :ref:`MtbEffector` to include missing swig interface file for a message definition and corrected
   message table in the module documentation.
 - Added smoothed bang-bang and smoothed bang-coast-bang profiler options to the :ref:`prescribedLinearTranslation`
-  simulation module
+  simulation module. Note that the optional module variable ``coastOptionRampDuration`` has been renamed to
+  ``coastOptionBangDuration``. The setter and getter methods for this variable are renamed to reflect this change as
+  ``setCoastOptionBangDuration()`` and  ``getCoastOptionBangDuration()``, respectively. See the module documentation
+  for the current usage of this parameter and these associated methods.
 - Added a new commanded linear force array :ref:`LinearTranslationRigidBodyMsgPayload`.
 - Added a new single-axis translating effector :ref:`linearTranslationOneDOFStateEffector`.
 - Added smoothed bang-bang and smoothed bang-coast-bang profiler options to the :ref:`prescribedRotation1DOF`

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -62,7 +62,7 @@ void PrescribedLinearTranslation::UpdateState(uint64_t callTime) {
         linearTranslationRigidBodyIn = this->linearTranslationRigidBodyInMsg();
     }
 
-    /* This loop is entered (a) initially and (b) when each rotation is complete.
+    /* This loop is entered (a) initially and (b) when the translation is complete.
     The parameters used to profile the translation are updated in this statement. */
     if (this->linearTranslationRigidBodyInMsg.timeWritten() <= callTime && this->convergence) {
         // Update the initial time as the current simulation time

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.cpp
@@ -667,7 +667,7 @@ void PrescribedLinearTranslation::writeOutputMessages(uint64_t callTime) {
  @return void
  @param coastOptionBangDuration [s] Bang segment time duration
 */
-void PrescribedLinearTranslation::setCoastOptionBangDuration(double coastOptionBangDuration) {
+void PrescribedLinearTranslation::setCoastOptionBangDuration(const double coastOptionBangDuration) {
     this->coastOptionBangDuration = coastOptionBangDuration;
 }
 
@@ -675,7 +675,7 @@ void PrescribedLinearTranslation::setCoastOptionBangDuration(double coastOptionB
  @return void
  @param smoothingDuration [s] Duration the acceleration is smoothed until reaching the given maximum acceleration value
 */
-void PrescribedLinearTranslation::setSmoothingDuration(double smoothingDuration) {
+void PrescribedLinearTranslation::setSmoothingDuration(const double smoothingDuration) {
     this->smoothingDuration = smoothingDuration;
 }
 
@@ -683,7 +683,7 @@ void PrescribedLinearTranslation::setSmoothingDuration(double smoothingDuration)
  @return void
  @param transAccelMax [m/s^2] Bang segment linear angular acceleration
 */
-void PrescribedLinearTranslation::setTransAccelMax(double transAccelMax) {
+void PrescribedLinearTranslation::setTransAccelMax(const double transAccelMax) {
     this->transAccelMax = transAccelMax;
 }
 
@@ -699,7 +699,7 @@ void PrescribedLinearTranslation::setTransHat_M(const Eigen::Vector3d &transHat_
  @return void
  @param transPosInit [m] Initial translating body position relative to the hub
 */
-void PrescribedLinearTranslation::setTransPosInit(double transPosInit) {
+void PrescribedLinearTranslation::setTransPosInit(const double transPosInit) {
     this->transPosInit = transPosInit;
 }
 

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/prescribedLinearTranslation.h
@@ -36,11 +36,11 @@ public:
     void SelfInit() override;                                                   //!< Member function to initialize the C-wrapped output message
     void Reset(uint64_t CurrentSimNanos) override;                              //!< Reset member function
     void UpdateState(uint64_t CurrentSimNanos) override;                        //!< Update member function
-    void setCoastOptionBangDuration(double bangDuration);                       //!< Setter method for the coast option bang duration
-    void setSmoothingDuration(double smoothingDuration);                        //!< Setter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
-    void setTransAccelMax(double transAccelMax);                                //!< Setter method for the bang segment scalar linear acceleration
+    void setCoastOptionBangDuration(const double bangDuration);                 //!< Setter method for the coast option bang duration
+    void setSmoothingDuration(const double smoothingDuration);                  //!< Setter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
+    void setTransAccelMax(const double transAccelMax);                          //!< Setter method for the bang segment scalar linear acceleration
     void setTransHat_M(const Eigen::Vector3d &transHat_M);                      //!< Setter method for the translating body axis of translation
-    void setTransPosInit(double transPosInit);                                  //!< Setter method for the initial translating body hub-relative position
+    void setTransPosInit(const double transPosInit);                            //!< Setter method for the initial translating body hub-relative position
     double getCoastOptionBangDuration() const;                                  //!< Getter method for the coast option bang duration
     double getSmoothingDuration() const;                                        //!< Getter method for the duration the acceleration is smoothed until reaching the given maximum acceleration value
     double getTransAccelMax() const;                                            //!< Getter method for the bang segment scalar linear acceleration


### PR DESCRIPTION
* **Tickets addressed:** bsk-656
* **Review:** By commit
* **Merge strategy:** squash and merge

## Description
This PR addresses a few changes that should be made to the existing `prescribedLinearTranslation` module to match the current changes being applied to the prescribedRotation1DOF module. These changes include:

1. Updating release notes to point out the renamed module variable `coastOptionBangDuration` and the associated setter and getter methods. 
2. Add `const` keyword to the module setter function parameters
3. Fixing up comments

## Verification
N/A

## Documentation
N/A

## Future work
N/A
