### PR TITLE
Re-download `de430.bsp` if it gets interrupted

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -14,6 +14,10 @@ Version |release|
   Developers and users alike should continue to use `python conanfile.py` installation.
 - If the :ref:`simIncludeRW` python tool was provided a specific ``Js`` value, it was being falsely converted
   before being assigned.  This is now corrected.
+- If ``supportData/EphemerisData/de430.bsp`` is not present the current build system will download the file
+  from JPL server.  However, if the download is interrupted, then the next build will find the file and
+  not attempt to re-download it.  This is now fixed in the current version where the file is only
+  stored in the ``supportData`` folder if the download was complete.
 
 Version 2.4.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,7 +33,9 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Added swirl torque information to :ref:`THRConfigMsg`, :ref:`thrustCMEstimation`, and :ref:`thrusterPlatformState`
-- Updated required version of `setuptools` to avoid installation error ("invalid command ``bdist_wheel``") on some environments.
+- Updated required version of `setuptools` to avoid installation error ("invalid command ``bdist_wheel``") on
+  some environments.
+- Made the initial Basilisk build more robust in case ``de430.bsp`` download was interrupted
 
 
 Version 2.4.0 (August 23, 2024)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,13 +381,16 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/de430.bsp")
   message(STATUS "File de430.bsp not found, downloading file:")
   file(DOWNLOAD
         "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp"
-        "${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/de430.bsp"
+        # Download it to the build directory (in case the download gets interrupted).
+        "${CMAKE_BINARY_DIR}/data/de430.bsp"
         SHOW_PROGRESS
         STATUS DOWNLOAD_RESULT_CODE
         )
   if(NOT DOWNLOAD_RESULT_CODE EQUAL 0)
         message(FATAL_ERROR "Failed downloading de430.bsp! Error: ${DOWNLOAD_RESULT}.")
   endif()
+  # Move the SPICE file into the appropriate directory.
+  file(RENAME "${CMAKE_BINARY_DIR}/data/de430.bsp" "${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/de430.bsp")
 else()
   message(STATUS "Found Spice files.")
 endif ()


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->

Fixes an issue when the `de430.bsp` file is not correctly downloaded (e.g. due to the build system being interrupted).

The fix introduced here is to download the `de430.bsp` file to a build directory first, and only move it to the `supportData` when the download completes.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->

Steps to reproduce:

1. `python conanfile.py`
2. Interrupt (e.g. Ctrl-C) the build while it is downloading `de430.bsp`
3. `python conanfile.py` again until completion
4. `pytest src/ -k "HaloOrbit"` -- this and other tests will fail due to the partially-downloaded ephemerides

With this fix, step 3 will correctly try to download `de430.bsp` again.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->

Not necessary.

## Future work
<!-- What next steps can we anticipate from here, if any? -->

Not necessary.