### PR TITLE
fix xcode 16 compiler warning

### DIFF
--- a/src/simulation/environment/albedo/albedo.cpp
+++ b/src/simulation/environment/albedo/albedo.cpp
@@ -222,7 +222,7 @@ void Albedo::UpdateState(uint64_t CurrentSimNanos)
     this->albOutData.clear();
     std::vector<SpicePlanetStateMsgPayload>::iterator planetIt;
     int idx;
-    for (size_t instIdx = 0; instIdx < this->albOutMsgs.size(); instIdx++)
+    for (int instIdx = 0; instIdx < (int) this->albOutMsgs.size(); instIdx++)
     {
         idx = 0;
         double tmpTot[4] = {};


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We were doing an implicit variable type conversion.  Return the size of the std::vector as an integer is sufficient for this application.

## Verification
All unit tests pass

## Documentation
None

## Future work
None