### PR TITLE
vizInterface unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ supportData/*/__init__.py
 src/utilities/vizProtobuffer/__init__.py
 src/utilities/vizProtobuffer/vizMessage.pb.cc
 src/utilities/vizProtobuffer/vizMessage.pb.h
+src/utilities/vizProtobuffer/vizMessage_pb2.py
 externalTools/fswAuto/autosetter/sets/*
 externalTools/fswAuto/autowrapper/wraps/*
 **/outputFiles/*

--- a/conanfile.py
+++ b/conanfile.py
@@ -191,7 +191,7 @@ class BasiliskConan(ConanFile):
             self.requires.add("xz_utils/5.4.0")
 
         if self.options.vizInterface or self.options.opNav:
-            self.requires.add("protobuf/3.17.1")
+            self.requires.add("protobuf/3.20.0")
             self.options['zeromq'].encryption = False  # Basilisk does not use data streaming encryption.
             self.requires.add("cppzmq/4.5.0")
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -50,6 +50,8 @@ Version  |release|
 - Updated :ref:`scenarioMonteCarloAttRW` to use more pythonic OOP for Monte Carlo data retention
 - Updated :ref:`scenarioMonteCarloSpice` to use more pythonic OOP for Monte Carlo data retention
 - Removed the now deprecated ``datashader_utilities.py`` in favor of the new bokeh plotting features in ``AnalysisBaseClass.py``
+- Upgraded protoc compiler to v3.20.0, added ``protobuf`` to optional package install list
+- Created unit tests for protobuffer packing and saving in :ref:`vizInterface`
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -7,3 +7,4 @@ pre-commit
 clang-format
 bokeh
 dask-expr
+protobuf==5.27.0

--- a/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
+++ b/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
@@ -1,0 +1,316 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+#   Unit Test Script
+#   Module Name:        vizInterface
+#   Author:             Jack Fox
+#   Creation Date:      November 4, 2024
+#
+
+import inspect
+import os
+import pytest
+import numpy as np
+
+# Protobuffer specific
+try:
+    import vizMessage_pb2
+    import google.protobuf.internal.decoder as decoder
+    protoFound = True
+except ModuleNotFoundError:
+    protoFound = False
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+
+# Import all modules that are going to be called in this simulation
+from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport,
+                                vizSupport, simIncludeThruster)
+from Basilisk.simulation import spacecraft
+from Basilisk.architecture import messaging
+from Basilisk.simulation import thrusterDynamicEffector
+import pytest
+import time
+try:
+    from Basilisk.simulation import vizInterface
+except ImportError:
+    pass
+
+
+# Uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed.
+# @pytest.mark.skipif(conditionstring)
+# Uncomment this line if this test has an expected failure, adjust message as needed.
+# @pytest.mark.xfail(conditionstring)
+# Provide a unique test method name, starting with 'test_'.
+# The following 'parametrize' function decorator provides the parameters and expected results for each
+# of the multiple test runs for this test.  Note that the order in that you add the parametrize method
+# matters for the documentation in that it impacts the order in which the test arguments are shown.
+# The first parametrize arguments are shown last in the pytest argument list
+@pytest.mark.parametrize("accuracy", [1e-8])
+def test_vizInterface(show_plots, accuracy):
+    r"""
+    **Validation Test Description**
+
+    This unit test script tests the vizInterface module. Though this module is largely hand-tested due to its
+    interactive nature, this script tests the packed protobuffers that are produces in the saved binary file to ensure
+    all elements are captured as expected.
+
+    **Test Parameters**
+
+    Args:
+        accuracy (float): absolute accuracy value used in the validation tests
+
+    """
+    [testResults, testMessage] = vizInterfaceTest(show_plots, accuracy)
+    assert testResults < 1, testMessage
+
+
+def vizInterfaceTest(show_plots, accuracy):
+    testFailCount = 0  # zero unit test result counter
+    testMessages = []  # create empty list to store test log messages
+
+    # Early quit if protobuf or Vizard not configured
+    if not protoFound or not vizSupport.vizFound:
+        return [testFailCount, ''.join(testMessages)]
+
+    # Create simulation variable names
+    unitTaskName = "unitTask"  # arbitrary name (don't change)
+    unitProcessName = "TestProcess"  # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    #
+    # Create the simulation process
+    #
+    testProcessRate = macros.sec2nano(1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    frames = 10
+    simulationTime = macros.sec2nano(frames)
+
+    #
+    # Set up the simulation tasks/objects
+    #
+
+    # Create the spacecraft object
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "testSat"
+    # Add spacecraft object to the simulation process
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+
+    # Setup Gravity Body
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    planet = gravFactory.createEarth()
+    planet.isCentralBody = True
+    mu = planet.mu
+    # Attach gravity model to spacecraft
+    gravFactory.addBodiesTo(scObject)
+
+    #
+    # Set up orbit
+    #
+    oe = orbitalMotion.ClassicElements()
+    rGEO = 42000. * 1000  # meters
+    oe.a = rGEO
+    oe.e = 0.00001
+    oe.i = 0.0 * macros.D2R
+    oe.Omega = 0 * macros.D2R
+    oe.omega = 0 * macros.D2R
+    oe.f = 0 * macros.D2R
+    rN, vN = orbitalMotion.elem2rv(mu, oe)
+    oe = orbitalMotion.rv2elem(mu, rN, vN)
+
+    #
+    # Initialize Spacecraft States with the initialization variables
+    #
+    scObject.hub.r_CN_NInit = rN                   # m   - r_BN_N
+    scObject.hub.v_CN_NInit = vN                   # m/s - v_BN_N
+    scObject.hub.omega_BN_BInit = (0.1, 0.2, 0.3)  # rad/s - sigma_BN
+
+    # Create spacecraft data container
+    scData = vizInterface.VizSpacecraftData()
+    scData.spacecraftName = scObject.ModelTag
+    scData.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
+
+    samplingTime = unitTestSupport.samplingTime(simulationTime, testProcessRate, 100)
+
+    # Create data recorders
+    scState_dataRec = scObject.scStateOutMsg.recorder(samplingTime)
+    unitTestSim.AddModelToTask(unitTaskName, scState_dataRec)
+
+    sName = "testVizInterface"
+    viz = vizSupport.enableUnityVisualization(unitTestSim, unitTaskName, scObject
+                                              , saveFile=sName)
+
+    viz.settings.orbitLinesOn = 1
+    viz.settings.spacecraftCSon = 1
+    viz.settings.keyboardLiveInput = "abcd"
+
+    #
+    #   Initialize/execute simulation
+    #
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(simulationTime)
+    unitTestSim.ExecuteSimulation()
+
+    # Read in binary save file, parse message list
+    msgList = read_protobuf_messages("./_VizFiles/" + sName + "_UnityViz.bin")
+
+    # Assert file size
+    assert len(msgList) == frames, "File is missing messages"
+
+    # Check spacecraft states (pos, vel, rot)
+    checkSpacecraftStates(msgList, scState_dataRec, accuracy)
+
+    # Check celestial bodies
+    checkCelestialBodies(msgList)
+
+    # Check settings
+    checkSettings(msgList, testProcessRate)
+
+    # Delete binary file
+    os.remove("./_VizFiles/" + sName + "_UnityViz.bin")
+
+    # Each test method requires a single assert method to be called
+    # This check below just makes sure no subtest failures were found
+    return [testFailCount, ''.join(testMessages)]
+
+
+# Parses varint from file
+def read_varint(file):
+    """Reads a varint from the file."""
+    varint_buffer = []
+    while True:
+        byte = file.read(1)
+        if not byte:
+            raise EOFError("Unexpected end of file while reading varint.")
+        varint_buffer.append(byte)
+        # If the highest bit is 0, this is the last byte of the varint.
+        if ord(byte) < 0x80:
+            break
+    # Convert the list of bytes into a bytes object.
+    varint_bytes = b"".join(varint_buffer)
+    # Decode the varint from the bytes object.
+    message_size, _ = decoder._DecodeVarint32(varint_bytes, 0)
+    return message_size
+
+
+# Parses protobuffer messages from binary file
+def read_protobuf_messages(fname):
+    messages = []
+    with open(fname, 'rb') as f:
+        while True:
+            try:
+                # Read the varint that indicates the message size.
+                message_size = read_varint(f)
+
+                # Now read the serialized message based on the decoded size.
+                serialized_message = f.read(message_size)
+                if len(serialized_message) != message_size:
+                    raise EOFError("File ended unexpectedly while reading a message.")
+
+                # Parse the message into a Protobuf object.
+                message = vizMessage_pb2.VizMessage()
+                message.ParseFromString(serialized_message)
+
+                # Append the parsed message to the list.
+                messages.append(message)
+
+            except EOFError:
+                # Break the loop if we reach the end of the file.
+                break
+
+    return messages
+
+
+# Checks spacecraft states between data recorder and saved binary
+def checkSpacecraftStates(msgList, scState_dataRec, accuracy):
+
+    r_BN_N = scState_dataRec.r_BN_N
+    v_BN_N = scState_dataRec.v_BN_N
+    sigma_BN = scState_dataRec.sigma_BN
+
+    n = len(msgList)
+
+    for i in range(n):
+        msg_i = msgList[i]
+        # Num spacecraft check
+        assert len(msg_i.spacecraft) == 1, "Number of spacecraft mismatch"
+        # Position check
+        protoPos = msg_i.spacecraft[0].position
+        recPos = r_BN_N[i+1][0:3]
+        assert np.isclose(protoPos, recPos, 0, accuracy).all(), "Position mismatch"
+        # Velocity check
+        protoVel = msg_i.spacecraft[0].velocity
+        recVel = v_BN_N[i+1][0:3]
+        assert np.isclose(protoVel, recVel, 0, accuracy).all(), "Velocity mismatch"
+        # Rotation check
+        protoRot = msg_i.spacecraft[0].rotation
+        recRot = sigma_BN[i+1][0:3]
+        assert np.isclose(protoRot, recRot, 0, accuracy).all(), "Rotation mismatch"
+
+
+# Checks number of celestial bodies and central body pos/vel
+def checkCelestialBodies(msgList):
+    n = len(msgList)
+    for i in range(n):
+        msg_i = msgList[i]
+        # Number of celestial bodies check
+        assert len(msg_i.celestialBodies) == 1, "Celestial bodies mismatch"
+        # Central body checks
+        assert msg_i.celestialBodies[0].position == [0.0, 0.0, 0.0], "Celestial body position mismatch"
+        assert msg_i.celestialBodies[0].velocity == [0.0, 0.0, 0.0], "Celestial body velocity mismatch"
+
+
+# Checks for settings message at first timestep, validates contents
+def checkSettings(msgList, testProcessRate):
+    n = len(msgList)
+    for i in range(n):
+        msg_i = msgList[i]
+
+        assert msg_i.currentTime.frameNumber == i+1, "Frame number is incorrect"
+        assert msg_i.currentTime.simTimeElapsed == testProcessRate*(i+1), "Sim time elapsed is incorrect"
+
+        if i == 0:
+            # Check for settings
+            assert msg_i.HasField("settings"), "Should have settings message at first timestep"
+            assert msg_i.HasField("epoch"), "Should have epoch message at first timestep"
+            # Validate specific settings
+            assert msg_i.settings.orbitLinesOn == 1, "Orbit lines not on"
+            assert msg_i.settings.spacecraftCSon == 1, "Spacecraft CS not on"
+            assert msg_i.settings.keyboardLiveInput == "abcd", "Incorrect key listeners"
+        else:
+            # Check for absence of settings
+            assert not msg_i.HasField("settings"), "Should only have settings message at first timestep"
+
+
+#
+# Run this unitTest as a stand-along python script
+#
+if __name__ == "__main__":
+    test_vizInterface(
+        False,  # show_plots
+        1e-8    # accuracy
+    )

--- a/src/utilities/vizProtobuffer/CMakeLists.txt
+++ b/src/utilities/vizProtobuffer/CMakeLists.txt
@@ -16,11 +16,12 @@ if(BUILD_VIZINTERFACE)
          get_filename_component(PROTO_TARGET "${PROTO_DEF}" NAME_WE)
 
          add_custom_command(
-             OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_TARGET}.pb.cc" "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_TARGET}.pb.h"
+             OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_TARGET}.pb.cc" "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_TARGET}.pb.h" "${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_TARGET}_pb2.py"
              COMMAND "${PROTOC_EXE}" "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}" "--cpp_out=${CMAKE_CURRENT_SOURCE_DIR}" "${PROTO_DEF}"
+             COMMAND "${PROTOC_EXE}" "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}" "--python_out=${CMAKE_CURRENT_SOURCE_DIR}" "${PROTO_DEF}"
              DEPENDS "${PROTO_DEF}"
              WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-             COMMENT "Generating protobuf (C++): ${PROTO_TARGET}"
+             COMMENT "Generating protobuf (C++, Python): ${PROTO_TARGET}"
          )
 
          message(STATUS "Defining protobuf interface library target: ${PROTO_TARGET}")

--- a/src/utilities/vizProtobuffer/vizMessage.proto
+++ b/src/utilities/vizProtobuffer/vizMessage.proto
@@ -2,6 +2,10 @@
  * Basilisk Sim to an external visualization application.
  * To generate the asscociate files for C++, run from a terminal window
  * protoc --cpp_out=./ vizMessage.proto
+ * To generate the asscociate files for C#, run from a terminal window
+ * protoc --csharp_out=./ vizMessage.proto
+ * To generate the associate files for Python, run from a terminal window
+ * protoc --python_out=./ vizMessage.proto
  *
  * If you get an error about not finding protoc, then you need to install the protobuffer compiler first.
  * see http://google.github.io/proto-lens/installing-protoc.html


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This branch creates a unit test for vizInterface, validating the performance of the protobuffer packing and file saving functions.

- Updated cmake to generate Python support file for vizMessage.proto
- Upgraded protoc compiler to stable release version 3.20.0. Added Python protobuf install to optional packages (required for test script).
- Created unit test which configures and executes a short scenario, saves to a binary file, then reads the file back in to evaluate. Only runs if vizInterface and protobuf are installed and configured.

## Verification
test_vizInterface.py 
Asserts that:
- Number of messages in binary matches number of simulated frames
- All spacecraft position, velocity, and rotation states match between binary file and message recorder, to specified accuracy
- Number of celestial bodies == 1, and position/velocity is 0 (since Earth is set to central body)
- Frame number and sim elapsed time match expected
- Settings message is present at first frame and not at any other frame (won't show up again in the binary since it is stripped away between broadcast and saving)
- Settings values including orbitLinesOn, spacecraftCSon, and keyboardLiveInput match expected
- Epoch message is present at first timestep

Binaries created with new protoc compiler are backwards compatible with Vizard (tested on Windows/Mac).

## Documentation
No functional BSK changes. Documentation file is auto-generated for test scenarios.

## Future work
Add more components to test scenario to enhance testing