### PR TITLE
Flush vizInterface outputStream buffer when saving to file

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -40,6 +40,7 @@ Version  |release|
 - Added documenation on installing with ``pip`` via source code in :ref:`pipInstall`
 - Updated :ref:`scenarioOrbitManeuver` to include a SPICE module that rotates the Earth
 - Changed the way polyhedron gravity is computed to be more computationally efficient
+- Updated :ref:`vizInterface` to flush the output buffer when saving binary files to avoid truncation
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1219,6 +1219,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
         if (!this->saveFile  || !message->SerializeToOstream(this->outputStream)) {
             return;
         }
+        this->outputStream->flush();
     }
 
     delete message;


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
When saving vizMessages to a binary file through vizInterface, the outputStream buffer was not being emptied fully. This led to early file truncation. Explicitly flushing the buffer after each sim step resolves this issue.

## Verification
Manual inspection of saved binaries, using protobuffer test scenario which will be pushed in a future branch.

## Documentation
Updated release notes

## Future work
None
