### PR TITLE
Feature/743 solar array reference update

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -71,6 +71,7 @@ Version |release|
 - Fixed use of spherical coordinate system in :ref:`magneticFieldWMM` model.
 - Added ability to run the GitHub ``pull_request.yml`` action on a select branch
 - Fixed mass depletion rate bug in :ref:`thrusterStateEffector` previously fixed at 100%
+- Enhanced :ref:`solarArrayReference` with a mode that can compute the reference for the solar arrays that maximizes SRP torque opposed to current RW net momentum.
 
 
 Version 2.3.0 (April 5, 2024)

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
@@ -58,6 +58,25 @@ void Reset_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t c
         _bskLog(configData->bskLogger, BSK_ERROR, "solarArrayReference.hingedRigidBodyInMsg wasn't connected.");
     }
     configData->count = 0;
+
+    if (configData->pointingMode == momentumManagement) {
+        if (!RWSpeedMsg_C_isLinked(&configData->rwSpeedsInMsg)) {
+            configData->pointingMode = powerGeneration;
+            _bskLog(configData->bskLogger, BSK_WARNING, "solarArrayReference.rwSpeedsInMsg wasn't connected. "
+                                                        "Switching to power generation mode.");
+        }
+        if (!RWArrayConfigMsg_C_isLinked(&configData->rwConfigDataInMsg)) {
+            configData->pointingMode = powerGeneration;
+            _bskLog(configData->bskLogger, BSK_WARNING, "solarArrayReference.rwConfigDataInMsg wasn't connected."
+                                                        "Switching to power generation mode.");
+        }
+        else {
+            /*! - read in the RW configuration message */
+            configData->rwConfigParams = RWArrayConfigMsg_C_read(&configData->rwConfigDataInMsg);
+        }
+    }
+
+    configData->priorT = callTime;
 }
 
 /*! This method computes the updated rotation angle reference based on current attitude, reference attitude, and current rotation angle
@@ -122,27 +141,65 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
     double cosThetaC = cos(hingedRigidBodyIn.theta);
     double thetaC = atan2(sinThetaC, cosThetaC);      // clip theta current between 0 and 2*pi
 
-    /*! compute reference angle and store in buffer msg */
+    /*! compute reference angle for power generation mode */
+    double thetaSunR;
     if (v3Norm(a2Hat_R) < epsilon) {
         // if norm(a2Hat_R) = 0, reference coincides with current angle
-        hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta;
+        thetaSunR = hingedRigidBodyIn.theta;
     }
     else {
-        double thetaR = acos( fmin(fmax(v3Dot(a2Hat_B, a2Hat_R),-1),1) );
-        // if a1Hat_B and a1Hat_R are opposite, take the negative of thetaR
+        thetaSunR = acos(fmin(fmax(v3Dot(a2Hat_B, a2Hat_R), -1), 1));
+        // if a1Hat_B and a1Hat_R are opposite, take the negative of thetaSunR
         if (v3Dot(a1Hat_B, a1Hat_R) < 0) {
-            thetaR = -thetaR;
+            thetaSunR = -thetaSunR;
         }
-        // always make the absolute difference |thetaR-thetaC| smaller that 2*pi
-        if (thetaR - thetaC > MPI) {
-            hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta + thetaR - thetaC - 2*MPI;
+    }
+
+    double thetaR = thetaSunR;
+
+    /*! compute reference angle for momentum dumping mode */
+    if (configData->pointingMode == momentumManagement) {
+        RWSpeedMsgPayload rwSpeedMsgIn = RWSpeedMsg_C_read(&configData->rwSpeedsInMsg);
+
+        /*! compute net RW momentum */
+        double vec3[3];       // individual RW momentum in B-frame (dummy variable)
+        double hs_B[3];       // total net RW momentum in B-frame
+        v3SetZero(hs_B);
+        for (int i = 0; i < configData->rwConfigParams.numRW; i++) {
+            v3Scale(configData->rwConfigParams.JsList[i] * rwSpeedMsgIn.wheelSpeeds[i],
+                    &configData->rwConfigParams.GsMatrix_B[i * 3], vec3);
+            v3Add(hs_B, vec3, hs_B);
         }
-        else if (thetaR - thetaC < - MPI) {
-            hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta + thetaR - thetaC + 2*MPI;
+
+        VehicleConfigMsgPayload vehConfigMsgIn = VehicleConfigMsg_C_read(&configData->vehConfigInMsg);
+        double r_AC_B[3];     // location of the solar array center of pressure w.r.t. the system CM (in B-frame)
+        v3Subtract(configData->r_AB_B, vehConfigMsgIn.CoM_B, r_AC_B);
+
+        double hs_R[3];      // total net RW momentum in the attitude reference frame
+        if (configData->attitudeFrame == bodyFrame) {
+            v3Copy(hs_B, hs_R);
         }
-        else {
-            hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta + thetaR - thetaC;
+        else if (configData->attitudeFrame == referenceFrame) {
+            m33MultV3(RB, hs_B, hs_R);
         }
+
+        double thetaSrpR;   // reference solar array angle that maximizes SRP dumping torque
+        double f;
+        computeSrpArrayNormal(a1Hat_B, a2Hat_B, a3Hat_B, rHat_SB_R, r_AC_B, hs_R, &thetaSrpR, &f);
+
+        // bias the reference angle towards thetaSrpR more if there is more potential to dump momentum (f = -1)
+        thetaR = thetaSunR - f * (thetaSrpR - thetaSunR);
+    }
+
+    // always make the absolute difference |thetaR-thetaC| smaller than 2*pi
+    if (thetaR - thetaC > MPI) {
+        hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta + thetaR - thetaC - 2*MPI;
+    }
+    else if (thetaR - thetaC < - MPI) {
+        hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta + thetaR - thetaC + 2*MPI;
+    }
+    else {
+        hingedRigidBodyRefOut.theta = hingedRigidBodyIn.theta + thetaR - thetaC;
     }
 
     /*! implement finite differences to compute thetaDotR */
@@ -161,4 +218,58 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
 
     /* write output message */
     HingedRigidBodyMsg_C_write(&hingedRigidBodyRefOut, &configData->hingedRigidBodyRefOutMsg, moduleID, callTime);
+}
+
+/*! This method computes the reference angle for the arrays that maximizes SRP torque in the direction
+ * opposite to current RW momentum (thetaSrpR). It also outputs a coefficient f that is proportional to the projection
+ * of the SRP torque along the RW net momentum.
+ @return void
+ */
+void computeSrpArrayNormal(double a1Hat_B[3], double a2Hat_B[3], double a3Hat_B[3],
+                           double sHat_R[3], double r_B[3], double H_B[3], double *thetaR, double *f)
+{
+    /*! Define map between body frame and array frame A */
+    double BA[3][3];        // DCM mapping between body frame and array frame
+    for (int i=0; i<3; ++i) {
+        BA[i][0] = a1Hat_B[i];
+        BA[i][1] = a2Hat_B[i];
+        BA[i][2] = a3Hat_B[i];
+    }
+
+    /*! Map vectors to array frame A */
+    double sHat_A[3];       // Sun heading in array frame
+    v3tMultM33(sHat_R, BA, sHat_A);
+    double hHat_B[3];       // h vector (see documentation) in body frame
+    v3Cross(r_B, H_B, hHat_B);
+    v3Normalize(hHat_B, hHat_B);
+    double hHat_A[3];       // h vector (see documentation) in array frame
+    v3tMultM33(hHat_B, BA, hHat_A);
+
+    /*! Define vector components in the local x-y plane */
+    double s2 = sHat_A[1];
+    double s3 = sHat_A[2];
+    double h2 = hHat_A[1];
+    double h3 = hHat_A[2];
+
+    // Discriminant of characteristic equation
+    double Delta = 8 * (pow(s2*h2, 2) + pow(s3*h3, 2) + pow(s2*h3, 2) + pow(s3*h2, 2)) + pow(s2*h2+s3*h3, 2);
+
+    // Solution that produces SRP torque opposite to current RW momentum
+    double t = atan( (3*(s3*h3 - s2*h2) - pow(Delta, 0.5)) / (4*s2*h3 + 2*s3*h2) );
+
+    // SA normal direction to maximize momentum dumping
+    double a2SrpHat_A[3] = {0.0, cos(t), sin(t)};
+
+    // Choose normal direction that is also power-positive
+    double dotS = v3Dot(sHat_A, a2SrpHat_A);
+    if (dotS < 0) {
+        v3Scale(-1, a2SrpHat_A, a2SrpHat_A);
+    }
+
+    double theta = atan2(a2SrpHat_A[2], a2SrpHat_A[1]);
+    double fVal = dotS * dotS * v3Dot(hHat_A, a2SrpHat_A);
+
+    // Return the corresponding solar array reference angle and momentum dumping coefficient
+    *thetaR = theta;
+    *f = fVal;
 }

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.i
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.i
@@ -30,6 +30,12 @@ struct NavAttMsg_C;
 struct AttRefMsg_C;
 %include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
 struct HingedRigidBodyMsg_C;
+%include "architecture/msgPayloadDefC/VehicleConfigMsgPayload.h"
+struct VehicleConfigMsg_C;
+%include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
+struct RWSpeedMsg_C;
+%include "architecture/msgPayloadDefC/RWArrayConfigMsgPayload.h"
+struct RWArrayConfigMsg_C;
 
 %pythoncode %{
 import sys


### PR DESCRIPTION
* **Tickets addressed:** bsk-743
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Add the capability to use solarArrayReference module to point the solar array(s) in the direction that leverages SRP to produce a torque opposed to current net RW momentum in order to perform continuous momentum management.

## Verification
Unit test is updated to reflect the changes.

## Documentation
Documentation is updated to reflect the changes.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
