### PR TITLE
Enhance SWIG support for various type arrays

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -16,6 +16,8 @@ Version |release|
   in :ref:`magnetometer` and :ref:`coarsesunsensor`
   the value was being multiplied by 1.5 when creating the diagonal noise matrix.
   This 1.5x multiplier has now been removed. This is corrected in current release.
+- SWIG wrapper does not fully support all array types in message payloads. This affects custom message
+  payloads that use these types for array members. Workaround is to add them to ``swig_conly_data.i``.
 
 Version 2.5.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -69,6 +69,8 @@ Version  |release|
 - Added :ref:`scenarioGaussMarkovRandomWalk` to showcase ``GaussMarkov`` class functionality
 - Added unit test coverage for ``GaussMarkov`` implementation in :ref:`tempMeasurement`,
   :ref:`simpleNav` and :ref:`planetNav`.
+- Fixed SWIG array handling for message payloads on macOS, particularly addressing issues with uint8_t arrays and other
+  array types in message payloads. This resolves compatibility issues between SWIG's array typemaps and builds.
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/architecture/_GeneralModuleFiles/swig_conly_data.i
+++ b/src/architecture/_GeneralModuleFiles/swig_conly_data.i
@@ -99,6 +99,11 @@ ARRAYASLIST(size_t, PyLong_FromSize_t, PyLong_AsSize_t)
 ARRAYASLIST(ssize_t, PyLong_FromSsize_t, PyLong_AsSsize_t)
 ARRAYASLIST(double, PyFloat_FromDouble, PyFloat_AsDouble)
 ARRAYASLIST(float, PyFloat_FromDouble, PyFloat_AsDouble)
+ARRAYASLIST(uint8_t, PyLong_FromUnsignedLong, PyLong_AsUnsignedLong)
+ARRAYASLIST(unsigned char, PyLong_FromUnsignedLong, PyLong_AsUnsignedLong)
+ARRAYASLIST(int8_t, PyLong_FromLong, PyLong_AsLong)
+ARRAYASLIST(signed char, PyLong_FromLong, PyLong_AsLong)
+ARRAYASLIST(bool, PyBool_FromLong, PyObject_IsTrue)
 
 %define ARRAY2ASLIST(type, fromfunc, asfunc)
 
@@ -179,6 +184,11 @@ ARRAY2ASLIST(size_t, PyLong_FromSize_t, PyLong_AsSize_t)
 ARRAY2ASLIST(ssize_t, PyLong_FromSsize_t, PyLong_AsSsize_t)
 ARRAY2ASLIST(double, PyFloat_FromDouble, PyFloat_AsDouble)
 ARRAY2ASLIST(float, PyFloat_FromDouble, PyFloat_AsDouble)
