### PR TITLE
add support for pre-commit and clang-format format checking

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+BasedOnStyle: Mozilla
+ColumnLimit: '120'
+IndentWidth: '4'
+TabWidth:    '4'
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      -   id: trailing-whitespace
+      -   id: end-of-file-fixer
+      -   id: check-yaml
+      -   id: check-added-large-files
+          args: ['--maxkb=10000']
+      -   id: check-case-conflict
+      -   id: check-merge-conflict
+      -   id: debug-statements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,19 @@ Now ```pre-commit``` will run automatically whenever you run ```git commit```!
 When ```pre-commit``` decides to edit some of your files,
 you will need to add those changes to your commit and commit again.
 
-#### ClangFormat
+#### Manually Running pre-commit
+
+For cases where `pre-commit` does not automatically run (for example when first
+installing and using `pre-commit`), you can
+manually run pre-commit on specific files you have edited. Use the
+command:
+```
+$ pre-commit run --files <file>
+```
+Note that you must run this command inside the directory containing
+the file you are running `pre-commit` on.
+
+### ClangFormat
 
 This repository uses a modified version of Mozilla's ```.clang-format``` file.
 Please be sure to reformat any C/C++ file with clang-format before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,35 @@ Now ```pre-commit``` will run automatically whenever you run ```git commit```!
 When ```pre-commit``` decides to edit some of your files,
 you will need to add those changes to your commit and commit again.
 
