### PR TITLE
fix: (hack) Ensure vizinterface knows about RWModels enum.

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -54,6 +54,8 @@ Version  |release|
 - Created unit tests for protobuffer packing and saving in :ref:`vizInterface`
 - Added YouTube video links of Vizard illustrating the :ref:`scenarioFlexiblePanel` and
   :ref:`scenarioRoboticArm` scenarios.
+- Fixed issue in which reading ``RWModel`` from RW message payloads when :ref:`vizInterface` was also
+  imported would return a Swig Object instead of an enumerated integer.
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/simulation/vizard/vizInterface/vizInterface.i
+++ b/src/simulation/vizard/vizInterface/vizInterface.i
@@ -59,6 +59,16 @@ namespace std {
 %include "vizInterface.h"
 %include "simulation/vizard/_GeneralModuleFiles/vizStructures.h"
 
+// Dan Padilha: Include the reactionWheelSupport to ensure that SWIG knows about the
+// RWModels enum, and can correctly interpret it as an integer and destroy it
+// without leaking memory. This needs to be imported here because of the way
+// that Basilisk is built, which causes copies of types to be scattered across
+// different modules. This means that instead of a model using the correct
+// message type of `Basilisk.architecture.messaging.RWConfigLogMsgPayload`, they
+// use `Basilisk.simulation.vizInterface.RWConfigLogMsgPayload` instead... :(
+// TODO: We should clean up the SWIG build system so such issues don't occur.
+%include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
+
 %include "architecture/msgPayloadDefC/CameraConfigMsgPayload.h"
 struct CameraConfigMsg_C;
 %include "architecture/msgPayloadDefC/RWConfigLogMsgPayload.h"


### PR DESCRIPTION
* **Tickets addressed:** 
* **Review:** By file  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->

Work-around to fix a minor issue when trying to read the `RWModel` value of `RWConfigLogMsgPayload`s when `vizInterface` is also available. Here, Python would interpret RWConfigLogMsgPayloads as actually coming from the `vizinterface` module. However, the `vizinterface` module was not aware of the "RWModels" enum, so SWIG did not know how to interpret it as an integer, nor how to destroy it (leading to some "detected a memory leak of type 'RWModels *'" warnings). With this fix, `RWModels` correctly returns an integer, and the warning disappears.

NOTE: This is not a proper fix, but only works around the issue in the same way we've been doing before. We should really tackle the root cause at some point.

Root cause: This kind of issue is also present in other types, e.g. `SysModel`, seemingly because of how we're copying SWIG types across many modules. For example, the `SysModel` definition re-appears in each individual message module. Fixing this (e.g. such that `SysModel` is only defined in one module) would probably significantly reduce the size of the total compiled Basilisk.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->

I don't really have a minimal way to test this, but basically, when getting the value of a `RWConfigLogMsgPayload`'s `.RWModel`, it was returning a `Swig Object of type 'RWModels *'` instead of an integer. After this fix, it correctly returns an integer.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->

## Future work
<!-- What next steps can we anticipate from here, if any? -->
