### PR TITLE
Update to latest sphinx and sphinx_rtd_theme

### DIFF
--- a/docs/source/Forum.rst
+++ b/docs/source/Forum.rst
@@ -8,13 +8,6 @@ News and Discussions
 
     - `<https://github.com/AVSLab/basilisk/discussions>`__
 
-.. warning::
-
-    A Google Talk Forum is now depreciated and will be removed in the future.  Please post new questions on the GitHub forum above.   The link to the forum is:
-
-    - `<https://groups.google.com/forum/embed/?place=forum%2Fbasilisk-forum>`__
-
-
 .. note::
 
     A YouTube channel is setup where all the Basilisk related tutorial and instructional videos can be found:

--- a/docs/source/Install/installOptionalPackages.rst
+++ b/docs/source/Install/installOptionalPackages.rst
@@ -69,6 +69,6 @@ Creating the Sphinx Basilisk Documentation
 Go to :ref:`createHtmlDocumentation` to learn what associated python tools are required.
 The following python packages must be installed via ``pip``::
 
-    pip3 install sphinx==5.3.0 sphinx_rtd_theme==0.5.1 breathe recommonmark docutils
+    pip3 install 'sphinx>7.0.0' sphinx_rtd_theme==2.0.0 breathe recommonmark docutils
 
 See the list at the top of this page for what versions of these packages are acceptable.

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -45,7 +45,7 @@ Version |release|
   to prevent SPICE errors when epochs ending with seconds higher than 59.95 seconds got rounded up to 60.0 seconds
 - The fuel tank module is refactored to remove the limitation of a only being able to have a single instance of a
   specific tank model type.
-
+- Update Basilisk documentation build system to use latest version of ``sphinx`` and ``sphinx_rtd_theme``
 
 
 Version 2.3.0 (April 5, 2024)

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -105,6 +105,26 @@ figure {
 		color:  #ccc;
 	}
 	
+	html.writer-html4 .rst-content dl:not(.docutils)>dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple)>dt
+	{
+		background-color: rgb(45, 65, 81);
+	}
+	
+	html.writer-html4 .rst-content dl:not(.docutils) .descclassname, html.writer-html4 .rst-content dl:not(.docutils) .descname, html.writer-html4 .rst-content dl:not(.docutils) .sig-name, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) .descclassname, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) .descname, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) .sig-name 
+	{
+		color: rgb(237, 240, 242);
+	}
+	
+	html.writer-html4 .rst-content dl:not(.docutils) dl:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple)>dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) dl:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple)>dt
+	{
+		background-color: #333;;
+	}
+	
+	html.writer-html4 .rst-content dl:not(.docutils) dl:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple)>dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) dl:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple)>dt
+	{
+		color: rgb(41, 128, 185);
+	}
+	
 	.highlight .go {
 		color:  #ccc;
 	}
@@ -183,8 +203,7 @@ figure {
 	}
 	
 	html.writer-html4 .rst-content dl:not(.docutils) dl:not(.field-list)>dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list)>dt, .rst-content dl:not(.docutils) dl dt {
-		background-color: #333;
-		color: #ccc;
+		background-color: black;
 	}
 	
 	.wy-table caption, .rst-content table.docutils caption, .rst-content table.field-list caption {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,7 @@ warnings.filterwarnings("ignore", category=BSKDeprecationWarning)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '7.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,11 +46,9 @@ needs_sphinx = '7.0'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
-    # 'sphinx.ext.inheritance_diagram',
     "sphinx_rtd_theme",
     'recommonmark',
     'breathe'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,30 +95,26 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'style_nav_header_background': '#CFB87C'
+    'logo_only': False,
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'style_external_links': True,
+    'vcs_pageview_mode': '',
+    'style_nav_header_background': '#CFB87C',
+    # Toc options
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'includehidden': True,
+    'titles_only': False
 }
 
-html_context = {
-    'css_files': ['_static/css/custom.css']
-}
+html_css_files = [
+    'css/custom.css',
+]
 
 html_logo = "./_images/static/Basilisk-Logo.png"
-#
-# html_theme_options = {
-#     'canonical_url': '',
-#     'logo_only': False,
-#     'display_version': True,
-#     'prev_next_buttons_location': 'bottom',
-#     'style_external_links': False,
-#     'vcs_pageview_mode': '',
-#     'style_nav_header_background': 'white',
-#     # Toc options
-#     'collapse_navigation': True,
-#     'sticky_navigation': True,
-#     'navigation_depth': 4,
-#     'includehidden': True,
-#     'titles_only': True
-# }
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,5 +1,5 @@
 breathe
 docutils
 recommonmark
-sphinx==5.3.0
-sphinx_rtd_theme==0.5.1
+sphinx>7.0.0
+sphinx_rtd_theme==2.0.0


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Basilisk documentation system was using an older version of `sphinx` and `sphinx_rtd_theme`.
This branch updates these to support the latest versions.  

## Verification
Did a clean build of the documentation and there were no issues or warnings.  
Make sphinx now check that version 7 or higher is used to build documentation.

## Documentation
Update the optional python packages page to discuss the latest `sphinx` and `sphinx_rtd_theme`.

## Future work
None for now.  
