### PR TITLE
fix gtest_output error message

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,6 @@ jobs:
           extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}
   build-linux:
     name: Build Linux
-    needs: pre-commit
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -90,7 +89,6 @@ jobs:
 
   build-windows:
     name: Build Windows
-    needs: pre-commit
     runs-on: windows-2019
     strategy:
       matrix:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,12 +79,7 @@ jobs:
         if: ${{ always() }}
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
-        run: ctest --gtest_output "json:../ctest/ctest-results-linux-${{ matrix.python-version }}.json"
-      - name: "Upload Google Test CTest results"
-        uses: actions/upload-artifact@v4
-        with:
-          name: ctest-results-${{ matrix.python-version }}
-          path: ctest/ctest-results-${{ matrix.python-version }}.json
+        run: ctest
         if: ${{ always() }}
 
   build-windows:
@@ -157,4 +152,5 @@ jobs:
         shell: pwsh
         run: |
           cd dist3
-          ctest --gtest_output "json:../ctest/ctest-results-windows-${{ matrix.python-version }}.json"; if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}
+          ctest
+          if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -12,6 +12,8 @@ Version |release|
 -----------------
 - The fuel tank models have become classes and python simulation code using tank modules need to be
   updated.  See :ref:`fueltank` or :ref:`scenarioFuelSlosh` for further documentation.
+- The CI test builds starting failing running the `gtest` unit test suite with the error
+  ``CMake Error: Unknown argument: --gtest_output``.  The current release fixes this issue.
 
 
 Version 2.3.0


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
On the CI server the gtest suite started to fail with errors saying `CMake Error: Unknown argument: --gtest_output`.  The fix is pulled from the LASP fork of Basilisk.

## Verification
The CI Builds pass again.

## Documentation
Updated release notes and know issues files

## Future work
None
