### PR TITLE
Feature/conan2

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -95,7 +95,7 @@ jobs:
         - name: "Install wheel and conan package"
           run: |
             source .venv/bin/activate
-            pip3 install wheel 'conan<2.0' cmake
+            pip3 install wheel conan cmake
 
         - name: "Build basilisk with OpNav"
           run: source .venv/bin/activate && python3 conanfile.py --opNav True --allOptPkg

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install wheel 'conan<2.0'
+          pip install wheel conan
       - name: Build basilisk
         run: |
           source .venv/bin/activate
@@ -79,7 +79,7 @@ jobs:
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
       - name: "Install wheel and conan package"
-        run: source .venv/bin/activate && pip3 install wheel 'conan<2.0.0'
+        run: source .venv/bin/activate && pip3 install wheel conan
       - name: "Build basilisk"
         run: source .venv/bin/activate && python3 conanfile.py
       - name: "Run Python Tests"
@@ -114,7 +114,7 @@ jobs:
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
       - name: "Install wheel and conan package"
-        run: source .venv/bin/activate && pip3 install wheel 'conan<2.0.0'
+        run: source .venv/bin/activate && pip3 install wheel conan
       - name: "Build basilisk"
         run: source .venv/bin/activate && python3 conanfile.py --opNav True
 
@@ -188,7 +188,7 @@ jobs:
         shell: pwsh
         run: |
             venv\Scripts\activate
-            pip install wheel 'conan<2.0'
+            pip install wheel conan
       - name: "Add basilisk and cmake path to env path"
         shell: pwsh
         run: |
@@ -240,7 +240,7 @@ jobs:
       - name: "Install wheel and conan package"
         run: |
           source .venv/bin/activate
-          pip3 install wheel 'conan<2.0' cmake
+          pip3 install wheel conan cmake
 
       - name: "Build basilisk with OpNav"
         run: source .venv/bin/activate && python3 conanfile.py --opNav True --allOptPkg
@@ -287,7 +287,7 @@ jobs:
       - name: "Install wheel and conan package"
         run: |
           source .venv/bin/activate
