### PR TITLE
Fix "invalid command `bdist_wheel`" errors during some Conanfile-based installs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -372,7 +372,7 @@ jobs:
         shell: pwsh
         run: |
             venv\Scripts\activate
-            pip install wheel 'conan<2.0' parse six pytest-xdist
+            pip install wheel 'conan<2.0' six pytest-xdist
       - name: "Add basilisk and cmake path to env path"
         shell: pwsh
         run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -123,10 +123,12 @@ class BasiliskConan(ConanFile):
         reqFile.close()
         pkgList = [x.lower() for x in required]
         pkgList += [
-            # XXX: Add build system requirements which were removed from requirements.txt.
+            # Also install build system requirements.
+            # TODO: Read these from the `pyproject.toml` file directly?
+            # NOTE: These are *NOT* runtime requirements and should *NOT* be in `requirements.txt`!
             "conan>=1.40.1, <2.00.0",
             "parse>=1.18.0",
-            "setuptools>=64",
+            "setuptools>=70.1.0",
             "setuptools-scm>=8.0",
             "cmake>=3.26",
         ]
@@ -288,6 +290,9 @@ class BasiliskConan(ConanFile):
 
     def add_basilisk_to_sys_path(self):
         print("Adding Basilisk module to python\n")
+        # NOTE: "--no-build-isolation" is used here only to force pip to use the
+        # packages installed directly by this Conanfile (using the
+        # "managePipEnvironment" option). Otherwise, it is not necessary.
         add_basilisk_module_command = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "."]
         if not is_running_virtual_env() and self.options.autoKey != 's':
             add_basilisk_module_command.append("--user")

--- a/conanfile.py
+++ b/conanfile.py
@@ -110,10 +110,7 @@ class BasiliskConan(ConanFile):
         # managePipEnvironment (i.e. conanfile.py-based build).
 
         # ensure latest pip is installed
-        if is_running_virtual_env() or platform.system() == "Windows":
-            cmakeCmdString = 'python -m pip install --upgrade pip'
-        else:
-            cmakeCmdString = 'python3 -m pip install --upgrade pip'
+        cmakeCmdString = f'{sys.executable} -m pip install --upgrade pip'
         print(statusColor + "Updating pip:" + endColor)
         print(cmakeCmdString)
         os.system(cmakeCmdString)
@@ -363,10 +360,7 @@ if __name__ == "__main__":
 
     # run conan install
     conanCmdString = list()
-    if is_running_virtual_env() or platform.system() == "Windows":
-        conanCmdString.append('python -m conans.conan install . --build=missing')
-    else:
-        conanCmdString.append('python3 -m conans.conan install . --build=missing')
+    conanCmdString.append(f'{sys.executable} -m conans.conan install . --build=missing')
     conanCmdString.append(' -s build_type=' + str(args.buildType))
     conanCmdString.append(' -if ' + buildFolderName)
     if args.generator:
@@ -393,10 +387,7 @@ if __name__ == "__main__":
     completedProcess = subprocess.run(conanCmdString, shell=True, check=True)
 
     # run conan build