+#### ClangFormat
+
+This repository uses a modified version of Mozilla's ```.clang-format``` file.
+Please be sure to reformat any C/C++ file with clang-format before committing.
+This can be done through the command line or with clion.
+
+To prevent a section from getting reformatted, wrap it with ```// clang-format off``` and ```// clang-format on```.
+
+For more information is available on the [clang-format](https://clang.llvm.org/docs/ClangFormat.html) website.
+
+#### Clion
+
+* To enable clang-format in clion, go to ```Settings - Editor - Code Style``` and enable ClangFormat.
+* This will automatically detect the .clang-format file in the project root.
+* To reformat code you have written, select that portion or the whole file
+     and call <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>L</kbd>.
+
+#### Command Line
+
+* You must ```pip install clang-format``` to use ClangFormat through the command line.
+* Use the command
+  ```
+  $ clang-format -i {file name(s)} -style=file
+  ```
+  where:
+     * ```-i``` makes the suggested changes to the file, otherwise they will be outputted to the cli
+     * ```-style=file``` tells ClangFormat to look for the .clang-format in your project directory,
+       otherwise it will use the LLVM's style guide
+
 ## Write-Ups About Good Commit/PR/Code Review Practice
 
 The following three articles describe in greater detail the ideals to which this repository adheres.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,23 @@ For more information is available on the [clang-format](https://clang.llvm.org/d
      * ```-style=file``` tells ClangFormat to look for the .clang-format in your project directory,
        otherwise it will use the LLVM's style guide
 
+#### macOS Code Editor
+
+Xcode no longer directly supports plugins.  However, you can set up an elegant
+[Automator script](https://www.apulsoft.ch/blog/clang-format-automator-quick-action/)
+that allows you to run the `clang-format` command from any text
+as a Service or a keyboard short-cut
+and replace the selected text with the newly formated text.
+This method will function in any C/C++ IDE, not just Xcode.
+
+The following Automator script is an example if Basilisk is running in a
+virtual environment:
+```
+~/Repos/basilisk/.venv/bin/clang-format --style=file:~/Repos/basilisk/.clang-format
+```
+To determine the path to your installed copy of ``clang-format`` you can
+run the command ``where clang-format`` from the command line.
+
 ## Write-Ups About Good Commit/PR/Code Review Practice
 
 The following three articles describe in greater detail the ideals to which this repository adheres.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 ## Branches
 
--   Branches should be named `feature/bsk-XXX--short-desc` or `hotfix/short-desc`, where "bsk-XXX" is the associated 
+-   Branches should be named `feature/bsk-XXX--short-desc` or `hotfix/short-desc`, where "bsk-XXX" is the associated
     Github project ticket.
     -   If a branch is not associated with a ticket, either it's a hotfix or it needs a ticket.
-    -   Hotfixes should be used sparingly. For instance, a bug introduced in the same release cycle 
-    (or discovered very shortly after merging a PR) can be hotfixed. Bugs that a user may have been exposed to should 
+    -   Hotfixes should be used sparingly. For instance, a bug introduced in the same release cycle
+    (or discovered very shortly after merging a PR) can be hotfixed. Bugs that a user may have been exposed to should
     be logged as tickets.
 
 ## Pull Requests
 
 -   Pull requests should be made against `develop`, using the pull request template in `.github/pull_request_template.md`.
-    
+
     -   GitHub will automatically populate a new PR with this template.
     -   Please fill out all information in the PR header, as well as any information in the subsections.
     -   Every PR should include a summary of changes that gives reviewers an idea of what they should pay attention to.
@@ -19,35 +19,66 @@
     -   Each commit should present one change or idea to a reviewer.
     -   Commits that merely "fix up" previous commits must be interactively rebased and squashed into their targets.
 -   Prefer the use of `git rebase`.
-    
-    1.  `git rebase` `git rebase` actually _rebases_ your branch from the current development branch's endpoint. This 
-    localizes conflicts to the commits at which they actually appear, though it can become complicated when there are 
+
+    1.  `git rebase` `git rebase` actually _rebases_ your branch from the current development branch's endpoint. This
+    localizes conflicts to the commits at which they actually appear, though it can become complicated when there are
     more than a few conflicts.
-    2.  `git merge` `git merge` pulls in all the updates that your branch does not have, and combines them with the 
-    updates you have made in a single merge commit. This allows you to deal with any and all conflicts at once, but 
+    2.  `git merge` `git merge` pulls in all the updates that your branch does not have, and combines them with the
+    updates you have made in a single merge commit. This allows you to deal with any and all conflicts at once, but
     information such as when conflicts originated is lost.
-    
+
     For more info on `git merge` vs `git rebase` see [here](https://www.atlassian.com/git/tutorials/merging-vs-rebasing).
-    
--   Before merging a PR, the following requirements must be met. These requirements ensure that history is effectively 
+
+-   Before merging a PR, the following requirements must be met. These requirements ensure that history is effectively
 linear, which aids readability and makes `git bisect` more useful and easier to reason about.
-    
+
     -   At least one (perferably two) reviewers have approved the PR.
     -   No outstanding review comments have been left unresolved.
     -   The branch passes continuous integration.
     -   The branch has been rebased onto the current `develop` branch.
--   The "Squash and merge" and "Rebase and merge" buttons on GitHub's PR interface should not be used (They are 
+-   The "Squash and merge" and "Rebase and merge" buttons on GitHub's PR interface should not be used (They are
 disabled). Always use the "Merge" strategy.
-    -   In combination with the restrictions above, this ensures that features are neatly bracketed by merge commits 
-    on either side, making a clear hierarchical separation between features added to `develop` and the work that went 
+    -   In combination with the restrictions above, this ensures that features are neatly bracketed by merge commits
+    on either side, making a clear hierarchical separation between features added to `develop` and the work that went
     into each feature.
 
 ## Coding Conventions
 
-A [coding conventions](https://hanspeterschaub.info/basilisk/Support/Developer/CodingGuidlines.html) document exists to 
+A [coding conventions](https://hanspeterschaub.info/basilisk/Support/Developer/CodingGuidlines.html) document exists to
 explain peculiarities and assist in onboarding.
 
-**tl;dr** All development should correspond to a Github ticket, and branch names and PRs should include the ticket name.
+-  All development should correspond to a Github ticket, and branch names and PRs should include the ticket name.
+
+### pre-commit
+
+Pre-commit is a tool used to automate code formatting for easy reading.
+This allows the reviewer to focus on the architecture of a change and not simple nitpicks.
+
+##### Installing pre-commit
+
+Open a terminal window to perform the following tasks.
+To install use the command:
+```
+pip install pre-commit
+```
+Verify pre-commit is installed with:
+```
+$ pre-commit --version
+pre-commit 3.6.2
+```
+
+If you are using python virtual environments, you may need to activate your environment to use pre-commit.
+
+Next, change your current directory to be the Basilisk repo folder.  Then run ```pre-commit install``` to set up the git hook scripts.
+You must run this inside of the repo folder and the associated files will only be installed inside that repository.
+```
+$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+Now ```pre-commit``` will run automatically whenever you run ```git commit```!
+
+When ```pre-commit``` decides to edit some of your files,
+you will need to add those changes to your commit and commit again.
 
 ## Write-Ups About Good Commit/PR/Code Review Practice
 

--- a/docs/source/Install/installOptionalPackages.rst
+++ b/docs/source/Install/installOptionalPackages.rst
@@ -12,8 +12,6 @@
 Installing Optional Packages
 ============================
 
-Listing of All Optional Packages
---------------------------------
 This page contains all the optional python packages that can be included to unlock additional Basilisk
 features or utilities.  For convenience the complete set of optional packages, including any constraints on
 acceptable versions, are listed here:
@@ -23,45 +21,6 @@ acceptable versions, are listed here:
 
 To automatically ensure that the system has all optional packages installed, use the ``allOptPkg``
 flag as discussed in :ref:`configureBuild`.
-
-Running unit and integrated tests via ``pytest``
-------------------------------------------------
-
-The ``pytest`` program can run a series of test on python scripts that begin with ``test_``. Install the ``pytest`` program with::
-
-    pip3 install pytest
-
-Note that version 4.0.1 or higher works properly with Basilisk, while versions between 3.6.1 and 4.0.0 had some bugs that impacted some Basilisk tests.
-
-Generating HTML Report of the ``pytest`` Results
-------------------------------------------------
-If you want to use ``pytest`` to generate a validation HTML report,
-then the ``pytest-html`` package must be installed::
-
-   pip3 install pytest-html
-
-When running ``pytest`` from the terminal, add the ``--html`` argument followed by the path to where
-to generate the report html folder.  It is recommended to put this inside a folder as HTML
-support folder will be created::
-
-    pytest --html report/report.html
-
-
-Multi-proccesing ``pytest``
----------------------------
-
-One can distribute python tests across multiple processes. This is achieved with the ``pytest-xdist``
-package using::
-
-   pip3 install pytest-xdist
-
-After installing this package you can now pytest such that it distribute tests across multi-processes.
-``pytest`` for the same number of processes as processors on the host machine using::
-
-   python3 -m pytest -n auto
-
-or replace `auto` with the number of processors (virtual or otherwise) you'd like to dedicate as test executions
-proccesses.
 
 
 Creating the Sphinx Basilisk Documentation

--- a/docs/source/Install/installOptionalPackages.rst
+++ b/docs/source/Install/installOptionalPackages.rst
@@ -72,3 +72,14 @@ The following python packages must be installed via ``pip``::
     pip3 install 'sphinx>7.0.0' sphinx_rtd_theme==2.0.0 breathe recommonmark docutils
 
 See the list at the top of this page for what versions of these packages are acceptable.
+
+
+Formatting Code Files using ``pre-commit`` and ``clang-format``
+---------------------------------------------------------------
+If you are developing new code to contribute back to Basilisk it must follow the
+:ref:`codingGuidelines`.  This requires installing::
+
+    pip3 install pre-commit clang-format
+
+The file `CONTRIBUTING.md <https://github.com/AVSLab/basilisk/blob/develop/CONTRIBUTING.md>`__
+explains how to setup and use these code formating tools.

--- a/docs/source/Support/Developer/CodingGuidlines.rst
+++ b/docs/source/Support/Developer/CodingGuidlines.rst
@@ -36,6 +36,11 @@ existing stylistic conventions in that package (unless you are
 retrofitting the whole package to follow this guide, for which you
 deserve an award).
 
+**Contribution Guidelines**: see the file `CONTRIBUTING.md
+<https://github.com/AVSLab/basilisk/blob/develop/CONTRIBUTING.md>`__
+for additional information on making code to contribute back to
+the Basilisk repository.
+
 What about non-conforming code?
 -------------------------------
 
@@ -223,4 +228,3 @@ Python Exceptions
    x = (4*9/2)-1
    # No
    x = (4 * 9 / 2) - 1
-

--- a/docs/source/Support/Developer/CodingGuidlines.rst
+++ b/docs/source/Support/Developer/CodingGuidlines.rst
@@ -228,3 +228,30 @@ Python Exceptions
    x = (4*9/2)-1
    # No
    x = (4 * 9 / 2) - 1
+
+
+Running Unit and Integrated Tests
+---------------------------------
+Prior to any code being pushed back to the Basilisk repo all unit and integrated tests must pass.
+The default packages include ``pytest`` which is a program that can run a series of tests on
+python scripts that begin with ``test_``.  The package ``pytest-xdist`` is also installed by default
+and allows these tests to be run in a multi-threaded manner using the argument ``-n auto``.
+
+Further, Basilisk uses the Google ``gtest`` suite to run unit tests on C or C++ support libraries.
+To run all the unit and integrated test open a terminal window and change your working directory
+to the root ``basilisk`` directory.  Activate the python virtual environment if needed.
+Next, run the command::
+
+    $ python run_all_test.py
+
+This will execute ``pytest`` and ``gtest`` checks.  All tests should pass.  If not all
+Basilisk modules are built (i.e. the build process turned off ``opNav`` option), then
+some tests will show up as skipped.
+
+If you want to use ``pytest`` to generate a validation HTML report,
+then the ``pytest-html`` package is used. In a terminal window, make your
+working directory ``basilisk/src``.  Next, run ``pytest`` by adding the ``--html`` argument
+followed by the path to where to generate the report html folder.  It is recommended to put
+this inside a folder as HTML support folder will be created::
+
+    $ pytest --html report/report.html

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -51,6 +51,7 @@ Version |release|
 - Added time tag to :ref:`CSSArraySensorMsgPayload`
 - updated Eigen library to 3.4.0
 - updated OpenCV library to 4.5.5
+- Added documentation on using pre-commit formatters and clang formating
 
 
 Version 2.3.0 (April 5, 2024)

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -3,3 +3,5 @@ docutils
 recommonmark
 sphinx>7.0.0
 sphinx_rtd_theme==2.0.0
+pre-commit
+clang-format


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This branch has been lifted from the LASP fork of Basilisk and the original author is @patkenneally.  The 
branch provides support for running `pre-commit` on each commit to a branch to ensure basic formatting.

Next, `clang-format` support is added along with instructions on how to format C/C++.

In addition to the original branch, this PR adds:

- edited `CONTRIBUTING.md` file to improve instructions
- added support on making short-cuts to run `clang-format` on macOS
- updated `CodingGuidlines.rst` to point to `CONTRIBUTING.md` for formatting instructions
- added `pre-commit` and `clang-format` to list of optional packages to install
- added info to release notes

## Verification
Tested the installation instructions on macOS as well as did test commits to ensure the formatting 
expectations were imposed.

## Documentation
Did a clean test build of Basilisk documentation and it completed without issues.

## Future work
None