### PR TITLE
Error on creating message recorders

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,6 +56,8 @@ Version |release|
 - Made sure that :ref:`astroFunctions` and :ref:`simIncludeGravBody` now all pull from the same set of
   astronautical data in :ref:`astroConstants`.  These tools now all use a consisten set of planet data
   referenced from NASA sources.
+- If ``messaging`` was not imported then the msg ``recorder()`` modules couldn't be setup.  Now
+  ``messaging`` is imported as part of the Basilisk package so the ``recorder()`` modules always work.
 
 
 Version 2.4.0 (August 23, 2024)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ Architecture
 
 .. sidebar:: Basilisk Info
 
-    .. image:: _images/static/Basilisk-Logo.svg
+    .. image:: _images/static/Basilisk-Logo.png
        :align: center
        :width: 300
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -648,9 +648,11 @@ file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Basilisk/ExternalModules")
 if(WIN32 AND (Python3_VERSION VERSION_GREATER 3.8))
   file(WRITE "${CMAKE_BINARY_DIR}/Basilisk/__init__.py"
        "#init file written by the build\n" "import sys, os\n" "from Basilisk import __path__\n"
-       "bskPath = __path__[0]\n" "os.add_dll_directory(bskPath)\n")
+       "bskPath = __path__[0]\n" "os.add_dll_directory(bskPath)\n"
+       "from Basilisk.architecture import messaging\n")
 else()
-  file(WRITE "${CMAKE_BINARY_DIR}/Basilisk/__init__.py" "#empty init file written by the build")
+  file(WRITE "${CMAKE_BINARY_DIR}/Basilisk/__init__.py"
+      "from Basilisk.architecture import messaging # ensure recorders() work without first importing messaging\n")
 endif()
 
 # TODO: Iterate through all dist directories and add __init__.py's where they don't exist

--- a/src/architecture/messaging/_UnitTest/test_MessagingInclude.py
+++ b/src/architecture/messaging/_UnitTest/test_MessagingInclude.py
@@ -1,0 +1,34 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+from Basilisk.moduleTemplates import cppModuleTemplate
+
+def test_messagingInclude(show_plots):
+    """test script to ensure any BSK include has access to messaging"""
+
+    module = cppModuleTemplate.CppModuleTemplate()
+
+    try:
+        dataLog = module.dataOutMsg.recorder()
+    except:
+        assert False, "messaging inclusion test failed"
+
+if __name__ == "__main__":
+    test_messagingInclude(
+        False  # show_plots
+    )

--- a/src/moduleTemplates/cModuleTemplate/cModuleTemplate.c
+++ b/src/moduleTemplates/cModuleTemplate/cModuleTemplate.c
@@ -18,7 +18,7 @@
  */
 /*
     FSW MODULE Template
- 
+
  */
 
 /* modify the path to reflect the new module names */
@@ -59,6 +59,11 @@ void Reset_cModuleTemplate(cModuleTemplateConfig *configData, uint64_t callTime,
     char info[MAX_LOGGING_LENGTH];
     sprintf(info, "Variable dummy set to %f in reset.",configData->dummy);
     _bskLog(configData->bskLogger, BSK_INFORMATION, info);
+
+    /* initialize the output message to zero on reset */
+    CModuleTemplateMsgPayload outMsgBuffer;       /*!< local output message copy */
+    outMsgBuffer = CModuleTemplateMsg_C_zeroMsgPayload();
+    CModuleTemplateMsg_C_write(&outMsgBuffer, &configData->dataOutMsg, moduleID, callTime);
 }
 
 /*! Add a description of what this main Update() routine does for this module
@@ -76,7 +81,7 @@ void Update_cModuleTemplate(cModuleTemplateConfig *configData, uint64_t callTime
     // always zero the output buffer first
     outMsgBuffer = CModuleTemplateMsg_C_zeroMsgPayload();
     v3SetZero(configData->inputVector);
-    
+
     /*! - Read the optional input messages */
     if (CModuleTemplateMsg_C_isLinked(&configData->dataInMsg)) {
         inMsgBuffer = CModuleTemplateMsg_C_read(&configData->dataInMsg);

--- a/src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.cpp
+++ b/src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.cpp
@@ -41,6 +41,10 @@ void CppModuleTemplate::Reset(uint64_t CurrentSimNanos)
     /*! - reset any required variables */
     this->dummy = 0.0;
     bskLogger.bskLog(BSK_INFORMATION, "Variable dummy set to %f in reset.",this->dummy);
+
+    /* zero output message on reset */
+    CModuleTemplateMsgPayload outMsgBuffer={};       /*!< local output message copy */
+    this->dataOutMsg.write(&outMsgBuffer, this->moduleID, CurrentSimNanos);
 }
 
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-791
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Getting any attribute or calling any method of a message object in Python will raise an error if messaging has never been imported from Basilisk.architecture. 
The error raised was not easy to understand.  To make the use of recorder
objects easier, we now include the message package when loading any packages from basilisk.

Added a test to ensure this works as expected.

## Verification
Clean build and all tests pass.

## Documentation
Added release notes

## Future work
None
