### PR TITLE
Feature/constraintEffector

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -31,6 +31,9 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
+- Added a new example scenario :ref:`scenarioConstrainedDynamics` demonstrating post-docked spacecraft dynamics
+- Created a :ref:`constraintDynamicEffector` dynamics module to couple separate spacecraft motion using holonomic
+  constraints
 - Removed the depreciated manner of creating python modules
 - Created a new example scenario :ref:`scenarioTempMeasurementAttitude` demonstrating the use of tempMeasurement module and generating random noise in the measurement.
 - Uncaught exceptions raised in Python modules are now printed to ``stderr`` before the program is terminated.

--- a/examples/_default.rst
+++ b/examples/_default.rst
@@ -212,6 +212,7 @@ Complex Spacecraft Dynamics Simulations
    Spacecraft with 1- or 2-DOF Panel using single effector <scenarioSpinningBodiesTwoDOF>
    Prescribed Motion Rotational Solar Array Deployment <scenarioDeployingSolarArrays>
    Robotic Arm Effector with Profiler <scenarioRoboticArm>
+   Two Spacecraft Connected Using Holonomic Constraints <scenarioConstrainedDynamics>
 
 Mission Simulations
 ---------------------------------------

--- a/examples/scenarioConstrainedDynamics.py
+++ b/examples/scenarioConstrainedDynamics.py
@@ -1,0 +1,272 @@
+# ISC License
+#
+# Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+r"""
+Overview
+--------
+
+This scenario demonstrates the capabilities of :ref:`constraintDynamicEffector` in simulating a dynamic coupling
+between two spacecraft. The constraint effector allows the simulation of two spacecraft rigid hubs attached
+through an arm of variable rigidity and is agnostic to the parameters of either vehicle. The scenario can be run
+with gravity to place the set of spacecraft in low Earth orbit or without gravity to simulate a deep space scenario.
+
+The script is found in the folder ``basilisk/examples`` and executed by using::
+
+    python3 scenarioConstrainedDynamics.py
+
+The scenario outputs two plots: one for the translational constraint violations, and another for the rotational constraint
+violations. These constraint violations can be used to evaluate whether the simulation is replicating coupled motion with
+the desired fidelity and tune gains if the bounds should be changed. Increasing alpha and beta will reduce the magnitude
+of the constraint violations while increasing run time.
+
+Illustration of Simulation Results
+----------------------------------
+
+::
+
+    show_plots = True, env = 'Gravity'
+
+Here, two identical spacecraft are connected along their body frame x-axes with a slight tumble rate while in low Earth orbit.
+The time history for both the holonomic direction and attitude constraint violations are shown below. Note the y-axis log scale
+showing the order of magnitude of the violations. The initial transient rises from perfect initial setup conditions before
+settling to an equilibrium. This equilibrium is impacted by how dynamic the scenario is (rotation rate, gravity, thrusting),
+the mass and inertia of the respective vehicles, and how stiff the gains are driven by the alpha and beta tuning parameters.
+
+.. image:: /_images/Scenarios/scenarioConstrainedDynamicsDirectionConstraint.svg
+   :align: center
+
+.. image:: /_images/Scenarios/scenarioConstrainedDynamicsAttitudeConstraint.svg
+   :align: center
+
+"""
+
+#
+#   Basilisk Scenario Script
+#
+#   Purpose:            Illustrates two spacecraft connected via a holonomic constraint
+#   Author:             Andrew Morell
+#   Creation Date:      May 14, 2024
+#
+
+# system imports
+import os
+
+# Basilisk imports
+from Basilisk.architecture import messaging
+from Basilisk.utilities import (SimulationBaseClass, orbitalMotion, macros, RigidBodyKinematics)
+from Basilisk.simulation import (spacecraft, constraintDynamicEffector, gravityEffector, svIntegrators)
+import matplotlib.pyplot as plt
+
+# Utility imports
+import numpy as np
+
+from Basilisk import __path__
+bskPath = __path__[0]
+fileName = os.path.basename(os.path.splitext(__file__)[0])
+
+def run(show_plots, env):
+    """
+    The scenario can be run with the following setup parameters:
+
+    Args:
+        show_plots (bool): Determines if the script should display plots
+        env (str): Choose whether in Earth orbit ``Gravity`` or deep space ``NoGravity``
+
+    """
+
+    # Create a sim module as an empty container
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    # Create simulation variable names
+    simTaskName = "simTask"  # arbitrary name (don't change)
+    simProcessName = "simProcess"  # arbitrary name (don't change)
+
+    # Create the simulation process and specify the integration update time
+    simulationTimeStep = macros.sec2nano(0.1)  # update process rate update time
+    dynProcess = scSim.CreateNewProcess(simProcessName)
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
+
+    # Create both spacecraft
+    scObject1 = spacecraft.Spacecraft()
+    scObject1.ModelTag = "spacecraftBody1"
+    scObject2 = spacecraft.Spacecraft()
+    scObject2.ModelTag = "spacecraftBody2"
+
+    # Set the integrator to RKF45
+    integratorObject1 = svIntegrators.svIntegratorRKF45(scObject1)
+    scObject1.setIntegrator(integratorObject1)
+    # Sync dynamics integration across both spacecraft
+    scObject1.syncDynamicsIntegration(scObject2)
+
+    # Define mass properties of the rigid hub of both spacecraft
+    scObject1.hub.mHub = 750.0
+    scObject1.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
+    scObject1.hub.IHubPntBc_B = [[600.0, 0.0, 0.0], [0.0, 600.0, 0.0], [0.0, 0.0, 600.0]]
+    scObject2.hub.mHub = 750.0
+    scObject2.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
+    scObject2.hub.IHubPntBc_B = [[600.0, 0.0, 0.0], [0.0, 600.0, 0.0], [0.0, 0.0, 600.0]]
+
+    # Add Earth gravity to the simulation if requested
+    if env == 'Gravity':
+        earthGravBody = gravityEffector.GravBodyData()
+        earthGravBody.planetName = "earth_planet_data"
+        earthGravBody.mu = 0.3986004415E+15  # [meters^3/s^2]
+        earthGravBody.isCentralBody = True
+        scObject1.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+        scObject2.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+        # set orbital altitude to LEO
+        oe = orbitalMotion.ClassicElements()
+        oe.a = earthGravBody.radEquator + 7500e3  # meters
+        oe.e = 0.01
+        oe.i = 30.0 * macros.D2R
+        oe.Omega = 60.0 * macros.D2R
+        oe.omega = 15.0 * macros.D2R
+        oe.f = 90.0 * macros.D2R
+        r_B2N_N_0, rDot_B2N_N = orbitalMotion.elem2rv(earthGravBody.mu, oe)
+    else: # If no gravity requested, place in free-floating space
+        r_B2N_N_0 = np.array([1,1,1])
+        rDot_B2N_N = np.array([1,1,1])
+
+    # With initial attitudes at zero (B1, B2, and N frames all initially aligned)
+    dir = r_B2N_N_0/np.linalg.norm(r_B2N_N_0)
+    l = 0.1
+    COMoffset = 0.1 # distance from COM to where the arm connects to the spacecraft hub, same for both spacecraft [meters]
+    r_P1B1_B1 = np.dot(dir,COMoffset)
+    r_P2B2_B2 = np.dot(-dir,COMoffset)
+    r_P2P1_B1Init = np.dot(dir,l)
+    r_B1N_N_0 = r_B2N_N_0 + r_P2B2_B2 - r_P2P1_B1Init - r_P1B1_B1
+    rDot_B1N_N = rDot_B2N_N
+
+    # Compute rotational states
+    # let C be the frame at the combined COM of the two vehicles
+    r_CN_N = (r_B1N_N_0 * scObject1.hub.mHub + r_B2N_N_0 * scObject2.hub.mHub) / (scObject1.hub.mHub + scObject2.hub.mHub)
+    r_B1C_N = r_B1N_N_0 - r_CN_N
+    r_B2C_N = r_B2N_N_0 - r_CN_N
+    # compute relative velocity due to spin and COM offset
+    target_spin = [0.01,0.01,0.01]
+    omega_CN_N = np.array(target_spin)
+    omega_B1N_B1_0 = omega_CN_N
+    omega_B2N_B2_0 = omega_CN_N
+    dv_B1C_N = np.cross(omega_CN_N,r_B1C_N)
+    dv_B2C_N = np.cross(omega_CN_N,r_B2C_N)
+    rDot_B1N_N_0 = rDot_B1N_N + dv_B1C_N
+    rDot_B2N_N_0 = rDot_B2N_N + dv_B2C_N
+
+    # Set the initial values for all spacecraft states
+    scObject1.hub.r_CN_NInit = r_B1N_N_0
+    scObject1.hub.v_CN_NInit = rDot_B1N_N_0
+    scObject1.hub.omega_BN_BInit = omega_B1N_B1_0
+    scObject2.hub.r_CN_NInit = r_B2N_N_0
+    scObject2.hub.v_CN_NInit = rDot_B2N_N_0
+    scObject2.hub.omega_BN_BInit = omega_B2N_B2_0
+
+    # Create the constraint effector module
+    constraintEffector = constraintDynamicEffector.ConstraintDynamicEffector()
+    # Set up the constraint effector physical parameters
+    constraintEffector.setR_P1B1_B1(r_P1B1_B1)
+    constraintEffector.setR_P2B2_B2(r_P2B2_B2)
+    constraintEffector.setR_P2P1_B1Init(r_P2P1_B1Init)
+    constraintEffector.setAlpha(1E2)
+    constraintEffector.setBeta(1e3)
+    constraintEffector.ModelTag = "constraintEffector"
+
+    # Add the constraint to both spacecraft
+    scObject1.addDynamicEffector(constraintEffector)
+    scObject2.addDynamicEffector(constraintEffector)
+
+    # Add the modules to runtime call list
+    scSim.AddModelToTask(simTaskName, scObject1)
+    scSim.AddModelToTask(simTaskName, scObject2)
+    scSim.AddModelToTask(simTaskName, constraintEffector)
+
+    # Record the spacecraft states
+    datLog1 = scObject1.scStateOutMsg.recorder()
+    datLog2 = scObject2.scStateOutMsg.recorder()
+    scSim.AddModelToTask(simTaskName, datLog1)
+    scSim.AddModelToTask(simTaskName, datLog2)
+
+    # Initialize the simulation
+    scSim.InitializeSimulation()
+    scSim.ShowExecutionOrder()
+
+    # Setup and run the simulation
+    stopTime = macros.min2nano(1)
+    scSim.ConfigureStopTime(stopTime)
+    scSim.ExecuteSimulation()
+
+    # Retrieve the recorded spacecraft states
+    constraintTimeData = datLog1.times() * macros.NANO2SEC
+    r_B1N_N_hist = datLog1.r_BN_N
+    sigma_B1N_hist = datLog1.sigma_BN
+    r_B2N_N_hist = datLog2.r_BN_N
+    sigma_B2N_hist = datLog2.sigma_BN
+
+    # Compute constraint violations
+    r_B1N_B1 = np.empty(r_B1N_N_hist.shape)
+    r_B2N_B1 = np.empty(r_B2N_N_hist.shape)
+    r_P2B2_B1 = np.empty(r_B1N_N_hist.shape)
+    sigma_B2B1 = np.empty(sigma_B1N_hist.shape)
+    for i in range(r_B1N_N_hist.shape[0]):
+        dcm_B1N = RigidBodyKinematics.MRP2C(sigma_B1N_hist[i,:])
+        r_B1N_B1[i,:] = dcm_B1N@r_B1N_N_hist[i,:]
+        r_B2N_B1[i,:] = dcm_B1N@r_B2N_N_hist[i,:]
+        dcm_NB2 = np.transpose(RigidBodyKinematics.MRP2C(sigma_B2N_hist[i,:]))
+        r_P2B2_B1[i,:] = dcm_B1N@dcm_NB2@r_P2B2_B2
+        sigma_B2B1[i,:] = RigidBodyKinematics.subMRP(sigma_B2N_hist[i,:],sigma_B1N_hist[i,:])
+    psi_B1 = r_B1N_B1 + r_P1B1_B1 + r_P2P1_B1Init - (r_B2N_B1 + r_P2B2_B1)
+
+    #
+    # Plotting Results
+    #
+    figureList = {}
+
+    plt.close("all")
+    plt.figure(1)
+    plt.clf()
+    for i in range(3):
+        plt.semilogy(constraintTimeData, np.abs(psi_B1[:, i]))
+    plt.semilogy(constraintTimeData, np.linalg.norm(psi_B1,axis=1))
+    plt.legend([r'$\psi_1$',r'$\psi_2$',r'$\psi_3$',r'$\psi$ magnitude'])
+    plt.xlabel('time (seconds)')
+    plt.ylabel(r'relative connection position: $\psi$ (meters)')
+    plt.title('Direction Constraint Violation Components')
+    pltName = fileName + "directionConstraint"
+    figureList[pltName] = plt.figure(1)
+
+    plt.figure(2)
+    plt.clf()
+    for i in range(3):
+        plt.semilogy(constraintTimeData, np.abs(4*np.arctan(sigma_B2B1[:, i]) * macros.R2D))
+    plt.semilogy(constraintTimeData, np.linalg.norm(4*np.arctan(sigma_B2B1) * macros.R2D,axis=1))
+    plt.legend([r'$\phi_1$',r'$\phi_2$',r'$\phi_3$',r'$\phi$ magnitude'])
+    plt.xlabel('time (seconds)')
+    plt.ylabel(r'relative attitude angle: $\phi$ (deg)')
+    plt.title('Attitude Constraint Violation Components')
+    pltName = fileName + "attitudeConstraint"
+    figureList[pltName] = plt.figure(2)
+
+    if show_plots:
+        plt.show()
+    plt.close("all") # close the plots being saved off to avoid over-writing old and new figures
+
+    return figureList
+
+if __name__ == "__main__":
+    run(
+        True,       # show_plots: True or False
+        'Gravity'   # env: either 'Gravity' or 'NoGravity'
+    )

--- a/src/simulation/dynamics/constraintEffector/_UnitTest/test_ConstraintDynamicEffectorUnit.py
+++ b/src/simulation/dynamics/constraintEffector/_UnitTest/test_ConstraintDynamicEffectorUnit.py
@@ -1,0 +1,489 @@
+# ISC License
+#
+# Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#
+#   Unit Test Script
+#   Module Name:        constraintEffector
+#   Author:             João Vaz Carneiro and Andrew Morell
+#   Creation Date:      May 14, 2024
+#
+
+import inspect
+import os
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+
+from Basilisk.utilities import SimulationBaseClass, unitTestSupport, orbitalMotion, macros, RigidBodyKinematics
+from Basilisk.simulation import spacecraft, constraintDynamicEffector, gravityEffector, svIntegrators
+
+# uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed
+# @pytest.mark.skipif(conditionstring)
+# uncomment this line if this test has an expected failure, adjust message as needed
+# @pytest.mark.xfail()
+
+@pytest.mark.parametrize("function", ["constraintEffectorOrbitalConservation", "constraintEffectorRotationalConservation"])
+def test_constraintEffector(show_plots, function):
+    r"""Module Unit Test
+    **Validation Test Description**
+
+    This unit test sets up two spacecraft connected by a holonomic constraint effector acting as a physical connection
+    between them. The two spacecraft are set up with an identical mass and symmetrical inertias. One scenario includes
+    gravity to check orbital conservation while the other scenario excludes gravity to check more sensitive constraint
+    violations.
+
+    **Description of Variables Being Tested**
+
+    In this file we are checking the principles of conservation of energy and angular momentum. Both the orbital and
+    rotational energy and angular momentum must be maintained. While Baumgarte stabilization is an approximate method,
+    there is still an expected threshold below which these quantities are conserved:
+
+    - ``combinedOrbAngMom``
+    - ``combinedOrbEnergy``
+    - ``combinedRotAngMom``
+    - ``combinedRotEnergy``
+
+    We are also checking the constraint violation magnitudes throughout the simulation. Due to the nature of the
+    Baumgarte stabilization method, there must first be a constraint violation before a force is applied to correct
+    the constraint violation and keep the spacecraft aligned. For slow moving spacecraft systems such as this, the
+    constraint violations are expected to remain below a threshold dependent on how dynamic a scenario is. The
+    threshold for the scenario with gravity therefore expects a larger threshold than the scenario without gravity.
+    Accuracy checks based on prior testings are included here to ensure that future changes don't worsen performance,
+    not to verify any theoretical thresholds. The direction and attitude constraint violations checked are:
+
+    - ``psi_B1``
+    - ``sigma_B2B1``
+
+    """
+
+    eval(function + '(show_plots)')
+
+def constraintEffectorOrbitalConservation(show_plots):
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    unitTaskName = "unitTask"  # arbitrary name (don't change)
+    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+    testProcessRate = macros.sec2nano(0.001)  # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create both spacecraft
+    scObject1 = spacecraft.Spacecraft()
+    scObject1.ModelTag = "spacecraftBody1"
+    scObject2 = spacecraft.Spacecraft()
+    scObject2.ModelTag = "spacecraftBody2"
+
+    # Set the integrator to RKF45
+    integratorObject1 = svIntegrators.svIntegratorRKF45(scObject1)
+    scObject1.setIntegrator(integratorObject1)
+    # Sync dynamics integration across both spacecraft
+    scObject1.syncDynamicsIntegration(scObject2)
+
+    # Define mass properties of the rigid hub of both spacecraft
+    scObject1.hub.mHub = 750.0
+    scObject1.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
+    scObject1.hub.IHubPntBc_B = [[600.0, 0.0, 0.0], [0.0, 600.0, 0.0], [0.0, 0.0, 600.0]]
+    scObject2.hub.mHub = 750.0
+    scObject2.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
+    scObject2.hub.IHubPntBc_B = [[600.0, 0.0, 0.0], [0.0, 600.0, 0.0], [0.0, 0.0, 600.0]]
+
+    # Add Earth gravity to the simulation
+    earthGravBody = gravityEffector.GravBodyData()
+    earthGravBody.planetName = "earth_planet_data"
+    earthGravBody.mu = 0.3986004415E+15  # [meters^3/s^2]
+    earthGravBody.isCentralBody = True
+    scObject1.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+    scObject2.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+    # set orbital altitude to LEO
+    oe = orbitalMotion.ClassicElements()
+    oe.a = earthGravBody.radEquator + 7500e3  # meters
+    oe.e = 0.01
+    oe.i = 30.0 * macros.D2R
+    oe.Omega = 60.0 * macros.D2R
+    oe.omega = 15.0 * macros.D2R
+    oe.f = 90.0 * macros.D2R
+    r_B2N_N_0, rDot_B2N_N = orbitalMotion.elem2rv(earthGravBody.mu, oe)
+
+    # With initial attitudes at zero (B1, B2, and N frames all initially aligned)
+    dir = r_B2N_N_0/np.linalg.norm(r_B2N_N_0)
+    l = 0.1
+    COMoffset = 0.1 # distance from COM to where the arm connects to the spacecraft hub, same for both spacecraft [meters]
+    r_P1B1_B1 = np.dot(dir,COMoffset)
+    r_P2B2_B2 = np.dot(-dir,COMoffset)
+    r_P2P1_B1Init = np.dot(dir,l)
+    r_B1N_N_0 = r_B2N_N_0 + r_P2B2_B2 - r_P2P1_B1Init - r_P1B1_B1
+    rDot_B1N_N = rDot_B2N_N
+
+    # Compute rotational states
+    # let C be the frame at the combined COM of the two vehicles
+    r_CN_N = (r_B1N_N_0 * scObject1.hub.mHub + r_B2N_N_0 * scObject2.hub.mHub) / (scObject1.hub.mHub + scObject2.hub.mHub)
+    r_B1C_N = r_B1N_N_0 - r_CN_N
+    r_B2C_N = r_B2N_N_0 - r_CN_N
+    # compute relative velocity due to spin and COM offset
+    target_spin = [0.01,0.01,0.01]
+    omega_CN_N = np.array(target_spin)
+    omega_B1N_B1_0 = omega_CN_N
+    omega_B2N_B2_0 = omega_CN_N
+    dv_B1C_N = np.cross(omega_CN_N,r_B1C_N)
+    dv_B2C_N = np.cross(omega_CN_N,r_B2C_N)
+    rDot_B1N_N_0 = rDot_B1N_N + dv_B1C_N
+    rDot_B2N_N_0 = rDot_B2N_N + dv_B2C_N
+
+    # Set the initial values for all spacecraft states
+    scObject1.hub.r_CN_NInit = r_B1N_N_0
+    scObject1.hub.v_CN_NInit = rDot_B1N_N_0
+    scObject1.hub.omega_BN_BInit = omega_B1N_B1_0
+    scObject2.hub.r_CN_NInit = r_B2N_N_0
+    scObject2.hub.v_CN_NInit = rDot_B2N_N_0
+    scObject2.hub.omega_BN_BInit = omega_B2N_B2_0
+
+    # Create the constraint effector module
+    constraintEffector = constraintDynamicEffector.ConstraintDynamicEffector()
+    # Set up the constraint effector
+    constraintEffector.ModelTag = "constraintEffector"
+    constraintEffector.setR_P1B1_B1(r_P1B1_B1)
+    constraintEffector.setR_P2B2_B2(r_P2B2_B2)
+    constraintEffector.setR_P2P1_B1Init(r_P2P1_B1Init)
+    constraintEffector.setAlpha(1E3)
+    constraintEffector.setBeta(1e3)
+    # Add constraints to both spacecraft
+    scObject1.addDynamicEffector(constraintEffector)
+    scObject2.addDynamicEffector(constraintEffector)
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, scObject1)
+    unitTestSim.AddModelToTask(unitTaskName, scObject2)
+    unitTestSim.AddModelToTask(unitTaskName, constraintEffector)
+
+    # Record the spacecraft state message
+    datLog1 = scObject1.scStateOutMsg.recorder()
+    datLog2 = scObject2.scStateOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, datLog1)
+    unitTestSim.AddModelToTask(unitTaskName, datLog2)
+
+    # Log energy and momentum variables
+    conservationData1 = scObject1.logger(["totOrbAngMomPntN_N", "totOrbEnergy"])
+    conservationData2 = scObject2.logger(["totOrbAngMomPntN_N", "totOrbEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName,conservationData1)
+    unitTestSim.AddModelToTask(unitTaskName,conservationData2)
+
+    # Initialize the simulation
+    unitTestSim.InitializeSimulation()
+
+    # Setup and run the simulation
+    stopTime = 1
+    unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
+    unitTestSim.ExecuteSimulation()
+
+    # collect the recorded spacecraft states
+    constraintTimeData = datLog1.times() * macros.NANO2SEC
+    r_B1N_N_hist = datLog1.r_BN_N
+    sigma_B1N_hist = datLog1.sigma_BN
+    r_B2N_N_hist = datLog2.r_BN_N
+    sigma_B2N_hist = datLog2.sigma_BN
+
+    # collect the logged conservation variables
+    conservationTimeData = conservationData1.times() * macros.NANO2SEC
+    orbEnergy1 = conservationData1.totOrbEnergy
+    orbAngMom1_N = conservationData1.totOrbAngMomPntN_N
+    orbEnergy2 = conservationData2.totOrbEnergy
+    orbAngMom2_N = conservationData2.totOrbAngMomPntN_N
+
+    # Compute constraint violations
+    r_B1N_B1 = np.empty(r_B1N_N_hist.shape)
+    r_B2N_B1 = np.empty(r_B2N_N_hist.shape)
+    r_P2B2_B1 = np.empty(r_B1N_N_hist.shape)
+    sigma_B2B1 = np.empty(sigma_B1N_hist.shape)
+    for i in range(orbAngMom1_N.shape[0]):
+        dcm_B1N = RigidBodyKinematics.MRP2C(sigma_B1N_hist[i,:])
+        r_B1N_B1[i,:] = dcm_B1N@r_B1N_N_hist[i,:]
+        r_B2N_B1[i,:] = dcm_B1N@r_B2N_N_hist[i,:]
+        dcm_NB2 = np.transpose(RigidBodyKinematics.MRP2C(sigma_B2N_hist[i,:]))
+        r_P2B2_B1[i,:] = dcm_B1N@dcm_NB2@r_P2B2_B2
+        sigma_B2B1[i,:] = RigidBodyKinematics.subMRP(sigma_B2N_hist[i,:],sigma_B1N_hist[i,:])
+    psi_B1 = r_B1N_B1 + r_P1B1_B1 + r_P2P1_B1Init - (r_B2N_B1 + r_P2B2_B1)
+
+    # Compute conservation quantities
+    combinedOrbAngMom = orbAngMom1_N + orbAngMom2_N
+    combinedOrbEnergy = orbEnergy1 + orbEnergy2
+
+    # Plotting
+    plt.close("all")
+    plt.figure()
+    plt.clf()
+    for i in range(3):
+        plt.semilogy(constraintTimeData, np.abs(psi_B1[:, i]))
+    plt.semilogy(constraintTimeData, np.linalg.norm(psi_B1,axis=1))
+    plt.legend([r'$\psi_1$',r'$\psi_2$',r'$\psi_3$',r'$\psi$ magnitude'])
+    plt.xlabel('time (seconds)')
+    plt.ylabel(r'variation from fixed position: $\psi$ (meters)')
+    plt.title('Direction Constraint Violation Components')
+
+    plt.figure()
+    plt.clf()
+    for i in range(3):
+        plt.semilogy(constraintTimeData, np.abs(4*np.arctan(sigma_B2B1[:, i]) * macros.R2D))
+    plt.semilogy(constraintTimeData, np.linalg.norm(4*np.arctan(sigma_B2B1) * macros.R2D,axis=1))
+    plt.legend([r'$\phi_1$',r'$\phi_2$',r'$\phi_3$',r'$\phi$ magnitude'])
+    plt.xlabel('time (seconds)')
+    plt.ylabel(r'relative attitude angle: $\phi$ (deg)')
+    plt.title('Attitude Constraint Violation Components')
+
+    plt.figure()
+    plt.clf()
+    plt.plot(conservationTimeData, (combinedOrbAngMom[:,0] - combinedOrbAngMom[0,0])/combinedOrbAngMom[0,0],
+            conservationTimeData, (combinedOrbAngMom[:,1] - combinedOrbAngMom[0,1])/combinedOrbAngMom[0,1],
+            conservationTimeData, (combinedOrbAngMom[:,2] - combinedOrbAngMom[0,2])/combinedOrbAngMom[0,2])
+    plt.xlabel('time (seconds)')
+    plt.ylabel('Relative Difference')
+    plt.title('Combined Orbital Angular Momentum')
+
+    plt.figure()
+    plt.clf()
+    plt.plot(conservationTimeData, (combinedOrbEnergy - combinedOrbEnergy[0])/combinedOrbEnergy[0])
+    plt.xlabel('time (seconds)')
+    plt.ylabel('Relative Difference')
+    plt.title('Combined Orbital Energy')
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # Testing setup
+    dirCnstAccuracy = 1E-7
+    attCnstAccuracy = 1E-4
+    accuracy = 1E-12
+    np.testing.assert_allclose(psi_B1, 0, atol=dirCnstAccuracy,
+                               err_msg='direction constraint component magnitude exceeded in orbital conservation test')
+    np.testing.assert_allclose(sigma_B2B1, 0, atol=attCnstAccuracy,
+                               err_msg='attitude constraint component magnitude exceeded in orbital conservation test')
+    for i in range(3):
+        np.testing.assert_allclose(orbAngMom1_N[:,i]+orbAngMom2_N[:,i], orbAngMom1_N[0,i]+orbAngMom2_N[0,i], atol=accuracy,
+                                   err_msg='orbital angular momentum difference component magnitude exceeded')
+    np.testing.assert_allclose(orbEnergy1+orbEnergy2, orbEnergy1[0]+orbEnergy2[0], atol=accuracy,
+                               err_msg='orbital energy difference magnitude exceeded')
+
+def constraintEffectorRotationalConservation(show_plots):
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    unitTaskName = "unitTask"  # arbitrary name (don't change)
+    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+    testProcessRate = macros.sec2nano(0.001)  # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create both spacecraft
+    scObject1 = spacecraft.Spacecraft()
+    scObject1.ModelTag = "spacecraftBody1"
+    scObject2 = spacecraft.Spacecraft()
+    scObject2.ModelTag = "spacecraftBody2"
+
+    # Set the integrator to RKF45
+    integratorObject1 = svIntegrators.svIntegratorRKF45(scObject1)
+    scObject1.setIntegrator(integratorObject1)
+    # Sync dynamics integration across both spacecraft
+    scObject1.syncDynamicsIntegration(scObject2)
+
+    # Define mass properties of the rigid hub of both spacecraft
+    scObject1.hub.mHub = 750.0
+    scObject1.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
+    scObject1.hub.IHubPntBc_B = [[600.0, 0.0, 0.0], [0.0, 600.0, 0.0], [0.0, 0.0, 600.0]]
+    scObject2.hub.mHub = 750.0
+    scObject2.hub.r_BcB_B = [[0.0], [0.0], [1.0]]
+    scObject2.hub.IHubPntBc_B = [[600.0, 0.0, 0.0], [0.0, 600.0, 0.0], [0.0, 0.0, 600.0]]
+
+    # With initial attitudes at zero (B1, B2, and N frames all initially aligned)
+    r_B2N_N_0 = np.array([1,1,1])
+    rDot_B2N_N = np.array([1,1,1])
+    dir = r_B2N_N_0/np.linalg.norm(r_B2N_N_0)
+    l = 0.1
+    COMoffset = 0.1 # distance from COM to where the arm connects to the spacecraft hub, same for both spacecraft [meters]
+    r_P1B1_B1 = np.dot(dir,COMoffset)
+    r_P2B2_B2 = np.dot(-dir,COMoffset)
+    r_P2P1_B1Init = np.dot(dir,l)
+    r_B1N_N_0 = r_B2N_N_0 + r_P2B2_B2 - r_P2P1_B1Init - r_P1B1_B1
+    rDot_B1N_N = rDot_B2N_N
+
+    # Compute rotational states
+    # let C be the frame at the combined COM of the two vehicles
+    r_CN_N = (r_B1N_N_0 * scObject1.hub.mHub + r_B2N_N_0 * scObject2.hub.mHub) / (scObject1.hub.mHub + scObject2.hub.mHub)
+    r_B1C_N = r_B1N_N_0 - r_CN_N
+    r_B2C_N = r_B2N_N_0 - r_CN_N
+    # compute relative velocity due to spin and COM offset
+    target_spin = [0.01,0.01,0.01]
+    omega_CN_N = np.array(target_spin)
+    omega_B1N_B1_0 = omega_CN_N
+    omega_B2N_B2_0 = omega_CN_N
+    dv_B1C_N = np.cross(omega_CN_N,r_B1C_N)
+    dv_B2C_N = np.cross(omega_CN_N,r_B2C_N)
+    rDot_B1N_N_0 = rDot_B1N_N + dv_B1C_N
+    rDot_B2N_N_0 = rDot_B2N_N + dv_B2C_N
+
+    # Set the initial values for all spacecraft states
+    scObject1.hub.r_CN_NInit = r_B1N_N_0
+    scObject1.hub.v_CN_NInit = rDot_B1N_N_0
+    scObject1.hub.omega_BN_BInit = omega_B1N_B1_0
+    scObject2.hub.r_CN_NInit = r_B2N_N_0
+    scObject2.hub.v_CN_NInit = rDot_B2N_N_0
+    scObject2.hub.omega_BN_BInit = omega_B2N_B2_0
+
+    # Create the constraint effector module
+    constraintEffector = constraintDynamicEffector.ConstraintDynamicEffector()
+    # Set up the constraint effector
+    constraintEffector.ModelTag = "constraintEffector"
+    constraintEffector.setR_P1B1_B1(r_P1B1_B1)
+    constraintEffector.setR_P2B2_B2(r_P2B2_B2)
+    constraintEffector.setR_P2P1_B1Init(r_P2P1_B1Init)
+    constraintEffector.setAlpha(1E3)
+    constraintEffector.setBeta(1e3)
+    # Add constraints to both spacecraft
+    scObject1.addDynamicEffector(constraintEffector)
+    scObject2.addDynamicEffector(constraintEffector)
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, scObject1)
+    unitTestSim.AddModelToTask(unitTaskName, scObject2)
+    unitTestSim.AddModelToTask(unitTaskName, constraintEffector)
+
+    # Record the spacecraft state message
+    datLog1 = scObject1.scStateOutMsg.recorder()
+    datLog2 = scObject2.scStateOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, datLog1)
+    unitTestSim.AddModelToTask(unitTaskName, datLog2)
+
+    # Log energy and momentum variables
+    conservationData1 = scObject1.logger(["totRotAngMomPntC_N", "totRotEnergy"])
+    conservationData2 = scObject2.logger(["totRotAngMomPntC_N", "totRotEnergy"])
+    unitTestSim.AddModelToTask(unitTaskName,conservationData1)
+    unitTestSim.AddModelToTask(unitTaskName,conservationData2)
+
+    # Initialize the simulation
+    unitTestSim.InitializeSimulation()
+
+    # Setup and run the simulation
+    stopTime = 1
+    unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
+    unitTestSim.ExecuteSimulation()
+
+    # collect the recorded spacecraft states
+    constraintTimeData = datLog1.times() * macros.NANO2SEC
+    r_B1N_N_hist = datLog1.r_BN_N
+    rdot_B1N_N_hist = datLog1.v_BN_N
+    sigma_B1N_hist = datLog1.sigma_BN
+    omega_B1N_B1_hist = datLog1.omega_BN_B
+    r_B2N_N_hist = datLog2.r_BN_N
+    rdot_B2N_N_hist = datLog2.v_BN_N
+    sigma_B2N_hist = datLog2.sigma_BN
+    omega_B2N_B2_hist = datLog2.omega_BN_B
+
+    # collect the logged conservation variables
+    conservationTimeData = conservationData1.times() * macros.NANO2SEC
+    rotAngMom1PntC1_N = conservationData1.totRotAngMomPntC_N
+    rotEnergy1 = conservationData1.totRotEnergy
+    rotAngMom2PntC2_N = conservationData2.totRotAngMomPntC_N
+    rotEnergy2 = conservationData2.totRotEnergy
+
+    # Compute constraint violations
+    r_B1N_B1 = np.empty(r_B1N_N_hist.shape)
+    r_B2N_B1 = np.empty(r_B2N_N_hist.shape)
+    r_P2B2_B1 = np.empty(r_B1N_N_hist.shape)
+    for i in range(rotAngMom1PntC1_N.shape[0]):
+        dcm_B1N = RigidBodyKinematics.MRP2C(sigma_B1N_hist[i,:])
+        r_B1N_B1[i,:] = dcm_B1N@r_B1N_N_hist[i,:]
+        r_B2N_B1[i,:] = dcm_B1N@r_B2N_N_hist[i,:]
+        dcm_NB2 = np.transpose(RigidBodyKinematics.MRP2C(sigma_B2N_hist[i,:]))
+        r_P2B2_B1[i,:] = dcm_B1N@dcm_NB2@r_P2B2_B2
+    psi_B1 = r_B1N_B1 + r_P1B1_B1 + r_P2P1_B1Init - (r_B2N_B1 + r_P2B2_B1)
+    sigma_B2B1 = sigma_B2N_hist-sigma_B1N_hist
+
+    # Compute conservation quantities
+    r_CN_N_hist = (r_B1N_N_hist * scObject1.hub.mHub + r_B2N_N_hist * scObject2.hub.mHub)/(scObject1.hub.mHub+scObject2.hub.mHub)
+    r_B1C_N_hist = r_B1N_N_hist - r_CN_N_hist
+    r_B2C_N_hist = r_B2N_N_hist - r_CN_N_hist
+    rdot_CN_N_hist = (rdot_B1N_N_hist * scObject1.hub.mHub + rdot_B2N_N_hist * scObject2.hub.mHub)/(scObject1.hub.mHub+scObject2.hub.mHub)
+    rdot_B1C_N_hist = rdot_B1N_N_hist - rdot_CN_N_hist
+    rdot_B2C_N_hist = rdot_B2N_N_hist - rdot_CN_N_hist
+    rotAngMom1PntCT_N = np.empty(rotAngMom1PntC1_N.shape)
+    rotAngMom2PntCT_N = np.empty(rotAngMom2PntC2_N.shape)
+    for i1 in range(rotAngMom1PntC1_N.shape[0]):
+        rotAngMom1PntCT_N[i1,:] = np.cross(r_CN_N_hist[i1,:],scObject1.hub.mHub*rdot_B1C_N_hist[i1,:]) + RigidBodyKinematics.MRP2C(sigma_B1N_hist[i1,:]).transpose()@(scObject1.hub.IHubPntBc_B@omega_B1N_B1_hist[i1,:]) + scObject1.hub.mHub*np.cross(r_B1C_N_hist[i1,:],rdot_B1C_N_hist[i1,:])
+        rotAngMom2PntCT_N[i1,:] = np.cross(r_CN_N_hist[i1,:],scObject2.hub.mHub*rdot_B2C_N_hist[i1,:]) + RigidBodyKinematics.MRP2C(sigma_B2N_hist[i1,:]).transpose()@(scObject2.hub.IHubPntBc_B@omega_B2N_B2_hist[i1,:]) + scObject2.hub.mHub*np.cross(r_B2C_N_hist[i1,:],rdot_B2C_N_hist[i1,:])
+    combinedRotAngMom = rotAngMom1PntCT_N + rotAngMom2PntCT_N
+    combinedRotEnergy = rotEnergy1 + rotEnergy2
+
+    # Plotting
+    plt.close("all")
+    plt.figure()
+    plt.clf()
+    for i in range(3):
+        plt.semilogy(constraintTimeData, np.abs(psi_B1[:, i]))
+    plt.semilogy(constraintTimeData, np.linalg.norm(psi_B1,axis=1))
+    plt.legend([r'$\psi_1$',r'$\psi_2$',r'$\psi_3$',r'$\psi$ magnitude'])
+    plt.xlabel('time (seconds)')
+    plt.ylabel(r'variation from fixed position: $\psi$ (meters)')
+    plt.title('Direction Constraint Violation Components')
+
+    plt.figure()
+    plt.clf()
+    for i in range(3):
+        plt.semilogy(constraintTimeData, np.abs(4*np.arctan(sigma_B2B1[:, i]) * macros.R2D))
+    plt.semilogy(constraintTimeData, np.linalg.norm(4*np.arctan(sigma_B2B1) * macros.R2D,axis=1))
+    plt.legend([r'$\phi_1$',r'$\phi_2$',r'$\phi_3$',r'$\phi$ magnitude'])
+    plt.xlabel('time (seconds)')
+    plt.ylabel(r'relative attitude angle: $\phi$ (deg)')
+    plt.title('Attitude Constraint Violation Components')
+
+    plt.figure()
+    plt.clf()
+    plt.plot(conservationTimeData, (combinedRotAngMom[:,0] - combinedRotAngMom[0,0])/combinedRotAngMom[0,0],
+             conservationTimeData, (combinedRotAngMom[:,1] - combinedRotAngMom[0,1])/combinedRotAngMom[0,1],
+             conservationTimeData, (combinedRotAngMom[:,2] - combinedRotAngMom[0,2])/combinedRotAngMom[0,2])
+    plt.xlabel('time (seconds)')
+    plt.ylabel('Relative Difference')
+    plt.title('Combined Rotational Angular Momentum')
+
+    plt.figure()
+    plt.clf()
+    plt.plot(conservationTimeData, (combinedRotEnergy - combinedRotEnergy[0])/combinedRotEnergy[0])
+    plt.xlabel('time (seconds)')
+    plt.ylabel('Relative Difference')
+    plt.title('Combined Rotational Energy')
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    # Testing setup
+    accuracy = 1E-12
+    np.testing.assert_allclose(psi_B1, 0, atol=accuracy,
+                               err_msg='direction constraint component magnitude exceeded in rotational conservation test')
+    np.testing.assert_allclose(sigma_B2B1, 0, atol=accuracy,
+                               err_msg='attitude constraint component magnitude exceeded in rotational conservation test')
+    for i in range(3):
+        np.testing.assert_allclose(rotAngMom1PntCT_N[:,i]+rotAngMom2PntCT_N[:,i], rotAngMom1PntCT_N[0,i]+rotAngMom2PntCT_N[0,i], atol=accuracy,
+                                   err_msg='rotational angular momentum difference component magnitude exceeded')
+    np.testing.assert_allclose(rotEnergy1+rotEnergy2, rotEnergy1[0]+rotEnergy2[0], atol=accuracy,
+                               err_msg='rotational energy difference magnitude exceeded')
+
+if __name__ == "__main__":
+    # constraintEffectorOrbitalConservation(True)
+    constraintEffectorRotationalConservation(True)

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.cpp
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.cpp
@@ -1,0 +1,222 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "constraintDynamicEffector.h"
+#include "architecture/utilities/avsEigenSupport.h"
+
+/*! This is the constructor, nothing to report here */
+ConstraintDynamicEffector::ConstraintDynamicEffector()
+{
+
+}
+
+/*! This is the destructor, nothing to report here */
+ConstraintDynamicEffector::~ConstraintDynamicEffector()
+{
+
+}
+
+/*! This method is used to reset the module.
+ @return void
+ */
+void ConstraintDynamicEffector::Reset(uint64_t CurrentSimNanos)
+{
+    // check if any individual gains are not specified
+    bool gainset = this->k_d != 0 || this->c_d != 0 || this->k_a != 0 || this->c_a != 0;
+    if (this->alpha <= 0 && !gainset) {
+        bskLogger.bskLog(BSK_ERROR, "Alpha must be set to a positive nonzero value prior to initialization");
+    }
+    if (this->beta <= 0 && !gainset) {
+        bskLogger.bskLog(BSK_ERROR, "Beta must be set to a positive nonzero value prior to initializaiton");
+    }
+    // if individual k's or c's are already set, don't use alpha & beta
+    if (this->k_d == 0) {
+        this->k_d = pow(this->alpha,2);
+    }
+    if (this->c_d == 0) {
+        this->c_d = 2*this->beta;
+    }
+    if (this->k_a == 0) {
+        this->k_a = pow(this->alpha,2);
+    }
+    if (this->c_a == 0) {
+        this->c_a = 2*this->beta;
+    }
+}
+
+void ConstraintDynamicEffector::setR_P2P1_B1Init(Eigen::Vector3d r_P2P1_B1Init) {
+    this->r_P2P1_B1Init = r_P2P1_B1Init;
+}
+
+void ConstraintDynamicEffector::setR_P1B1_B1(Eigen::Vector3d r_P1B1_B1) {
+    this->r_P1B1_B1 = r_P1B1_B1;
+}
+
+void ConstraintDynamicEffector::setR_P2B2_B2(Eigen::Vector3d r_P2B2_B2) {
+    this->r_P2B2_B2 = r_P2B2_B2;
+}
+
+void ConstraintDynamicEffector::setAlpha(double alpha) {
+    if (alpha > 0.0)
+        this->alpha = alpha;
+    else {
+        bskLogger.bskLog(BSK_ERROR, "Proportional gain tuning variable alpha must be greater than 0.");
+    }
+}
+
+void ConstraintDynamicEffector::setBeta(double beta) {
+    if (beta > 0.0)
+        this->beta = beta;
+    else {
+        bskLogger.bskLog(BSK_ERROR, "Derivative gain tuning parameter beta must be greater than 0.");
+    }
+}
+
+void ConstraintDynamicEffector::setK_d(double k_d) {
+    if (k_d > 0.0)
+        this->k_d = k_d;
+    else {
+        bskLogger.bskLog(BSK_ERROR, "Direction constraint proportional gain k_d must be greater than 0.");
+    }
+}
+
+void ConstraintDynamicEffector::setC_d(double c_d) {
+    if (c_d > 0.0)
+        this->c_d = c_d;
+    else {
+        bskLogger.bskLog(BSK_ERROR, "Direction constraint derivative gain c_d must be greater than 0.");
+    }
+}
+
+void ConstraintDynamicEffector::setK_a(double k_a) {
+    if (k_a > 0.0)
+        this->k_a = k_a;
+    else {
+        bskLogger.bskLog(BSK_ERROR, "Attitude constraint proportional gain k_a must be greater than 0.");
+    }
+}
+
+void ConstraintDynamicEffector::setC_a(double c_a) {
+    if (c_a > 0.0)
+        this->c_a = c_a;
+    else {
+        bskLogger.bskLog(BSK_ERROR, "Attitude constraint derivative gain c_a must be greater than 0.");
+    }
+}
+
+/*! This method allows the constraint effector to have access to the parent states
+ @return void
+ @param states The states to link
+ */
+void ConstraintDynamicEffector::linkInStates(DynParamManager& states)
+{
+    if (this->scInitCounter > 1) {
+        bskLogger.bskLog(BSK_ERROR, "constraintDynamicEffector: tried to attach more than 2 spacecraft");
+    }
+
+    this->hubSigma.push_back(states.getStateObject("hubSigma"));
+	this->hubOmega.push_back(states.getStateObject("hubOmega"));
+    this->hubPosition.push_back(states.getStateObject("hubPosition"));
+    this->hubVelocity.push_back(states.getStateObject("hubVelocity"));
+
+    this->scInitCounter++;
+}
+
+/*! This method computes the forces on torques on each spacecraft body.
+ @return void
+ @param integTime Integration time
+ @param timeStep Current integration time step used
+ */
+void ConstraintDynamicEffector::computeForceTorque(double integTime, double timeStep)
+{
+    if (this->scInitCounter == 2) { // only proceed once both spacecraft are added
+        // alternate assigning the constraint force and torque
+        if (this->scID == 0) { // compute all forces and torques once, assign to spacecraft 1 and store for spacecraft 2
+            // - Collect states from both spacecraft
+            Eigen::Vector3d r_B1N_N = this->hubPosition[0]->getState();
+            Eigen::Vector3d rDot_B1N_N = this->hubVelocity[0]->getState();
+            Eigen::Vector3d omega_B1N_B1 = this->hubOmega[0]->getState();
+            Eigen::MRPd sigma_B1N;
+            sigma_B1N = (Eigen::Vector3d)this->hubSigma[0]->getState();
+            Eigen::Vector3d r_B2N_N = this->hubPosition[1]->getState();
+            Eigen::Vector3d rDot_B2N_N = this->hubVelocity[1]->getState();
+            Eigen::Vector3d omega_B2N_B2 = this->hubOmega[1]->getState();
+            Eigen::MRPd sigma_B2N;
+            sigma_B2N = (Eigen::Vector3d)this->hubSigma[1]->getState();
+
+            // computing direction constraint psi in the N frame
+            Eigen::Matrix3d dcm_B1N = (sigma_B1N.toRotationMatrix()).transpose();
+            Eigen::Matrix3d dcm_B2N = (sigma_B2N.toRotationMatrix()).transpose();
+            Eigen::Vector3d r_P1B1_N = dcm_B1N.transpose() * this->r_P1B1_B1;
+            Eigen::Vector3d r_P2B2_N = dcm_B2N.transpose() * this->r_P2B2_B2;
+            Eigen::Vector3d r_P2P1_N = r_P2B2_N + r_B2N_N - r_P1B1_N - r_B1N_N;
+
+            // computing length constraint rate of change psiPrime in the N frame
+            Eigen::Vector3d rDot_P1B1_B1 = omega_B1N_B1.cross(this->r_P1B1_B1);
+            Eigen::Vector3d rDot_P2B2_B2 = omega_B2N_B2.cross(this->r_P2B2_B2);
+            Eigen::Vector3d rDot_P1N_N = dcm_B1N.transpose() * rDot_P1B1_B1 + rDot_B1N_N;
+            Eigen::Vector3d rDot_P2N_N = dcm_B2N.transpose() * rDot_P2B2_B2 + rDot_B2N_N;
+            Eigen::Vector3d rDot_P2P1_N = rDot_P2N_N - rDot_P1N_N;
+            Eigen::Vector3d omega_B1N_N = dcm_B1N.transpose() * omega_B1N_B1;
+
+            // calculate the direction constraint violations
+            this->psi_N = r_P2P1_N - dcm_B1N.transpose() * this->r_P2P1_B1Init;
+            this->psiPrime_N = rDot_P2P1_N - omega_B1N_N.cross(r_P2P1_N);
+
+            // calculate the attitude constraint violations
+            this->sigma_B2B1 = eigenC2MRP(dcm_B2N * dcm_B1N.transpose()); // calculate the difference in attitude
+            Eigen::Vector3d omega_B1N_B2 = dcm_B2N * dcm_B1N.transpose() * omega_B1N_B1;
+            this->omega_B2B1_B2 = omega_B2N_B2 - omega_B1N_B2; // difference in angular rate
+
+            // calculate the constraint force
+            this->Fc_N = this->k_d * this->psi_N + this->c_d * this->psiPrime_N; // store the constraint force for spacecraft 2
+            this->forceExternal_N = this->Fc_N;
+
+            // calculate the torque on each spacecraft from the direction constraint
+            Eigen::Vector3d Fc_B1 = dcm_B1N * this->Fc_N;
+            Eigen::Vector3d L_B1_len = (this->r_P1B1_B1).cross(Fc_B1);
+            Eigen::Vector3d Fc_B2 = dcm_B2N * this->Fc_N;
+            Eigen::Vector3d L_B2_len = -this->r_P2B2_B2.cross(Fc_B2);
+
+            // calculate the constraint torque imparted on each spacecraft from the attitude constraint
+            Eigen::Matrix3d dcm_B1B2 = dcm_B1N * dcm_B2N.transpose();
+            Eigen::Vector3d L_B2_att = -this->k_a * eigenMRPd2Vector3d(sigma_B2B1) - this->c_a * 0.25 * sigma_B2B1.Bmat() * omega_B2B1_B2;
+            Eigen::Vector3d L_B1_att = - dcm_B1B2 * L_B2_att;
+            this->L_B2 = L_B2_len + L_B2_att; // store the constraint torque for spacecraft 2
+
+            // assign forces and torques for spacecraft 1
+            this->forceExternal_N = this->Fc_N;
+            this->torqueExternalPntB_B = L_B1_len + L_B1_att;
+        }
+        else if (this->scID == 1) {
+            // assign forces and torques for spacecraft 2
+            this->forceExternal_N = - this->Fc_N;
+            this->torqueExternalPntB_B = this->L_B2;
+        }
+        this->scID = (1 + pow(-1,this->scID))/2; // toggle spacecraft to be assigned forces and torques
+    }
+}
+
+/*! Update state method, nothing to report here
+ @return void
+ */
+void ConstraintDynamicEffector::UpdateState(uint64_t CurrentSimNanos)
+{
+
+}

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.h
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.h
@@ -1,0 +1,121 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+#ifndef CONSTRAINT_DYNAMIC_EFFECTOR_H
+#define CONSTRAINT_DYNAMIC_EFFECTOR_H
+
+#include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+
+#include "architecture/messaging/messaging.h"
+
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/utilities/avsEigenMRP.h"
+#include <Eigen/Dense>
+#include <vector>
+// #include <iostream>
+// #include <cstring>
+
+/*! @brief constraint dynamic effector class */
+class ConstraintDynamicEffector: public SysModel, public DynamicEffector {
+public:
+    ConstraintDynamicEffector();
+    ~ConstraintDynamicEffector();
+    void Reset(uint64_t CurrentSimNanos);
+    void linkInStates(DynParamManager& states);
+    void computeForceTorque(double integTime, double timeStep);
+    void UpdateState(uint64_t CurrentSimNanos);
+
+    /** setter for `r_P2P1_B1Init` initial spacecraft separation */
+    void setR_P2P1_B1Init(Eigen::Vector3d r_P2P1_B1Init);
+    /** setter for `r_P1B1_B1` connection point position on spacecraft 1 */
+    void setR_P1B1_B1(Eigen::Vector3d r_P1B1_B1);
+    /** setter for `r_P2B2_B2` connection point position on spacecraft 2 */
+    void setR_P2B2_B2(Eigen::Vector3d r_P2B2_B2);
+    /** setter for `alpha` gain tuning parameter */
+    void setAlpha(double alpha);
+    /** setter for `beta` gain tuning parameter */
+    void setBeta(double beta);
+    /** setter for `k_d` gain */
+    void setK_d(double k_d);
+    /** setter for `c_d` gain */
+    void setC_d(double c_d);
+    /** setter for `k_a` gain */
+    void setK_a(double k_a);
+    /** setter for `c_a` gain */
+    void setC_a(double c_a);
+
+    /** getter for `r_P2P1_B1Init` initial spacecraft separation */
+    Eigen::Vector3d getR_P2P1_B1Init() const {return this->r_P2P1_B1Init;};
+    /** getter for `r_P1B1_B1` connection point position on spacecraft 1 */
+    Eigen::Vector3d getR_P1B1_B1() const {return this->r_P1B1_B1;};
+    /** getter for `r_P2B2_B2` connection point position on spacecraft 2 */
+    Eigen::Vector3d getR_P2B2_B2() const {return this->r_P2B2_B2;};
+    /** getter for `alpha` gain tuning parameter */
+    double getAlpha() const {return this->alpha;};
+    /** getter for `beta` gain tuning parameter */
+    double getBeta() const {return this->beta;};
+    /** getter for `k_d` gain */
+    double getK_d() const {return this->k_d;};
+    /** getter for `c_d` gain */
+    double getC_d() const {return this->c_d;};
+    /** getter for `k_a` gain */
+    double getK_a() const {return this->k_a;};
+    /** getter for `c_a` gain */
+    double getC_a() const {return this->c_a;};
+
+private:
+    // Counters and flags
+    int scInitCounter = 0; //!< counter to kill simulation if more than two spacecraft initialized
+    int scID = 1; //!< 0,1 alternating spacecraft tracker to output appropriate force/torque
+
+    // Constraint length and direction
+    Eigen::Vector3d r_P1B1_B1 = Eigen::Vector3d::Zero(); //!< [m] position vector from spacecraft 1 hub to its connection point P1
+    Eigen::Vector3d r_P2B2_B2 = Eigen::Vector3d::Zero(); //!< [m] position vector from spacecraft 2 hub to its connection point P2
+    Eigen::Vector3d r_P2P1_B1Init = Eigen::Vector3d::Zero(); //!< [m] precribed position vector from spacecraft 1 connection point to spacecraft 2 connection point
+
+    // Gains for PD controller
+    double alpha = 0.0; //!< Baumgarte stabilization gain tuning variable
+    double beta = 0.0; //!< Baumgarte stabilization gain tuning variable
+    double k_d = 0.0; //!< direction constraint proportional gain
+    double c_d = 0.0; //!< direction constraint derivative gain
+    double k_a = 0.0; //!< attitude constraint proportional gain
+    double c_a = 0.0; //!< attitude constraint derivative gain
+
+    // Simulation variable pointers
+    std::vector<StateData*> hubPosition;    //!< [m] parent inertial position vector
+    std::vector<StateData*> hubVelocity;    //!< [m/s] parent inertial velocity vector
+    std::vector<StateData*> hubSigma;       //!< parent attitude Modified Rodrigues Parameters (MRPs)
+    std::vector<StateData*> hubOmega;       //!< [rad/s] parent inertial angular velocity vector
+
+    // Constraint violations
+    Eigen::Vector3d psi_N = Eigen::Vector3d::Zero(); //!< [m] direction constraint violation in inertial frame
+    Eigen::Vector3d psiPrime_N = Eigen::Vector3d::Zero(); //!< [m/s] direction rate constraint violation in inertial frame
+    Eigen::MRPd sigma_B2B1 = Eigen::MRPd::Identity(); //!< attitude constraint violation
+    Eigen::Vector3d omega_B2B1_B2 = Eigen::Vector3d::Zero(); //!< [rad/s] angular velocity constraint violation in spacecraft 2 body frame
+
+    // Force and torque quantities stored to be assigned on the alternating call of computeForceTorque
+    Eigen::Vector3d Fc_N = Eigen::Vector3d::Zero(); //!< [N] force applied on each spacecraft COM in the inertial frame
+    Eigen::Vector3d L_B2 = Eigen::Vector3d::Zero(); //!< [N-m] torque applied on spacecraft 2 in its body frame
+};
+
+
+#endif /* CONSTRAINT_DYNAMIC_EFFECTOR_H */

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.i
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.i
@@ -1,0 +1,45 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+
+%module constraintDynamicEffector
+%{
+   #include "constraintDynamicEffector.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_eigen.i"
+%include "swig_conly_data.i"
+
+// Instantiate templates used by example
+%include "std_vector.i"
+
+%include "sys_model.i"
+%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+%include "constraintDynamicEffector.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.rst
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.rst
@@ -1,0 +1,92 @@
+
+Executive Summary
+-----------------
+
+The constraint effector class is used to define a physical connection between two separate
+spacecraft. This class takes in the connection location on each spacecraft in their respective
+body frames as well as a relative vector between these two connection points. It also takes in
+two gain tuning parameters to tailor the stiffness and damping of the connection between the
+two spacecraft.
+
+The constraint effector class is an instantiation of the dynamic effector abstract class. The
+included test is validating the interaction between two spacecraft rigid body hubs that are
+attached through a constraint effector. In this case, two identical spacecraft are connected
+by a 0.1 meter long arm which is enforced with high stiffness and damping to be virtually rigid.
+
+Detailed Module Description
+---------------------------
+
+A constraint effector is a combination of two separate 3-degree-of-freedom holonomic constraints: a
+direction constraint which enforces the position of the connection point on each spacecraft
+relative to the other, and an attitude constraint which enforces the attitude of each spacecraft
+relative to the other. The constraint effector works by correcting violations of these constraints
+as well as their derivatives.
+
+Mathematical Modeling
+^^^^^^^^^^^^^^^^^^^^^
+See the following conference paper for a detailed description of the mathematical model.
+
+.. note::
+
+    J. Vaz Carneiro, A. Morell and H. Schaub, `"Post-Docking Complex
+    Spacecraft Dynamics Using Baumgarte Stabilization" <https://hanspeterschaub.info/Papers/VazCarneiro2023b.pdf>`_,
+    AAS/AIAA Astrodynamics Specialist Conference, Big Sky, Montana, Aug. 13-17, 2023
+
+User Guide
+----------
+This section outlines the steps needed to setup a Constraint Dynamic Effector in Python using Basilisk.
+
+#. Import the constraintDynamicEffector class::
+
+    from Basilisk.simulation import constraintDynamicEffector
+
+#. Create an instantiation of a holonomic constraint::
+
+    constraintEffector = constraintDynamicEffector.ConstraintDynamicEffector()
+
+#. Define all physical parameters for the constraint::
+
+    constraintEffector.setR_P1B1_B1(r_P1B1_B1)
+    constraintEffector.setR_P2B2_B2(r_P2B2_B2)
+    constraintEffector.setR_P2P1_B1Init(r_P2P1_B1Init)
+
+#. Define the stiffness and damping of the connection. See the recommended starting gains here::
+
+    constraintEffector.setAlpha(1E2)
+    constraintEffector.setBeta(1e3)
+
+#. (Optional) Define exact gains for the direction and attitude constraints separately. These are internally set based on alpha and beta during reset, but can be overridden in this way::
+
+    constraintEffector.setK_d(alpha**2)
+    constraintEffector.setC_d(2*beta)
+    constraintEffector.setK_a(alpha**2)
+    constraintEffector.setC_a(2*beta)
+
+#. Add the effector to both spacecraft::
+
+    scObject1.addDynamicEffector(constraintEffector)
+    scObject2.addDynamicEffector(constraintEffector)
+
+   See :ref:`spacecraft` documentation on how to set up a spacecraft object.
+
+#. Add the module to the task list::
+
+    Sim.AddModelToTask(TaskName, constraintEffector)
+
+#. Ensure that the dynamics integration is synced between the connected spacecraft. For best results use a variable timestep integrator::
+
+    integratorObject1 = svIntegrators.svIntegratorRKF45(scObject1)
+    scObject1.setIntegrator(integratorObject1)
+    scObject1.syncDynamicsIntegration(scObject2)
+
+#. (Optional) Retrieve the constraint effector's physical parameters, gain tuning parameters, or exact gains for the direction and attitude constraints::
+
+    constraintEffector.getR_P1B1_B1(r_P1B1_B1)
+    constraintEffector.getR_P2B2_B2(r_P2B2_B2)
+    constraintEffector.getR_P2P1_B1Init(r_P2P1_B1Init)
+    constraintEffector.getAlpha(1E2)
+    constraintEffector.getBeta(1e3)
+    constraintEffector.getK_d(alpha**2)
+    constraintEffector.getC_d(2*beta)
+    constraintEffector.getK_a(alpha**2)
+    constraintEffector.getC_a(2*beta)

--- a/src/tests/test_scenarioConstrainedDynamics.py
+++ b/src/tests/test_scenarioConstrainedDynamics.py
@@ -1,0 +1,78 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+# Basilisk Scenario Script and Integrated Test
+#
+# Purpose:  Integrated test of the constraintDynamicEffector module. Illustrates setting up
+#           a pair of connected spacecraft with an initial relative spin.
+# Author:    João Vaz Carneiro and Andrew Morell
+# Creation Date:  May, 14 2024
+#
+
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import unitTestSupport
+
+# Get current file path
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+sys.path.append(path + '/../../examples')
+import scenarioConstrainedDynamics
+
+
+# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
+# @pytest.mark.skipif(conditionstring)
+# uncomment this line if this test has an expected failure, adjust message as needed
+# @pytest.mark.xfail(True)
+
+@pytest.mark.scenarioTest
+
+def test_scenarioConstrainedDynamics(show_plots):
+    '''This function is called by the py.test environment.'''
+    # each test method requires a single assert method to be called
+
+    testFailCount = 0  # zero unit test result counter
+    testMessages = []  # create empty array to store test log messages
+
+    try:
+        figureList = scenarioConstrainedDynamics.run(show_plots, 'Gravity')
+        # save the figures to the Doxygen scenario images folder
+        for pltName, plt in list(figureList.items()):
+            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+
+    except OSError as err:
+        testFailCount += 1
+        testMessages.append("scenarioConstrainedDynamics  test are failed.")
+
+    #   print out success message if no error were found
+    if testFailCount == 0:
+        print("PASSED ")
+    else:
+        print(testFailCount)
+        print(testMessages)
+
+    # each test method requires a single assert method to be called
+    # this check below just makes sure no sub-test failures were found
+    assert testFailCount < 1, testMessages


### PR DESCRIPTION
* **Tickets addressed:** bsk-240
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
A constraint effector was created which enforces a dynamic coupling between two spacecraft. The new effector takes in the physical parameters of the coupling (relative position, attitude) as well as gain tuning parameters alpha and beta which determine the stiffness and damping of the coupling. This module is well suited to modeling the post-docked dynamics of attached vehicles.

Commits are organized by type of files being added: first the module (.cpp, .h, and .i files), then the unit test, followed by documentation, an example scenario, and finally release notes.

## Verification
This new module is validated via a unit test created to check the conservation quantities: orbital and rotational angular momentum and energy. The conservation quantities checked are the combined values of the two spacecraft since each exerts forces and torques on the other. What is important is that these forces and torques act effectively as internal and therefore cancel out. Due to the damping in the modeling of the connection, there is slight energy loss over time. Additionally there are oscillations in both the combined rotational angular momentum and energy due to some dynamical oscillation about the connection point, but what is important is that these oscillations are small, zero-bias in the case of angular momentum, and minimally biased in the case of energy.

Additionally checked in the unit test for the constraint effector module are the constraint violations. For the stiffness and damping defined for the effector, the constraint violations should remain bounded below a certain threshold based on prior testing of the module. Testing these thresholds is designed to monitor that the constraint violations don't increase due to later Basilisk changes, not to check that the constraint violations are below any theoretical threshold.

There is also a test file for executing the example scenario which is effectively the same as the unit test except with conservation quantities removed and a coarser time step and gains.

## Documentation
Documentation is added for the constraint effector module providing a walkthrough of the relevant parameters and what code to include when setting one up. There is also documentation added explaining the example scenario.

Release notes have been updated to reflect the create of the constraint effector module and addition of its example scenario.

## Future work
Future work includes potentially adding more complex scenario examples with either more complex individual spacecraft, more than two spacecraft linked together, or multiple constraint effectors between two spacecraft.

Further, future enhancements could include logging the constraint internal forces and torques through an output message, maybe provide filtered values in this message, and add the capability to turn this effector on and off.  This will allow us to simulate a component being released from a parent body.
