### PR TITLE
Bug/850 mtbeffector causes issues when interacting with dynmanagersetstate

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -20,6 +20,9 @@ Version |release|
   payloads that use these types for array members. Workaround is to add them to ``swig_conly_data.i``.
 - A bug was fixed in the :ref:`facetSRPDynamicEffector` module. A transpose was required to be added to a dcm
   in order to correctly express rotated facet normals in the spacecraft body frame.
+- The ``MtbEffector.py`` module was not being imported correctly in Python due to lack of ``swig_eigen.i``
+  include file in ``MtbEffector.i``. This is fixed in the current release, however it remains unknown why
+  the dynamics engine is re-swigged for every individual effector/dynamics related class.
 
 Version 2.5.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -77,7 +77,8 @@ Version  |release|
   variables ``numFacets`` and ``numArticulatedFacets``. A deprecation warning is added to the module documentation
   stating that these variables will be moved to private module variables in Dec 2025. To access these variables
   the added setters and getters must be used.
-
+- Fixed a bug in which the ``MtbEffector.py`` module was not being imported correctly in Python due to lack of ``swig_eigen.i``
+  include file in ``MtbEffector.i``.
 
 Version 2.5.0 (Sept. 30, 2024)
 ------------------------------

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.i
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.i
@@ -25,6 +25,7 @@
 %pythoncode %{
     from Basilisk.architecture.swig_common_model import *
 %}
+%include "swig_eigen.i"
 %include "std_string.i"
 %include "swig_conly_data.i"
 


### PR DESCRIPTION
* **Tickets addressed:** issue #850 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->

## Verification
The error was reproduced per the issue #850 instructions and was resolved with the suggested fix of including the swig_eigen.i file in the MtbEffector.i file. This involved running scenarioHohmann.py with the include and ensuring it runs properly when importing the MtbEffector module.

## Documentation
No documentation invalidated, or created, merely one less bug in basilisk. Just the release notes and known issues were updated.

## Future work
Still need to look into why the dynamics engine is re-swigged for every individual effector/dynamics related class, and whether this is necessary or not. This was the recommendation of the user who posted issue #850.
