### PR TITLE
make CI chache names unique to Linux OS

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
         id: cache-conan
         uses: actions/cache@v4
         env:
-          cache-name: cache-conan-packages
+          cache-name: cache-conan-packages-ubuntu-20-04
         with:
           # conan cache files are stored in `~/.conan` on Linux/macOS
           path: ~/.conan
@@ -105,7 +105,7 @@ jobs:
         id: cache-conan
         uses: actions/cache@v4
         env:
-          cache-name: cache-conan-packages
+          cache-name: cache-conan-packages-ubuntu-20-04
         with:
           # conan cache files are stored in `~/.conan` on Linux/macOS
           path: ~/.conan
@@ -169,7 +169,7 @@ jobs:
         id: cache-conan
         uses: actions/cache@v4
         env:
-          cache-name: cache-conan-packages
+          cache-name: cache-conan-packages-ubuntu-22-04
         with:
           # conan cache files are stored in `~/.conan` on Linux/macOS
           path: ~/.conan
@@ -234,7 +234,7 @@ jobs:
         id: cache-conan
         uses: actions/cache@v4
         env:
-          cache-name: cache-conan-packages
+          cache-name: cache-conan-packages-ubuntu-22-04
         with:
           # conan cache files are stored in `~/.conan` on Linux/macOS
           path: ~/.conan
@@ -298,7 +298,7 @@ jobs:
         id: cache-conan
         uses: actions/cache@v4
         env:
-          cache-name: cache-conan-packages
+          cache-name: cache-conan-packages-ubuntu-22-04
         with:
           # conan cache files are stored in `~/.conan` on Linux/macOS
           path: ~/.conan


### PR DESCRIPTION
* **Tickets addressed:** bsk-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Linux 20 and 22 CI runs use the same cache name which can cause conflicts in 
python packages being installed that don't work on either OS.  This fix provides
unique cache names for each version of Linux.

## Verification
CI builds without issues if run multiple times.

## Documentation
None required

## Future work
None