### PR TITLE
Feature/726 Support Numpy 2.0

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -64,6 +64,7 @@ Version |release|
 - Updated :ref:`makeDraftModule` to make C++ modules with private module variables using setter/getter methods
 - Updated :ref:`cppModules-1` to discuss the new expectation that C++ modules are all private.  This enables
   gracefull module variable depreciation if needed.
+- Added support for numpy 2.0.
 
 
 Version 2.3.0 (April 5, 2024)

--- a/src/fswAlgorithms/attGuidance/waypointReference/_UnitTest/test_WaypointReference.py
+++ b/src/fswAlgorithms/attGuidance/waypointReference/_UnitTest/test_WaypointReference.py
@@ -52,17 +52,17 @@ def test_waypointReference(show_plots, attType, MRPswitching, useReferenceFrame,
     **Validation Test Description**
 
     This unit test script tests the capability of the WaypointReference module to correctly read time-tagged
-    attitude parameters, angular rates and angular accelerations from a text file. 
-    First a text file is generated that contains a sequence of time-tagged attitude parameters, angular rates 
+    attitude parameters, angular rates and angular accelerations from a text file.
+    First a text file is generated that contains a sequence of time-tagged attitude parameters, angular rates
     and angular accelerations; subsequently, the same file is fed to the waypointReference module.
     The module is tested against all the attitude types that it supports:
     - MRPs
     - Euler Parameters (quaternion) [q0, q1, q2, q3]
     - Euler Parameters (quaternion) [q1, q2, q3, qs]
-    and with angular rates and accelerations that can be expressed either in the inertial frame N or in the 
+    and with angular rates and accelerations that can be expressed either in the inertial frame N or in the
     reference frame R.
-    This unit test writes 5 time-tagged attitudes at times t = [1.0, 2.0, 3.0, 4.0, 5.0]s. Real values of 
-    attitude parameters, angular rates and angular accelerations in inertial frames are stored in 
+    This unit test writes 5 time-tagged attitudes at times t = [1.0, 2.0, 3.0, 4.0, 5.0]s. Real values of
+    attitude parameters, angular rates and angular accelerations in inertial frames are stored in
     ``attReal_RN``, ``omegaReal_RN_N`` and ``omegaDotReal_RN_N`` respectively.
 
     **Test Parameters**
@@ -75,21 +75,21 @@ def test_waypointReference(show_plots, attType, MRPswitching, useReferenceFrame,
 
     **Description of Variables Being Tested**
 
-    This unit test checks the correctness of the output attitude reference message 
+    This unit test checks the correctness of the output attitude reference message
 
     - ``attRefMsg``
 
     compared to the real values stored in the data file  ``attReal_RN``, ``omegaReal_RN_N`` and ``omegaDotReal_RN_N``.
     The simulation is run with a sampling frequency of 0.25 s, which is higher than the frequency with which the attitude
-    waypoints are saved in the data file (1.0 s), starting at t = 0. 
+    waypoints are saved in the data file (1.0 s), starting at t = 0.
 
-    For t < 1.0 s we check that the attitude in ``attRefMsg`` coincides with ``attReal_RN`` at time t = 1.0 s, 
+    For t < 1.0 s we check that the attitude in ``attRefMsg`` coincides with ``attReal_RN`` at time t = 1.0 s,
     while rates and accelerations in ``attRefMsg`` are zero.
 
-    For t > 5.0 s we check that the attitude in ``attRefMsg`` coincides with ``attReal_RN`` at time t = 5.0 s, 
+    For t > 5.0 s we check that the attitude in ``attRefMsg`` coincides with ``attReal_RN`` at time t = 5.0 s,
     while rates and accelerations in ``attRefMsg`` are zero.
 
-    For 1.0 s <= t <= 5.0 s we check that the attitude, rates and accelerations in ``attRefMsg`` coincide with 
+    For 1.0 s <= t <= 5.0 s we check that the attitude, rates and accelerations in ``attRefMsg`` coincide with
     the linear interpolation of ``attReal_RN``, ``omegaReal_RN_N`` and ``omegaDotReal_RN_N``.
     """
 
@@ -132,7 +132,7 @@ def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accu
     dataFileName = os.path.join(path, dataFileName)
     delimiter = ","
     fDataFile = open(dataFileName, "w+")
-    
+
     # create the datafile and store the real attitude, rate and acceleration values
     t = []
     attReal_RN = []
@@ -162,11 +162,11 @@ def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accu
         elif attType == 2:
             q = rbk.MRP2EP(attReal_RN[-1])
             qs = [q[1], q[2], q[3], q[0]]
-            lineString += str(qs)[1:-1] + delimiter
+            lineString += str([float(elem) for elem in qs])[1:-1] + delimiter
         else:
             print("Invalid attitude type")
             return
-        
+
         if not useReferenceFrame:
             lineString += str(omegaReal_RN_N[-1].tolist())[1:-1] + delimiter + str(omegaDotReal_RN_N[-1].tolist())[1:-1] + '\n'
         else:
@@ -174,7 +174,7 @@ def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accu
             omegaReal_RN_R = np.matmul(RN, omegaReal_RN_N[-1])
             omegaDotReal_RN_R = np.matmul(RN, omegaDotReal_RN_N[-1])
             lineString += str(omegaReal_RN_R.tolist())[1:-1] + delimiter + str(omegaDotReal_RN_R.tolist())[1:-1] + '\n'
-        
+
         # write line on file
         fDataFile.write(lineString)
 
@@ -201,17 +201,17 @@ def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accu
 
     # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
-    unitTestSim.ConfigureStopTime(simulationTime) 
+    unitTestSim.ConfigureStopTime(simulationTime)
 
     # Begin the simulation time run set above
     unitTestSim.ExecuteSimulation()
 
     # This pulls the sampling times from the simulation run.
     timeData = dataLog.times() * macros.NANO2SEC
-    
+
     # Check if logged data matches the real attitude, rates and accelerations
     j = 0
-    
+
     sigma_RN = [[], [], []]
     # checking attitude msg for t < t_min
     for i in range(len(timeData)-1):
@@ -229,7 +229,7 @@ def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accu
             if not unitTestSupport.isVectorEqual(dataLog.domega_RN_N[i], np.array([0.0, 0.0, 0.0]), accuracy):
                 testFailCount += 1
                 testMessages.append("FAILED: " + testModule.ModelTag + " Module failed angular acceleration check at time t = {}".format(timeData[i]))
-        
+
         # checking attitude msg for t_min <= t <= t_max
         elif timeData[i] >= t[0] and timeData[i] <= t[-1]:
             while (timeData[i] >= t[j] and timeData[i] <= t[j+1]) == False:
@@ -256,7 +256,7 @@ def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accu
             if not unitTestSupport.isVectorEqual(dataLog.domega_RN_N[i], omegaDot_RN_N_int, accuracy):
                 testFailCount += 1
                 testMessages.append("FAILED: " + testModule.ModelTag + " Module failed angular acceleration check at time t = {}".format(timeData[i]))
-        
+
         # checking attitude msg for t < t_max
         else:
             if not unitTestSupport.isVectorEqual(dataLog.sigma_RN[i], attReal_RN[-1], accuracy):
@@ -290,4 +290,3 @@ if __name__ == "__main__":
         1e-12)
     if os.path.exists(dataFileName):
         os.remove(dataFileName)
-	   

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
@@ -99,13 +99,13 @@ def executeSimRun(simContainer, thrusterSet, simRate, totalTime):
 
 def fixMDotData(mDotData):
     """This test was written before a bug in variable logging was fixed.
-    
+
     This bug made it so consecutive logged zeros would get removed, which
     is why we need to remove all zero rows at the beginning of mDotData
     but one.
     """
     firstNonZeroRow = np.nonzero(mDotData[:,1])[0][0]
-    return np.row_stack([[0,0], mDotData[firstNonZeroRow:, :]])
+    return np.vstack([[0,0], mDotData[firstNonZeroRow:, :]])
 
 # uncomment this line if this test has an expected failure, adjust message as needed
 # @pytest.mark.xfail(True)

--- a/src/utilities/fswSetupRW.py
+++ b/src/utilities/fswSetupRW.py
@@ -27,7 +27,7 @@ rwList = []
 def create(
         gsHat_B,
         Js,
-        uMax = numpy.NaN
+        uMax = numpy.nan
     ):
     """
     Create a FSW RW object

--- a/src/utilities/orbitalMotion.py
+++ b/src/utilities/orbitalMotion.py
@@ -626,14 +626,14 @@ def rv2elem(mu, rVec, vVec):
 
     if (np.isnan(np.sum(rVec)) or np.isnan(np.sum(vVec))):
         print("ERROR: received NAN rVec or vVec values.")
-        elements.a = np.NaN
-        elements.alpha = np.NaN
-        elements.e = np.NaN
-        elements.i = np.NaN
-        elements.AN = np.NaN
-        elements.AP = np.NaN
-        elements.f = np.NaN
-        elements.rmag = np.NaN
+        elements.a = np.nan
+        elements.alpha = np.nan
+        elements.e = np.nan
+        elements.i = np.nan
+        elements.AN = np.nan
+        elements.AP = np.nan
+        elements.f = np.nan
+        elements.rmag = np.nan
         return
 
 
@@ -816,7 +816,7 @@ def atmosphericDrag(Cd, A, m, rvec, vvec):
         print("ERROR: atmosphericDrag() received rvec = [{} {} {}].". \
             format(str(rvec[1]), str(rvec[2]), str(rvec[3])))
         print('The value of rvec should produce a positive altitude for the Earth.')
-        advec.fill(np.NaN)
+        advec.fill(np.nan)
         return
 
     # get the Atmospheric density at the given altitude in kg/m^3 #
@@ -1184,5 +1184,3 @@ def hill2rv(rc_N, vc_N, rho_H, rhoPrime_H):
     rd_N = rc_N + np.matmul(NH, rho_H)
     vd_N = vc_N + np.matmul(NH, rhoPrime_H + np.cross(omega_HN_H, rho_H))
     return rd_N, vd_N
-
-

--- a/src/utilities/readAtmTable.py
+++ b/src/utilities/readAtmTable.py
@@ -29,8 +29,8 @@ def readAtmTable(filename,typename):
         altList, rhoList, tempList = readJupiterGRAM(filename)
     else:
         print('Type not recognized')
-        return np.NaN, np.NaN, np.NaN
-    
+        return np.nan, np.nan, np.nan
+
     return altList, rhoList, tempList
 
 def readStdAtm76(filename):
@@ -40,8 +40,8 @@ def readStdAtm76(filename):
     tempList = df.Temperature.to_list()
     rhoList = df.Density.to_list()
     return altList, rhoList, tempList
-    
-    
+
+
 def readEarthGRAM(filename):
     df = pd.read_csv(filename, sep=r'\s+')
     df.sort_values(by=['Hgtkm'],ascending=True, inplace=True)
@@ -49,7 +49,7 @@ def readEarthGRAM(filename):
     altList = df.Hgtkm.to_list()
     rhoList = df.DensMean.to_list()
     tempList = df.Tmean.to_list()
-    
+
     return altList, rhoList, tempList
 
 def readMarsGRAM(filename):
@@ -61,7 +61,7 @@ def readMarsGRAM(filename):
 	tempList = df.Temp.to_list()
 
 	return altList, rhoList, tempList
-	
+
 
 def readVenusGRAM(filename):
 	df = pd.read_csv(filename, skiprows=[1])
@@ -72,7 +72,7 @@ def readVenusGRAM(filename):
 	tempList = df.Temperature_K.to_list()
 
 	return altList, rhoList, tempList
-	
+
 
 def readUranusGRAM(filename):
 	df = pd.read_csv(filename, skiprows=[1])
@@ -83,7 +83,7 @@ def readUranusGRAM(filename):
 	tempList = df.Temperature_K.to_list()
 
 	return altList, rhoList, tempList
-	
+
 
 def readTitanGRAM(filename):
 	df = pd.read_csv(filename, skiprows=[1])
@@ -113,9 +113,8 @@ def readMSIS(filename):
     df.sort_values(by=['alt'],ascending=True, inplace=True)
     df.alt = df.alt * 1000
     altList = df.alt.to_list()
-    df.rho = df.rho / 1000 * 100**3 
+    df.rho = df.rho / 1000 * 100**3
     rhoList = df.rho.to_list()
     tempList = df.temp.to_list()
- 	
-    return altList, rhoList, tempList
 
+    return altList, rhoList, tempList


### PR DESCRIPTION
* **Tickets addressed:** #726 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Unit tests were run with numpy 2.0.0, and failures were addressed:

* `np.NaN` was removed and usages replaced by `np.nan`.
* A difference in `str()` called on list of `np.float64` objects resulted in a test failing, the usage in the test was fixed one-off.

## Verification

All unit tests now pass even with numpy 2.0.0. Tests continue to pass with numpy 1.26.4.

## Documentation

None

## Future work

None
