### PR TITLE
add macOS support to CI tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -445,17 +445,6 @@ jobs:
         run: ctest -C Release
         if: ${{ always() }}
 
-      - name: "Build basilisk without vizInterface"
-        run: source .venv/bin/activate && python3 conanfile.py --clean --vizInterface False
-
-      - name: "Run Python Tests"
-        run: |
-          source .venv/bin/activate
-          cd src
-          pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
-
       - name: "Build Documentation"
         run: |
           source .venv/bin/activate

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -483,3 +483,69 @@ jobs:
           path: junit/test-results-no-vizInterface-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
+
+  build-macOS-no-vizInterface:
+    name: Build macOS
+    runs-on: macos-14
+    strategy:
+      matrix:
+        python-version: [ "3.11" ]
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache conan packages
+        id: cache-conan
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-conan-packages-macOS-no-vizInterface
+        with:
+          # conan cache files are stored in `~/.conan` on Linux/macOS
+          path: ~/.conan
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+      - name: Cache pip modules
+        id: cache-pip
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-pip-modules
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install swig
+
+      - name: "Create virtual Environment"
+        run: python3 -m venv .venv
+      - name: "Install wheel and conan package"
+        run: |
+          source .venv/bin/activate
+          pip3 install wheel 'conan<2.0' cmake
+
+      - name: "Build basilisk without vizInterface"
+        run: source .venv/bin/activate && python3 conanfile.py --vizInterface False
+      - name: "Run Python Tests"
+        run: |
+          source .venv/bin/activate
+          cd src
+          pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
+      - name: "Upload pytest test results"
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-macOS-no-vizInterface-${{ matrix.python-version }}
+          path: junit/test-results-no-vizInterface-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -332,8 +332,8 @@ jobs:
       - name: "Upload pytest test results"
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-results-${{ matrix.python-version }}
-          path: junit/test-results-${{ matrix.python-version }}.xml
+          name: pytest-results-pip-x${{ matrix.python-version }}
+          path: junit/test-results-pip-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
@@ -398,3 +398,72 @@ jobs:
           cd dist3
           ctest
           if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}