+ARRAY2ASLIST(uint8_t, PyLong_FromUnsignedLong, PyLong_AsUnsignedLong)
+ARRAY2ASLIST(unsigned char, PyLong_FromUnsignedLong, PyLong_AsUnsignedLong)
+ARRAY2ASLIST(int8_t, PyLong_FromLong, PyLong_AsLong)
+ARRAY2ASLIST(signed char, PyLong_FromLong, PyLong_AsLong)
+ARRAY2ASLIST(bool, PyBool_FromLong, PyObject_IsTrue)
 
 %define STRUCTASLIST(type)
 %typemap(in) type [ANY] (type temp[$1_dim0]) {

--- a/src/architecture/messaging/_UnitTest/test_CMsgTypes.py
+++ b/src/architecture/messaging/_UnitTest/test_CMsgTypes.py
@@ -46,6 +46,11 @@ def test_cMsgTypes():
     assert type(test.ui64Test) is int
     assert type(test.f32Test) is float
     assert type(test.f64Test) is float
+    assert type(test.uint8Test) is int
+    assert type(test.ucharTest) is int
+    assert type(test.int8Test) is int
+    assert type(test.scharTest) is int
+    assert type(test.boolTest) is bool
 
     assert type(test.i16TestArray[0]) is int
     assert type(test.ui16TestArray[0]) is int
@@ -65,6 +70,12 @@ def test_cMsgTypes():
     assert type(test.f32TestArray2[0][0]) is float
     assert type(test.f64TestArray2[0][0]) is float
 
+    assert type(test.uint8TestArray2[0][0]) is int
+    assert type(test.ucharTestArray2[0][0]) is int
+    assert type(test.int8TestArray2[0][0]) is int
+    assert type(test.scharTestArray2[0][0]) is int
+    assert type(test.boolTestArray2[0][0]) is bool
+
     assert len(test.i16TestArray) == messaging.TYPES_TEST_ARRAY_SIZE
     assert len(test.ui16TestArray) == messaging.TYPES_TEST_ARRAY_SIZE
     assert len(test.i32TestArray) == messaging.TYPES_TEST_ARRAY_SIZE
@@ -82,6 +93,18 @@ def test_cMsgTypes():
     assert len(test.ui64TestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
     assert len(test.f32TestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
     assert len(test.f64TestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
+
+    assert len(test.uint8TestArray) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.ucharTestArray) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.int8TestArray) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.scharTestArray) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.boolTestArray) == messaging.TYPES_TEST_ARRAY_SIZE
+
+    assert len(test.uint8TestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.ucharTestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.int8TestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.scharTestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
+    assert len(test.boolTestArray2[0]) == messaging.TYPES_TEST_ARRAY_SIZE
 
 
 if __name__ == "__main__":

--- a/src/architecture/msgPayloadDefC/TypesTestMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/TypesTestMsgPayload.h
@@ -37,6 +37,11 @@ typedef struct {
     uint64_t ui64Test;  //!< Test variable of uint64_t
     float f32Test;      //!< Test variable of float
     double f64Test;     //!< Test variable of double
+    uint8_t uint8Test;      //!< Test variable of uint8_t (alias)
+    unsigned char ucharTest; //!< Test variable of unsigned char
+    int8_t int8Test;        //!< Test variable of int8_t (alias)
+    signed char scharTest;   //!< Test variable of signed char
+    bool boolTest;          //!< Test variable of bool
 
     // 1D Arrays, integer
     int16_t i16TestArray[TYPES_TEST_ARRAY_SIZE];    //!< Test variable of array of int16_t
@@ -45,6 +50,11 @@ typedef struct {
     uint32_t ui32TestArray[TYPES_TEST_ARRAY_SIZE];  //!< Test variable of array of uint32_t
     int64_t i64TestArray[TYPES_TEST_ARRAY_SIZE];    //!< Test variable of array of int64_t
     uint64_t ui64TestArray[TYPES_TEST_ARRAY_SIZE];  //!< Test variable of array of uint64_t
+    uint8_t uint8TestArray[TYPES_TEST_ARRAY_SIZE];      //!< Array test of uint8_t
+    unsigned char ucharTestArray[TYPES_TEST_ARRAY_SIZE]; //!< Array test of unsigned char
+    int8_t int8TestArray[TYPES_TEST_ARRAY_SIZE];        //!< Array test of int8_t
+    signed char scharTestArray[TYPES_TEST_ARRAY_SIZE];   //!< Array test of signed char
+    bool boolTestArray[TYPES_TEST_ARRAY_SIZE];          //!< Array test of bool
 
     // 2D Arrays, integer
     int16_t i16TestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];    //!< Test variable of 2D array of int16_t
@@ -53,6 +63,11 @@ typedef struct {
     uint32_t ui32TestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];  //!< Test variable of 2D array of uint32_t
     int64_t i64TestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];    //!< Test variable of 2D array of int64_t
     uint64_t ui64TestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];  //!< Test variable of 2D array of uint64_t
+    uint8_t uint8TestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];      //!< 2D Array test of uint8_t
+    unsigned char ucharTestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE]; //!< 2D Array test of unsigned char
+    int8_t int8TestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];        //!< 2D Array test of int8_t
+    signed char scharTestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];   //!< 2D Array test of signed char
+    bool boolTestArray2[TYPES_TEST_ARRAY_SIZE][TYPES_TEST_ARRAY_SIZE];          //!< 2D Array test of bool
 
     // 1D Arrays, floating point
     float f32TestArray[TYPES_TEST_ARRAY_SIZE];   //!< Test variable of array of float


### PR DESCRIPTION
* **Tickets addressed:** issue #851
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Problem was reproduced using issue #851 posting.

## Verification
Problem reproduction with changes resolves issues. Arrays of all the types requested are now supported with swig.

## Documentation
No documentation invalidated. Less trouble for users.

## Future work
If any more requests for specific types arise, they can easily be added in this fashion.
