### PR TITLE
Feature/bsk 857 polymorphic state data

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -90,6 +90,17 @@ Version  |release|
     You have to upgrade your python ``conan`` package to be able to build Basilisk.
     Use ``python install --upgrade conan``.
 
+- Added support for subclassing ``StateData`` and overloading certain methods. This enables support for custom state
+  behavior, such as quaternions, which have size 4 but their derivative is size 3. This is done in preparation of
+  a future MuJoCo integration. Note the warning below regarding SWIG files for ``dynamicEffector`` and ``stateEffector``.
+
+  .. warning::
+
+    SWIG files for subclasses of ``dynamicEffector`` and ``stateEffector`` must now
+    ``%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"`` instead of
+    ``%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"``. See
+    ``src/simulation/dynamics/dragEffector/dragDynamicEffector.i`` for an example.
+
 
 Version 2.5.0 (Sept. 30, 2024)
 ------------------------------

--- a/examples/scenarioVariableTimeStepIntegrators.py
+++ b/examples/scenarioVariableTimeStepIntegrators.py
@@ -275,9 +275,8 @@ def run(show_plots, integratorCase, relTol, absTol):
     if integratorCase == "rkf78":
         plt.close("all")
 
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
-    return posData, figureList
+    # return some information of value for testing
+    return dataLog.times(), posData, velData, figureList
 
 
 #

--- a/src/simulation/dynamics/FuelTank/fuelTank.i
+++ b/src/simulation/dynamics/FuelTank/fuelTank.i
@@ -30,9 +30,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "fuelTank.h"
 
 %include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"

