### PR TITLE
Feature/658 Print exceptions raised in Python modules

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,6 +32,7 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Removed the depreciated manner of creating python modules
+- Uncaught exceptions raised in Python modules are now printed to ``stderr`` before the program is terminated.
 
 
 Version 2.3.0 (April 5, 2024)


### PR DESCRIPTION
* **Tickets addressed:** Closes #658 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Any exception raised in `UpdateState` or `Reset` in python modules will be printed to the `stderr` (with full stacktrace) before propagating to C++ (and crashing the program). I would have preferred to transform this Python exception to a C++ exception, propagate that through C++, and then raise the exception back in Python when we call `ExecuteSimulation`. This is normally done through exception unrolling (https://swig.org/Doc4.1/SWIGDocumentation.html#Python_nn36). I tried to implement that, but I couldn't get an elegant solution to work. Other developers are welcome to propose a better fix for this issue, but this solution should at least address the main concern raised in #658 .

## Verification
`src\architecture\system_model\_UnitTest\test_PySysModel.py` was updated to test that the methods are printing their exceptions.

## Future work
Figure out proper exception unrolling. If we do so, we will get the nice error prints + ability to capture exceptions in `try except` blocks + support for any kind of special handling of exceptions that users might use.