### PR TITLE
fix viz settings msg not recording

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -20,6 +20,7 @@ Version |release|
   stored in the ``supportData`` folder if the download was complete.
 - :ref:`vizInterface` was not able to save to a binary data file.
   This is now fixed in the current release.
+- :ref:`vizInterface` was not saving the Vizard settings to the binary file.  Fixed now.
 
 
 Version 2.4.0

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -38,6 +38,7 @@ Version |release|
 - Made the initial Basilisk build more robust in case ``de430.bsp`` download was interrupted
 - Enhanced :ref:`thrusterDynamicEffector` to allow automatic scaling down of thrust and Isp as fuel mass depletes.
 - Fixed issue with :ref:`vizInterface` not being able to save to file
+- Fixed issue with :ref:`vizInterface` not saving off Vizard protobuffer message on first time step
 
 
 Version 2.4.0 (August 23, 2024)


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The vizInterface module was no longer saving off the Vizard settings protobuffer message.  This 
has been corrected now.

## Verification
Ran a scenario and saved off the panel that needed a settings message.  The playback is working
properly again.

## Documentation
Updated release notes

## Future work
None