### PR TITLE
Add SPICE module to scenarioOrbitManeuver scenario

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -38,6 +38,7 @@ Version  |release|
   on the AVS lab web page that used to host the documentation.
 - Updated :ref:`scenarioBasicOrbitStream` to add the ability to pause and resume the live BSK stream
 - Added documenation on installing with ``pip`` via source code in :ref:`pipInstall`
+- Updated :ref:`scenarioOrbitManeuver` to include a SPICE module that rotates the Earth
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/examples/scenarioOrbitManeuver.py
+++ b/examples/scenarioOrbitManeuver.py
@@ -158,13 +158,21 @@ def run(show_plots, maneuverCase):
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
 
-    # setup Gravity Body
+    # setup Gravity Body and SPICE definitions
     gravFactory = simIncludeGravBody.gravBodyFactory()
     earth = gravFactory.createEarth()
     earth.isCentralBody = True  # ensure this is the central gravitational body
 
     # attach gravity model to spacecraft
     gravFactory.addBodiesTo(scObject)
+
+    # setup spice library for Earth ephemeris
+    timeInitString = "2024 September 21, 21:00:00.0 TDB"
+    spiceObject = gravFactory.createSpiceInterface(time=timeInitString, epochInMsg=True)
+    spiceObject.zeroBase = 'Earth'
+
+    # need spice to run before spacecraft module as it provides the spacecraft translational states
+    scSim.AddModelToTask(simTaskName, spiceObject)
 
     #
     #   setup orbit and simulation time
@@ -290,6 +298,9 @@ def run(show_plots, maneuverCase):
     # run simulation for 3rd chunk
     scSim.ConfigureStopTime(simulationTime + T2 + T3)
     scSim.ExecuteSimulation()
+
+    # unload Spice kernel
+    gravFactory.unloadSpiceKernels()
 
     #
     #   retrieve the logged data


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adding spice module into scenarioOrbitManeuver.py scenario, to enable Earth rotation

## Verification
Manual testing, Earth spinning in Vizard. Matches implementation in scenarioSpiceSpacecraft.py

## Documentation
No updates

## Future work
None