--- a/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.i
+++ b/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.i
@@ -33,9 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 
 // Instantiate templates used by example
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 
 %include "GravityGradientEffector.h"
 

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "hingedRigidBodyStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.i
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.i
@@ -33,10 +33,9 @@ from Basilisk.architecture.swig_common_model import *
 %include "stdint.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/fuelSlosh.h"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "linearSpringMassDamper.h"
 
 %pythoncode %{

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.i
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.i
@@ -30,9 +30,8 @@
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "MtbEffector.h"
 
 %include "architecture/msgPayloadDefC/MTBCmdMsgPayload.h"

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "nHingedRigidBodyStateEffector.h"
 
 %pythoncode %{

--- a/src/simulation/dynamics/RadiationPressure/radiationPressure.i
+++ b/src/simulation/dynamics/RadiationPressure/radiationPressure.i
@@ -28,8 +28,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "sys_model.i"
 %include "radiationPressure.h"
 

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
@@ -38,9 +38,8 @@ namespace std {
 }
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "thrusterDynamicEffector.h"
 
 %include "simulation/dynamics/_GeneralModuleFiles/THRTimePair.h"

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.i
@@ -34,9 +34,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h"
 %include "thrusterStateEffector.h"
 

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.i
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.i
@@ -29,11 +29,9 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
-%include "../_GeneralModuleFiles/stateData.h"
+%include "../_GeneralModuleFiles/dynParamManager.i"
 %include "../_GeneralModuleFiles/stateEffector.h"
 %include "../_GeneralModuleFiles/dynamicEffector.h"
-%include "../_GeneralModuleFiles/dynParamManager.h"
-%include "../_GeneralModuleFiles/dynamicObject.h"
 %include "vscmgStateEffector.h"
 
 %include "architecture/msgPayloadDefC/VSCMGCmdMsgPayload.h"

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.cpp
@@ -17,177 +17,127 @@
 
  */
 
-
 #include "dynParamManager.h"
+#include <algorithm>
 #include <iostream>
 
-DynParamManager::DynParamManager()
+StateVector::StateVector(const StateVector& other)
 {
-    return;
+    *this = other;
 }
 
-DynParamManager::~DynParamManager()
+StateVector&
+StateVector::operator=(const StateVector& other)
 {
-    return;
+    stateMap.clear();
+    for (const auto& [key, value] : other.stateMap) {
+        stateMap.emplace(key, value->clone());
+    }
+    return *this;
 }
 
-StateData* DynParamManager::registerState(uint32_t nRow, uint32_t nCol,
-    std::string stateName)
+void StateVector::setStates(const StateVector& operand)
 {
-    if (stateName == "") {
-        bskLogger.bskLog(BSK_ERROR, "Your state name can't be an empty string.  Come on.  You get null.");
-        return nullptr;
+    for (auto [it1, it2] = std::tuple{std::begin(this->stateMap), std::begin(operand.stateMap)};
+         it1 != std::end(this->stateMap) && it2 != std::end(operand.stateMap);
+         ++it1, ++it2) {
+        it1->second->setState(it2->second->getState());
     }
+}
 
-    std::map<std::string, StateData>::iterator it;
-    it = stateContainer.stateMap.find(stateName);
-    if(it != stateContainer.stateMap.end())
-    {
-        bskLogger.bskLog(BSK_WARNING, "You created a state with the name: %s more than once.  Go ahead and don't do this.", stateName.c_str());
-        if(it->second.getRowSize() != nRow || it->second.getColumnSize() != nCol)
-        {
-            bskLogger.bskLog(BSK_ERROR, "In addition to that, you tried to change the size of the state in question.  Come on.  You get null.");
-            return nullptr;
-        }
+void StateVector::addStates(const StateVector& operand)
+{
+    for (auto [it1, it2] = std::tuple{std::begin(this->stateMap), std::begin(operand.stateMap)};
+         it1 != std::end(this->stateMap) && it2 != std::end(operand.stateMap);
+         ++it1, ++it2) {
+        it1->second->addState(*it2->second);
     }
-    else
-    {
-        Eigen::MatrixXd stateMatrix;
-        stateMatrix.resize(nRow, nCol);
-        StateData newState(stateName, stateMatrix);
-        stateContainer.stateMap.insert(std::pair<std::string, StateData>
-                              (stateName, newState));
-        it = stateContainer.stateMap.find(stateName);
+}
+
+void StateVector::scaleStates(double scaleFactor)
+{
+    for (const auto& [key, value] : stateMap) {
+        value->scaleState(scaleFactor);
     }
-    return (&(it->second));
+}
+
+void StateVector::propagateStates(double dt)
+{
+    for (const auto& [key, value] : stateMap) {
+        value->propagateState(dt);
+    }
 }
 
 StateData* DynParamManager::getStateObject(std::string stateName)
 {
-    StateData *statePtr;
-    std::map<std::string, StateData>::iterator it;
-
-    statePtr = nullptr;
-    it = stateContainer.stateMap.find(stateName);
-    if(it != stateContainer.stateMap.end())
-    {
-        statePtr = &(it->second);
+    if (stateContainer.stateMap.count(stateName) > 0) {
+        return stateContainer.stateMap.at(stateName).get();
     }
 
-    if (statePtr == nullptr)
-    {
-        /*  The requested state could not be found.
-            Either the state name was miss-spelled, or the state simply
-            doesn't exit in the current simulaiton setup (i.e. asking for the
-            hub attitude in a translation only simulation setup */
-        bskLogger.bskLog(BSK_WARNING, "You requested this non-existent state name: %s You either miss-typed the stateName, or you asked for a state that doesn't exist in your simulation setup. stateName = ", stateName.c_str());
-    }
+    /*  The requested state could not be found.
+        Either the state name was miss-spelled, or the state simply
+        doesn't exit in the current simulaiton setup (i.e. asking for the
+        hub attitude in a translation only simulation setup */
+    bskLogger.bskLog(
+        BSK_WARNING,
+        "You requested this non-existent state name: %s You either miss-typed the stateName, or "
+        "you asked for a state that doesn't exist in your simulation setup.",
+        stateName.c_str());
 
-    return(statePtr);
+    return nullptr;
 }
 
-StateVector DynParamManager::getStateVector()
+void DynParamManager::updateStateVector(const StateVector& newState)
 {
-    return(stateContainer);
+    this->stateContainer.setStates(newState);
 }
 
-void DynParamManager::updateStateVector(const StateVector & newState)
-{
-
-    std::map<std::string, StateData>::iterator it;
-    std::map<std::string, StateData>::const_iterator inIt;
-    for (it = stateContainer.stateMap.begin(), inIt = newState.stateMap.begin();
-         it != stateContainer.stateMap.end() && inIt != newState.stateMap.end(); it++, inIt++)
-    {
-        it->second.setState(inIt->second.getState());
-
-    }
-}
-
-void DynParamManager::propagateStateVector(double dt)
-{
-    std::map<std::string, StateData>::iterator it;
-    for (it = stateContainer.stateMap.begin();
-         it != stateContainer.stateMap.end(); it++)
-    {
-        it->second.propagateState(dt);
-
-    }
-}
-
-StateVector StateVector::operator+(const StateVector& operand)
-{
-    std::map<std::string, StateData>::iterator it;
-    std::map<std::string, StateData>::const_iterator opIt;
-    StateVector outVector;
-    for (it = stateMap.begin(), opIt = operand.stateMap.begin();
-         it != stateMap.end() && opIt != operand.stateMap.end(); it++, opIt++)
-    {
-        StateData newState = it->second + opIt->second;
-        outVector.stateMap.insert(std::pair<std::string, StateData>
-                                  (it->first, newState));
-
-    }
-    return outVector;
-}
-
-StateVector StateVector::operator*(double scaleFactor)
-{
-    StateVector outVector;
-    std::map<std::string, StateData>::iterator it;
-    for (it = stateMap.begin(); it != stateMap.end(); it++)
-    {
-        outVector.stateMap.insert(std::pair<std::string, StateData>
-                                  (it->first, it->second*scaleFactor));
-
-    }
-
-    return outVector;
-}
+void DynParamManager::propagateStateVector(double dt) { this->stateContainer.propagateStates(dt); }
 
 Eigen::MatrixXd* DynParamManager::createProperty(std::string propName,
-    const Eigen::MatrixXd & propValue)
+                                                 const Eigen::MatrixXd& propValue)
 {
     std::map<std::string, Eigen::MatrixXd>::iterator it;
     it = dynProperties.find(propName);
-    if(it == dynProperties.end())
-    {
-        dynProperties.insert(std::pair<std::string, Eigen::MatrixXd>
-                             (propName, propValue));
+    if (it == dynProperties.end()) {
+        dynProperties.insert(std::pair<std::string, Eigen::MatrixXd>(propName, propValue));
     }
-    else{
-        bskLogger.bskLog(BSK_WARNING, "You created the dynamic property: %s more than once.  You shouldn't be doing that.", propName.c_str());
+    else {
+        bskLogger.bskLog(
+            BSK_WARNING,
+            "You created the dynamic property: %s more than once.  You shouldn't be doing that.",
+            propName.c_str());
         it->second = propValue;
     }
-    return(&(dynProperties.find(propName)->second));
+    return (&(dynProperties.find(propName)->second));
 }
 
 Eigen::MatrixXd* DynParamManager::getPropertyReference(std::string propName)
 {
     std::map<std::string, Eigen::MatrixXd>::iterator it;
     it = dynProperties.find(propName);
-    if(it == dynProperties.end())
-    {
-        bskLogger.bskLog(BSK_ERROR, "You requested the property: %s which doesn't exist.  Null returned.", propName.c_str());
+    if (it == dynProperties.end()) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "You requested the property: %s which doesn't exist.  Null returned.",
+                         propName.c_str());
         return nullptr;
     }
-    else
-    {
-        return(&(it->second));
+    else {
+        return (&(it->second));
     }
 }
 
-void DynParamManager::setPropertyValue(const std::string propName,
-                      const Eigen::MatrixXd & propValue)
+void DynParamManager::setPropertyValue(const std::string propName, const Eigen::MatrixXd& propValue)
 {
     std::map<std::string, Eigen::MatrixXd>::iterator it;
     it = dynProperties.find(propName);
-    if(it == dynProperties.end())
-    {
-        bskLogger.bskLog(BSK_ERROR, "You tried to set the property value for: %s which has not been created yet. I can't do that.", propName.c_str());
+    if (it == dynProperties.end()) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "You tried to set the property value for: %s which has not been created "
+                         "yet. I can't do that.",
+                         propName.c_str());
     }
-    else
-    {
+    else {
         it->second = propValue;
     }
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.h
@@ -17,48 +17,179 @@
 
  */
 
-
 #ifndef STATE_MANAGER_H
 #define STATE_MANAGER_H
 
-#include <stdint.h>
-#include <map>
-#include <vector>
-#include <Eigen/Dense>
-#include "stateData.h"
 #include "architecture/utilities/bskLogging.h"
+#include "stateData.h"
+#include <Eigen/Dense>
+#include <map>
+#include <stdint.h>
+#include <type_traits>
+#include <vector>
 
-
-/*! state vector class */
+/** StateVector represents an ordered collection of StateData,
+ * with each state having a unique name.
+ */
 class StateVector {
-public:
-    std::map<std::string, StateData> stateMap;          //!< class method
-public:
-    StateVector operator+(const StateVector& operand);  //!< class method
-    StateVector operator*(double scaleFactor);          //!< class method
+  public:
+    /** All states managed by the StateVector, cached
+     * by name.
+     *
+     * StateData classes have virtual methods, and this class
+     * should be capable of supporting subclasses of StateData.
+     * To do so, we need to store StateData objects as pointers.
+     * To facilitate memory management, we use unique_ptr.
+     */
+    std::map<std::string, std::unique_ptr<StateData>> stateMap;
+
+  public:
+    /** Default constructor */
+    StateVector() = default;
+
+    /** Copy constructor */
+    StateVector(const StateVector& other);
+
+    /** Assignment operator */
+    StateVector& operator= (const StateVector&);
+
+    /** Sets the values of the states of this StateVector to a copy the
+     * values of the states of the other StateVector.
+     *
+     * Note that we assume that both StateVectors have the same states
+     * and in the same order !!!*/
+    void setStates(const StateVector& operand);
+
+    /** Adds the states of the given StateVector to the states of
+     * this StateVector.
+     *
+     * Note that we assume that both StateVectors have the same states
+     * and in the same order !!!*/
+    void addStates(const StateVector& operand);
+
+    /** Scales the states of this StateVector by the given factor */
+    void scaleStates(double scaleFactor);
+
+    /** Scales the states of this StateVector by the given delta time */
+    void propagateStates(double dt);
 };
 
-/*! dynamic parameter manager class */
+/** A class that manages a set of states and properties. */
 class DynParamManager {
-public:
-    std::map<std::string, Eigen::MatrixXd> dynProperties; //!< class variable
-    StateVector stateContainer;                             //!< class variable
-    BSKLogger bskLogger;                      //!< -- BSK Logging
-public:
-    DynParamManager();
-    ~DynParamManager();
-    StateData* registerState(uint32_t nRow, uint32_t nCol, std::string stateName); //!< class method
-    StateData* getStateObject(std::string stateName); //!< class method
-    StateVector getStateVector(); //!< class method
-    void updateStateVector(const StateVector & newState); //!< class method
-    void propagateStateVector(double dt); //!< class method
-    Eigen::MatrixXd* createProperty(std::string propName,
-                                    const Eigen::MatrixXd & propValue); //!< class method
-    Eigen::MatrixXd* getPropertyReference(std::string propName); //!< class method
-    void setPropertyValue(const std::string propName,
-                          const Eigen::MatrixXd & propValue); //!< class method
-    
+  public:
+    /** A map of properties managed by this class.
+     *
+     * Properties are matrices of doubles that are defined and updated
+     * by modules. They are not integrated at any point, so it is the
+     * responsability of the user to update them so that they remain
+     * current.
+     */
+    std::map<std::string, Eigen::MatrixXd> dynProperties;
+
+    /** A collection of states managed by this class */
+    StateVector stateContainer;
+
+    /** Logger used by this class */
+    BSKLogger bskLogger;
+
+  public:
+    /** Creates and stores a new state to be managed by this class.
+     *
+     * The state name should be unique: registering two states with the
+     * same name will cause either an error or a warning.
+     *
+     * This method may optionally be templated to create StateData of
+     * subclasses of StateData.
+     */
+    template <typename StateDataType = StateData,
+              std::enable_if_t<std::is_base_of_v<StateData, StateDataType>, bool> = true>
+    StateDataType* registerState(uint32_t nRow, uint32_t nCol, std::string stateName);
+
+    /** Retrieves the handler to a previously registered StateData.
+     *
+     * Calling this method for a state name not previously registered will raise a warning
+     * and return a nullptr.
+     */
+    StateData* getStateObject(std::string stateName);
+
+    /** Creates and stores a new property to be managed by this class.
+     *
+     * The property name should be unique: registering two properties with the
+     * same name will cause a warning or an error.
+     */
+    Eigen::MatrixXd* createProperty(std::string propName, const Eigen::MatrixXd& propValue);
+
+    /** Retrieves the handler to a previously registered property.
+     *
+     * Calling this method for a property name not previously registered
+     * will raise an error.
+     */
+    Eigen::MatrixXd* getPropertyReference(std::string propName);
+
+    /** Sets the value for a property.
+     *
+     * An error will be raised if no property exists with name or the size of the
+     * given matrix is different from the size of the existing property.
+     */
+    void setPropertyValue(const std::string propName, const Eigen::MatrixXd& propValue);
+
+    /** Sets the values of the states managed by this class to a copy the
+     * values of the states of the given StateVector.
+     *
+     * Note that we assume that given StateVector have the same states
+     * and in the same order as this object !!!*/
+    void updateStateVector(const StateVector& newState);
+
+    /** Propagates the states managed by this class a given delta time.  */
+    void propagateStateVector(double dt);
 };
 
+template <typename StateDataType,
+          std::enable_if_t<std::is_base_of_v<StateData, StateDataType>, bool>>
+StateDataType* DynParamManager::registerState(uint32_t nRow, uint32_t nCol, std::string stateName)
+{
+    if (stateName == "") {
+        bskLogger.bskLog(BSK_ERROR,
+                         "Your state name can't be an empty string.  Come on.  You get null.");
+        return nullptr;
+    }
+
+    if (stateContainer.stateMap.count(stateName) > 0) {
+        bskLogger.bskLog(
+            BSK_WARNING,
+            "You created a state with the name: %s more than once.  Go ahead and don't do this.",
+            stateName.c_str());
+
+        auto& stateData = stateContainer.stateMap.at(stateName);
+
+        if (stateData->getRowSize() != nRow || stateData->getColumnSize() != nCol) {
+            bskLogger.bskLog(BSK_ERROR,
+                             "In addition to that, you tried to change the size of the state in "
+                             "question.  Come on.  You get null.");
+            return nullptr;
+        }
+
+        auto casted = dynamic_cast<StateDataType*>(stateData.get());
+        if (!casted) {
+            bskLogger.bskLog(BSK_ERROR,
+                             "In addition to that, you tried to change the StateData type.  Come "
+                             "on.  You get null.");
+            return nullptr;
+        }
+
+        return casted;
+    }
+
+    Eigen::MatrixXd stateMatrix;
+    stateMatrix.resize(nRow, nCol);
+
+    // Emplacing this stateData in the map will wrap the raw
+    // pointer in a unique_ptr, so no worries about leaks.
+    // I didn't emplace `std::make_unique<StateDataType>(...)
+    // because I needed the raw pointer anyway to return it.
+    StateDataType* stateData = new StateDataType(stateName, stateMatrix);
+    stateContainer.stateMap.emplace(stateName, stateData);
+    return stateData;
+}
 
 #endif /* STATE_MANAGER_H */

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.i
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.i
@@ -1,0 +1,20 @@
+
+%module dynParamManager
+%{
+   #include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+   #include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%}
+
+// There are other accesor methods to query these objects that are
+// better than using the class variables directly
+%ignore StateVector::stateMap;
+%ignore DynParamManager::dynProperties;
+
+// Uses unique_ptr, don't need it at the Python level
+%ignore StateData::clone;
+
+%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+
+// Used in testing in Python, we use the default template arguments
+%template(registerState) DynParamManager::registerState<StateData, true>;

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -73,6 +73,19 @@ ExtendedStateVector ExtendedStateVector::operator+=(const ExtendedStateVector& r
     return *this;
 }
 
+ExtendedStateVector ExtendedStateVector::operator-(const ExtendedStateVector& rhs) const
+{
+    ExtendedStateVector copy = *this;
+
+    copy.modify([&rhs](const size_t& dynObjIndex,
+                       const std::string& stateName,
+                       Eigen::MatrixXd& thisState) {
+        thisState -= rhs.at({dynObjIndex, stateName});
+    });
+
+    return copy;
+}
+
 ExtendedStateVector ExtendedStateVector::operator*(const double rhs) const
 {
     return this->map([rhs](const size_t& dynObjIndex,

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -98,9 +98,20 @@ void ExtendedStateVector::setStates(std::vector<DynamicObject*>& dynPtrs) const
     this->apply([&dynPtrs](const size_t& dynObjIndex,
                                  const std::string& stateName,
                                  const Eigen::MatrixXd& thisState) {
-        StateData& stateData =
-            dynPtrs.at(dynObjIndex)->dynManager.stateContainer.stateMap.at(stateName);
-        stateData.setState(thisState);
+        dynPtrs.at(dynObjIndex)
+            ->dynManager.stateContainer.stateMap.at(stateName)
+            ->setState(thisState);
+    });
+}
+
+void ExtendedStateVector::setDerivatives(std::vector<DynamicObject*>& dynPtrs) const
+{
+    this->apply([&dynPtrs](const size_t& dynObjIndex,
+                           const std::string& stateName,
+                           const Eigen::MatrixXd& thisDerivative) {
+        dynPtrs.at(dynObjIndex)
+            ->dynManager.stateContainer.stateMap.at(stateName)
+            ->setDerivative(thisDerivative);
     });
 }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -124,8 +124,7 @@ ExtendedStateVector::fromStateData(const std::vector<DynamicObject*>& dynPtrs,
     for (size_t dynIndex = 0; dynIndex < dynPtrs.size(); dynIndex++) {
         for (auto&& [stateName, stateData] :
              dynPtrs.at(dynIndex)->dynManager.stateContainer.stateMap) {
-            if (stateData->isStateActive())
-                result.emplace(std::make_pair(dynIndex, stateName), functor(*stateData.get()));
+            result.emplace(std::make_pair(dynIndex, stateName), functor(*stateData.get()));
         }
     }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -124,7 +124,8 @@ ExtendedStateVector::fromStateData(const std::vector<DynamicObject*>& dynPtrs,
     for (size_t dynIndex = 0; dynIndex < dynPtrs.size(); dynIndex++) {
         for (auto&& [stateName, stateData] :
              dynPtrs.at(dynIndex)->dynManager.stateContainer.stateMap) {
-            result.emplace(std::make_pair(dynIndex, stateName), functor(*stateData.get()));
+            if (stateData->isStateActive())
+                result.emplace(std::make_pair(dynIndex, stateName), functor(*stateData.get()));
         }
     }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -124,7 +124,7 @@ ExtendedStateVector::fromStateData(const std::vector<DynamicObject*>& dynPtrs,
     for (size_t dynIndex = 0; dynIndex < dynPtrs.size(); dynIndex++) {
         for (auto&& [stateName, stateData] :
              dynPtrs.at(dynIndex)->dynManager.stateContainer.stateMap) {
-            result.emplace(std::make_pair(dynIndex, stateName), functor(stateData));
+            result.emplace(std::make_pair(dynIndex, stateName), functor(*stateData.get()));
         }
     }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
@@ -134,8 +134,11 @@ class ExtendedStateVector
      */
     ExtendedStateVector operator*(const double rhs) const;
 
-    /** Calls StateData::setState for every entry in in this */
+    /** Calls StateData::setState for every entry in this */
     void setStates(std::vector<DynamicObject*>& dynPtrs) const;
+
+    /** Calls StateData::setDerivative for every entry in this */
+    void setDerivatives(std::vector<DynamicObject*>& dynPtrs) const;
 
   private:
     static ExtendedStateVector fromStateData(const std::vector<DynamicObject*>& dynPtrs,

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
@@ -124,6 +124,12 @@ class ExtendedStateVector
      */
     ExtendedStateVector operator+=(const ExtendedStateVector& rhs);
 
+    /** Subtracts the values of `rhs` to from this
+     *
+     * This functions as a state-wise subtraction operation.
+     */
+    ExtendedStateVector operator-(const ExtendedStateVector& rhs) const;
+
     /** Returns a new ExtendedStateVector that is the result of multiplying each state by a constant
      */
     ExtendedStateVector operator*(const double rhs) const;

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateData.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateData.cpp
@@ -24,7 +24,6 @@ std::unique_ptr<StateData> StateData::clone() const
 {
     auto result = std::make_unique<StateData>(this->stateName, this->state);
     result->stateDeriv = this->stateDeriv;
-    result->stateEnabled = this->stateEnabled;
     return result;
 }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateData.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateData.cpp
@@ -20,40 +20,25 @@
 
 #include "stateData.h"
 
-StateData::StateData()
+std::unique_ptr<StateData> StateData::clone() const
 {
-    return;
-}
-
-StateData::StateData(const StateData &inState)
-{
-    state = inState.state;
-    stateDeriv = inState.stateDeriv;
-    stateName = inState.stateName;
-    stateEnabled = inState.stateEnabled;
-}
-
-StateData::~StateData()
-{
-    return;
+    auto result = std::make_unique<StateData>(this->stateName, this->state);
+    result->stateDeriv = this->stateDeriv;
+    result->stateEnabled = this->stateEnabled;
+    return result;
 }
 
 StateData::StateData(std::string inName, const Eigen::MatrixXd & newState)
+: stateName(inName)
 {
-    stateName = inName;
     setState(newState);
-    if(state.innerSize() != stateDeriv.innerSize() ||
-       state.outerSize() != stateDeriv.outerSize())
-    {
-        stateDeriv = state;
-    }
-    stateDeriv.setZero();
+    stateDeriv.resizeLike(state);
+    setDerivative( Eigen::MatrixXd::Zero(state.innerSize(), state.outerSize()) );
 }
 
 void StateData::setState(const Eigen::MatrixXd & newState)
 {
     state = newState;
-    return;
 }
 
 void StateData::propagateState(double dt)
@@ -72,14 +57,7 @@ void StateData::scaleState(double scaleFactor)
     state *= scaleFactor;
 }
 
-StateData StateData::operator+(const StateData& operand)
+void StateData::addState(const StateData& other)
 {
-    return StateData(stateName, state+operand.getState());
-}
-
-StateData StateData::operator* (double scaleFactor)
-{
-    StateData newState(stateName, state);
-    newState.scaleState(scaleFactor);
-    return(newState);
+    state += other.state;
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateData.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateData.h
@@ -31,7 +31,6 @@ public:
     Eigen::MatrixXd state;       //!< [-] State value storage
     Eigen::MatrixXd stateDeriv;  //!< [-] State derivative value storage
     const std::string stateName; //!< [-] Name of the state
-    bool stateEnabled = true;    //!< [-] Flag indicating state is enabled
     BSKLogger bskLogger;         //!< -- BSK Logging
 
 public:
@@ -73,18 +72,6 @@ public:
 
     /** Returns the column-size of the derivative of the state */
     uint32_t getDerivativeColumnSize() const { return ((uint32_t)stateDeriv.outerSize()); }
-
-    /** Returns whether the state is "enabled".
-     *
-     * Disabled states are ignored by the integrator and thus dynamic objects need
-     * not update the state derivative. */
-    bool isStateActive() { return stateEnabled; }
-
-    /** Marks the state is "disabled" */
-    void disable() { stateEnabled = false; }
-
-    /** Marks the state is "enabled" */
-    void enable() { stateEnabled = true; }
 
     /** Multiples the state by a scalar */
     void scaleState(double scaleFactor);

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateData.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateData.h
@@ -20,40 +20,80 @@
 #ifndef STATE_DATA_H
 #define STATE_DATA_H
 #include <Eigen/Dense>
+#include <memory>
 #include <stdint.h>
 #include "architecture/utilities/bskLogging.h"
 
-/*! @brief state data class*/
-class StateData {
+/** @brief Represents a physical state, which has a name, a value, and a derivative. */
+class StateData
+{
 public:
-    Eigen::MatrixXd state;                        //!< [-] State value storage
-    Eigen::MatrixXd stateDeriv;                   //!< [-] State derivative value storage
-    std::string stateName;                        //!< [-] Name of the state
-    bool stateEnabled;                            //!< [-] Flag indicating state is enabled
-    BSKLogger bskLogger;                          //!< -- BSK Logging
+    Eigen::MatrixXd state;       //!< [-] State value storage
+    Eigen::MatrixXd stateDeriv;  //!< [-] State derivative value storage
+    const std::string stateName; //!< [-] Name of the state
+    bool stateEnabled = true;    //!< [-] Flag indicating state is enabled
+    BSKLogger bskLogger;         //!< -- BSK Logging
 
 public:
-    StateData();
-    StateData(std::string inName, const Eigen::MatrixXd & newState);  //!< class method
-    StateData(const StateData &inState);                //!< class method
-    ~StateData();
-    void setState(const Eigen::MatrixXd & newState);    //!< class method
-    void propagateState(double dt);                     //!< class method
-    void setDerivative(const Eigen::MatrixXd & newDeriv);   //!< class method
-    Eigen::MatrixXd getState() const {return state;}    //!< class method
-    Eigen::MatrixXd getStateDeriv() const {return stateDeriv;}  //!< class method
-    std::string getName() const {return stateName;}     //!< class method
-    uint32_t getRowSize() const {return((uint32_t)state.innerSize());}  //!< class method
-    uint32_t getColumnSize() const {return((uint32_t)state.outerSize());}   //!< class method
-    bool isStateActive() {return stateEnabled;}         //!< class method
-    void disable() {stateEnabled = false;}              //!< class method
-    void enable() {stateEnabled = true;}                //!< class method
-    void scaleState(double scaleFactor);                //!< class method
+    /** Creates a new state with the given name and set's the initial state.
+     *
+     * The state derivative will be resized to the same size as the state and zero'd.
+     */
+    StateData(std::string inName, const Eigen::MatrixXd& newState);
 
-    StateData operator+ (const StateData & operand);    //!< class method
-    StateData operator* (double scaleFactor);           //!< class method
+    /** Clone constructor for polymorphic class */
+    virtual std::unique_ptr<StateData> clone() const;
 
+    /** Destructor */
+    virtual ~StateData() = default;
+
+    /** Updates the value of the state */
+    void setState(const Eigen::MatrixXd& newState);
+
+    /** Updates the derivative of the value of the state */
+    void setDerivative(const Eigen::MatrixXd& newDeriv);
+
+    /** Retrieves a copy of the current state */
+    Eigen::MatrixXd getState() const { return state; }
+
+    /** Retrieves a copy of the current state derivative */
+    Eigen::MatrixXd getStateDeriv() const { return stateDeriv; }
+
+    /** Returns the name of the state */
+    std::string getName() const { return stateName; }
+
+    /** Returns the row-size of the state */
+    uint32_t getRowSize() const { return ((uint32_t)state.innerSize()); }
+
+    /** Returns the column-size of the state */
+    uint32_t getColumnSize() const { return ((uint32_t)state.outerSize()); }
+
+    /** Returns the row-size of the derivative of the state */
+    uint32_t getDerivativeRowSize() const { return ((uint32_t)stateDeriv.innerSize()); }
+
+    /** Returns the column-size of the derivative of the state */
+    uint32_t getDerivativeColumnSize() const { return ((uint32_t)stateDeriv.outerSize()); }
+
+    /** Returns whether the state is "enabled".
+     *
+     * Disabled states are ignored by the integrator and thus dynamic objects need
+     * not update the state derivative. */
+    bool isStateActive() { return stateEnabled; }
+
+    /** Marks the state is "disabled" */
+    void disable() { stateEnabled = false; }
+
+    /** Marks the state is "enabled" */
+    void enable() { stateEnabled = true; }
+
+    /** Multiples the state by a scalar */
+    void scaleState(double scaleFactor);
+
+    /** Adds the values of the other state to this state */
+    void addState(const StateData& other);
+
+    /** Propagates the state in time with the stored derivative */
+    virtual void propagateState(double dt);
 };
-
 
 #endif /* STATE_DATA_H */

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.i
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.i
@@ -34,9 +34,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "constraintDynamicEffector.h"
 
 %include "architecture/msgPayloadDefC/ConstDynEffectorMsgPayload.h"

--- a/src/simulation/dynamics/dragEffector/dragDynamicEffector.i
+++ b/src/simulation/dynamics/dragEffector/dragDynamicEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 
 // Instantiate templates used by example
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 
 %include "dragDynamicEffector.h"
 

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_vector.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "dualHingedRigidBodyStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.i
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 
 // Instantiate templates used by example
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "facetDragDynamicEffector.h"
 
 %include "architecture/msgPayloadDefC/AtmoPropsMsgPayload.h"

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 
 // Instantiate templates used by example
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "facetSRPDynamicEffector.h"
 
 %include "architecture/msgPayloadDefC/SpicePlanetStateMsgPayload.h"

--- a/src/simulation/dynamics/gravityEffector/gravityEffector.i
+++ b/src/simulation/dynamics/gravityEffector/gravityEffector.i
@@ -68,8 +68,9 @@ from typing import Optional, Union
 
 %import "simulation/dynamics/gravityEffector/gravityModel.i"
 
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+
 %include "sys_model.i"
 #pragma SWIG nowarn=362
 %include "simulation/dynamics/_GeneralModuleFiles/gravityEffector.h"
@@ -79,7 +80,7 @@ struct SpicePlanetStateMsg_C;
 
 %extend GravBodyData {
     %pythoncode %{
-    
+
     """
     If we were to call GravBodyData::gravityModel we would obtain a pointer to the
     parent object GravityModel, as this is what is stored in the GravBodyData C++
@@ -92,7 +93,7 @@ struct SpicePlanetStateMsg_C;
     @property
     def gravityModel(self):
         return self._pyGravityModel
-    
+
     @gravityModel.setter
     def gravityModel(self, value):
         self._gravityModel = value
@@ -101,7 +102,7 @@ struct SpicePlanetStateMsg_C;
     @property
     def useSphericalHarmParams(self):
         return isinstance(self.gravityModel, SphericalHarmonicsGravityModel)
-   
+
     @useSphericalHarmParams.setter
     def useSphericalHarmParams(self, value: bool):
         deprecated.deprecationWarn(
@@ -122,7 +123,7 @@ struct SpicePlanetStateMsg_C;
     @property
     def usePolyhedral(self):
         return isinstance(self.gravityModel, PolyhedralGravityModel)
-   
+
     @usePolyhedral.setter
     def usePolyhedral(self, value: bool):
         deprecated.deprecationWarn(
@@ -151,7 +152,7 @@ struct SpicePlanetStateMsg_C;
     @spherHarm.setter
     def spherHarm(self, value: SphericalHarmonicsGravityModel):
         self.gravityModel = value
-   
+
     @property
     def poly(self) -> PolyhedralGravityModel:
         if self.usePolyhedral:
@@ -185,14 +186,13 @@ struct SpicePlanetStateMsg_C;
                 data for the polyhedral.
         """
         self.gravityModel = PolyhedralGravityModel().loadFromFile(file)
-        
+
     %}
 }
 
 %pythoncode %{
 import sys
-protectAllClasses(sys.modules[__name__])        
+protectAllClasses(sys.modules[__name__])
 %}
 
 %pythoncode "simulation/dynamics/gravityEffector/gravCoeffOps.py"
-

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.i
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.i
@@ -33,9 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "linearTranslationNDOFStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.i
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.i
@@ -33,9 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 %include <std_array.i>
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "linearTranslationOneDOFStateEffector.h"
 
 %include "architecture/msgPayloadDefC/ArrayMotorForceMsgPayload.h"

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.i
@@ -32,9 +32,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 %include "sys_model.i"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %include "prescribedMotionStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
@@ -29,11 +29,9 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynamicObject.h"
 %include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
 %include "reactionWheelStateEffector.h"
 %include "architecture/utilities/macroDefinitions.h"

--- a/src/simulation/dynamics/spacecraft/spacecraft.i
+++ b/src/simulation/dynamics/spacecraft/spacecraft.i
@@ -32,10 +32,9 @@ from Basilisk.simulation.gravityEffector import GravBodyVector
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicObject.h"
 %import  "simulation/dynamics/gravityEffector/gravityEffector.i"
 %include "spacecraft.h"

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.i
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.i
@@ -32,8 +32,7 @@ from Basilisk.simulation.gravityEffector import GravBodyVector
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
-%include "../_GeneralModuleFiles/stateData.h"
-%include "../_GeneralModuleFiles/dynParamManager.h"
+%include "../_GeneralModuleFiles/dynParamManager.i"
 %include "../_GeneralModuleFiles/dynamicObject.h"
 %import  "simulation/dynamics/gravityEffector/gravityEffector.i"
 %include "../_GeneralModuleFiles/stateEffector.h"

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.i
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.i
@@ -34,9 +34,8 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "sys_model.i"
 %include "../_GeneralModuleFiles/fuelSlosh.h"
-%include "../_GeneralModuleFiles/stateData.h"
+%include "../_GeneralModuleFiles/dynParamManager.i"
 %include "../_GeneralModuleFiles/stateEffector.h"
-%include "../_GeneralModuleFiles/dynParamManager.h"
 
 %include "sphericalPendulum.h"
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.i
@@ -33,9 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "spinningBodyNDOFStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.i
@@ -33,9 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 %include <std_array.i>
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "spinningBodyOneDOFStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.i
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.i
@@ -33,9 +33,8 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 
 %include "sys_model.i"
-%include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 %include "spinningBodyTwoDOFStateEffector.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"

--- a/src/simulation/dynamics/stateArchitecture/stateArchitecture.i
+++ b/src/simulation/dynamics/stateArchitecture/stateArchitecture.i
@@ -31,8 +31,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "../_GeneralModuleFiles/dynParamManager.h"
-%include "../_GeneralModuleFiles/stateData.h"
+%include "../_GeneralModuleFiles/dynParamManager.i"
 %include "../../../architecture/utilities/avsEigenSupport.h"
 
 %pythoncode %{

--- a/src/simulation/dynamics/stateArchitecture/stateArchitecture.i
+++ b/src/simulation/dynamics/stateArchitecture/stateArchitecture.i
@@ -31,6 +31,14 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
+// This method should not be exposed, but it's used in
+// test_stateArchitecture.py, so we enable it here. If
+// the test is every reworked, this extension should be removed.
+%extend DynParamManager
+{
+   StateVector getStateVector() {return self->stateContainer;}
+}
+
 %include "../_GeneralModuleFiles/dynParamManager.i"
 %include "../../../architecture/utilities/avsEigenSupport.h"
 

--- a/src/tests/test_scenarioVariableTimeStepIntegrators.py
+++ b/src/tests/test_scenarioVariableTimeStepIntegrators.py
@@ -31,7 +31,14 @@ import os
 import sys
 
 import pytest
+
+import numpy as np
+import numpy.testing as npt
+
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import orbitalMotion
+from Basilisk.utilities import simIncludeGravBody
+from Basilisk.utilities import macros
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -40,71 +47,48 @@ path = os.path.dirname(os.path.abspath(filename))
 sys.path.append(path + '/../../examples')
 import scenarioVariableTimeStepIntegrators
 
-
-# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
-# @pytest.mark.skipif(conditionstring)
-# uncomment this line if this test has an expected failure, adjust message as needed
-# @pytest.mark.xfail(True, reason="Scott's brain no-worky\n")
-# The following 'parametrize' function decorator provides the parameters and expected results for each
-#   of the multiple test runs for this test.
-# @pytest.mark.parametrize("integratorCase", ["rk4", "rkf45", "euler", "rk2"])
 @pytest.mark.scenarioTest
 def test_scenarioIntegrators(show_plots):
-    """This function is called by the py.test environment."""
+    """This function is called by the pytest environment."""
 
-    testFailCount = 0  # zero unit test result counter
-    testMessages = []  # create empty array to store test log messages
-
-    # for integratorCase in ["rk4", "rkf45", "rkf78"]:
-    for integratorCase in ["rk4", "rkf45", "rkf78"]:
+    for integratorCase in ["rkf45", "rkf78"]:
 
         # each test method requires a single assert method to be called
-        posData, figureList = scenarioVariableTimeStepIntegrators.run(show_plots, integratorCase, 1e-4, 1e-8)
+        timeData, posData, velData, figureList = scenarioVariableTimeStepIntegrators.run(show_plots, integratorCase, 1e-8, 1e-12)
 
-        numTruthPoints = 5
-        skipValue = int(len(posData) / (numTruthPoints - 1))
-        dataPosRed = posData[::skipValue]
+        analyticalPos = getAnalyticalSolution(posData[0,:], velData[0,:], timeData[-1] * macros.NANO2SEC)
 
-        # setup truth data for unit test
-        if integratorCase == "rk4":
-            truePos = [
-                [2.6965319797723856e+07, -4.0438014777803928e+07, -3.0909521009497888e+07]
-                , [-1.8150865887545696e+08, -6.3070993898878656e+07,  6.1267913051301539e+07]
-                , [-1.9303771205266798e+08, -1.5676982447684008e+08,  2.5889372561579809e+07]
-                , [-9.5984847333963335e+07, -1.6150851236724496e+08, -2.3710816061730530e+07]
-            ]
-        if integratorCase == "rkf45":
-            truePos = [
-                [2.6965319797723856e+07, -4.0438014777803928e+07, -3.0909521009497888e+07]
-                , [-1.9216506804530445e+08, -5.6289160679974444e+07,  6.9455499628984332e+07]
-                , [-2.3299581149964386e+08, -1.5552472452278799e+08,  4.6001444710378133e+07]
-                , [-1.8459881436340547e+08, -1.9692546690809220e+08,  4.1756159526298083e+06]
-            ]
-        if integratorCase == "rkf78":
-            truePos = [
-                [2.6965319797723856e+07, -4.0438014777803928e+07, -3.0909521009497888e+07]
-                , [-1.9213620413957629e+08, -5.6231399043057553e+07,  6.9466655149912968e+07]
-                , [-2.3288519903034091e+08, -1.5542401202654269e+08,  4.5991374262165107e+07]
-                , [-1.8431058525168183e+08, -1.9672328614927649e+08,  4.1229949341833070e+06]
-            ]
+        absTolerance = {
+            "rkf45": 2000,  # m
+            "rkf78": 100  # m
+        }
 
-        # compare the results to the truth values
-        accuracy = 1.0  # meters
-        testFailCount, testMessages = unitTestSupport.compareArray(
-            truePos, dataPosRed, accuracy, "r_BN_N Vector, case: " + integratorCase,
-            testFailCount, testMessages)
+        npt.assert_allclose(
+            posData[-1, :],
+            analyticalPos,
+            rtol=0,
+            atol=absTolerance[integratorCase],
+            err_msg = "r_BN_N Vector, case: " + integratorCase
+        )
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
         unitTestSupport.saveScenarioFigure(pltName, plt, path)
 
-    #   print out success message if no error were found
-    if testFailCount == 0:
-        print("PASSED ")
-    else:
-        print(testFailCount)
-        print(testMessages)
+def getAnalyticalSolution(r0, v0, dt):
+    mu = simIncludeGravBody.gravBodyFactory().createEarth().mu
+    oe = orbitalMotion.rv2elem(mu, r0, v0)
 
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
-    assert testFailCount < 1, testMessages
+    E0 = orbitalMotion.f2E(oe.f, oe.e)
+    M0 = orbitalMotion.E2M(E0, oe.e)
+    Mf = M0 + np.sqrt(mu / oe.a / oe.a / oe.a) * dt
+    Ef = orbitalMotion.M2E(Mf, oe.e)
+    ff = orbitalMotion.E2f(Ef, oe.e)
+
+    oe.f = ff
+
+    rF, _ = orbitalMotion.elem2rv(mu, oe)
+    return rF
+
+if __name__ == "__main__":
+    pytest.main([__file__, "--tb=native"])


### PR DESCRIPTION
* **Tickets addressed:** closes #857
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
`StateData` was made polymorphic, `StateData::propagateState` is now virtual.

This also required improvements to how the integrators work. `ExtendedStateVector` was given additional methods and updated to handle the polymorphic `StateData`. Similarly, `DynParamManager` had to be updated (`registerState` is now a templated method for different state classes, for example). Unfortunately, this means a SWIG file is now necessary for `DynParamManager` (templated code needs some extra massaging in SWIG), which in turn means a lot of SWIG interface files must be updated to use this new SWIG file.

I'm a good boy scout, so I also tried to clean up code and add extra docstrings in these classes.

## Verification
Commit 8976004 (or it's current equivalent) removes support for `operator+` and `operator*` on `StateData`, that `test_stateArchitecture` depended on. This test has been updated to use other, equivalent, methods.

No new tests added. Essentially all other Basilisk tests use `StateData` and integration, thus these tests passing should prove the refactored system works as expected. For now, only one `StateData` class appears in Basilisk (with the standard propagation function), and that should be shown to work. New `StateData` classes should be tested as they are implemented.

## Documentation
No changes. API remains very similar: by default `DynParamManager` assumes you want to create a standard `StateData`. The state system is not discussed on the prosaic documentation, thus no changes are needed.

## Future work
Implement custom `StateData` classes, such as the `MRPStateData` or `QuaternionStateData` classes described in #857
