### PR TITLE
Fix bug #690: Write epoch string for SPICE with microsecond precision instead of 0.1 second

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,7 +32,7 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Removed the depreciated manner of creating python modules
-- Created a new example scenario :ref:`scenarioTempMeasurementAttitude` demonstrating the use of tempMeasurement module and generating random noise in the measurement. 
+- Created a new example scenario :ref:`scenarioTempMeasurementAttitude` demonstrating the use of tempMeasurement module and generating random noise in the measurement.
 - Uncaught exceptions raised in Python modules are now printed to ``stderr`` before the program is terminated.
 - Added a new N-axis spinning effector :ref:`spinningBodyNDOFStateEffector`. This is an expansion of :ref:`spinningBodyOneDOFStateEffector`
   and :ref:`spinningBodyTwoDOFStateEffector` to any number of degrees of freedom.
@@ -41,6 +41,8 @@ Version |release|
 - Added support for arrays and 2D arrays of 16 and 64 bit integers in message definitions
 - Fixed bug where 2D arrays of 32 bit integers would have elements of type ``float`` in python.
 - Fixed the ``Identity()`` method in avsEigenMRP library.
+- Fixed the ``SpiceInterface::initTimeData()`` method to write epoch strings with microsecond precision instead of 0.1 second precision
+  to prevent SPICE errors when epochs ending with seconds higher than 59.95 seconds got rounded up to 60.0 seconds
 
 
 Version 2.3.0 (April 5, 2024)
@@ -51,8 +53,8 @@ Version 2.3.0 (April 5, 2024)
 - Fixed a python version checking bug that prevented Basilisk from compiling on Windows
 - Created a new example scenario :ref:`scenarioHaloOrbit` demonstrating a near-Halo orbit simulation
 - Updated versioning to better follow the `semantic versioning <https://semver.org>`_ standard, in the format
-  ``MAJOR.MINOR.PATCH``. Releases will increment the minor version number, while pull requests into develop will 
-  automatically increment the patch number. This allows users to reference/require specific versions of Basilisk 
+  ``MAJOR.MINOR.PATCH``. Releases will increment the minor version number, while pull requests into develop will
+  automatically increment the patch number. This allows users to reference/require specific versions of Basilisk
   outside of the release cycle.
   Online documentation is only built for the ``MAJOR.MINOR.0`` releases
 - updated plotting of ``opNav`` example scenarios to work again with latest version of ``matplotlib``
@@ -152,7 +154,7 @@ Version 2.2.1 (Dec. 22, 2023)
 - Added a new method ``setDataBuffer()`` to :ref:`simpleStorageUnit` and :ref:`partitionedStorageUnit` to add or remove data from specified partitions.
 - Refactored ``simIncludeGravBody``. The most notable change for users is that the commonly used line
   ``scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))``
