### PR TITLE
Add support for numpy 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas
 matplotlib
-numpy<=2.0.1
+numpy
 colorama
 tqdm
 Pillow

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorqueParametrized.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorqueParametrized.py
@@ -235,7 +235,7 @@ def rwMotorTorqueTest(show_plots, numControlAxes, numWheels, RWAvailMsg):
                                                                  MAX_EFF_CNT, testFailCount, testMessages)
 
 
-    GsMatrix = np.transpose(np.reshape(rwConfigParams.GsMatrix_B,(MAX_EFF_CNT,3),"C"))
+    GsMatrix = np.transpose(np.reshape(rwConfigParams.GsMatrix_B, (MAX_EFF_CNT, 3), order="C"))
     F = np.transpose(moduleOutput[0])
     receivedTorque = -1.0*np.array([np.matmul(GsMatrix,F)])
     receivedTorque = np.append(np.array([]), receivedTorque)

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/Support/Results_thrForceMapping.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/Support/Results_thrForceMapping.py
@@ -16,7 +16,7 @@ class Results_thrForceMapping():
         self.numThrusters = numThrusters # number of explicitly configured thrusters
 
         self.C = np.array(COrig) # Control "Frame" (could be 1, 2, or 3 axii controllable)
-        self.C = np.reshape(self.C, ((len(self.C)//3),3),'C')
+        self.C = np.reshape(self.C, ((len(self.C)//3), 3), order='C')
 
         self.epsilon = epsilon
         self.use2ndLoop = use2ndLoop
@@ -52,7 +52,7 @@ class Results_thrForceMapping():
             for i in range(0,len(F)):
                 if t[i]:
                     DNew = np.append(DNew, np.cross((self.rData[i,:] - self.COM), self.gData[i]))
-            DNew = np.reshape(DNew, (3, (len(DNew) // 3)), 'F')
+            DNew = np.reshape(DNew, (3, (len(DNew) // 3)), order='F')
             FNew = self.mapToForce(DNew, Lr_Bar)
             if (self.thrForceSign > 0):
                 FNew = self.subtractMin(FNew,len(DNew[0])) # Produced negative forces when doing 2nd loop, dropped thruster, and COM offset


### PR DESCRIPTION
* **Tickets addressed:** Closes #769 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
https://github.com/numpy/numpy/pull/26292 included in numpy 2.1.0 breaks usage of `order` as a positional argument into `np.reshape`. It is slated for fix in 2.1.1, however, to improve the robustness of the scripts, usage of `order` will be changed to a positional argument.

## Verification
Tests pass with numpy 2.1.0 and continue passing with older numpy.

## Documentation
None

## Future work
None
