### PR TITLE
Fix RPATH when installing from source for macOS

### DIFF
--- a/docs/source/Install/pipInstall.rst
+++ b/docs/source/Install/pipInstall.rst
@@ -61,6 +61,14 @@ The main benefit of this approach will come in the future, when a set of pre-com
 allowing most users to easily ``pip install Basilisk`` without compilation, in the same way that packages like
 ``numpy``, ``scipy``, and ``pandas`` are available.
 
+Alternatively, if you download a zip'd folder of the Basilisk source code you can install it via ``pip``
+using::
+
+    pip install Basilisk*.tar.gz
+
+The following command is used to both download the code and compile Basilisk with pip::
+
+    pip install git+https://github.com/AVSLab/basilisk.git
 
 Wheel Compatibility
 -------------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -37,6 +37,8 @@ Version  |release|
 - updated README file.  Links now point to local documentation instead of to the pages
   on the AVS lab web page that used to host the documentation.
 - Updated :ref:`scenarioBasicOrbitStream` to add the ability to pause and resume the live BSK stream
+- Added documenation on installing with ``pip`` via source code in :ref:`pipInstall`
+
 
 Version 2.5.0 (Sept. 30, 2024)
 ------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = []  # XXX: Leave blank, populated automatically by setup.py.
 include-package-data = true
 
 [tool.setuptools.package-data]
-"*" = ["*.so", "*.dll", "*.lib", "*.pyd"]  # Include all built objects.
+"*" = ["*.so", "*.dll", "*.lib", "*.pyd", "*.a", "*.dylib"]  # Include all built objects.
 Basilisk = ["supportData/**/*"]            # Include all support data.
 
 [tool.setuptools.dynamic]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -487,7 +487,14 @@ elseif(APPLE)
   set(CMAKE_SKIP_BUILD_RPATH FALSE) # use, i.e. don't skip the full RPATH for the build tree
   set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE) # when building, don't use the install RPATH already (but later on when
                                            # installing)
-  set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/Basilisk") # the RPATH to be used when installing
+  set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/Basilisk"  # the RPATH to be used when installing
+      # Also add relative paths so we can install from wheel/sdist.
+      # TODO: Is there a proper way to set relative library paths without just
+      # guessing how many parent ".." directories to use?
+      "@loader_path"
+      "@loader_path/.."
+      "@loader_path/../.."
+  )
 
   # don't add the automatically determined parts of the RPATH which point to directories outside the build tree to the
   # install RPATH


### PR DESCRIPTION
* **Tickets addressed:** #826 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The fix described in #826 which guesses the correct RPATH (similar to how it works on Linux) was implemented.

## Verification

Tested:

* Installing from git repo link
* Installing from source tarball
* Installing from a sdist hosted on our internal package repository

## Documentation
None

## Future work
None
