### PR TITLE
Feature/771 adding swirl torque

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,7 +32,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
-- text here
+- Added swirl torque information to :ref:`THRConfigMsg`, :ref:`thrustCMEstimation`, and :ref:`thrusterPlatformState`
 
 
 Version 2.4.0 (August 23, 2024)

--- a/src/architecture/msgPayloadDefC/THRConfigMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/THRConfigMsgPayload.h
@@ -27,6 +27,7 @@ typedef struct {
     double rThrust_B[3];        //!< [m] Location of the thruster in the spacecraft
     double tHatThrust_B[3];     //!< [-] Unit vector of the thrust direction
     double maxThrust;			//!< [N] Max thrust
+    double swirlTorque;         //!< [Nm] Swirl torque
 }THRConfigMsgPayload;
 
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/_UnitTest/test_thrusterPlatformState.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/_UnitTest/test_thrusterPlatformState.py
@@ -78,6 +78,7 @@ def platformRotationTestFunction(show_plots, theta1, theta2, accuracy):
     r_FM_F = np.array([0.0, 0.0, -0.1])
     r_TF_F = np.array([-0.01, 0.03, 0.02])
     T_F    = np.array([1.0, 1.0, 10.0])
+    swirlFactor = 0.1
 
     unitTaskName = "unitTask"                # arbitrary name (don't change)
     unitProcessName = "TestProcess"          # arbitrary name (don't change)
@@ -107,6 +108,7 @@ def platformRotationTestFunction(show_plots, theta1, theta2, accuracy):
     THRConfig = messaging.THRConfigMsgPayload()
     THRConfig.rThrust_B = r_TF_F
     THRConfig.maxThrust = np.linalg.norm(T_F)
+    THRConfig.swirlTorque = THRConfig.maxThrust * swirlFactor
     THRConfig.tHatThrust_B = T_F / THRConfig.maxThrust
     thrConfigFMsg = messaging.THRConfigMsg().write(THRConfig)
     platform.thrusterConfigFInMsg.subscribeTo(thrConfigFMsg)
@@ -140,6 +142,7 @@ def platformRotationTestFunction(show_plots, theta1, theta2, accuracy):
     rThrust_B = thrConfigLog.rThrust_B[0]
     tHatThrust_B = thrConfigLog.tHatThrust_B[0]
     tMax = thrConfigLog.maxThrust[0]
+    tSwirl = thrConfigLog.swirlTorque[0]
 
     FM = rbk.euler1232C([theta1, theta2, 0.0])
     MB = rbk.MRP2C(sigma_MB)
@@ -151,6 +154,7 @@ def platformRotationTestFunction(show_plots, theta1, theta2, accuracy):
     np.testing.assert_allclose(rThrust_B, r_TB_B, rtol=0, atol=accuracy, verbose=True)
     np.testing.assert_allclose(tHatThrust_B, tHat_B, rtol=0, atol=accuracy, verbose=True)
     np.testing.assert_allclose(tMax, np.linalg.norm(T_F), rtol=0, atol=accuracy, verbose=True)
+    np.testing.assert_allclose(tSwirl, np.linalg.norm(T_F) * swirlFactor, rtol=0, atol=accuracy, verbose=True)
 
     return
 

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/thrusterPlatformState.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/thrusterPlatformState.c
@@ -91,6 +91,7 @@ void Update_thrusterPlatformState(thrusterPlatformStateConfig *configData, uint6
     v3Subtract(r_TM_B, r_BM_B, thrusterConfigBOut.rThrust_B);
     m33tMultV3(FB, thrusterConfigFIn.tHatThrust_B, thrusterConfigBOut.tHatThrust_B);
     thrusterConfigBOut.maxThrust = thrusterConfigFIn.maxThrust;
+    thrusterConfigBOut.swirlTorque = thrusterConfigFIn.swirlTorque;
 
     /*! write output thruster config msg */
     THRConfigMsg_C_write(&thrusterConfigBOut, &configData->thrusterConfigBOutMsg, moduleID, callTime);


### PR DESCRIPTION
* **Tickets addressed:** bsk-771
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adding swirl torque information to THRConfigMsg and modules that read/output that message.
In thrustCMEstimation, the swirl torque is added to the measurement model which is now made of the two components of the thruster torque: moment arm x thrust force + swirl torque.

## Verification
Unit test for thrusterPlatformState has been updated

## Documentation
n/a

## Future work
n/a
