### PR TITLE
Remove un-needed install code for Linux system

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -356,14 +356,6 @@ if __name__ == "__main__":
         # if profile already exists the above command returns an error.  Just ignore in this
         # case.  We don't want to overwrite an existing profile file
         pass
-
-    if platform.system() == "Linux":
-        try:
-            # XXX: This fixes a linker issue due to the dual C++ ABI.
-            subprocess.check_output(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"])
-            print("\nConfiguring: " + statusColor + "use libstdc++11 by default" + endColor)
-        except:
-            pass
     print(statusColor + "Checking conan configuration:" + endColor + " Done")
 
     parser = argparse.ArgumentParser(description="Configure the Basilisk framework.")


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
With conan2 the need for this command line is gone.  This command failed and did nothing.

## Verification
All CI tests, including the range of Linux tests, built without issues.

## Documentation
N/A

## Future work
N/A