### PR TITLE
vizInterface not saving binary file

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,14 +10,17 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
-- pip-based installation in editable mode using `pip install -e .` is not currently supported.
-  Developers and users alike should continue to use `python conanfile.py` installation.
+- pip-based installation in editable mode using ``pip install -e .`` is not currently supported.
+  Developers and users alike should continue to use ``python conanfile.py`` installation.
 - If the :ref:`simIncludeRW` python tool was provided a specific ``Js`` value, it was being falsely converted
   before being assigned.  This is now corrected.
 - If ``supportData/EphemerisData/de430.bsp`` is not present the current build system will download the file
   from JPL server.  However, if the download is interrupted, then the next build will find the file and
   not attempt to re-download it.  This is now fixed in the current version where the file is only
   stored in the ``supportData`` folder if the download was complete.
+- :ref:`vizInterface` was not able to save to a binary data file.
+  This is now fixed in the current release.
+
 
 Version 2.4.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -37,6 +37,7 @@ Version |release|
   some environments.
 - Made the initial Basilisk build more robust in case ``de430.bsp`` download was interrupted
 - Enhanced :ref:`thrusterDynamicEffector` to allow automatic scaling down of thrust and Isp as fuel mass depletes.
+- Fixed issue with :ref:`vizInterface` not being able to save to file
 
 
 Version 2.4.0 (August 23, 2024)

--- a/src/architecture/system_model/sys_process.cpp
+++ b/src/architecture/system_model/sys_process.cpp
@@ -24,7 +24,6 @@
 /*! Make a process AND attach a storage bucket with the provided name. Give
     the process the same name.
     @return void
-    @param messageContainer The amount of nanoseconds between calls to this Task.
  */
 SysProcess::SysProcess(std::string name) : SysProcess()
 {

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1103,7 +1103,8 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
 
         /* If settings were broadcast, remove from message before saving & sending to 2-way socket to reduce message
            size. Message must be re-serialized here as its contents have changed. */
-        if (this->liveStream && (this->firstPass != 0) && (this->lastSettingsSendTime == this->now)) {
+        if ((this->liveStream && (this->firstPass != 0) && (this->lastSettingsSendTime == this->now))
+             || this->saveFile) {
             // Zero-out settings to reduce message size if not at first timestep
             message->set_allocated_settings(nullptr);
             // Re-serialize


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
If the scenario script uses the `saveFile` option to save off a Vizard binary data file, the simulation
data was not being properly recorded.  As a result Vizard hung trying to open this heavily corrupted file.

## Verification
Vizard is able to again properly open binary files saved off with the `vizInterface` module.

## Documentation
Updated release notes.

## Future work
None
