### PR TITLE
Update docs to reflect Python requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots/plots to help explain your problem.
 **Desktop (please complete the following information):**
 - OS: [e.g. Macos]
 - Version [e.g. 12.6.1]
-- Python version [e.g. 3.9.15]
+- Python version [e.g. 3.10.14]
 
 **Additional context**
 Add any other context about the problem or potential solution paths here.

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,6 +24,7 @@ try:
         print("use version 1.40.1 to 1.xx.0 to work with the conan repo changes." + endColor)
         exit(0)
     from conans.tools import Version
+
     # check conan version 1.xx
     if conan_version < Version("1.40.1"):
         print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
@@ -160,8 +161,8 @@ class BasiliskConan(ConanFile):
 
         # check the version of Python
         print("\nChecking Python version:")
-        if not (sys.version_info.major == 3 and sys.version_info.minor >= 8):
-            print(warningColor + "Python 3.8 or newer should be used with Basilisk." + endColor)
+        if not (sys.version_info.major == 3 and sys.version_info.minor >= 10):
+            print(warningColor + "Python 3.10 or newer should be used with Basilisk." + endColor)
             print("You are using Python {}.{}.{}".format(sys.version_info.major,
                                                          sys.version_info.minor, sys.version_info.micro))
         else:

--- a/docs/source/Install/customPython.rst
+++ b/docs/source/Install/customPython.rst
@@ -13,7 +13,7 @@ The following instructions are guidelines on how to run Basilisk with a
 computer that is not using a system installed version of Python.
 
 -  Basilisk must be built and run with the same Python binary.
-   For example, you cannot build for Python 3.8 and run against Python 3.9.
+   For example, you cannot build for Python 3.10 and run against Python 3.11.
 -  The best way to work with different versions of python installed on your computer is to setup
    a virtual python environment, such as with ``venv``.  In this case only that python used to create the
    virtual environment is available and conflicts with other versions are avoided.

--- a/docs/source/Install/installOnMacOS.rst
+++ b/docs/source/Install/installOnMacOS.rst
@@ -18,7 +18,7 @@ The following python package dependencies are automatically checked and installe
 .. attention::
     If you are running a new Apple computer with the M-series ARM64 processor, be sure to download a
     version of Python that is compatible with M-series processor.  The
-    `Python.org <https://python.org>`__ web site contains Universal binaries for Python 3.9 and
+    `Python.org <https://python.org>`__ web site contains Universal binaries for Python 3.10 and
     onward.  Regarding the python packages via ``pip`` and ``brew``, the required packages
     can all be installed readily in a native form using the standard installation instructions below.
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -64,6 +64,7 @@ Version |release|
 - Updated :ref:`makeDraftModule` to make C++ modules with private module variables using setter/getter methods
 - Updated :ref:`cppModules-1` to discuss the new expectation that C++ modules are all private.  This enables
   gracefull module variable depreciation if needed.
+- Updated documentation and conanfile to reflect that Python must be 3.10 or newer
 
 
 Version 2.3.0 (April 5, 2024)


### PR DESCRIPTION
* **Tickets addressed:** #723 and others
* **Merge strategy:** Merge (no squash)

## Description
Users have been running into issues with Python ≤3.9 for a while now. While we never formally deprecated support for 3.9, Basilisk has only compiled on ≥3.10 for a few months now. I don't think it's worth anybody's time to track down when 3.9 support was lost, so I propose updating the documentation and conanfile to reflect the 3.10 requirement.

## Verification
N/A.

## Documentation
Primarily documentation changes.

## Future work
N/A