### PR TITLE
Update scenarios to include YouTube videos

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -52,6 +52,8 @@ Version  |release|
 - Removed the now deprecated ``datashader_utilities.py`` in favor of the new bokeh plotting features in ``AnalysisBaseClass.py``
 - Upgraded protoc compiler to v3.20.0, added ``protobuf`` to optional package install list
 - Created unit tests for protobuffer packing and saving in :ref:`vizInterface`
+- Added YouTube video links of Vizard illustrating the :ref:`scenarioFlexiblePanel` and
+  :ref:`scenarioRoboticArm` scenarios.
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/examples/scenarioFlexiblePanel.py
+++ b/examples/scenarioFlexiblePanel.py
@@ -40,6 +40,17 @@ comprehensive Vizard simulation which creates an appropriate to-scale model for 
 Illustration of Simulation Results
 ----------------------------------
 
+.. raw:: html
+
+   <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;
+   max-width: 100%; height: auto;">
+        <iframe src="https://www.youtube.com/embed/kbcqUD4MW9c?si=B09rp8jm_m9pbsra"
+        style="position: absolute;
+        top: 0; left: 0; width: 100%; height: 100%;" frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media;
+        gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+
 .. image:: /_images/Scenarios/scenarioFlexiblePanel_theta.svg
    :align: center
 

--- a/examples/scenarioRoboticArm.py
+++ b/examples/scenarioRoboticArm.py
@@ -40,6 +40,17 @@ to-scale model for the defined scenario.
 Illustration of Simulation Results
 ----------------------------------
 
+.. raw:: html
+
+   <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;
+   max-width: 100%; height: auto;">
+        <iframe src="https://www.youtube.com/embed/4mMCCTVHZkA?si=L3Pj9dfy7a8DSwjQ"
+        style="position: absolute;
+        top: 0; left: 0; width: 100%; height: 100%;" frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media;
+        gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+
 .. image:: /_images/Scenarios/scenarioRoboticArm_theta.svg
    :align: center
 

--- a/examples/scenarioRotatingPanel.py
+++ b/examples/scenarioRotatingPanel.py
@@ -20,7 +20,7 @@ r"""
 Overview
 --------
 
-This scenario demonstrates how to set up a spacecraft spacecraft with rotating panel.  A
+This scenario demonstrates how to set up a spacecraft with rotating panel.  A
 :ref:`coarseSunSensor` is then
 attached onto this panel such that it's bore-sight axis rotates with the panel.  Further, the panel state
 message is connected to :ref:`simpleSolarPanel`.


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The BSK YouTube video channel contained two Vizard illustration videos of `scenarioRoboticArm.py` and `scenarioFlexiblePanel.py` scenario links.  However, the RST documentation did not include a link to these videos.  This is now corrected.

## Verification
Did a clean documentation build and everything displayed as expected.

## Documentation
Updated release notes

## Future work
None