-          pip3 install wheel 'conan<2.0' cmake
+          pip3 install wheel conan cmake
 
       - name: "Build basilisk without vizInterface"
         run: source .venv/bin/activate && python3 conanfile.py --vizInterface False

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ externalTools/fswAuto/autowrapper/wraps/*
 **/outputFiles/*
 src/moduleTemplates/autoCModule/*
 src/moduleTemplates/autoCppModule/*
+src/CMakeUserPresets.json
 
 supportData/EphemerisData/*.bsp
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -271,7 +271,7 @@ class BasiliskConan(ConanFile):
         generatorString = str(self.options.get_safe("generator"))
         if generatorString == "":
             # Select default generator supplied to cmake based on os
-            if self.settings.os == "Macos":
+            if self.settings.os == "Macos" and not self.options.get_safe("buildProject"):
                 generatorString = "Xcode"
                 tc.generator = generatorString
             elif self.settings.os == "Windows":

--- a/conanfile.py
+++ b/conanfile.py
@@ -214,13 +214,6 @@ class BasiliskConan(ConanFile):
             self.options['opencv'].with_quirc = False  # QR code lib
             self.options['opencv'].with_webp = False  # raster graphics file format for web
 
-            # Raise an issue to conan-center to fix this bug. Using workaround to disable freetype for windows
-            # Issue link: https://github.com/conan-community/community/issues/341
-            #TODO Remove this once they fix this issue.
-            # TODO: Confirm if still needed.
-            if is_msvc(self):
-                self.options['opencv'].freetype = False
-
         if is_msvc(self):
             self.options["*"].shared = True
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,8 +8,17 @@ from datetime import datetime
 
 import pkg_resources
 
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.microsoft import is_msvc
+from pathlib import Path
+
 sys.path.insert(1, './src/utilities/')
 import makeDraftModule
+
+# XXX: this statement is needed to enable Windows to print ANSI codes in the Terminal
+# see https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python/3332860#3332860
+os.system("")
 
 # define the print color codes
 statusColor = '\033[92m'
@@ -17,30 +26,12 @@ failColor = '\033[91m'
 warningColor = '\033[93m'
 endColor = '\033[0m'
 
-# TODO: Remove this check (deprecated, same as managePipEnvironment flag below).
-try:
-    from conans import __version__ as conan_version
-    if int(conan_version[0]) >= 2:
-        print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
-        print("use version 1.40.1 to 1.xx.0 to work with the conan repo changes." + endColor)
-        exit(0)
-    from conans.tools import Version
-    # check conan version 1.xx
-    if conan_version < Version("1.40.1"):
-        print(failColor + "conan version " + conan_version + " is not compatible with Basilisk.")
-        print("use version 1.40.1+ to work with the conan repo changes from 2021." + endColor)
-        exit(0)
-    from conans import ConanFile, CMake, tools
-except ModuleNotFoundError:
-    print("Please make sure you install python conan (version 1.xx, not 2.xx) package\nRun command `pip install \"conan<2\"` "
-          "for Windows\nRun command `pip3 install \"conan<2\"` for Linux/MacOS")
-    sys.exit(1)
 
-# define BSK module option list (option name and default value)
+# # define BSK module option list (option name and default value)
 bskModuleOptionsBool = {
-    "opNav": False,
-    "vizInterface": True,
-    "buildProject": True,
+    "opNav": [[True, False], False],
+    "vizInterface": [[True, False], True],
+    "buildProject": [[True, False], True],
 
     # XXX: Set managePipEnvironment to True to keep the old behaviour of
     # managing the `pip` environment directly (upgrading, installing Python
@@ -48,16 +39,16 @@ bskModuleOptionsBool = {
     # installation, and should only be required for users who are still calling
     # this file with `python conanfile.py ...`.
     # TODO: Remove all managePipEnvironment behaviour!
-    "managePipEnvironment": True
+    "managePipEnvironment": [[True, False], True],
 }
 bskModuleOptionsString = {
-    "autoKey": "",  # TODO: Remove, used only for managePipEnvironment.
-    "pathToExternalModules": "",
-    "pyLimitedAPI": "",
+    "autoKey": [["", "u", "s","c"], ""],  # TODO: Remove, used only for managePipEnvironment.
+    "pathToExternalModules": [["ANY"], ""],
+    "pyLimitedAPI": [["ANY"], ""],
 }
 bskModuleOptionsFlag = {
-    "clean": False,
-    "allOptPkg": False  # TODO: Remove, used only for managePipEnvironment.
+    "clean": [[True, False], False],
+    "allOptPkg": [[True, False], False]  # TODO: Remove, used only for managePipEnvironment.
 }
 
 # this statement is needed to enable Windows to print ANSI codes in the Terminal
@@ -67,43 +58,51 @@ os.system("")
 def is_running_virtual_env():
     return sys.prefix != sys.base_prefix
 
+required_conan_version = ">=2.0.5"
+
 class BasiliskConan(ConanFile):
     name = "Basilisk"
     homepage = "https://avslab.github.io/basilisk/"
     f = open('docs/source/bskVersion.txt', 'r')
     version = f.read()
     f.close()
-    generators = "cmake_find_package_multi"
-    requires = "eigen/3.4.0"
+    # generators = "CMakeDeps"
     settings = "os", "compiler", "build_type", "arch"
     build_policy = "missing"
     license = "ISC"
 
-    options = {"generator": "ANY"}
-    default_options = {"generator": ""}
+    # Requirements
+    requires = [
+        "eigen/3.4.0",
+    ]
+    package_type = "shared-library"
+    options = {
+        # define BSK module option list
+        "sourceFolder": ["ANY"],
+        "buildFolder": ["ANY"],
+        "generator": ["ANY"],
+    }
+    default_options = {
+        "sourceFolder": "src",
+        "buildFolder": "dist3",
+        "generator": "",
+    }
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "setup.py", "CMakeLists.txt", "src/*", "include/*"
 
     for opt, value in bskModuleOptionsBool.items():
-        options.update({opt: [True, False]})
-        default_options.update({opt: value})
+        options.update({opt: value[0]})
+        default_options.update({opt: value[1]})
     for opt, value in bskModuleOptionsString.items():
-        options.update({opt: "ANY"})
-        default_options.update({opt: value})
+        options.update({opt: value[0]})
+        default_options.update({opt: value[1]})
     for opt, value in bskModuleOptionsFlag.items():
-        options.update({opt: [True, False]})
-        default_options.update({opt: value})
-
-    # set cmake generator default
-    generator = None
-
-
-    try:
-        # enable this flag for access revised conan modules.
-        subprocess.check_output(["conan", "config", "set", "general.revisions_enabled=1"])
-    except:
-        pass
+        options.update({opt: value[0]})
+        default_options.update({opt: value[1]})
 
     def system_requirements(self):
-        if not self.options.managePipEnvironment:
+        if not self.options.get_safe("managePipEnvironment"):
             return  # Don't need to manage any pip requirements
 
         # TODO: Remove everything here, which only runs if we have set
@@ -126,7 +125,7 @@ class BasiliskConan(ConanFile):
             # Also install build system requirements.
             # TODO: Read these from the `pyproject.toml` file directly?
             # NOTE: These are *NOT* runtime requirements and should *NOT* be in `requirements.txt`!
-            "conan>=1.40.1, <2.00.0",
+            "conan>=2.0.5",
             "setuptools>=70.1.0",
             "setuptools-scm>=8.0",
             "packaging>=22",
@@ -134,7 +133,7 @@ class BasiliskConan(ConanFile):
         ]
 
         checkStr = "Required"
-        if self.options.allOptPkg:
+        if self.options.get_safe("allOptPkg"):
             optFile = open('requirements_optional.txt', 'r')
             optionalPkgs = optFile.read().replace("`", "").split('\n')
             optFile.close()
@@ -160,8 +159,8 @@ class BasiliskConan(ConanFile):
             installCmd = [sys.executable, "-m", "pip", "install"]
 
             if not is_running_virtual_env():
-                if self.options.autoKey:
-                    choice = self.options.autoKey
+                if self.options.get_safe("autoKey"):
+                    choice = self.options.get_safe("autoKey")
                 else:
                     choice = input(warningColor + f"Required python package " + elem + " is missing" + endColor +
                                     "\nInstall for user (u), system (s) or cancel(c)? ")
@@ -177,62 +176,60 @@ class BasiliskConan(ConanFile):
             except subprocess.CalledProcessError:
                 print(failColor + f"Was not able to install " + elem + endColor)
 
-    def requirements(self):
-        if self.options.opNav:
-            self.requires.add("pcre/8.45")
-            self.requires.add("opencv/4.5.5")
-            self.options['opencv'].with_ffmpeg = False  # video frame encoding lib
-            self.options['opencv'].with_ade = False  # graph manipulations framework
-            self.options['opencv'].with_tiff = False  # encode/decode image in TIFF format
-            self.options['opencv'].with_openexr = False  # encode/decode image in EXR format
-            self.options['opencv'].with_webp = False  # encode/decode image in WEBP format
-            self.options['opencv'].with_quirc = False  # QR code lib
-            self.requires.add("zlib/1.2.13")
-            self.requires.add("xz_utils/5.4.0")
+    def build_requirements(self):
+        # Protobuf is also required as a tool (in order for CMake to find the
+        # Conan-installed `protoc` compiler).
+        # See https://github.com/conan-io/conan-center-index/issues/21737
+        # and https://github.com/conan-io/conan-center-index/pull/22244#issuecomment-1910770387
+        if self.options.get_safe("vizInterface") or self.options.get_safe("opNav"):
+            self.tool_requires("protobuf/<host_version>")
 
-        if self.options.vizInterface or self.options.opNav:
-            self.requires.add("protobuf/3.20.0")
-            self.options['zeromq'].encryption = False  # Basilisk does not use data streaming encryption.
-            self.requires.add("cppzmq/4.5.0")
+    def requirements(self):
+        if self.options.get_safe("opNav"):
+            self.requires("opencv/4.5.5")
+
+        if self.options.get_safe("vizInterface") or self.options.get_safe("opNav"):
+            self.requires("protobuf/3.21.12")
+            self.requires("cppzmq/4.5.0")
 
     def configure(self):
-        if self.options.clean:
+        if self.options.get_safe("clean"):
             # clean the distribution folder to start fresh
-            self.options.clean = False
             root = os.path.abspath(os.path.curdir)
             distPath = os.path.join(root, "dist3")
             if os.path.exists(distPath):
                 shutil.rmtree(distPath, ignore_errors=True)
-        if self.settings.build_type == "Debug":
+        if self.settings.get_safe("build_type") == "Debug":
             print(warningColor + "Build type is set to Debug. Performance will be significantly lower." + endColor)
 
+        self.options['zeromq'].encryption = False  # Basilisk does not use data streaming encryption.
+
         # Install additional opencv methods
-        if self.options.opNav:
+        if self.options.get_safe("opNav"):
             self.options['opencv'].contrib = True
+            self.options['opencv'].with_ffmpeg = False  # video frame encoding lib
+            self.options['opencv'].gapi = False  # graph manipulations framework
+            self.options['opencv'].with_tiff = False  # generate image in TIFF format
+            self.options['opencv'].with_openexr = False  # generate image in EXR format
+            self.options['opencv'].with_quirc = False  # QR code lib
+            self.options['opencv'].with_webp = False  # raster graphics file format for web
+
             # Raise an issue to conan-center to fix this bug. Using workaround to disable freetype for windows
             # Issue link: https://github.com/conan-community/community/issues/341
             #TODO Remove this once they fix this issue.
-            if self.settings.os == "Windows":
-                self.options['opencv'].contrib_freetype = False
+            # TODO: Confirm if still needed.
+            if is_msvc(self):
+                self.options['opencv'].freetype = False
 
-        if self.options.generator == "":
-            # Select default generator supplied to cmake based on os
-            if self.settings.os == "Macos":
-                self.generator = "Xcode"
-            elif self.settings.os == "Windows":
-                self.generator = "Visual Studio 16 2019"
-                self.options["*"].shared = True
-            else:
-                print("Creating a make file for project. ")
-                print("Specify your own using the -o generator='Name' flag during conan install")
-        else:
-            self.generator = str(self.options.generator)
-            if self.settings.os == "Windows":
-                self.options["*"].shared = True
-        print("cmake generator set to: " + statusColor + str(self.generator) + endColor)
+        if is_msvc(self):
+            self.options["*"].shared = True
+
+        # Other dependency options
+        self.options['zeromq'].encryption = False # Basilisk does not use data streaming encryption.
+
 
     def package_id(self):
-        if self.settings.compiler == "Visual Studio":
+        if self.info.settings.compiler == "Visual Studio":
             if "MD" in self.settings.compiler.runtime:
                 self.info.settings.compiler.runtime = "MD/MDd"
             else:
@@ -243,55 +240,88 @@ class BasiliskConan(ConanFile):
             self.keep_imports = True
             self.copy("*.dll", "../Basilisk", "bin")
 
-    def build(self):
-        if self.options.pathToExternalModules:
+    def layout(self):
+        cmake_layout(self,
+                     src_folder=str(self.options.get_safe("sourceFolder")),
+                     build_folder=str(self.options.get_safe("buildFolder"))
+                     )
+
+        # XXX: Override the build folder again to keep it consistent between
+        # multi- (e.g. Visual Studio) and single-config (e.g. Make) generators.
+        # Otherwise, it's too difficult to extract the value of this into the
+        # setup.py file programmatically.
+        self.folders.build = str(self.options.get_safe("buildFolder"))
+
+    def generate(self):
+        if self.options.get_safe("pathToExternalModules"):
             print(statusColor + "Including External Folder: " + endColor + str(self.options.pathToExternalModules))
 
-        root = os.path.abspath(os.path.curdir)
+        if self.settings.build_type == "Debug":
+            self.output.warning("Build type is set to Debug. Performance will be significantly slower.")
 
-        self.folders.source = os.path.join(root, "src")
-        self.folders.build = os.path.join(root, "dist3")
+        # -------------------------------------------------------------
+        # Run the CMake configuration generators.
+        # -------------------------------------------------------------
+        deps = CMakeDeps(self)
+        deps.set_property("eigen", "cmake_target_name", "Eigen3::Eigen3")   # XXX: Override, original is "Eigen3::Eigen"
+        deps.set_property("cppzmq", "cmake_target_name", "cppzmq::cppzmq")  # XXX: Override, original is "cppzmq"
+        deps.generate()
 
-        cmake = CMake(self, set_cmake_flags=True, generator=self.generator)
-        if self.settings.compiler == "Visual Studio":
-            cmake.definitions["CONAN_LINK_RUNTIME_MULTI"] = cmake.definitions["CONAN_LINK_RUNTIME"]
-            cmake.definitions["CONAN_LINK_RUNTIME"] = False
-        cmake.definitions["BUILD_OPNAV"] = self.options.opNav
-        cmake.definitions["BUILD_VIZINTERFACE"] = self.options.vizInterface
-        cmake.definitions["EXTERNAL_MODULES_PATH"] = self.options.pathToExternalModules
-        cmake.definitions["PYTHON_VERSION"] = f"{sys.version_info.major}.{sys.version_info.minor}"
+        tc = CMakeToolchain(self)
+        generatorString = str(self.options.get_safe("generator"))
+        if generatorString == "":
+            # Select default generator supplied to cmake based on os
+            if self.settings.os == "Macos":
+                generatorString = "Xcode"
+                tc.generator = generatorString
+            elif self.settings.os == "Windows":
+                generatorString = "Visual Studio 16 2019"
+                tc.generator = generatorString
+                self.options["*"].shared = True
+            else:
+                print("Creating a make file for project. ")
+                print("Specify your own using the -o generator='Name' flag during conan install")
+        else:
+            tc.generator = generatorString
+            if self.settings.os == "Windows":
+                self.options["*"].shared = True
+        print("cmake generator set to: " + statusColor + generatorString + endColor)
 
-        if self.options.pyLimitedAPI != "":
-            cmake.definitions["PY_LIMITED_API"] = self.options.pyLimitedAPI
-
+        tc.cache_variables["BUILD_OPNAV"] = bool(self.options.get_safe("opNav"))
+        tc.cache_variables["BUILD_VIZINTERFACE"] = bool(self.options.get_safe("vizInterface"))
+        if self.options.get_safe("pathToExternalModules"):
+            tc.cache_variables["EXTERNAL_MODULES_PATH"] = Path(str(self.options.pathToExternalModules)).resolve().as_posix()
+        tc.cache_variables["PYTHON_VERSION"] = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
         # Set the build rpath, since we don't install the targets, so that the
         # shared libraries can find each other using relative paths.
-        cmake.definitions["CMAKE_BUILD_RPATH_USE_ORIGIN"] = True
+        tc.cache_variables["CMAKE_BUILD_RPATH_USE_ORIGIN"] = True
+        # Set the minimum buildable MacOS version.
+        # tc.cache_variables["CMAKE_OSX_DEPLOYMENT_TARGET"] = "10.13"
+        tc.parallel = True
 
-        # TODO: Set the minimum buildable MacOS version.
-        # (This might be necessary but I'm not sure yet, leaving it here for future reference.)
-        # cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"] = "10.13"
+        # Generate!
+        tc.generate()
 
-        cmake.parallel = True
+    def build(self):
+
+        cmake = CMake(self)
         print(statusColor + "Configuring cmake..." + endColor)
         cmake.configure()
-        if self.options.managePipEnvironment:
+
+        if self.options.get_safe("managePipEnvironment"):
             # TODO: it's only needed when conanfile.py is handling pip installations.
             self.add_basilisk_to_sys_path()
-        if self.options.buildProject:
+
+        if self.options.get_safe("buildProject"):
             print(statusColor + "\nCompiling Basilisk..." + endColor)
             start = datetime.now()
-            if self.generator == "Xcode":
-                # Xcode multi-threaded needs specialized arguments
-                cmake.build(['--', '-jobs', str(tools.cpu_count()), '-parallelizeTargets'])
-            else:
-                cmake.build()
+            cmake.build()
             print("Total Build Time: " + str(datetime.now() - start))
             print(f"{statusColor}The Basilisk build is successful and the scripts are ready to run{endColor}")
         else:
             print(f"{statusColor}Finished configuring the Basilisk project.{endColor}")
             if self.settings.os != "Linux":
-                print(f"{statusColor}Please open project file inside dist3 with {self.generator} IDE "
+                print(f"{statusColor}Please open project file inside dist3 with IDE "
                       f"and build the project for {self.settings.build_type}{endColor}")
             else:
                 print(f"{statusColor}Please go to dist3 folder and run command "
@@ -299,17 +329,17 @@ class BasiliskConan(ConanFile):
         return
 
     def add_basilisk_to_sys_path(self):
-        print("Adding Basilisk module to python\n")
+        print(f"{statusColor}Adding Basilisk module to python{endColor}\n")
         # NOTE: "--no-build-isolation" is used here only to force pip to use the
         # packages installed directly by this Conanfile (using the
         # "managePipEnvironment" option). Otherwise, it is not necessary.
-        add_basilisk_module_command = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "."]
+        add_basilisk_module_command = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "../"]
 
-        if self.options.allOptPkg:
+        if self.options.get_safe("allOptPkg"):
             # Install the optional requirements as well
             add_basilisk_module_command[-1] = ".[optional]"
 
-        if not is_running_virtual_env() and self.options.autoKey != 's':
+        if not is_running_virtual_env() and self.options.get_safe("autoKey") != 's':
             add_basilisk_module_command.append("--user")
 
         process = subprocess.Popen(add_basilisk_module_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -327,19 +357,20 @@ if __name__ == "__main__":
     # XXX: This needs to be run before dispatching to Conan (i.e. outside of the
     # ConanFile object), because it affects the configuration of the first run.
     # (Running it here fixes https://github.com/AVSLab/basilisk/issues/525)
-    if platform.system() != "Darwin":
+    try:
+        subprocess.check_output(["conan", "profile", "detect", "--exist-ok"])
+    except:
+        # if profile already exists the above command returns an error.  Just ignore in this
+        # case.  We don't want to overwrite an existing profile file
+        pass
+
+    if platform.system() == "Linux":
         try:
-            subprocess.check_output(["conan", "profile", "new", "default", "--detect"])
+            # XXX: This fixes a linker issue due to the dual C++ ABI.
+            subprocess.check_output(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"])
+            print("\nConfiguring: " + statusColor + "use libstdc++11 by default" + endColor)
         except:
             pass
-
-        if platform.system() == "Linux":
-            try:
-                # XXX: This fixes a linker issue due to the dual C++ ABI.
-                subprocess.check_output(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"])
-                print("\nConfiguring: " + statusColor + "use libstdc++11 by default" + endColor)
-            except:
-                pass
     print(statusColor + "Checking conan configuration:" + endColor + " Done")
 
     parser = argparse.ArgumentParser(description="Configure the Basilisk framework.")
@@ -348,23 +379,23 @@ if __name__ == "__main__":
     parser.add_argument("--buildType", help="build type", default="Release", choices=["Release", "Debug"])
     # parser.add_argument("--clean", help="make a clean distribution folder", action="store_true")
     for opt, value in bskModuleOptionsBool.items():
-        parser.add_argument("--" + opt, help="build modules for " + opt + " behavior", default=value,
+        parser.add_argument("--" + opt, help="build modules for " + opt + " behavior", default=value[1],
                             type=lambda x: (str(x).lower() == 'true'))
     for opt, value in bskModuleOptionsString.items():
-        parser.add_argument("--" + opt, help="using string option for " + opt, default=value)
+        parser.add_argument("--" + opt, help="using string option for " + opt, default=value[1])
     for opt, value in bskModuleOptionsFlag.items():
         if sys.version_info < (3, 9, 0):
-            parser.add_argument("--" + opt, help="using flag option for " + opt, default=value, action='store_true')
+            parser.add_argument("--" + opt, help="using flag option for " + opt, default=value[1], action='store_true')
         else:
-            parser.add_argument("--" + opt, help="using flag option for " + opt, default=value,
+            parser.add_argument("--" + opt, help="using flag option for " + opt, default=value[1],
                                 action=argparse.BooleanOptionalAction)
     args = parser.parse_args()
 
     # set the build destination folder
-    buildFolderName = 'dist3/conan'
+    # buildFolderName = 'dist3/conan'
 
     # run the auto-module generation script
-    # this ensures that this script is up to date with the latest BSK code base
+    # this ensures that this script is up-to-date with the latest BSK code base
     # and that the associated unit test draft file runs
     print(statusColor + "Auto-Generating Draft Modules... " + endColor, end=" ")
     genMod = makeDraftModule.moduleGenerator()
@@ -380,32 +411,34 @@ if __name__ == "__main__":
     conanCmdString = list()
     conanCmdString.append(f'{sys.executable} -m conans.conan install . --build=missing')
     conanCmdString.append(' -s build_type=' + str(args.buildType))
-    conanCmdString.append(' -if ' + buildFolderName)
+    optionsString = list()
     if args.generator:
-        conanCmdString.append(' -o generator="' + str(args.generator) + '"')
+        optionsString.append(' -o "&:generator=' + str(args.generator) + '"')
     for opt, value in bskModuleOptionsBool.items():
-        conanCmdString.append(' -o ' + opt + '=' + str(vars(args)[opt]))
+        optionsString.append(' -o "&:' + opt + '=' + str(vars(args)[opt]) + '"')
+    conanCmdString.append(''.join(optionsString))
+
     for opt, value in bskModuleOptionsString.items():
         if str(vars(args)[opt]):
             if opt == "pathToExternalModules":
                 externalPath = os.path.abspath(str(vars(args)[opt]).rstrip(os.path.sep))
                 if os.path.exists(externalPath):
-                    conanCmdString.append(' -o ' + opt + '=' + externalPath)
+                    conanCmdString.append(' -o "&:' + opt + '=' + externalPath + '"')
                 else:
                     print(f"{failColor}Error: path {str(vars(args)[opt])} does not exist{endColor}")
                     sys.exit(1)
             else:
-                conanCmdString.append(' -o ' + opt + '=' + str(vars(args)[opt]))
+                conanCmdString.append(' -o "&:' + opt + '=' + str(vars(args)[opt]) + '"')
     for opt, value in bskModuleOptionsFlag.items():
         if vars(args)[opt]:
-            conanCmdString.append(' -o ' + opt + '=True')
+            conanCmdString.append(' -o "&:' + opt + '=True"')
     conanCmdString = ''.join(conanCmdString)
-    print(statusColor + "Running this conan command:" + endColor)
+    print(statusColor + "Running:" + endColor)
     print(conanCmdString)
     completedProcess = subprocess.run(conanCmdString, shell=True, check=True)
 
     # run conan build
-    cmakeCmdString = f'{sys.executable} -m conans.conan build . -if ' + buildFolderName
-    print(statusColor + "Running cmake:" + endColor)
-    print(cmakeCmdString)
-    completedProcess = subprocess.run(cmakeCmdString, shell=True, check=True)
+    buildCmdString = f'{sys.executable} -m conans.conan build . ' + ''.join(optionsString)
+    print(statusColor + "Running:" + endColor)
+    print(buildCmdString)
+    completedProcess = subprocess.run(buildCmdString, shell=True, check=True)

--- a/docs/source/Install/installBuildConan.rst
+++ b/docs/source/Install/installBuildConan.rst
@@ -27,11 +27,11 @@ Step 1: Installing Basilisk Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The first command, in its minimalist form, is::
 
-    conan install . -if dist3/conan --build=missing
+    conan install . --build=missing
 
 This conan command will create the distribution folder, ``dist3`` in the above case, if needed, collect all the
-require Basilisk 3rd party resources and compile them if their binaries are missing.  The cmake files to access these
-3rd party libraries are stored in ``dist3/conan``.
+require Basilisk 3rd party resources and compile them if their binaries are missing. All build files
+are stored in ``dist3``.
 
 There are several options that can be provided to this ``conan install`` command as shown in the following table.
 Note that the option names for groupings of Basilisk modules are the same as with the one-step build above.
@@ -81,7 +81,7 @@ Note that the option names for groupings of Basilisk modules are the same as wit
 Thus, using the same build example as in the one-step section, to create a build with ``opNav`` modes enabled,
 but no :ref:`vizInterface`, and using a clean distribution folder, and that is built right away, you could use::
 
-    conan install . -if dist3/conan --build=missing -o clean=True -o buildProject=True -o opNav=True -o vizInterface=False
+    conan install . --build=missing -o clean=True -o buildProject=True -o opNav=True -o vizInterface=False
 
 Note how much more verbose this is, but it gives you full control if you want to store the compiled binaries and
 cmake files in directories other than ``dist3/conan``.
@@ -91,7 +91,12 @@ Step 2: Creating the IDE Project
 The final step is to create the IDE project file and possibly build the executables directly.
 At this stage there are no options to be provided.  This step is done with::
 
-    conan build . -if dist3/conan
+    conan build .
+
+.. note::
+
+    If you provide the ``conan install`` step some optional arguments with ``-o``, the same
+    arguments must be provided for the ``conan build`` step.
 
 .. warning::
 
@@ -188,4 +193,3 @@ Example build commands forArch x64, MSVC Year 2019, MSVC Version 16::
     cmake -G “Visual Studio 16 2019” -A x64 ../src -DCMAKE_BUILD_TYPE=Release
 
     cmake -G “Visual Studio 15 2017 Win64” ../src -DCMAKE_BUILD_TYPE=Release
-

--- a/docs/source/Install/installOnLinux.rst
+++ b/docs/source/Install/installOnLinux.rst
@@ -111,14 +111,9 @@ Dependencies
 
 #. Ensure ``wheel`` is installed and install ``conan`` using pip, an example is below::
 
-       (venv) $ pip3 install wheel 'conan<2.0'
+       (venv) $ pip3 install wheel conan
 
-   The conan repositories information is automatically setup by ``conanfile.py``.
-
-   .. warning::
-
-      If you are upgrading from a version of Basilisk prior to 1.8.0, be sure to delete the ``.conan`` folder in your
-      home directory to create a clean copy compatible with the current build system.
+   The ``conan`` repositories information is automatically setup by ``conanfile.py``.
 
 #. CMake: You can install cmake using pip3.  This makes it easy to overcome limitations of which version of ``cmake``
    the ``apt-get`` command provides::

--- a/docs/source/Install/installOnMacOS.rst
+++ b/docs/source/Install/installOnMacOS.rst
@@ -120,15 +120,9 @@ Installing required python support packages
 #. Basilisk uses ``conan`` for package managing. In order to do so, users
    must ensure ``wheel`` is installed and install ``conan``::
 
-       (.venv) $ pip3 install wheel 'conan<2.0'
+       (.venv) $ pip3 install wheel conan
 
-   The conan repositories information is automatically setup by ``conanfile.py``.
-
-
-   .. warning::
-
-      If you are upgrading from a version of Basilisk prior to 1.8.0, be sure to delete the ``.conan`` folder in your
-      home directory to create a clean copy compatible with the current build system.
+   The ``conan`` repositories information is automatically setup by ``conanfile.py``.
 
 #. The required python packages for Basilisk will be installed automatically when running ``conanfile.py``.
 

--- a/docs/source/Install/installOnWindows.rst
+++ b/docs/source/Install/installOnWindows.rst
@@ -126,21 +126,14 @@ Installing required python support packages
 #. Basilisk uses conan for package managing. In order to do so, users
    must ensure ``wheel`` is installed and install ``conan``::
 
-       (venv) $ pip install wheel 'conan<2.0'
+       (venv) $ pip install wheel conan
 
-   The conan repositories information is automatically setup by ``conanfile.py``.
-
+   The ``conan`` repositories information is automatically setup by ``conanfile.py``.
 
    .. warning::
 
       Don't use the ``conan`` binary installed from the `conan web site <https://conan.io/downloads.html>`__.
       This causes several issues with the current build system.
-
-
-   .. warning::
-
-      If you are upgrading from a version of Basilisk prior to 1.8.0, be sure to delete the ``.conan`` folder in your
-      home directory to create a clean copy compatible with the current build system.
 
 #. The required python packages for Basilisk will be installed automatically when running ``conanfile.py``.
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -23,6 +23,13 @@ Version |release|
 - The ``MtbEffector.py`` module was not being imported correctly in Python due to lack of ``swig_eigen.i``
   include file in ``MtbEffector.i``. This is fixed in the current release, however it remains unknown why
   the dynamics engine is re-swigged for every individual effector/dynamics related class.
+- This release uses ``conan`` version 2.x which creates a new folder ``.conan2`` in
+  the home folder.  Thus, the first time Basilisk is build the project dependencies will
+  be downloaded again into ``.conan2``
+- If configuring and building Basilisk directly with ``conan install`` and ``build`` commands,
+  the ``-if dist3/conan`` argument is no longer needed.  The Basilisk install location is
+  setup with ``conan 2`` arguments inside ``conanfile.py``.
+
 
 Version 2.5.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -79,6 +79,13 @@ Version  |release|
   the added setters and getters must be used.
 - Fixed a bug in which the ``MtbEffector.py`` module was not being imported correctly in Python due to lack of ``swig_eigen.i``
   include file in ``MtbEffector.i``.
+- Update the build process to use ``conan`` version 2.x
+
+  .. warning::
+
+    You have to upgrade your python ``conan`` package to be able to build Basilisk.
+    Use ``python install --upgrade conan``.
+
 
 Version 2.5.0 (Sept. 30, 2024)
 ------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     # Requirements for building Basilisk through conanfile
     "conan>=2.0.5",
     "cmake>=3.26",
-    "swig==4.2.1"  # Known to work with https://github.com/nightlark/swig-pypi/pull/120
+    "swig>=4.2.1"  # Known to work with https://github.com/nightlark/swig-pypi/pull/120
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "packaging>=22",        # Due to incompatibility: https://github.com/pypa/setuptools/issues/4483
 
     # Requirements for building Basilisk through conanfile
-    "conan>=1.40.1, <2.00.0",
+    "conan>=2.0.5",
     "cmake>=3.26",
     "swig==4.2.1"  # Known to work with https://github.com/nightlark/swig-pypi/pull/120
 ]

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class BuildConanExtCommand(Command, SubCommand):
 
         # Set limited ABI compatibility by default, targeting the minimum required Python version.
         # See https://docs.python.org/3/c-api/stable.html
-        # NOTE: Swig 4.2.0 is required, see https://github.com/swig/swig/pull/2727
+        # NOTE: Swig 4.2.1 or higher is required, see https://github.com/swig/swig/pull/2727
         min_version = next(self.distribution.python_requires.filter([f"3.{i}" for i in range(2, 100)])).replace(".", "")
         bdist_wheel = self.reinitialize_command("bdist_wheel", py_limited_api=f"cp{min_version}")
         bdist_wheel.ensure_finalized()


### PR DESCRIPTION
* **Tickets addressed:** bsk-860
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Basilisk build system was not compatible with conan 2.x.  The conan project now is no longer updating conan 1.x recipes.

## Verification
The build system works again with conan 2.x installed.  All the CI tests passed.  Wheels were built and installed with the expected results.

## Documentation
The build documentation was updated to say that the latest version of conan can be installed.  The release notes were updated.  The known issue file has a comment that because conan 2.x uses a new `.conan2` folder for the dependencies, the first time this BSK commit is built the conan dependencies are downloaded and installed.  This is a one-time action.

## Future work
Hopefully conan 3.x won't break conan 2.x scripts...