### PR TITLE
Fix bug in simIncludeRW.py on setting Js value

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -12,7 +12,8 @@ Version |release|
 -----------------
 - pip-based installation in editable mode using `pip install -e .` is not currently supported.
   Developers and users alike should continue to use `python conanfile.py` installation.
-
+- If the :ref:`simIncludeRW` python tool was provided a specific ``Js`` value, it was being falsely converted
+  before being assigned.  This is now corrected.
 
 Version 2.4.0
 -------------
@@ -26,6 +27,8 @@ Version 2.4.0
   Developers and users alike should continue to use `python conanfile.py` installation.
 - The CI test builds starting failing running the `gtest` unit test suite with the error
   ``CMake Error: Unknown argument: --gtest_output``.  The current release fixes this issue.
+- If the :ref:`simIncludeRW` python tool was provided a specific ``Js`` value, it was being falsely converted
+  before being assigned.
 
 
 Version 2.3.0

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
@@ -518,6 +518,21 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
     # testMessage
     return [testFailCount, ''.join(testMessages)]
 
+def test_setJs(show_plots):
+    """Module Unit Test of settign Js value"""
+    rwFactory = simIncludeRW.rwFactory()
+
+    RW = rwFactory.create(
+        'custom'
+        , [1, 0, 0]  # gsHat_B
+        , rWB_B=[0.1, 0., 0.]  # m
+        , u_max= 0.01 # N
+        , Js=0.1 # kg*m^2
+    )
+    assert RW.Js == 0.1, "Setting Js through RW factory class create function failed"
+
+
 if __name__ == "__main__":
     # reactionWheelIntegratedTest(True,True,'BalancedWheels')
-    reactionWheelIntegratedTest(True,True,'BOE')
+    # reactionWheelIntegratedTest(True,True,'BalancedWheels')
+    test_setJs(False)

--- a/src/utilities/simIncludeRW.py
+++ b/src/utilities/simIncludeRW.py
@@ -81,7 +81,7 @@ class rwFactory(object):
                 Viscous friction coefficient
             Js: float
                 RW inertia about spin axis
-        
+
         Returns
         -------
         RWConfigSimMsg : message structure
@@ -237,7 +237,7 @@ class rwFactory(object):
                 print('ERROR: Js must be a FLOAT argument')
                 exit(1)
             if varJs > 0.0:
-                RW.Js = varJs * macros.RPM
+                RW.Js = varJs
                 RW.Jt = 0.5 * RW.Js
                 RW.Jg = RW.Jt
             else:
@@ -371,9 +371,9 @@ class rwFactory(object):
         JsList = []
         uMaxList = []
         for rw in self.rwList.values():
-            
+
             flatGsHat = [element for sublist in rw.gsHat_B for element in sublist]
-            
+
             GsMatrix_B.extend(flatGsHat)
             JsList.extend([rw.Js])
             uMaxList.extend([rw.u_max])


### PR DESCRIPTION
* **Tickets addressed:** bsk-763
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The `simIncludeRW.py` file did a false unit conversion if `Js` was set directly.  This is now corrected.

## Verification
Added unit test to check this.

## Documentation
Added issue to the known issues RST document

## Future work
None
