### PR TITLE
Update CODEOWNERS to actually assign code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@AVSLab/basilisk-reviewers
+* @AVSLab/basilisk-reviewers


### PR DESCRIPTION
* **Tickets addressed:** #589 
* **Review:** By commit
* **Merge strategy:** Merge

## Description
It appears none of the files in the repo were being marked as owned. This should assign all files to be owned by BSK reviewers, and enforce that they provide a review. See this for more details on syntax:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

## Verification
Checked in my test repository that this format will correctly assign ownership of all files. Files previewed on GitHub will show a little lock by the name and list code owners once this change is made; note that our files don't currently show this.

<img width="658" alt="Screenshot 2024-04-09 at 4 30 25 PM" src="https://github.com/AVSLab/basilisk/assets/1545655/835efbbb-08a2-4514-a0b9-bffdefa51a2d">

## Future work
None.