### PR TITLE
Add latest linux OS to CI build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,8 +94,8 @@ jobs:
 
 
   build-linux-3-11:
-    name: Linux 22.04 opNav
-    runs-on: ubuntu-22.04
+    name: Linux Latest opNav
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -51,6 +51,7 @@ Version |release|
   for the use of ``ClassicElements()`` defined in :ref:`orbitalMotionutilities`.
 - Added ``packaging>=22`` dependency for installing Basilisk to solve an incompatibility issue with ``setuptools``.
 - Added support for macOS to the CI test builds, including opNav for all three platforms
+- Added CI support to test Linux on latest Ubuntu with opNav
 - Added CI support to build and test Basilisk documentation on the GitHub macOS platform
 - Added new scenario :ref:`scenarioOrbitManeuverTH` to do Hohmann transfer using thrusters
 - Made sure that :ref:`astroFunctions` and :ref:`simIncludeGravBody` now all pull from the same set of


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Specify that CI linux build with the newest python version also uses the latest OS version.

## Verification
All CI test builds continue to pass

## Documentation
Updated release notes

## Future work
None