-    if is_running_virtual_env() or platform.system() == "Windows":
-        cmakeCmdString = 'python -m conans.conan build . -if ' + buildFolderName
-    else:
-        cmakeCmdString = 'python3 -m conans.conan build . -if ' + buildFolderName
+    cmakeCmdString = f'{sys.executable} -m conans.conan build . -if ' + buildFolderName
     print(statusColor + "Running cmake:" + endColor)
     print(cmakeCmdString)
     completedProcess = subprocess.run(cmakeCmdString, shell=True, check=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -127,7 +127,6 @@ class BasiliskConan(ConanFile):
             # TODO: Read these from the `pyproject.toml` file directly?
             # NOTE: These are *NOT* runtime requirements and should *NOT* be in `requirements.txt`!
             "conan>=1.40.1, <2.00.0",
-            "parse>=1.18.0",
             "setuptools>=70.1.0",
             "setuptools-scm>=8.0",
             "cmake>=3.26",

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,8 +32,8 @@ try:
         exit(0)
     from conans import ConanFile, CMake, tools
 except ModuleNotFoundError:
-    print("Please make sure you install python conan (version 1.xx, not 2.xx) package\nRun command `pip install conan` "
-          "for Windows\nRun command `pip3 install conan` for Linux/MacOS")
+    print("Please make sure you install python conan (version 1.xx, not 2.xx) package\nRun command `pip install \"conan<2\"` "
+          "for Windows\nRun command `pip3 install \"conan<2\"` for Linux/MacOS")
     sys.exit(1)
 
 # define BSK module option list (option name and default value)

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,6 +33,7 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Added swirl torque information to :ref:`THRConfigMsg`, :ref:`thrustCMEstimation`, and :ref:`thrusterPlatformState`
+- Updated required version of `setuptools` to avoid installation error ("invalid command ``bdist_wheel``") on some environments.
 
 
 Version 2.4.0 (August 23, 2024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=64",       # For PEP 660 (Allow editable installs from pyproject.toml)
+    "setuptools>=70.1.0",   # Required for "bdist_wheel" to work correctly.
     "setuptools-scm>=8.0",  # Automatically include all Git-controlled files in sdist
 
     # Requirements for building Basilisk through conanfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires = [
     # Requirements for building Basilisk through conanfile
     "conan>=1.40.1, <2.00.0",
     "cmake>=3.26",
-    "parse>=1.18.0",
     "swig==4.2.1"  # Known to work with https://github.com/nightlark/swig-pypi/pull/120
 ]
 

--- a/src/architecture/messaging/CMakeLists.txt
+++ b/src/architecture/messaging/CMakeLists.txt
@@ -9,7 +9,7 @@ function(generate_messages searchDir generateCCode)
   foreach(msgFile ${message_files})
     get_filename_component(TARGET_NAME ${msgFile} NAME_WE)
     get_filename_component(TARGET_DIR ${msgFile} DIRECTORY)
-    set(COMP_OUT_NAME "${CMAKE_CURRENT_SOURCE_DIR}/../../../dist3/autoSource/${TARGET_NAME}.i")
+    set(COMP_OUT_NAME "${CMAKE_BINARY_DIR}/autoSource/${TARGET_NAME}.i")
     add_custom_command(
       OUTPUT ${COMP_OUT_NAME}
       COMMAND ${Python3_EXECUTABLE} generateSWIGModules.py ${COMP_OUT_NAME} ${msgFile} ${TARGET_NAME} ${searchDir}


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fixes an error that could occur during some `python conanfile.py` installations.

In short, if the user had `setuptools>=64.0,<70.1.0` installed, but did *not* have `wheel` installed (as it is not required), the `python conanfile.py` installation could fail with an "invalid command `bdist_wheel`" type of error. This is fixed by upgrading the minimum build requirement to `setuptools>=70.1.0` in both `conanfile.py` and `pyproject.toml`.

As a sidenote, this only affected the Conanfile installs because it now installs Basilisk using the `pip --no-build-isolation` flag. Without the `--no-build-isolation` flag, the latest version of `setuptools` is automatically installed temporarily, thus avoiding this issue. However, this is technically a different environment to the one that `conanfile.py` installs, so I prefer to leave the `--no-build-isolation` flag in place.
  
Three unrelated but useful changes are also included, and could be split into a separate merge request if you want. I left them here because they're small and shouldn't affect anything:

- Remove a leftover hardcoded build path (to `dist3`) in one of the CMake files.
- Replaced "python" and "python3" usage in `conanfile.py` to the more appropriate "sys.executable".
- Updated error message about running `pip install conan` to `pip install "conan<2"`.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->

No changes to tests, should continue to pass CI.

Only expected change for users is that they might have their `setuptools` automatically upgraded when running `python conanfile.py`. In general, this is a good thing, but it could potentially cause some compatibility issues when installing some older packages.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->

Not required.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Not required.