-  can be replaced by ``gravFactory.addBodiesTo(scObject)`` (where ``scObject`` is a ``spacecraft.Spacecraft`` 
+  can be replaced by ``gravFactory.addBodiesTo(scObject)`` (where ``scObject`` is a ``spacecraft.Spacecraft``
   or  ``spacecraftSystem.SpacecraftSystem``, and ``gravFactory`` is a ``simIncludeGravBody.gravBodyFactory``)
 - Added condition in :ref:`thrustCMEstimation` to avoid measurement updates when input ``attGuidInMsg`` has not been written.
 - Added :ref:`scenarioSepMomentumManagement` to show how to use a dual-gimbaled electric thruster to perform contunuous
@@ -179,8 +181,8 @@ Version 2.2.0 (June 28, 2023)
   format, with_quirc QR code lib. Users that have Basilisk control the build of these modules through the External
   Modules CMake integration will need to manual toggle these OpenCV build options.
 - Updated :ref:`SmallBodyNavEKF` with several bug fixes. Removed spacecraft attitude estimation component.
-- Bug fix made to :ref:`eclipse`: Saturn, Jupiter, Uranus, and Neptune radii were incorrectly being assigned the 
-  radius of Mars. 
+- Bug fix made to :ref:`eclipse`: Saturn, Jupiter, Uranus, and Neptune radii were incorrectly being assigned the
+  radius of Mars.
 - Added custom planet name to :ref:`eclipse` in case the user wants to use a body not contained within the module.
 - Removed all instances of using ``unitTestSupport.np2EigenVectorXd()``, as this function is now unneeded.
 - Created a :ref:`facetSRPDynamicEffector` dynamics module to calculate the B frame SRP force and torque acting on a
@@ -206,7 +208,7 @@ Version 2.2.0 (June 28, 2023)
 - Refactored the :ref:`prescribedMotionStateEffector` dynamics module to vary the prescribed states across the dynamics
   integration time step.
 - The encryption build option for the project's conan zmq dependency is disabled because it is uneeded.
-- Added an optional ``controllerStatus`` variable and ``deviceStatusInMsg`` message to the :ref:`simpleInstrumentController` to 
+- Added an optional ``controllerStatus`` variable and ``deviceStatusInMsg`` message to the :ref:`simpleInstrumentController` to
   match the functionality of the corresponding data and power modules
 - Corrected tasks priorities in several scenarios and added checks in two modules to ensure that C MSG read errors are not thrown
 - Reworked how integrators are implemented. New Runge-Kutta integrators may
@@ -363,7 +365,7 @@ Version 2.1.4 (Oct. 1, 2022)
 - added new attitude pointing scenario :ref:`scenarioAttitudeFeedback2T_stateEffTH` that uses
   the new :ref:`thrusterStateEffector`
 - added ability to simulate faults within :ref:`coarseSunSensor` module
-- created a 1-DoF rotating rigid body class ``SpinningBodyStateEffector``. It is built in a general way to simulate 
+- created a 1-DoF rotating rigid body class ``SpinningBodyStateEffector``. It is built in a general way to simulate
   any effector with a single spinning axis.
 
 
@@ -443,7 +445,7 @@ Version 2.1.1 (Dec. 15, 2021)
 
 Version 2.1.0 (Nov. 13, 2021)
 -----------------------------
-- added BSpline function to ``utilities`` and related UnitTest. 
+- added BSpline function to ``utilities`` and related UnitTest.
 - added kinematic relations between angular accelerations and second derivative of MRP set to
   :ref:`rigidBodyKinematicsutilities` library
 - updated the installation script to function with the latest ``conan`` program and the recent
@@ -460,7 +462,7 @@ Version 2.1.0 (Nov. 13, 2021)
 - added new scenario :ref:`scenarioVariableTimeStepIntegrators`
 - updated :ref:`scenarioIntegrators` to include the ``rkf45`` and ``rkf78`` options
 - changed the way :ref:`spacecraftReconfig` gets the deputy's mass properties. It now receives that information
-  through a message of the type ``VehicleConfigMsgPayload`` instead of an internal variable. Relevant example 
+  through a message of the type ``VehicleConfigMsgPayload`` instead of an internal variable. Relevant example
   scripts have been updated.
 - new tutorial example scenario script :ref:`scenarioTAMcomparison`
 - new mass sensor that converts a ``simulation`` mass properties message to a ``FSW`` vehicle configuration message :ref:`simpleMassProps`
@@ -505,13 +507,13 @@ Version 2.0.6
   using the above new MTB related modules to change the momentum, as well as drive the nominal momentum to
   a desired value using :ref:`rwNullSpace`.
 - created a new architecture based on ``BskSim`` called ``MultiSatBskSim``. It exploits the new messaging system to create a simulation
-  with any number of spacecraft in a highly modular way. It allows for the addition of homogeneous or heterogeneous satellites without 
+  with any number of spacecraft in a highly modular way. It allows for the addition of homogeneous or heterogeneous satellites without
   having to hard code their properties into a single dynamics or FSW script. It will be a foundation to test the upcoming multithreading
   capabilities of Basilisk.
-- added three example scenarios that showcase this new architecture. See :ref:`scenario_BasicOrbitMultiSat`, :ref:`scenario_AttGuidMultiSat` 
+- added three example scenarios that showcase this new architecture. See :ref:`scenario_BasicOrbitMultiSat`, :ref:`scenario_AttGuidMultiSat`
   and :ref:`scenario_StationKeepingMultiSat`.
 - added a new FSW module :ref:`formationBarycenter`. It computes the barycenter's position and velocity of a swarm of satellites. This barycenter
-  can be either computed with cartesian coordinates (usual mass-weighted average), or using orbital elements weighted average. Will be useful 
+  can be either computed with cartesian coordinates (usual mass-weighted average), or using orbital elements weighted average. Will be useful
   for spacecraft formations defined around the barycenter of the swarm and not a chief spacecraft.
 - enhanced :ref:`locationPointing` to support the target input msg being either a location message or an
   ephemeris message
@@ -545,7 +547,7 @@ Version 2.0.5
   two modules are connected
 - updated :ref:`gravityEffector` documentation to properly pull in the RST documentation and link to the
   PDF describing the gravity models
-- updated ``setAllButCurrentEventActivity`` method in :ref:`SimulationBaseClass` to work with multiple satellites. We can now add an index at the 
+- updated ``setAllButCurrentEventActivity`` method in :ref:`SimulationBaseClass` to work with multiple satellites. We can now add an index at the
   end of each event name that guarantees only events with the same index are affected. The ``useIndex`` flag must be set to ``True``.
 - added new magnetic torque bar effector in :ref:`MtbEffector`
 - added new FSW module to control the RW momentum using MTBs in :ref:`mtbMomentumManagement`
@@ -751,7 +753,7 @@ Version 2.0.0
 - updated ``spacecraftPlus`` to allow the attitude motion to be prescribed through
   an optional input message of type ``attRefMsg``.
 - fixed sign issue in :ref:`simpleSolarPanel`
-- support Vizard 1.6.0 scripting  
+- support Vizard 1.6.0 scripting
 
 
 
@@ -849,7 +851,7 @@ Version 2.0.0
   BSK messages.  For example, this allows :ref:`vizInterface` store the simulation data into a Vizard compatible manner.
 - Updated :ref:`spiceInterface` to allow for optional overriding the IAU planet frame with custom values
 - Updated :ref:`vizInterface` to allow setting ``show24hrClock`` and ``showDataRateDisplay`` flags for Vizard files
-  supported in Vizard v1.3.0 
+  supported in Vizard v1.3.0
 
 Version 1.7.4
 
@@ -1130,7 +1132,7 @@ simple and robust solution.
 
 -  added new tutorial on calling Python Spice functions within a Monte Carlo BSK simulation
 -  Added Keplerian Orbit utility class which is swig'd. This first implementation takes in elliptical orbit elements and can produce a range of related outputs like position, velocity, orbital period, etc.  This makes it easier to create Keplerian orbits within python.
--  Added a LimbFinding module for OpNav: limbFinding. This module performs a Canny transform to find the end of the planet and saves away the non-zero pixels for pose-estimation. 
+-  Added a LimbFinding module for OpNav: limbFinding. This module performs a Canny transform to find the end of the planet and saves away the non-zero pixels for pose-estimation.
 - made BSK compatible with both swig version 3 and 4
 
 .. raw:: html

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
@@ -376,6 +376,42 @@ def unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos
     # this check below just makes sure no sub-test failures were found
     return [testFailCount, ''.join(testMessages)]
 
+def test_59_999999_second_epoch():
+    """
+    Unit test added to reproduce issue #690
+    """
+    DateSpice = "2015 February 10, 00:00:59.999999 UTC"
+
+    # Create a sim module as an empty container
+    unitTaskName = "unitTask"  # arbitrary name (don't change)
+    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    TotalSim = SimulationBaseClass.SimBaseClass()
+
+    DynUnitTestProc = TotalSim.CreateNewProcess(unitProcessName)
+    # create the dynamics task and specify the integration update time
+    DynUnitTestProc.addTask(TotalSim.CreateNewTask(unitTaskName, macros.sec2nano(0.1)))
+
+    # Initialize the spice modules that we are using.
+    SpiceObject = spiceInterface.SpiceInterface()
+    SpiceObject.ModelTag = "SpiceInterfaceData"
+    SpiceObject.SPICEDataPath = bskPath + '/supportData/EphemerisData/'
+
+    TotalSim.AddModelToTask(unitTaskName, SpiceObject)
+
+    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(DateSpice)
+    SpiceObject.epochInMsg.subscribeTo(epochMsg)
+
+    # Configure simulation
+    TotalSim.ConfigureStopTime(int(60.0 * 1E9))
+
+    # Execute simulation
+    TotalSim.InitializeSimulation()
+    TotalSim.ExecuteSimulation()
+
+    print(SpiceObject.UTCCalInit)
+    assert(SpiceObject.UTCCalInit[-15:] == "59.999999 (UTC)")
 
 # This statement below ensures that the unit test scrip can be run as a
 # stand-along python script

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -172,7 +172,7 @@ void SpiceInterface::initTimeData()
         } else {
             // Set the epoch information from the input message
             char string[255];
-            snprintf(string, 255, "%4d/%02d/%02d, %02d:%02d:%04.1f (UTC)", epochMsg.year, epochMsg.month, epochMsg.day, epochMsg.hours, epochMsg.minutes, epochMsg.seconds);
+            snprintf(string, 255, "%4d/%02d/%02d, %02d:%02d:%04.6f (UTC)", epochMsg.year, epochMsg.month, epochMsg.day, epochMsg.hours, epochMsg.minutes, epochMsg.seconds);
             this->UTCCalInit = string;
         }
     }


### PR DESCRIPTION
* **Tickets addressed:** [#690](https://github.com/AVSLab/basilisk/issues/690)
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The fix was described in [#690](https://github.com/AVSLab/basilisk/issues/690)

## Verification
A test case was added to `test_unitSpice.py`. Unfortunately, before SpiceInterface::initTimeData() is fixed, pytest will just stop the execution before the assert and not print any error. But after the fix, this test case runs successfully.
