### PR TITLE
Add pause function to 2-way scenario

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -36,6 +36,7 @@ Version  |release|
   other CI systems to use these wheels for testing with Basilisk as a dependency.
 - updated README file.  Links now point to local documentation instead of to the pages
   on the AVS lab web page that used to host the documentation.
+- Updated :ref:`scenarioBasicOrbitStream` to add the ability to pause and resume the live BSK stream
 
 Version 2.5.0 (Sept. 30, 2024)
 ------------------------------

--- a/docs/source/Vizard/vizardAdvanced/vizardLiveComm.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardLiveComm.rst
@@ -424,3 +424,14 @@ To use the ``noDisplay`` flag:
 	viz = vizSupport.enableUnityVisualization(scSim, dynTaskName, scObject
                                               , noDisplay=True
                                               )
+
+
+Pausing/Exiting a Scenario
+==========================
+In some instances, it is convenient to have the ability to pause a BSK scenario that is connected to Vizard in ``liveStream`` mode. We can take advantage of the existing Vizard key listener for this behavior.
+
+It is important to still call the ``UpdateState()`` method for the ``vizInterface`` module while paused, which allows for the 'unpause' response to be acknowledged. Any panel responses or other Vizard inputs will still be received and processed, and will immediately take effect once unpaused.
+
+Additionally, repeatedly resetting the ``clock_sync`` module while paused keeps the visualization from trying to 'catch up' once unpaused.
+
+See :ref:`scenarioBasicOrbitStream` for an implementation that pauses/unpauses the scenario using the ``<p>`` key and cleanly quits the scenario using ``<z>``.

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -33,6 +33,9 @@ try:
 except ImportError:
     vizFound = False
 
+pauseFlag = False
+endFlag = False
+
 bskPath = __path__[0]
 
 firstSpacecraftName = ''


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Vizard key listener configured to set pause flag, which skips ExecuteSimulation() call. Keeps vizInterface module updating while paused in order to: 
1) allow broadcast users to connect
2) listen for the unpause key
3) process panel responses and keyboard inputs that enact immediately once unpaused

Continually resets clock_sync module to keep Vizard from accelerating to catch up after unpause. 
Can press 'z' to cleanly end scenario, even while paused.

## Verification
Manual live-stream testing

## Documentation
Updated vizardLiveComm page to discuss logic needed to handle pausing

## Future work
None
