### PR TITLE
deprecate classicElements() structure

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -45,6 +45,9 @@ Version |release|
 - Removed deprecated way to log Basilisk module variables
 - Removed deprecated way to create C-wrapped Basilisk modules
 - Corrected Equations (11) and (12) in the :ref:`celestialTwoBodyPoint` PDF documentation
+- Untangled :ref:`ClassicElementsMsgPayload` which was used both as a message payload definition
+  and as a data structure inside modules.  The use of ``classicElements()`` is now depreciated
+  for the use of ``ClassicElements()`` defined in :ref:`orbitalMotionutilities`.
 
 
 Version 2.4.0 (August 23, 2024)

--- a/examples/scenarioAsteroidArrival.py
+++ b/examples/scenarioAsteroidArrival.py
@@ -56,7 +56,7 @@ Next, the module is configured by specifying the orbital parameters of Bennu::
     G = 6.67408 * (10 ** -11)  # m^3 / kg*s^2
     massBennu = 7.329 * (10 ** 10)  # kg
     mu = G * massBennu  # Bennu grav. parameter, m^3/s^2
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1264 * orbitalMotion.AU * 1000  # m
     oeAsteroid.e = 0.20375
     oeAsteroid.i = 6.0349 * macros.D2R
@@ -257,7 +257,7 @@ def run(show_plots):
     G = 6.67408 * (10 ** -11)  # m^3 / kg*s^2
     massBennu = 7.329 * (10 ** 10)  # kg
     mu = G * massBennu  # Bennu grav. parameter, m^3/s^2
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1264 * orbitalMotion.AU * 1000  # m
     oeAsteroid.e = 0.20375
     oeAsteroid.i = 6.0349 * macros.D2R

--- a/examples/scenarioCustomGravBody.py
+++ b/examples/scenarioCustomGravBody.py
@@ -130,7 +130,7 @@ def run(show_plots):
     gravBodyEphem.setPlanetNames(planetEphemeris.StringVector(["Itokawa", "earth"]))
 
     # specify orbits of gravitational bodies
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.3241 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.2801
     oeAsteroid.i = 1.6214*macros.D2R
@@ -138,7 +138,7 @@ def run(show_plots):
     oeAsteroid.omega = 162.82*macros.D2R
     oeAsteroid.f = 90.0*macros.D2R
 
-    oeEarth = planetEphemeris.ClassicElementsMsgPayload()
+    oeEarth = planetEphemeris.ClassicElements()
     oeEarth.a = orbitalMotion.AU * 1000  # meters
     oeEarth.e = 0.0167086
     oeEarth.i = 7.155 * macros.D2R

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -252,7 +252,7 @@ def run(show_plots):
     # specify orbits of gravitational bodies
     # https://ssd.jpl.nasa.gov/horizons.cgi#results
     # December 31st, 2018
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R

--- a/examples/scenarioSmallBodyLandmarks.py
+++ b/examples/scenarioSmallBodyLandmarks.py
@@ -288,7 +288,7 @@ def run(show_plots, useBatch):
 
     # Specify asteroid orbit elements and rotational state January 21st, 2022
     # https://ssd.jpl.nasa.gov/horizons.cgi#results
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.4583 * 149597870.7*1e3  # meters
     oeAsteroid.e = 0.2227
     oeAsteroid.i = 10.829 * np.pi/180

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -456,7 +456,7 @@ def run(show_plots):
     # specify orbits of gravitational bodies
     # https://ssd.jpl.nasa.gov/horizons.cgi#results
     # December 31st, 2018
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R

--- a/examples/scenarioSmallBodyNavUKF.py
+++ b/examples/scenarioSmallBodyNavUKF.py
@@ -314,7 +314,7 @@ def run(show_plots):
 
     # specify small body o.e. and rotational state January 21st, 2022
     # https://ssd.jpl.nasa.gov/horizons.cgi#results
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 2.3612 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.08823
     oeAsteroid.i = 7.1417*macros.D2R

--- a/src/architecture/utilities/keplerianOrbit.cpp
+++ b/src/architecture/utilities/keplerianOrbit.cpp
@@ -28,7 +28,7 @@ KeplerianOrbit::KeplerianOrbit()
 }
 
 /*! The constructor requires orbital elements and a gravitational constant value */
-KeplerianOrbit::KeplerianOrbit(classicElements oe, const double mu) : mu(mu),
+KeplerianOrbit::KeplerianOrbit(ClassicElements oe, const double mu) : mu(mu),
                                                                       semi_major_axis(oe.a),
                                                                       eccentricity(oe.e),
                                                                       inclination(oe.i),
@@ -136,10 +136,10 @@ void KeplerianOrbit::set_f(double f){this->true_anomaly = f; this->change_f();};
 
 
 /*! This method returns the orbital element set for the orbit
- @return classicElements oe
+ @return ClassicElements oe
  */
