### PR TITLE
Bugfix/760 Fixes for debugger

### DIFF
--- a/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
@@ -1,10 +1,16 @@
 %{{
 #include "cMsgCInterface/{type}_C.h"
+#include "architecture/messaging/messaging.h"
 %}}
 %include "cMsgCInterface/{type}_C.h"
 %include "architecture/messaging/msgHeader.h"
 typedef struct {type};
 %extend {type}_C {{
+    Recorder<{type}Payload> recorder(uint64_t timeDiff = 0) {{
+        self->header.isLinked = 1;
+        return Recorder<{type}Payload>{{static_cast<void*>(self), timeDiff}};
+    }}
+
     %pythoncode %{{
 
     def subscribeTo(self, source):
@@ -33,12 +39,6 @@ typedef struct {type};
         else:
             return 0
 
-
-    def recorder(self, timeDiff=0):
-        """create a recorder module for this message"""
-        from Basilisk.architecture.messaging import {type}Recorder
-        self.header.isLinked = 1
-        return {type}Recorder(self, timeDiff)
 
     def init(self, data=None):
         """returns a Msg copy connected to itself"""

--- a/src/utilities/pythonVariableLogger.py
+++ b/src/utilities/pythonVariableLogger.py
@@ -26,10 +26,22 @@ class PythonVariableLogger(sysModel.SysModel):
         timesSquared = log.a
         timesCubed   = log.b
     """
+    def __new__(cls, logging_functions: Dict[str, LoggingFunction], min_log_period: int=0):
+        # Generate an instance specific class that has properties for each logging function
+        # NOTE: properties must be set on the class, not the instance itself
+        properties = {
+            name: property(
+                    lambda self, name=name: np.array(self._variables[name])
+                )
+                for name in logging_functions
+        }
+        dyncls = type('PythonVariableLoggerDynamic', (cls, ), properties)
+
+        return super(PythonVariableLogger, dyncls).__new__(dyncls)
 
     def __init__(
-        self, 
-        logging_functions: Dict[str, LoggingFunction], 
+        self,
+        logging_functions: Dict[str, LoggingFunction],
         min_log_period: int = 0
     ) -> None:
         """Initializer.
@@ -38,7 +50,7 @@ class PythonVariableLogger(sysModel.SysModel):
             logging_functions (Dict[str, LoggingFunction]): A dictionary where the
                 keys are the names of variables to store, and the values are functions
                 called to retrieve these variables. These functions must accept a single
-                input, an integer with the time in nanoseconds when the function is 
+                input, an integer with the time in nanoseconds when the function is
                 called.
             min_log_period (int, optional): The minimum interval between data recordings
                 Defaults to 0.
@@ -59,11 +71,11 @@ class PythonVariableLogger(sysModel.SysModel):
     def times(self):
         """Retrieve the times when the data was logged"""
         return np.array(self._times)
-    
+
     def Reset(self, CurrentSimNanos):
         self.clear()
         return super().Reset(CurrentSimNanos)
-    
+
     def UpdateState(self, CurrentSimNanos):
         if CurrentSimNanos >= self._next_update_time:
             self._times.append(CurrentSimNanos)
@@ -71,7 +83,7 @@ class PythonVariableLogger(sysModel.SysModel):
                 try:
                     val = logging_function(CurrentSimNanos)
                 except Exception as ex:
-                    self.bskLogger.bskLog(sysModel.BSK_ERROR, 
+                    self.bskLogger.bskLog(sysModel.BSK_ERROR,
                                         f"Error while logging '{variable_name}'"
                                         f" in logger '{self.ModelTag}': {ex}")
                     val = None
@@ -80,9 +92,3 @@ class PythonVariableLogger(sysModel.SysModel):
 
             self._next_update_time += self.min_log_period
         return super().UpdateState(CurrentSimNanos)
-    
-    def __getattr__(self, __name: str) -> Any:
-        if __name in self._variables:
-            return np.array(self._variables[__name])
-        raise AttributeError(f"Logger is not logging '{__name}'. "
-                             f"Must be one of: {', '.join(self._variables)}")


### PR DESCRIPTION
* **Tickets addressed:** Closes #760 Closes #249
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

* `PythonVariableLogger` was modified to create properties in `__new__` instead of using `__getattr__`. The original snippet on #760 does not work because properties must be set on the class object not the object itself. A new solution was written. Thanks @juan-g-bonilla 
* C Message Recorders were modified to be created from the C/C++ side similar to C++ Message Recorders, rather than from the Python side.

## Verification
The example script from #760 was run with all unproblematic lines uncommented to confirm that the weird debugger behavior was not present. It seems prohibitively difficult unit test this bug or fix.

Unit tests were run to check for regressions.

## Documentation
None

## Future work
Follow up with the SWIG project if we can demonstrate the weird behavior without involving the rest of Basilisk. This would allow us to undo the fix for at least `pythonVariableLogger` so the custom error message in `__getattr__` can be used.
