### PR TITLE
simIncludeRW didn't allow specify certain RW friction parameters

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -24,7 +24,8 @@ Version |release|
 - Installing Basilisk 2.4.0 while ``packaging<22`` is installed can lead to an incompatibility and raise a
   "TypeError: ``canonicalize_version()`` got an unexpected keyword argument ``strip_trailing_zero``" error.
   Newer versions of Basilisk now upgrade ``packaging>=22`` to solve this issue.
-
+- :ref:`simIncludeRW` didn't allow ``fCoulomb``, ``fStatic`` and ``cViscous`` to be
+  specified even if a prebuilt RW data set is used. This is corrected in the current release.
 
 Version 2.4.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,6 +56,8 @@ Version |release|
 - Made sure that :ref:`astroFunctions` and :ref:`simIncludeGravBody` now all pull from the same set of
   astronautical data in :ref:`astroConstants`.  These tools now all use a consisten set of planet data
   referenced from NASA sources.
+- Updated :ref:`simIncludeRW` to allow values of ``fCoulomb``, ``fStatic`` and ``cViscous`` to be
+  specified even if a prebuilt RW data set is used.
 - If ``messaging`` was not imported then the msg ``recorder()`` modules couldn't be setup.  Now
   ``messaging`` is imported as part of the Basilisk package so the ``recorder()`` modules always work.
 - Added the ability for GitHub to rebuild the BSK documentation each time a branch is merged back into develop.

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
@@ -108,7 +108,19 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
                 ,rWB_B = [0.1,0.,0.]    # m
                 ,maxMomentum = varMaxMomentum
                 ,RWModel= varRWModel
+                ,fCoulomb=10
+                ,fStatic=5
+                ,cViscous=3
+                ,useRWfriction=True
                 )
+        assert rwFactory.rwList["RW1"].fCoulomb == 10, "wasn't able to set custom fCoulomb value"
+        assert rwFactory.rwList["RW1"].fStatic == 5, "wasn't able to set custom fStatic value"
+        assert rwFactory.rwList["RW1"].cViscous == 3, "wasn't able to set custom cViscous value"
+        # reset RW values to continue the test
+        rwFactory.rwList["RW1"].fCoulomb = 0.0
+        rwFactory.rwList["RW1"].fStatic = 0.0
+        rwFactory.rwList["RW1"].cViscous = 0.0
+
         rwFactory.create(
                 'Honeywell_HR16',
                 [0,1,0]                 # gsHat_B
@@ -533,6 +545,6 @@ def test_setJs(show_plots):
 
 
 if __name__ == "__main__":
+    reactionWheelIntegratedTest(True,True,'BalancedWheels')
     # reactionWheelIntegratedTest(True,True,'BalancedWheels')
-    # reactionWheelIntegratedTest(True,True,'BalancedWheels')
-    test_setJs(False)
+    # test_setJs(False)

--- a/src/utilities/simIncludeRW.py
+++ b/src/utilities/simIncludeRW.py
@@ -142,24 +142,6 @@ class rwFactory(object):
             varMaxPower = -1.0              # default value turns off max power limit
         RW.P_max = varMaxPower
 
-        if 'fCoulomb' in kwargs:
-            varfCoulomb = kwargs['fCoulomb']
-            if not isinstance(varfCoulomb, float):
-                print('ERROR: fCoulomb must be a FLOAT argument')
-                exit(1)
-        else:
-            varfCoulomb = 0.0       # default value
-        RW.fCoulomb = varfCoulomb
-
-        if 'fStatic' in kwargs:
-            varfStatic = kwargs['fStatic']
-            if not isinstance(varfStatic, float):
-                print('ERROR: fStatic must be a FLOAT argument')
-                exit(1)
-        else:
-            varfStatic = 0.0       # default value
-        RW.fStatic = varfStatic
-
         if 'betaStatic' in kwargs:
             varbetaStatic = kwargs['betaStatic']
             if not isinstance(varbetaStatic, float):
@@ -171,15 +153,6 @@ class rwFactory(object):
         else:
             varbetaStatic = -1.0       # default value turns off Stribeck friction model
         RW.betaStatic = varbetaStatic
-
-        if 'cViscous' in kwargs:
-            varcViscous =  kwargs['cViscous']
-            if not isinstance(varcViscous, float):
-                print('ERROR: cViscous must be a FLOAT argument')
-                exit(1)
-        else:
-            varcViscous = 0.0       # default value
-        RW.cViscous = varcViscous
 
         # set device label name
         if 'label' in kwargs:
@@ -200,6 +173,24 @@ class rwFactory(object):
         except:
             print('ERROR: RW type ' + rwType + ' is not implemented')
             exit(1)
+
+        if 'fCoulomb' in kwargs:
+            RW.fCoulomb = kwargs['fCoulomb']
+            if not isinstance(RW.fCoulomb, float):
+                print('ERROR: fCoulomb must be a FLOAT argument')
+                exit(1)
+
+        if 'fStatic' in kwargs:
+            RW.fStatic = kwargs['fStatic']
+            if not isinstance(RW.fStatic, float):
+                print('ERROR: fStatic must be a FLOAT argument')
+                exit(1)
+
+        if 'cViscous' in kwargs:
+            RW.cViscous =  kwargs['cViscous']
+            if not isinstance(RW.cViscous, float):
+                print('ERROR: cViscous must be a FLOAT argument')
+                exit(1)
 
         if 'u_min' in kwargs:
             varu_min = kwargs['u_min']


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When using `simIncludeRW.py` the user can specify custom ``fCoulomb``, ``fStatic`` and ``cViscous`` values. However, if the RW templates also specify these the custom values were overwritten.  


## Verification
All tests pass.  Expanded RW unit test to check if a custom friction value is set and retained.

## Documentation
Updated release notes and known issues document.

## Future work
None
