### PR TITLE
AVS Eigen Library Identity MRP Fix

### DIFF
--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -122,7 +122,7 @@ namespace Eigen {
         /** \returns a MRP representing an identity rotation
          * \sa MatrixBase::Identity()
          */
-        static inline MRP<Scalar> Identity() { return MRP<Scalar>(Scalar(1), Scalar(0), Scalar(0), Scalar(0)); }
+        static inline MRP<Scalar> Identity() { return MRP<Scalar>(Scalar(0), Scalar(0), Scalar(0)); }
 
         /** \sa MRPBase::Identity(), MatrixBase::setIdentity()
          */


### PR DESCRIPTION
* **Tickets addressed:** bsk-693
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
The Identity() method for AVS Eigen MRP initialization was changed to appropriately create an identity rotation MRP instead of an identity quaternion which was the bug.

## Verification
This changes passes build checks.

## Documentation
No documentation was created or invalidated.

## Future work
NA
