### PR TITLE
Fix incompatibility due to old versions of `packaging`.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -129,6 +129,7 @@ class BasiliskConan(ConanFile):
             "conan>=1.40.1, <2.00.0",
             "setuptools>=70.1.0",
             "setuptools-scm>=8.0",
+            "packaging>=22",
             "cmake>=3.26",
         ]
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -21,6 +21,9 @@ Version |release|
 - :ref:`vizInterface` was not able to save to a binary data file.
   This is now fixed in the current release.
 - :ref:`vizInterface` was not saving the Vizard settings to the binary file.  Fixed now.
+- Installing Basilisk 2.4.0 while ``packaging<22`` is installed can lead to an incompatibility and raise a
+  "TypeError: ``canonicalize_version()`` got an unexpected keyword argument ``strip_trailing_zero``" error.
+  Newer versions of Basilisk now upgrade ``packaging>=22`` to solve this issue.
 
 
 Version 2.4.0

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -48,6 +48,7 @@ Version |release|
 - Untangled :ref:`ClassicElementsMsgPayload` which was used both as a message payload definition
   and as a data structure inside modules.  The use of ``classicElements()`` is now depreciated
   for the use of ``ClassicElements()`` defined in :ref:`orbitalMotionutilities`.
+- Added ``packaging>=22`` dependency for installing Basilisk to solve an incompatibility issue with ``setuptools``.
 
 
 Version 2.4.0 (August 23, 2024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [
     "setuptools>=70.1.0",   # Required for "bdist_wheel" to work correctly.
     "setuptools-scm>=8.0",  # Automatically include all Git-controlled files in sdist
+    "packaging>=22",        # Due to incompatibility: https://github.com/pypa/setuptools/issues/4483
 
     # Requirements for building Basilisk through conanfile
     "conan>=1.40.1, <2.00.0",


### PR DESCRIPTION
* **Review:** By file <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->

Fixes a compatibility issue between the newer `setuptools>71` (as introduced by https://github.com/AVSLab/basilisk/pull/778) and `packaging<22`. This is fixed by adding `packaging>=22` as an additional build dependency.

Refer to https://github.com/pypa/setuptools/issues/4483 for details.

Note: this issue affects only installations in editable mode (as done by `python conanfile.py`). It does not affect `pip install .` installations.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
Steps to reproduce the behavior:
1. `pip install "packaging<22"`
2. `python conanfile.py`
3. See error: "TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'"

With this fix, `packaging` is upgraded automatically and the build works.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
Not required.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
Not required.