### PR TITLE
Bug/thruster state effector isp factor

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -14,6 +14,8 @@ Version |release|
   updated.  See :ref:`fueltank` or :ref:`scenarioFuelSlosh` for further documentation.
 - The CI test builds starting failing running the `gtest` unit test suite with the error
   ``CMake Error: Unknown argument: --gtest_output``.  The current release fixes this issue.
+- There was an issue with the :ref:`thrusterStateEffector` such that its mass depletion rate was
+  hard-coded to 100% for all firings. This is corrected in the current release.
 
 
 Version 2.3.0

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -70,6 +70,7 @@ Version |release|
 - Added support for numpy 2.0.
 - Fixed use of spherical coordinate system in :ref:`magneticFieldWMM` model.
 - Added ability to run the GitHub ``pull_request.yml`` action on a select branch
+- Fixed mass depletion rate bug in :ref:`thrusterStateEffector` previously fixed at 100%
 
 
 Version 2.3.0 (April 5, 2024)

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -180,7 +180,7 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
         trueSigma = [[1.4401781243854264e-01, -6.4168702021364002e-02, 3.0166086824900967e-01]]
     elif thrustersEffector.__class__.__name__ == "ThrusterStateEffector":
         truePos = [[-6781593.400948599, 4946868.619447934, 5486741.690842073]]
-        trueSigma = [[0.14367298348925786, -0.06487574480164254, 0.3032693696902734]]
+        trueSigma = [[0.14366625871003397, -0.06488330854626220, 0.3032637107362375]]
 
     for i in range(0, len(truePos)):
         np.testing.assert_allclose(dataPos[i], truePos[i], rtol=1e-6, err_msg="Thruster position not equal")
@@ -189,6 +189,10 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
         # check a vector values
         np.testing.assert_allclose(dataSigma[i], trueSigma[i], rtol=1e-4, err_msg="Thruster attitude not equal")
 
+    # target value computed from MaxThrust / (EARTH_GRAV * steadyIsp)
+    np.testing.assert_allclose(fuelMassDot[100], -0.000403404216123, rtol=1e-3,
+                               err_msg="Thruster mass depletion not ramped up")
+    np.testing.assert_allclose(fuelMassDot[-1],0, rtol=1e-12, err_msg="Thruster mass depletion not ramped down")
 
 if __name__ == "__main__":
     test_massDepletionTest(True, thrusterDynamicEffector.ThrusterDynamicEffector)

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
@@ -309,7 +309,7 @@ def unitThrusters(testFixture, show_plots, thrustNumber, initialConditions, dura
             # Compute the torque
             expectedTorqueData[0:3, i] = np.cross(loc1, force1) + thrustFactor1 * swirlTorque * dir1
             # Compute the mass flow rate
-            expectedMDot[0, i] = thruster1.MaxThrust / (g * Isp)
+            expectedMDot[0, i] = thruster1.MaxThrust * thrustFactor1 / (g * Isp)
         else:
             # Compute the thrust force
             if duration == 0.:
@@ -327,7 +327,7 @@ def unitThrusters(testFixture, show_plots, thrustNumber, initialConditions, dura
             # Compute the torque
             expectedTorqueData[0:3, i] = np.cross(loc1, force1) + thrustFactor1 * swirlTorque * dir1 + np.cross(loc2, force2)
             # Compute the mass flow rate
-            expectedMDot[0, i] = (thruster1.MaxThrust + thruster2.MaxThrust) / (g * Isp)
+            expectedMDot[0, i] = (thruster1.MaxThrust * thrustFactor1 + thruster2.MaxThrust * thrustFactor2) / (g * Isp)
 
     # Modify expected values for comparison and define errorTolerance
     TruthForce = np.transpose(expectedThrustData)

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -341,9 +341,6 @@ void ThrusterStateEffector::computeDerivatives(double integTime, Eigen::Vector3d
             kappaDot(i, 0) = -this->kappaState->state(i, 0) * it->cutoffFrequency;
         }
 
-        // Set the IspFactor to 1 to check that there is mass flow
-        ops->IspFactor = 1.0;
-
         // Save the state to thruster ops
         ops->ThrustFactor = this->kappaState->state(i, 0);
     }
@@ -409,7 +406,7 @@ void ThrusterStateEffector::calcForceTorqueOnBody(double integTime, Eigen::Vecto
         if (!it->updateOnly) {
             //! - Add the mass depletion force contribution
             mDotNozzle = 0.0;
-            if (it->steadyIsp * ops->IspFactor > 0.0)
+            if (it->steadyIsp * ops->ThrustFactor > 0.0)
             {
                 mDotNozzle = it->MaxThrust / (EARTH_GRAV * it->steadyIsp);
             }
@@ -455,7 +452,7 @@ void ThrusterStateEffector::updateEffectorMassProps(double integTime) {
     {
         ops = &it->ThrustOps;
         mDotSingle = 0.0;
-        if (it->steadyIsp * ops->IspFactor > 0.0)
+        if (it->steadyIsp * ops->ThrustFactor > 0.0)
         {
             mDotSingle = it->MaxThrust / (EARTH_GRAV * it->steadyIsp);
         }

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -408,7 +408,7 @@ void ThrusterStateEffector::calcForceTorqueOnBody(double integTime, Eigen::Vecto
             mDotNozzle = 0.0;
             if (it->steadyIsp * ops->ThrustFactor > 0.0)
             {
-                mDotNozzle = it->MaxThrust / (EARTH_GRAV * it->steadyIsp);
+                mDotNozzle = it->MaxThrust * ops->ThrustFactor / (EARTH_GRAV * it->steadyIsp);
             }
             this->forceOnBody_B += 2 * mDotNozzle * (this->bodyToHubInfo.at(index).omega_FB_B + omegaLocal_BN_B).cross(thrustLocation_B);
 
@@ -454,7 +454,7 @@ void ThrusterStateEffector::updateEffectorMassProps(double integTime) {
         mDotSingle = 0.0;
         if (it->steadyIsp * ops->ThrustFactor > 0.0)
         {
-            mDotSingle = it->MaxThrust / (EARTH_GRAV * it->steadyIsp);
+            mDotSingle = it->MaxThrust * ops->ThrustFactor / (EARTH_GRAV * it->steadyIsp);
         }
         this->mDotTotal += mDotSingle;
     }


### PR DESCRIPTION
* **Tickets addressed:** bsk-735 "Hardcoded Isp in thrusterStateEffector"
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
A hard coded value is removed from the `thrusterStateEffector` that was erroneously forcing mass depletion always on. Then mass depletion logic is updated to check `ThrustFactor `to see if a thruster is firing rather than `IspFactor` which is unused by the `thrusterStateEffector`. Additionally, the mass depletion is changed to now scale its expenditure according to the scaled value of thrust following ramp up/down.

## Verification
The FuelTank mass depletion unit test already produces plots of the fuel expenditure for a thruster dynamic and state effector, and the state effector's plots for `mass` and `massDot` vs. time now accurately reflect the firing pattern. While mass depletion was being plotted, no assertions were made as to accuracy of the values, so two assertions have been added to the fuel tank's mass depletion unit test checking that massDot is ramped up when the thruster is firing and ramped down when the thruster is commanded off.

Additionally, the `thrusterStateEffector` unit test is updated to scale the thrust by its ramp up/down factor when computing truth values for massDot comparison when toggled on for mass depletion force contributions.

## Documentation
No documentation is invalidated by these changes, just fixing code to match what the documentation outlines. Release notes and known issues have been updated to identify this issue and resolution.