### PR TITLE
Fix Windows CI build

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -174,13 +174,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Choco help
-        uses: crazy-max/ghaction-chocolatey@v3
-        with:
-          args: -h
-      - name: "Install swig and cmake"
-        shell: pwsh
-        run: choco install swig cmake -y
+#      - name: Choco help
+#        uses: crazy-max/ghaction-chocolatey@v3
+#        with:
+#          args: -h
+#      - name: "Install swig and cmake"
+#        shell: pwsh
+#        run: choco install swig cmake -y
       - name: "Create python virtual env"
         shell: pwsh
         run: python -m venv venv


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Windows CI builds were failing because of an install error.  Turns out swig and cmake are now already included this led to the failure.  The code is just commented out in case it is needed in the future again.

## Verification
CI Windows builds complete without issue again.

## Documentation
Not applicable.

## Future work
I left the `choco` install code in the GitHub action, but commented out.  This was done intentionally in case I have to use choco again in the future.