### PR TITLE
update CI scripts

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -99,7 +99,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/requirements.txt'
       - name: Choco help
-        uses: crazy-max/ghaction-chocolatey@v2
+        uses: crazy-max/ghaction-chocolatey@v3
         with:
           args: -h
       - name: "Install swig and cmake"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,8 +11,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - id: file_changes
         uses: tj-actions/changed-files@v44
       - uses: pre-commit/action@v3.0.1
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cache conan packages
         id: cache-conan
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: Cache pip modules
         id: cache-pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-pip-modules
         with:
@@ -72,7 +72,7 @@ jobs:
           source .venv/bin/activate
           cd src && pytest -n 2 -m "not scenarioTest" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
       - name: "Upload pytest test results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
@@ -82,7 +82,7 @@ jobs:
         working-directory: ./dist3
         run: ctest --gtest_output "json:../ctest/ctest-results-linux-${{ matrix.python-version }}.json"
       - name: "Upload Google Test CTest results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ctest-results-${{ matrix.python-version }}
           path: ctest/ctest-results-${{ matrix.python-version }}.json

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,8 +8,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - id: file_changes
+        uses: tj-actions/changed-files@v44
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}
   build-linux:
     name: Build Linux
+    needs: pre-commit
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -79,6 +90,7 @@ jobs:
 
   build-windows:
     name: Build Windows
+    needs: pre-commit
     runs-on: windows-2019
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ## Branches
 
 -   Branches should be named `feature/bsk-XXX--short-desc` or `hotfix/short-desc`, where "bsk-XXX" is the associated
-    Github project ticket.
+    GitHub project ticket.
     -   If a branch is not associated with a ticket, either it's a hotfix or it needs a ticket.
     -   Hotfixes should be used sparingly. For instance, a bug introduced in the same release cycle
     (or discovered very shortly after merging a PR) can be hotfixed. Bugs that a user may have been exposed to should
@@ -47,12 +47,17 @@ disabled). Always use the "Merge" strategy.
 A [coding conventions](https://hanspeterschaub.info/basilisk/Support/Developer/CodingGuidlines.html) document exists to
 explain peculiarities and assist in onboarding.
 
--  All development should correspond to a Github ticket, and branch names and PRs should include the ticket name.
+-  All development should correspond to a GitHub ticket, and branch names and PRs should include the ticket name.
 
 ### pre-commit
 
 Pre-commit is a tool used to automate code formatting for easy reading.
 This allows the reviewer to focus on the architecture of a change and not simple nitpicks.
+
+The coder should run the pre-commit tools locally before
+requesting a pull-request (PR) on the Basilisk GitHub repository.  However,
+the PR action will run the pre-commit tools on the server as well
+when running the continuous integration tests.
 
 ##### Installing pre-commit
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Pulled CI changes from the LASP work.  Original authors are @patkenneally and Bryson Smith.

Make CI builds run only if the ``pre-commit`` passes.  This branch also updates some CI packages used.
No changes were made to the original commits.

## Verification
The PR CI builds pass successfully with the new scripts.

## Documentation
Discuss ``pre-commit`` running automatically on the CI servers with a PR is requested.

## Future work
None