### PR TITLE
Add ability to run `pull_request` action on a select branch

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -1,3 +1,5 @@
+name: "Pull Request Closed"
+
 on:
     pull_request:
         types:
@@ -14,7 +16,7 @@ jobs:
           uses: actions/checkout@v4
           with:
             ref: develop
-            fetch-depth: 0 
+            fetch-depth: 0
             token: ${{ secrets.BOT_ACCESS_TOKEN }}
         - name: Bump version
           run: ./.github/workflows/version-bumper.sh ./docs/source/bskVersion.txt

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
       - name: "Install wheel and conan package"
-        run: source .venv/bin/activate && pip3 install wheel conan==1.61.0 pytest datashader holoviews pytest-xdist
+        run: source .venv/bin/activate && pip3 install wheel 'conan<2.0' pytest datashader holoviews pytest-xdist
       - name: "Build basilisk"
         run: source .venv/bin/activate && python3 conanfile.py
       - name: "Run Python Tests"
@@ -118,7 +118,7 @@ jobs:
         shell: pwsh
         run: |
             venv\Scripts\activate
-            pip install wheel conan==1.61.0 parse six pytest-xdist
+            pip install wheel 'conan<2.0' parse six pytest-xdist
       - name: "Add basilisk and cmake path to env path"
         shell: pwsh
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Test"
+name: "Pull Request"
 
 on:
   pull_request:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,7 @@ name: "Pull Request Test"
 
 on:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -69,6 +69,7 @@ Version |release|
   gracefull module variable depreciation if needed.
 - Added support for numpy 2.0.
 - Fixed use of spherical coordinate system in :ref:`magneticFieldWMM` model.
+- Added ability to run the GitHub ``pull_request.yml`` action on a select branch
 
 
 Version 2.3.0 (April 5, 2024)


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
To test that the CI integrated tests build and run properly we had to setup a draft PR that couldn't be deleted afterwards.  The pull request action has been updated such that it can now be called on a select branch before even creating a PR.

## Verification
Installed GitHub GL (https://cli.github.com) to test
```
gh workflow run pull-request.yml --ref feature/workflow_dispatch
```
This caused GitHub to run the pull request action script on the branch `feature/workflow_displatch`

## Documentation
Added release notes

## Future work
None

