### PR TITLE
remove sun sensor gauss markov multiplier

### DIFF
--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
@@ -52,7 +52,7 @@ path = os.path.dirname(os.path.abspath(__file__))
         (False, 1.0, 3 * np.pi / 8., 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 10., 1e-10, "fieldOfView", -2, 5.),
         (False, 1.0, np.pi / 2., 0.15, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 10., 1e-10, "kellyFactor", 1, 5.),
         (False, 1.0, np.pi / 2., 0.0, 2.0, 0.0, 0.0, 0.0, 1.0, 0.0, 10., 1e-10, "scaleFactor", 2, 5.),
-        (False, 1.0, np.pi / 2., 0.0, 1.0, 0.0, 0.125, 0.0, 1.0, -0.375, 0.375, 0.5, "deviation", -5, 1.),
+        (False, 1.0, np.pi / 2., 0.0, 1.0, 0.0, 0.225, 0.0, 1.0, -0.375, 0.375, 3e-2, "deviation", -5, 1.),
         # low tolerance for std deviation comparison
         (False, 1.0, np.pi / 2., 0.0, 1.0, 0.0, 0.0, 0.5, 1.0, 0.0, 10., 1e-10, "albedo", -4, 5.),
         (False, 1.0, np.pi / 2., 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.25, 0.75, 1e-10, "saturation", 5, 2.),

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
@@ -134,7 +134,7 @@ void CoarseSunSensor::Reset(uint64_t CurrentSimNanos)
 
     this->noiseModel.setRNGSeed(this->RNGSeed);
 
-    nMatrix(0,0) = this->senNoiseStd*1.5;
+    nMatrix(0,0) = this->senNoiseStd;
     this->noiseModel.setNoiseMatrix(nMatrix);
 
     bounds(0,0) = this->walkBounds;


### PR DESCRIPTION
* **Tickets addressed:** issue #867 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
I missed a 1.5x multiplier in my GaussMarkov #862 pr in coarseSunSensor.cpp and so I removed it and adjusted the relevant unit test.

## Verification
Issue brought to light in issue #867 and was verified visually, along with the fix.

## Documentation
No documentation changes as this ideally would have been included in PR #862 

## Future work
Possibly refactor sensor models to have more consistent use of GaussMarkov noise model as suggested in issue #867 