+
+  build-macOS:
+    name: Build macOS
+    runs-on: macos-14
+    strategy:
+      matrix:
+        python-version: [ "3.11" ]
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache conan packages
+        id: cache-conan
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-conan-packages-macOS
+        with:
+          # conan cache files are stored in `~/.conan` on Linux/macOS
+          path: ~/.conan
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+      - name: Cache pip modules
+        id: cache-pip
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-pip-modules
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install swig
+
+      - name: "Create virtual Environment"
+        run: python3 -m venv .venv
+      - name: "Install wheel and conan package"
+        run: |
+          source .venv/bin/activate
+          pip3 install wheel 'conan<2.0' cmake
+      - name: "Build basilisk"
+        run: source .venv/bin/activate && python3 conanfile.py
+      - name: "Run Python Tests"
+        run: |
+          source .venv/bin/activate
+          cd src
+          pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
+      - name: "Upload pytest test results"
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-macOS-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+      - name: "Run C/C++ Tests"
+        working-directory: ./dist3
+        run: ctest -C Release
+        if: ${{ always() }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -450,7 +450,7 @@ jobs:
           source .venv/bin/activate
           pip3 install wheel 'conan<2.0' cmake
       - name: "Build basilisk"
-        run: source .venv/bin/activate && python3 conanfile.py
+        run: source .venv/bin/activate && python3 conanfile.py --opNav True
       - name: "Run Python Tests"
         run: |
           source .venv/bin/activate

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -449,7 +449,7 @@ jobs:
         run: |
           source .venv/bin/activate
           cd docs
-          make html
+          make html SPHINXOPTS="-W"
         if: ${{ always() }}
 
   build-macOS-no-vizInterface:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -449,7 +449,8 @@ jobs:
         run: |
           source .venv/bin/activate
           pip3 install wheel 'conan<2.0' cmake
-      - name: "Build basilisk"
+
+      - name: "Build basilisk with OpNav"
         run: source .venv/bin/activate && python3 conanfile.py --opNav True
       - name: "Run Python Tests"
         run: |
@@ -466,4 +467,19 @@ jobs:
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
         run: ctest -C Release
+        if: ${{ always() }}
+
+      - name: "Build basilisk without vizInterface"
+        run: source .venv/bin/activate && python3 conanfile.py --clean --vizInterface False
+      - name: "Run Python Tests"
+        run: |
+          source .venv/bin/activate
+          cd src
+          pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
+      - name: "Upload pytest test results"
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-macOS-no-vizInterface-${{ matrix.python-version }}
+          path: junit/test-results-no-vizInterface-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
       - id: file_changes
         uses: tj-actions/changed-files@v44
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -416,27 +416,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache conan packages
-        id: cache-conan
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-conan-packages-macOS
-        with:
-          # conan cache files are stored in `~/.conan` on Linux/macOS
-          path: ~/.conan
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-      - name: Cache pip modules
-        id: cache-pip
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-pip-modules
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - name: Install Homebrew
         run: |
@@ -452,17 +431,12 @@ jobs:
 
       - name: "Build basilisk with OpNav"
         run: source .venv/bin/activate && python3 conanfile.py --opNav True
+
       - name: "Run Python Tests"
         run: |
           source .venv/bin/activate
           cd src
           pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
-      - name: "Upload pytest test results"
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results-macOS-${{ matrix.python-version }}
-          path: junit/test-results-${{ matrix.python-version }}.xml
-        # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
@@ -476,16 +450,11 @@ jobs:
           source .venv/bin/activate
           cd src
           pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
-      - name: "Upload pytest test results"
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results-macOS-no-vizInterface-${{ matrix.python-version }}
-          path: junit/test-results-no-vizInterface-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
   build-macOS-no-vizInterface:
-    name: Build macOS
+    name: Build macOS no vizInterface
     runs-on: macos-14
     strategy:
       matrix:
@@ -501,27 +470,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache conan packages
-        id: cache-conan
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-conan-packages-macOS-no-vizInterface
-        with:
-          # conan cache files are stored in `~/.conan` on Linux/macOS
-          path: ~/.conan
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-      - name: Cache pip modules
-        id: cache-pip
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-pip-modules
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - name: Install Homebrew
         run: |
@@ -542,10 +490,5 @@ jobs:
           source .venv/bin/activate
           cd src
           pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
-      - name: "Upload pytest test results"
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-results-macOS-no-vizInterface-${{ matrix.python-version }}
-          path: junit/test-results-no-vizInterface-${{ matrix.python-version }}.xml
-        # Use always() to always run this step to publish test results when there are test failures
+
         if: ${{ always() }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -420,7 +420,7 @@ jobs:
       - name: Install Homebrew
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install swig
+          brew install swig doxygen
 
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
@@ -430,7 +430,7 @@ jobs:
           pip3 install wheel 'conan<2.0' cmake
 
       - name: "Build basilisk with OpNav"
-        run: source .venv/bin/activate && python3 conanfile.py --opNav True
+        run: source .venv/bin/activate && python3 conanfile.py --opNav True --allOptPkg
 
       - name: "Run Python Tests"
         run: |
@@ -445,12 +445,20 @@ jobs:
 
       - name: "Build basilisk without vizInterface"
         run: source .venv/bin/activate && python3 conanfile.py --clean --vizInterface False
+
       - name: "Run Python Tests"
         run: |
           source .venv/bin/activate
           cd src
           pytest -n auto -m "not ciSkip" --junitxml=../junit/test-results-${{ matrix.python-version }}.xml
         # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+
+      - name: "Build Documentation"
+        run: |
+          source .venv/bin/activate
+          cd docs
+          make html
         if: ${{ always() }}
 
   build-macOS-no-vizInterface:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,7 +27,7 @@ clean :
 view:
 	    # works on macOS
 		open build/html/index.html
-	
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -50,6 +50,8 @@ Version |release|
   and as a data structure inside modules.  The use of ``classicElements()`` is now depreciated
   for the use of ``ClassicElements()`` defined in :ref:`orbitalMotionutilities`.
 - Added ``packaging>=22`` dependency for installing Basilisk to solve an incompatibility issue with ``setuptools``.
+- Added support for macOS to the CI test builds, including opNav
+- Added CI support to build and test Basilisk documentation on the GitHub macOS platform
 
 
 Version 2.4.0 (August 23, 2024)

--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -323,8 +323,9 @@ Press 'z' to stop the simulation."""
         alt = np.linalg.norm(currState.r_BN_N) - planet.radEquator
         velNorm = np.linalg.norm(currState.v_BN_N)
 
-        hudpanel.displayString = f"HUD\nAltitude: {alt/1000:.2f} km\nInertial Velocity: {velNorm/1000:.2f} km/s"
-        viz.vizEventDialogs.append(hudpanel)
+        if vizSupport.vizFound:
+            hudpanel.displayString = f"HUD\nAltitude: {alt/1000:.2f} km\nInertial Velocity: {velNorm/1000:.2f} km/s"
+            viz.vizEventDialogs.append(hudpanel)
 
         # Here, I only want to run a single BSK timestep before checking for user responses.
         incrementalStopTime += simulationTimeStep


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The CI server tests did not include a test on macOS, nor did we build with `opNav` flag or build the BSK documentation.  This branch now builds on macOS the full Basilisk software with `opNav` modules and scenarios included.  We also build now the Basilisk documentation where we treat any warnings of wrong links, etc., as errors and the CI test will fail.  The documentation needs to build without warnings.

Further, a second macOS build is done where `vizInterface` build option is turned off.  This allows us to check if BSK scripts and test pass, or are correctly skipped, if the `vizInterface` module is not built.

## Verification
All the pull request actions complete as expected and without errors.

## Documentation
Added release notes

## Future work
Still need to work on adding `opNav` support to Linux and Windows CI tests.  Further, want to add the ability to build the documentation automatically when a PR is merged with `develop`.