-classicElements KeplerianOrbit::oe(){
-    classicElements elements;
+ClassicElements KeplerianOrbit::oe(){
+    ClassicElements elements;
     elements.a = this->semi_major_axis;
     elements.e = this->eccentricity;
     elements.i = this->inclination;
@@ -170,7 +170,7 @@ void KeplerianOrbit::change_orbit(){
 void KeplerianOrbit::change_f(){
     double r[3];
     double v[3];
-    classicElements oe = this->oe(); //
+    ClassicElements oe = this->oe(); //
     elem2rv(this->mu, &oe, r, v); //
     this->position_BP_P = cArray2EigenVector3d(r); //
     this->velocity_BP_P = cArray2EigenVector3d(v); //
@@ -185,6 +185,3 @@ void KeplerianOrbit::change_f(){
 void KeplerianOrbit::set_mu(const double mu){
     this->mu = mu;
 }
-
-
-

--- a/src/architecture/utilities/keplerianOrbit.h
+++ b/src/architecture/utilities/keplerianOrbit.h
@@ -30,7 +30,7 @@
 class KeplerianOrbit {
 public:
     KeplerianOrbit();
-    KeplerianOrbit(classicElements oe, const double mu);
+    KeplerianOrbit(ClassicElements oe, const double mu);
     KeplerianOrbit(const KeplerianOrbit &orig);
     ~KeplerianOrbit();
 
@@ -59,7 +59,7 @@ public:
     double p() const;
     double rDot() const;
     double c3() const;
-    classicElements oe();
+    ClassicElements oe();
     void set_mu(const double mu);
     void set_a(double a);
     void set_e(double e);
@@ -67,7 +67,7 @@ public:
     void set_omega(double omega);
     void set_RAAN(double RAAN);
     void set_f(double f);
-    
+
 private:
     double mu = MU_EARTH;
     double semi_major_axis = 1E5;
@@ -96,4 +96,3 @@ private:
     void change_orbit();
     void change_f();
 };
-

--- a/src/architecture/utilities/keplerianOrbit.i
+++ b/src/architecture/utilities/keplerianOrbit.i
@@ -27,7 +27,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 %include "keplerianOrbit.h"
-%include "architecture/msgPayloadDefC/ClassicElementsMsgPayload.h"
+%include "orbitalMotion.h"
 
 %pythoncode %{
 import sys

--- a/src/architecture/utilities/orbitalMotion.c
+++ b/src/architecture/utilities/orbitalMotion.c
@@ -50,8 +50,6 @@ void hillFrame(double *rc_N, double *vc_N, double HN[3][3])
     v3Copy(ir_N, HN[0]);
     v3Copy(itheta_N, HN[1]);
     v3Copy(ih_N, HN[2]);
-
-    return;
 }
 
 /*!
@@ -91,8 +89,6 @@ void  hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, dou
     v3Add(vd_N, rhoPrime_H, vd_N);
     m33MultV3(NH, vd_N, vd_N);
     v3Add(vd_N, vc_N, vd_N);
-
-    return;
 }
 
 
@@ -107,7 +103,7 @@ void  hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, dou
  *   rho_H: deputy Hill position vector
  *   rhoPrime_H: deputy Hill velocity vector
  */
-void    rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *rho_H, double *rhoPrime_H)
+void rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *rho_H, double *rhoPrime_H)
 {
     double HN[3][3];        /* DCM of Hill frame relative to inertial */
     double hVec_N[3];       /* orbit angular momentum vector */
@@ -133,8 +129,6 @@ void    rv2hill(double *rc_N, double *vc_N, double *rd_N, double *vd_N, double *
     m33MultV3(HN, rhoDot_N, rhoDot_H);
     v3Cross(omega_HN_H, rho_H, rhoPrime_H);
     v3Subtract(rhoDot_H, rhoPrime_H, rhoPrime_H);
-
-    return;
 }
 
 
@@ -575,8 +569,6 @@ void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
     if (elements->f < 0.0) {
         elements->f += 2*M_PI;
     }
-
-    return;
 }
 
 /*!
@@ -1023,5 +1015,4 @@ void clElem2eqElem(ClassicElements *elements_cl, equinoctialElements *elements_e
     double M        = E2M(E, elements_cl->e);
     elements_eq->l  = elements_cl->Omega + elements_cl->omega + M;
     elements_eq->L  = elements_cl->Omega + elements_cl->omega + elements_cl->f;
-    return;
 }

--- a/src/architecture/utilities/orbitalMotion.c
+++ b/src/architecture/utilities/orbitalMotion.c
@@ -384,7 +384,7 @@ double N2H(double N, double e)
  *   rVec = position vector
  *   vVec = velocity vector
  */
-void elem2rv(double mu, classicElements *elements, double *rVec, double *vVec)
+void elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec)
 {
     double e;                   /* eccentricty */
     double a;                   /* semi-major axis */
@@ -479,7 +479,7 @@ void elem2rv(double mu, classicElements *elements, double *rVec, double *vVec)
  * Outputs:
  *   elements = orbital elements
  */
-void rv2elem(double mu, double *rVec, double *vVec, classicElements *elements)
+void rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements)
 {
     double hVec[3];             /* orbit angular momentum vector */
     double ihHat[3];            /* normalized orbit angular momentum vector */
@@ -929,7 +929,7 @@ void solarRad(double A, double m, double *sunvec, double *arvec)
 }
 
 /*! maps classical mean orbit elements to Osculating elements */
-void clMeanOscMap(double req, double J2, classicElements *elements, classicElements *elements_p, double sgn) {
+void clMeanOscMap(double req, double J2, ClassicElements *elements, ClassicElements *elements_p, double sgn) {
     // Classical orbital elements = (a,e,i,Omega,omega,f)
     // First-order J2 Mapping Between Mean and Osculating Orbital Elements
     // sgn=1:mean2osc, sgn=-1:osc2mean
@@ -1007,11 +1007,10 @@ void clMeanOscMap(double req, double J2, classicElements *elements, classicEleme
     elements_p->Omega = Omegap;
     elements_p->omega = omegap;
     elements_p->f = fp;
-    return;
 }
 
 /*! maps from classical orbit elements to equinoctial elements */
-void clElem2eqElem(classicElements *elements_cl, equinoctialElements *elements_eq) {
+void clElem2eqElem(ClassicElements *elements_cl, equinoctialElements *elements_eq) {
     // conversion
     // from classical orbital elements (a,e,i,Omega,omega,f)
     // to equinoctial orbital elements (a,P1,P2,Q1,Q2,l,L)

--- a/src/architecture/utilities/orbitalMotion.h
+++ b/src/architecture/utilities/orbitalMotion.h
@@ -19,7 +19,6 @@
 
 #ifndef _ORBITAL_MOTION_0_H_
 #define _ORBITAL_MOTION_0_H_
-#include <architecture/utilities/bskLogging.h>
 
 #define N_DEBYE_PARAMETERS 37
 

--- a/src/architecture/utilities/orbitalMotion.h
+++ b/src/architecture/utilities/orbitalMotion.h
@@ -20,10 +20,22 @@
 #ifndef _ORBITAL_MOTION_0_H_
 #define _ORBITAL_MOTION_0_H_
 #include <architecture/utilities/bskLogging.h>
-#include "architecture/msgPayloadDefC/ClassicElementsMsgPayload.h"
 
 #define N_DEBYE_PARAMETERS 37
 
+/*! @brief Structure used to define classic orbit elements */
+typedef struct {
+    double a;         //!< object semi-major axis
+    double e;         //!< Eccentricity of the orbit
+    double i;         //!< inclination of the orbital plane
+    double Omega;     //!< Right ascension of the ascending node
+    double omega;     //!< Argument of periapsis of the orbit
+    double f;         //!< True anomaly of the orbit
+    double rmag;      //!< Magnitude of the position vector (extra)
+    double alpha;     //!< Inverted semi-major axis (extra)
+    double rPeriap;   //!< Radius of periapsis (extra)
+    double rApoap;    //!< Radius if apoapsis (extra)
+} ClassicElements;
 
 /* Celestial object being orbited */
 typedef enum {
@@ -77,10 +89,10 @@ extern "C" {
     double  H2N(double H, double e);
     double  M2E(double M, double e);
     double  N2H(double N, double e);
-    void    elem2rv(double mu, classicElements *elements, double *rVec, double *vVec);
-    void    rv2elem(double mu, double *rVec, double *vVec, classicElements *elements);
-    void    clMeanOscMap(double req, double J2, classicElements *elements, classicElements *elements_p, double sgn);
-    void    clElem2eqElem(classicElements *elements_cl, equinoctialElements *elements_eq);
+    void    elem2rv(double mu, ClassicElements *elements, double *rVec, double *vVec);
+    void    rv2elem(double mu, double *rVec, double *vVec, ClassicElements *elements);
+    void    clMeanOscMap(double req, double J2, ClassicElements *elements, ClassicElements *elements_p, double sgn);
+    void    clElem2eqElem(ClassicElements *elements_cl, equinoctialElements *elements_eq);
 
     void    hillFrame(double *rc_N, double *vc_N, double HN[3][3]);
     void    hill2rv(double *rc_N, double *vc_N, double *rho_H, double *rhoPrime_H, double *rd_N, double *vd_N);

--- a/src/architecture/utilities/tests/test_orbitalMotion.cpp
+++ b/src/architecture/utilities/tests/test_orbitalMotion.cpp
@@ -101,7 +101,7 @@ TEST(OrbitalMotion, elem2rv1DEccentric)
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
     elements.a = 7500.0;
     elements.e = 1.0;
     elements.i = 40.0 * D2R;
@@ -123,7 +123,7 @@ TEST(OrbitalMotion, elem2rv1DHyperbolic)
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
     elements.a = -7500.0;
     elements.e = 1.0;
     elements.i = 40.0 * D2R;
@@ -145,7 +145,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.a = -7500.0;
@@ -188,7 +188,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.alpha = 0.0; /* zero orbit energy, i.e. parabolic */
@@ -229,7 +229,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.a     = 7500.0;
@@ -271,7 +271,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.a = 7500.0;
@@ -309,7 +309,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
     double eps2 = 1e-12 * 0.5;
 
     void SetUp() override {
@@ -347,7 +347,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
     double eps2 = 1e-12 * 0.5;
 
     void SetUp() override {
@@ -385,7 +385,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.a = 7500.0;
@@ -422,7 +422,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.a = 7500.0;
@@ -460,7 +460,7 @@ protected:
     double v[3];
     double r2[3];
     double v3_2[3];
-    classicElements elements;
+    ClassicElements elements;
 
     void SetUp() override {
         elements.a = 7500.0;
@@ -493,7 +493,7 @@ TEST_F(CircularEquitorialRetrograde, rv2elem) {
 }
 
 TEST(OrbitalMotion, classicElementsToMeanElements) {
-    classicElements elements;
+    ClassicElements elements;
     elements.a     = 1000.0;
     elements.e     = 0.2;
     elements.i     = 0.2;
@@ -502,7 +502,7 @@ TEST(OrbitalMotion, classicElementsToMeanElements) {
     elements.f     = 0.2;
     double req = 300.0;
     double J2 = 1e-3;
-    classicElements elements_p;
+    ClassicElements elements_p;
     clMeanOscMap(req, J2, &elements, &elements_p, 1);
     EXPECT_PRED3(isEqualRel, elements_p.a, 1000.07546442015950560744386166334152, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_p.e, 0.20017786852908628358882481279579, orbitalElementsAccuracy);
@@ -513,7 +513,7 @@ TEST(OrbitalMotion, classicElementsToMeanElements) {
 }
 
 TEST(OrbitalMotion, classicElementsToEquinoctialElements) {
-    classicElements elements;
+    ClassicElements elements;
     elements.a     = 1000.0;
     elements.e     = 0.2;
     elements.i     = 0.2;

--- a/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.c
+++ b/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.c
@@ -117,7 +117,7 @@ void computeVelocityPointingReference(velocityPointConfig *configData,
     double  ddfdt2;                  /* rotational acceleration of the frame */
     double  omega_RN_R[3];           /* reference angular velocity vector in Reference frame R components */
     double  domega_RN_R[3];          /* reference angular acceleration vector in Reference frame R components */
-    classicElements oe;              /* Orbit Elements set */
+    ClassicElements oe;              /* Orbit Elements set */
 
     double  temp33[3][3];
     double  temp;

--- a/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.h
+++ b/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.h
@@ -22,7 +22,6 @@
 
 #include <stdint.h>
 
-#include "architecture/utilities/orbitalMotion.h"
 #include "cMsgCInterface/EphemerisMsg_C.h"
 #include "cMsgCInterface/NavTransMsg_C.h"
 #include "cMsgCInterface/AttRefMsg_C.h"

--- a/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.h
+++ b/src/fswAlgorithms/attGuidance/velocityPoint/velocityPoint.h
@@ -34,10 +34,10 @@
 /*!@brief Data structure for module to compute the orbital velocity spinning pointing navigation solution.
  */
 typedef struct {
-    
+
     /* declare module private variables */
-    double mu;                                      //!< Planet gravitational parameter 
-   
+    double mu;                                      //!< Planet gravitational parameter
+
     /* declare module IO interfaces */
     AttRefMsg_C attRefOutMsg;               //!<        The name of the output message
     NavTransMsg_C transNavInMsg;            //!<        The name of the incoming attitude command
@@ -52,7 +52,7 @@ typedef struct {
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
     void SelfInit_velocityPoint(velocityPointConfig *configData, int64_t moduleID);
     void Update_velocityPoint(velocityPointConfig *configData, uint64_t callTime, int64_t moduleID);
     void Reset_velocityPoint(velocityPointConfig *configData, uint64_t callTime, int64_t moduleID);

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.c
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.c
@@ -232,7 +232,7 @@ void calc_RelativeMotionControl(etSphericalControlConfig *configData, NavTransMs
     double phiDot = XDot[2];
     // control matrices [F] and [G]
     double mu = configData->mu; // [m^3/s^2] Earth's gravitational parameter
-    classicElements elements;
+    ClassicElements elements;
     rv2elem(mu, servicerTransInMsgBuffer.r_BN_N, servicerTransInMsgBuffer.v_BN_N, &elements);
     double a = elements.a;
     double n = sqrt(mu/a/a/a); // mean motion

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.h
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.h
@@ -43,7 +43,7 @@ typedef struct {
     CmdForceInertialMsg_C eForceInMsg;                  //!< servicer electrostatic force input message
     CmdForceInertialMsg_C forceInertialOutMsg;          //!< servicer inertial frame control force output message
     CmdForceBodyMsg_C forceBodyOutMsg;                  //!< servicer body frame control force output message
-    
+
     double mu;                                          //!< [m^3/s^2]  gravitational parameter
     double L_r;                                         //!< [m]  reference separation distance
     double theta_r;                                     //!< [rad]  reference in-plane rotation angle

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.h
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/etSphericalControl.h
@@ -29,7 +29,6 @@
 #include "cMsgCInterface/CmdForceBodyMsg_C.h"
 
 #include "architecture/utilities/bskLogging.h"
-#include "architecture/utilities/orbitalMotion.h"
 
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {

--- a/src/fswAlgorithms/formationFlying/formationBarycenter/formationBarycenter.cpp
+++ b/src/fswAlgorithms/formationFlying/formationBarycenter/formationBarycenter.cpp
@@ -20,7 +20,6 @@
 
 #include "fswAlgorithms/formationFlying/formationBarycenter/formationBarycenter.h"
 #include "architecture/utilities/orbitalMotion.h"
-#include "architecture/msgPayloadDefC/ClassicElementsMsgPayload.h"
 #include <math.h>
 
 
@@ -111,8 +110,8 @@ void FormationBarycenter::computeBaricenter() {
             barycenterVelocity[n] /= totalMass;
         }
     } else {
-        classicElements orbitElements = {}; // zero the orbit elements first
-        classicElements tempElements;
+        ClassicElements orbitElements = {}; // zero the orbit elements first
+        ClassicElements tempElements;
         double OmegaSineSum = 0;
         double OmegaCosineSum = 0;
         double omegaSineSum = 0;
@@ -128,7 +127,7 @@ void FormationBarycenter::computeBaricenter() {
             orbitElements.a += this->scPayloadBuffer.at(c).massSC * tempElements.a;
             orbitElements.e += this->scPayloadBuffer.at(c).massSC * tempElements.e;
             orbitElements.i += this->scPayloadBuffer.at(c).massSC * tempElements.i;
-            
+
             OmegaSineSum += this->scPayloadBuffer.at(c).massSC * sin(tempElements.Omega);
             OmegaCosineSum += this->scPayloadBuffer.at(c).massSC * cos(tempElements.Omega);
             omegaSineSum += this->scPayloadBuffer.at(c).massSC * sin(tempElements.omega);
@@ -177,4 +176,3 @@ void FormationBarycenter::UpdateState(uint64_t CurrentSimNanos)
     this->computeBaricenter();
     this->WriteOutputMessage(CurrentSimNanos);
 }
-

--- a/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.c
+++ b/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.c
@@ -29,7 +29,7 @@
 
 static void calc_LyapunovFeedback(meanOEFeedbackConfig *configData, NavTransMsgPayload chiefTransMsg,
                                   NavTransMsgPayload deputyTransMsg, CmdForceInertialMsgPayload *forceMsg);
-static void calc_B_cl(double mu, classicElements oe_cl, double B[6][3]);
+static void calc_B_cl(double mu, ClassicElements oe_cl, double B[6][3]);
 static void calc_B_eq(double mu, equinoctialElements oe_eq, double B[6][3]);
 static double adjust_range(double lower, double upper, double angle);
 
@@ -111,11 +111,11 @@ void Update_meanOEFeedback(meanOEFeedbackConfig *configData, uint64_t callTime, 
 static void calc_LyapunovFeedback(meanOEFeedbackConfig *configData, NavTransMsgPayload chiefTransMsg,
                                   NavTransMsgPayload deputyTransMsg, CmdForceInertialMsgPayload *forceMsg) {
     // position&velocity to osculating classic orbital elements
-    classicElements oe_cl_osc_c, oe_cl_osc_d;
+    ClassicElements oe_cl_osc_c, oe_cl_osc_d;
     rv2elem(configData->mu, chiefTransMsg.r_BN_N, chiefTransMsg.v_BN_N, &oe_cl_osc_c);
     rv2elem(configData->mu, deputyTransMsg.r_BN_N, deputyTransMsg.v_BN_N, &oe_cl_osc_d);
     // osculating classic oe to mean classic oe
-    classicElements oe_cl_mean_c, oe_cl_mean_d;
+    ClassicElements oe_cl_mean_c, oe_cl_mean_d;
     clMeanOscMap(configData->req, configData->J2, &oe_cl_osc_c, &oe_cl_mean_c, -1);
     clMeanOscMap(configData->req, configData->J2, &oe_cl_osc_d, &oe_cl_mean_d, -1);
     // calculate necessary Force in LVLH frame
@@ -181,7 +181,7 @@ static void calc_LyapunovFeedback(meanOEFeedbackConfig *configData, NavTransMsgP
  @param oe_cl nonsingular orbital elements
  @param B
  */
-static void calc_B_cl(double mu, classicElements oe_cl, double B[6][3]) {
+static void calc_B_cl(double mu, ClassicElements oe_cl, double B[6][3]) {
     // define parameters necessary to calculate Bmatrix
     double a = oe_cl.a;
     double e = oe_cl.e;

--- a/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.c
+++ b/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.c
@@ -20,7 +20,6 @@
 #include "meanOEFeedback.h"
 
 #include <math.h>
-#include <string.h>
 
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/linearAlgebra.h"

--- a/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.h
+++ b/src/fswAlgorithms/formationFlying/meanOEFeedback/meanOEFeedback.h
@@ -26,7 +26,6 @@
 #include "cMsgCInterface/NavTransMsg_C.h"
 
 #include "architecture/utilities/bskLogging.h"
-#include "architecture/utilities/orbitalMotion.h"
 
 /*! @brief Top level structure for the sub-module routines. */
 typedef struct {

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
@@ -150,7 +150,7 @@ void UpdateManeuver(spacecraftReconfigConfig *configData, NavTransMsgPayload chi
                      uint64_t callTime, int64_t moduleID)
 {
     /* conversion from r,v to classical orbital elements */
-    classicElements oe_c, oe_d;
+    ClassicElements oe_c, oe_d;
     rv2elem(configData->mu,chiefTransMsgBuffer.r_BN_N,chiefTransMsgBuffer.v_BN_N,&oe_c);
     rv2elem(configData->mu,deputyTransMsgBuffer.r_BN_N,deputyTransMsgBuffer.v_BN_N,&oe_d);
 
@@ -331,8 +331,8 @@ int CompareTime(const void * n1, const void * n2)
  @param thrustConfigMsgBuffer
  @param vehicleConfigMsgBuffer deputy's vehicle config information
  */
-void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
-                          classicElements oe_d, THRArrayConfigMsgPayload thrustConfigMsgBuffer, VehicleConfigMsgPayload vehicleConfigMsgBuffer)
+void ScheduleDV(spacecraftReconfigConfig *configData,ClassicElements oe_c,
+                          ClassicElements oe_d, THRArrayConfigMsgPayload thrustConfigMsgBuffer, VehicleConfigMsgPayload vehicleConfigMsgBuffer)
 {
     // calculation necessary variables
     double da     = oe_d.a - oe_c.a;
@@ -488,7 +488,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     double M_d_dvrtp = M_d + configData->burnArrayInfoOutMsgBuffer.burnArray[0].t*n;
     double E_d_dvrtp = M2E(M_d_dvrtp, oe_d.e);
     double f_d_dvrtp = E2f(E_d_dvrtp, oe_d.e);
-    classicElements oe_d_dvrtp;
+    ClassicElements oe_d_dvrtp;
     oe_d_dvrtp   = oe_d;
     oe_d_dvrtp.f = f_d_dvrtp;
     double rVec_d_dvrtp[3], vVec_d_dvrtp[3], hVec_d_dvrtp[3],tVec_d_dvrtp[3];
@@ -524,7 +524,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     double M_d_dvrta = M_d + configData->burnArrayInfoOutMsgBuffer.burnArray[1].t*n;
     double E_d_dvrta = M2E(M_d_dvrta, oe_d.e);
     double f_d_dvrta = E2f(E_d_dvrta, oe_d.e);
-    classicElements oe_d_dvrta;
+    ClassicElements oe_d_dvrta;
     oe_d_dvrta   = oe_d;
     oe_d_dvrta.f = f_d_dvrta;
     double rVec_d_dvrta[3], vVec_d_dvrta[3], hVec_d_dvrta[3],tVec_d_dvrta[3];
@@ -560,7 +560,7 @@ void ScheduleDV(spacecraftReconfigConfig *configData,classicElements oe_c,
     double M_d_dvn = M_d + configData->burnArrayInfoOutMsgBuffer.burnArray[2].t*n;
     double E_d_dvn = M2E(M_d_dvn, oe_d.e);
     double f_d_dvn = E2f(E_d_dvn, oe_d.e);
-    classicElements oe_d_dvn;
+    ClassicElements oe_d_dvn;
     oe_d_dvn = oe_d;
     oe_d_dvn.f = f_d_dvn;
     double rVec_d_dvn[3], vVec_d_dvn[3], hVec_d_dvn[3];

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.h
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.h
@@ -75,8 +75,8 @@ extern "C" {
                              uint64_t callTime, int64_t moduleID);
     double AdjustRange(double lower, double upper, double angle);
     int CompareTime(const void * n1, const void * n2);
-    void ScheduleDV(spacecraftReconfigConfig *configData, classicElements oe_c,
-                         classicElements oe_d, THRArrayConfigMsgPayload thrustConfigMsgBuffer, VehicleConfigMsgPayload vehicleConfigMsgBuffer);
+    void ScheduleDV(spacecraftReconfigConfig *configData, ClassicElements oe_c,
+                         ClassicElements oe_d, THRArrayConfigMsgPayload thrustConfigMsgBuffer, VehicleConfigMsgPayload vehicleConfigMsgBuffer);
 
 #ifdef __cplusplus
 }

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/_UnitTest/test_smallBodyWaypointFeedback.py
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/_UnitTest/test_smallBodyWaypointFeedback.py
@@ -20,7 +20,6 @@
 import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import smallBodyWaypointFeedback
-from Basilisk.simulation import planetEphemeris
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
@@ -84,7 +83,7 @@ def smallBodyWaypointFeedbackTestFunction1():
     module.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Set the orbital parameters of the asteroid
-    oeAsteroid = planetEphemeris.ClassicElements()
+    oeAsteroid = orbitalMotion.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R
@@ -172,7 +171,7 @@ def smallBodyWaypointFeedbackTestFunction2():
     module.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Set the orbital parameters of the asteroid
-    oeAsteroid = planetEphemeris.ClassicElements()
+    oeAsteroid = orbitalMotion.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/_UnitTest/test_smallBodyWaypointFeedback.py
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/_UnitTest/test_smallBodyWaypointFeedback.py
@@ -1,12 +1,12 @@
-# 
+#
 #  ISC License
-# 
+#
 #  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado Boulder
-# 
+#
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
 #  copyright notice and this permission notice appear in all copies.
-# 
+#
 #  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 #  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 #  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,8 +14,8 @@
 #  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-# 
-# 
+#
+#
 
 import numpy as np
 from Basilisk.architecture import messaging
@@ -84,7 +84,7 @@ def smallBodyWaypointFeedbackTestFunction1():
     module.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Set the orbital parameters of the asteroid
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R
@@ -172,7 +172,7 @@ def smallBodyWaypointFeedbackTestFunction2():
     module.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Set the orbital parameters of the asteroid
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000  # meters
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R
@@ -234,5 +234,3 @@ def smallBodyWaypointFeedbackTestFunction2():
 
 if __name__ == "__main__":
     test_smallBodyWaypointFeedback(False)
-
-

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h"
+#include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <math.h>
 

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h
@@ -84,7 +84,7 @@ private:
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector
     Eigen::Vector3d o_hat_1;  //!< First asteroid orbit frame base vector
     Eigen::MatrixXd I;  //!< 3 x 3 identity matrix
-    classicElements oe_ast;  //!< Orbital elements of the asteroid
+    ClassicElements oe_ast;  //!< Orbital elements of the asteroid
     double F_dot;  //!< Time rate of change of true anomaly
     double F_ddot;  //!< Second time derivative of true anomaly
     Eigen::Vector3d r_BN_N;

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h
@@ -31,7 +31,6 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/utilities/orbitalMotion.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/astroConstants.h"
 
 /*! @brief This module is provides a Lyapunov feedback control law for waypoint to waypoint guidance and control about
  * a small body. The waypoints are defined in the Hill frame of the body.

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
@@ -20,6 +20,7 @@
 
 #include "fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h"
 #include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <math.h>
 

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -32,7 +32,6 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/utilities/orbitalMotion.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include "architecture/utilities/macroDefinitions.h"
 
 /*! @brief This module estimates relative spacecraft position and velocity with respect to the body and attitude and attitude rate of the body wrt. the inertial frame
  */

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -126,7 +126,7 @@ private:
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector
     Eigen::Vector3d o_hat_1;  //!< First asteroid orbit frame base vector
     Eigen::MatrixXd I;  //!< 3 x 3 identity matrix
-    classicElements oe_ast;  //!< Orbital elements of the asteroid
+    ClassicElements oe_ast;  //!< Orbital elements of the asteroid
     double F_dot;  //!< Time rate of change of true anomaly
     double F_ddot;  //!< Second time derivative of true anomaly
     Eigen::Matrix3d dcm_ON;  //!< DCM from the inertial frame to the small-body's hill frame

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.c
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/oeStateEphem.c
@@ -69,7 +69,7 @@ void Update_oeStateEphem(OEStateEphemData *configData, uint64_t callTime, int64_
     int i;
     TDBVehicleClockCorrelationMsgPayload localCorr;
     EphemerisMsgPayload tmpOutputState;
-    classicElements orbEl;
+    ClassicElements orbEl;
 
     tmpOutputState = EphemerisMsg_C_zeroMsgPayload();
 

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.cpp
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.cpp
@@ -69,7 +69,18 @@ void OrbElemConvert::Reset(uint64_t CurrentSimNanos)
 void OrbElemConvert::WriteOutputMessages(uint64_t CurrentClock)
 {
     if (this->elemOutMsg.isLinked() && this->inputsGood) {
-        this->elemOutMsg.write(&this->CurrentElem, this->moduleID, CurrentClock);
+        auto payload = ClassicElementsMsgPayload();
+        payload.a = this->CurrentElem.a;
+        payload.e = this->CurrentElem.e;
+        payload.i = this->CurrentElem.i;
+        payload.Omega = this->CurrentElem.Omega;
+        payload.omega = this->CurrentElem.omega;
+        payload.f = this->CurrentElem.f;
+        payload.rmag = this->CurrentElem.rmag;
+        payload.alpha = this->CurrentElem.alpha;
+        payload.rPeriap = this->CurrentElem.rPeriap;
+        payload.rApoap = this->CurrentElem.rApoap;
+        this->elemOutMsg.write(&payload, this->moduleID, CurrentClock);
     }
     if (this->scStateOutMsg.isLinked() && this->inputsGood) {
         SCStatesMsgPayload scMsg;
@@ -111,7 +122,19 @@ void OrbElemConvert::ReadInputs()
 {
     this->inputsGood = false;
     if (this->elemInMsg.isLinked()) {
-        this->CurrentElem = this->elemInMsg();
+        auto elements = ClassicElements();
+        auto inputElement = this->elemInMsg();
+        elements.a = inputElement.a;
+        elements.e = inputElement.e;
+        elements.i = inputElement.i;
+        elements.Omega = inputElement.Omega;
+        elements.omega = inputElement.omega;
+        elements.f = inputElement.f;
+        elements.rmag = inputElement.rmag;
+        elements.alpha = inputElement.alpha;
+        elements.rPeriap = inputElement.rPeriap;
+        elements.rApoap = inputElement.rApoap;
+        this->CurrentElem = elements;
         this->inputsGood = this->elemInMsg.isWritten();
     }
 

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.h
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/orbElemConvert.h
@@ -38,19 +38,19 @@ class OrbElemConvert: public SysModel {
 public:
     OrbElemConvert();
     ~OrbElemConvert();
-    
+
     void Reset(uint64_t CurrentSimNanos);
     void UpdateState(uint64_t CurrentSimNanos);
     void WriteOutputMessages(uint64_t CurrentClock);
     void Elements2Cartesian();
     void Cartesian2Elements();
     void ReadInputs();
-    
+
 public:
     double r_N[3];                    //!< m  Current position vector (inertial)
     double v_N[3];                    //!< m/s Current velocity vector (inertial)
     double mu;                        //!< -- Current grav param (inertial)
-    ClassicElementsMsgPayload CurrentElem;                      //!< -- Current orbital elements
+    ClassicElements CurrentElem;                      //!< -- Current orbital elements
     SCStatesMsgPayload statesIn;                            //!< -- spacecraft state message
     SpicePlanetStateMsgPayload planetIn;                        //!< -- planet state message
     ReadFunctor<SCStatesMsgPayload> scStateInMsg;           //!< -- sc state input message

--- a/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravitySpacecraft.py
+++ b/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravitySpacecraft.py
@@ -335,7 +335,7 @@ def polyGravityBody(show_plots):
     DynUnitTestProc.addTask(unitTestSim.CreateNewTask(unitTaskName, macros.sec2nano(intTime)))
 
     # specify orbit of polyhedral body
-    oePolyBody = planetEphemeris.ClassicElementsMsgPayload()
+    oePolyBody = planetEphemeris.ClassicElements()
     oePolyBody.a = 2.3612 * orbitalMotion.AU * 1000
     oePolyBody.e = 0
     oePolyBody.i = 0*macros.D2R

--- a/src/simulation/environment/eclipse/_UnitTest/test_eclipse.py
+++ b/src/simulation/environment/eclipse/_UnitTest/test_eclipse.py
@@ -350,7 +350,7 @@ def unitEclipseCustom(show_plots):
     gravBodyEphem.setPlanetNames(planetEphemeris.StringVector(["custom"]))
 
     # Specify bennu orbit
-    oeAsteroid = planetEphemeris.ClassicElementsMsgPayload()
+    oeAsteroid = planetEphemeris.ClassicElements()
     oeAsteroid.a = 1.1259 * orbitalMotion.AU * 1000. # m
     oeAsteroid.e = 0.20373
     oeAsteroid.i = 6.0343 * macros.D2R

--- a/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemeris.py
+++ b/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemeris.py
@@ -96,16 +96,16 @@ def planetEphemerisTest(show_plots, setRAN, setDEC, setLST, setRate):
 
     mu = orbitalMotion.MU_SUN*1000.*1000.*1000  # m^3/s^2
     # setup planet ephemeris states
-    oeEarth = planetEphemeris.ClassicElementsMsgPayload()
-    oeEarth.a = planetEphemeris.SMA_EARTH*1000  # meters
+    oeEarth = planetEphemeris.ClassicElements()
+    oeEarth.a = orbitalMotion.SMA_EARTH*1000  # meters
     oeEarth.e = 0.001
     oeEarth.i = 10.0*macros.D2R
     oeEarth.Omega = 30.0*macros.D2R
     oeEarth.omega = 20.0*macros.D2R
     oeEarth.f = 90.0*macros.D2R
 
-    oeVenus = planetEphemeris.ClassicElementsMsgPayload()
-    oeVenus.a = planetEphemeris.SMA_VENUS*1000  # meters
+    oeVenus = planetEphemeris.ClassicElements()
+    oeVenus.a = orbitalMotion.SMA_VENUS*1000  # meters
     oeVenus.e = 0.001
     oeVenus.i = 5.0*macros.D2R
     oeVenus.Omega = 110.0*macros.D2R

--- a/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemerisMsgDeprecated.py
+++ b/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemerisMsgDeprecated.py
@@ -1,0 +1,55 @@
+
+# ISC License
+#
+# Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#
+#   Unit Test Script
+#   Module Name:        planetEphemeris
+#   Author:             Hanspeter Schaub
+#   Creation Date:      August 5, 2024
+#
+
+
+# Import all of the modules that we are going to be called in this simulation
+from Basilisk.simulation import planetEphemeris
+
+import warnings
+from Basilisk.utilities import deprecated
+
+
+
+# update "module" in this function name to reflect the module name
+def test_module(show_plots):
+    """Module Unit Test"""
+
+    testResults = 0
+    testMessage = ""
+
+    # when the depreciation warning period is over, then the following tasks must be done:
+    # - remove this file
+    # - delete the swig deprecation warning in planetEphemeris.i
+    # - delete the typedef of classicalElements in PlanetEphemerisMsgPayload.h
+    warnings.filterwarnings("ignore", category=deprecated.BSKDeprecationWarning)
+
+    try:
+        # This setting of this message structure is depreciate. But, this test won't raise
+        # a depreciation warning until the 1-year grace period is passed.
+        msg = planetEphemeris.ClassicElementsMsgPayload()
+    except:
+        testResults += 1
+        testMessage = "planetEphemeris not able to set ClassicElementsMsgPayload"
+
+    assert testResults < 1, testMessage

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.cpp
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.cpp
@@ -19,8 +19,9 @@
 #include "simulation/environment/planetEphemeris/planetEphemeris.h"
 #include <iostream>
 #include <string.h>
-#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/astroConstants.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 
 

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.h
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.h
@@ -26,10 +26,8 @@
 #include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 #include "architecture/messaging/messaging.h"
 
-#include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/orbitalMotion.h"
 #include "architecture/utilities/bskLogging.h"
-#include <Eigen/Dense>
 
 
 /*! @brief planet ephemeris class */

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.h
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.h
@@ -37,16 +37,16 @@ class PlanetEphemeris: public SysModel {
 public:
     PlanetEphemeris();
     ~PlanetEphemeris();
-    
+
     void Reset(uint64_t CurrentSimNanos);
     void UpdateState(uint64_t CurrentSimNanos);
 
     void setPlanetNames(std::vector<std::string> planetNames);
-    
+
 public:
     std::vector<Message<SpicePlanetStateMsgPayload>*> planetOutMsgs; //!< -- vector of planet state output messages
 
-    std::vector<classicElements>planetElements; //!< -- Vector of planet classical orbit elements
+    std::vector<ClassicElements>planetElements; //!< -- Vector of planet classical orbit elements
 
     std::vector<double> rightAscension;         //!< [r] right ascension of the north pole rotation axis (pos. 3-axis)
     std::vector<double> declination;            //!< [r] Declination of the north pole rotation axis (neg. 2-axis)

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.i
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.i
@@ -30,13 +30,12 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 
 namespace std {
-    %template(classicElementVector) vector<ClassicElementsMsgPayload>;
+    %template(classicElementVector) vector<ClassicElements>;
 }
 
 %include "sys_model.i"
 %include "planetEphemeris.h"
 %include "architecture/utilities/orbitalMotion.h"
-%include "architecture/msgPayloadDefC/ClassicElementsMsgPayload.h"
 %include "architecture/utilities/astroConstants.h"
 
 

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.i
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.i
@@ -42,6 +42,13 @@ namespace std {
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"
 struct SpicePlanetStateMsg_C;
 
+%include "swig_deprecated.i"
+%deprecated_function(ClassicElementsMsgPayload, "2025/09/02", "Replace ClassicElementsMsgPayload() with ClassicalElements() defined in orbitalMotion")
+%inline %{
+    ClassicElements ClassicElementsMsgPayload() {
+        return (ClassicElements());
+    }
+%}
 
 %pythoncode %{
 import sys


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
In the early days of Basilisk the use of the `ClassicElementsMsgPayload()` message structure was also used
inside some BSK modules as an internal data structure to store orbit element information.  This entanglement
survived the move from BSK v1 to v2 but is now untangled in this branch.  The use of `classicElements()` is 
now deprecated.  Instead, a new data structure called `ClassicElements()` is defined in `orbitalMotion.h`
and should be used if a module need to store classical orbit elements. The use of `planetEmphemeris.ClassicElementsMsgPayload()` still works but is deprecated as well.  
The python scripts have been updated
such that they all now define orbit element data structures using `orbitalMotion.ClassicElements()`.

The code was lifted from the LASP fork of BSK and revised to ensure all commits do compile, added deprecation 
functionality and release notes.

## Verification
The deprecation was tests on the python scripts prior to them being updated to the new `ClassicElements()`
data structures.  All tests pass again without issues.

## Documentation
Update release notes

## Future work
In one year the use of `classicalElements()` should be removed.