### PR TITLE
Feature/877 add battery capacity fault capability

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -79,6 +79,7 @@ Version  |release|
   the added setters and getters must be used.
 - Fixed a bug in which the ``MtbEffector.py`` module was not being imported correctly in Python due to lack of ``swig_eigen.i``
   include file in ``MtbEffector.i``.
+- Added the capability to simulate a fault in the :ref:`simpleBattery` module that reduces the actual storage capacity without directly altering the stated capacity.
 - Cleaned up what python packages are required to build BSK (``requirements_dev.txt``),
   to run BSK (``requirements.txt``) and to build BSK documentation (``requirements_doc.txt``).
 - The BSK install instructions are updated to ask users to install by first ``pip`` installing build

--- a/src/architecture/msgPayloadDefC/PowerStorageFaultMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/PowerStorageFaultMsgPayload.h
@@ -1,0 +1,30 @@
+/*
+ ISC License
+
+ Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef BASILISK_POWERSTORAGEFAULTSIMMSG_H
+#define BASILISK_POWERSTORAGEFAULTSIMMSG_H
+
+
+
+/*! @brief Message to store current battery stored charge, maximum charge, and received power.*/
+typedef struct{
+    double faultCapacityRatio; //!< Fault capacity ratio (faulted capacity / nominal capacity)
+}PowerStorageFaultMsgPayload;
+
+#endif //BASILISK_POWERSTORAGEFAULTSIMMSG_H

--- a/src/simulation/power/simpleBattery/_UnitTest/test_simpleBatteryFault.py
+++ b/src/simulation/power/simpleBattery/_UnitTest/test_simpleBatteryFault.py
@@ -1,0 +1,127 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2024, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import inspect
+import os
+import pytest
+import numpy as np
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+bskName = 'Basilisk'
+splitPath = path.split(bskName)
+
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.architecture import messaging
+from Basilisk.simulation import simpleBattery
+from Basilisk.utilities import macros
+
+params_set_data = [(5., 5., 5., 10., 0.3),
+                    (1., 1., 5., 10., 0.3),
+                    (5., 5., 5., 10., 0),
+                    (5., 5., 5., 10., 1),
+                    (5, 5, 5, 10, 1e-3),
+                    (5., -5., 5., 10., 0.5)]
+
+@pytest.mark.parametrize(
+        "storedChargeInit, netPower_1, netPower_2, batteryCapacity, faultCapacityRatio",
+        params_set_data)
+
+def test_storage_limits(storedChargeInit, netPower_1, netPower_2, batteryCapacity, faultCapacityRatio):
+    """
+    **Validation Test Description**
+
+    1. Check if the battery capacity matches its nominal value when a fault occurs.
+    2. Verify that the charged capacity does not exceed the faulted capacity or drop below zero.
+
+    :param storedChargeInit: [W] Initial stored charge in the battery.
+    :param netPower_1: [W-s] Power input to the battery.
+    :param netPower_2: [W-s] Power input to the battery.
+    :param batteryCapacity: [W] Battery capacity.
+    :param faultCapacityRatio: [-] Fault capacity ratio.
+
+    :return: void
+    """
+
+    unitTaskName = "unitTask"               # arbitrary name (don't change)
+    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    test_battery = simpleBattery.SimpleBattery()
+    test_battery.storedCharge_Init = storedChargeInit
+    test_battery.storageCapacity = batteryCapacity
+
+    powerMsg1 = messaging.PowerNodeUsageMsgPayload()
+    powerMsg1.netPower = netPower_1
+    pw1Msg = messaging.PowerNodeUsageMsg().write(powerMsg1)
+    powerMsg2 = messaging.PowerNodeUsageMsgPayload()
+    powerMsg2.netPower = netPower_2
+    pw2Msg = messaging.PowerNodeUsageMsg().write(powerMsg2)
+
+    faultMsg = messaging.PowerStorageFaultMsgPayload()
+    faultMsg.faultCapacityRatio = faultCapacityRatio
+    faultStatusMsg = messaging.PowerStorageFaultMsg().write(faultMsg)
+    test_battery.batteryFaultInMsg.subscribeTo(faultStatusMsg)
+
+    # Test the addNodeToStorage method:
+    test_battery.addPowerNodeToModel(pw1Msg)
+    test_battery.addPowerNodeToModel(pw2Msg)
+
+    unitTestSim.AddModelToTask(unitTaskName, test_battery)
+
+    dataLog = test_battery.batPowerOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(5.0))
+
+    unitTestSim.ExecuteSimulation()
+
+    storedChargeLog = dataLog.storageLevel
+    capacityLog = dataLog.storageCapacity
+
+    #   Check 1 - is capacity logged correctly?
+    for ind in range(0,len(capacityLog)):
+        capacity = capacityLog[ind]
+        np.testing.assert_allclose(capacity, batteryCapacity, atol=1e-4,
+            err_msg=("FAILED: SimpleBattery with fault did not correctly log the capacity."))
+
+    #   Check 2 - is stored power correct?
+    for ind in range(0,len(storedChargeLog)):
+        storedCharge = storedChargeLog[ind]
+        assert storedCharge <= capacityLog[ind] * faultCapacityRatio, (
+            "FAILED: SimpleBattery's stored charge exceeded its faulted capacity.")
+
+        assert storedCharge >= 0., (
+            "FAILED: SimpleBattery's stored charge was negative.")
+
+
+if __name__ == "__main__":
+    storedChargeInit = 1.
+    netPower_1 = 1.
+    netPower_2 = 5.
+    batteryCapacity = 10.
+    faultCapacityRatio = 0.3
+    test_storage_limits(storedChargeInit, netPower_1, netPower_2, batteryCapacity, faultCapacityRatio)

--- a/src/simulation/power/simpleBattery/simpleBattery.h
+++ b/src/simulation/power/simpleBattery/simpleBattery.h
@@ -22,6 +22,7 @@
 
 
 #include "simulation/power/_GeneralModuleFiles/powerStorageBase.h"
+#include "architecture/msgPayloadDefC/PowerStorageFaultMsgPayload.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/bskLogging.h"
 
@@ -32,10 +33,13 @@ class SimpleBattery: public PowerStorageBase {
 public:
     SimpleBattery();
     ~SimpleBattery();
+    void readInputMessage();
+    ReadFunctor<PowerStorageFaultMsgPayload> batteryFaultInMsg; //!< input message to record battery status
 
 private:
     void customReset(uint64_t CurrentClock);
     void evaluateBatteryModel(PowerStorageStatusMsgPayload *msg);
+    double faultCapacityRatio; //!< Fault capacity ratio (faulted capacity / nominal capacity)
 
 public:
     double storageCapacity; //!< [W-s] Battery capacity in Watt-seconds (Joules).

--- a/src/simulation/power/simpleBattery/simpleBattery.i
+++ b/src/simulation/power/simpleBattery/simpleBattery.i
@@ -17,27 +17,6 @@
 
  */
 
-
-/*
- ISC License
-
- Copyright (c) 2016, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
-
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
-
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
- */
-
-
 %module simpleBattery
 %{
     #include "simpleBattery.h"
@@ -59,6 +38,8 @@ from Basilisk.architecture.swig_common_model import *
 struct PowerNodeUsageMsg_C;
 %include "architecture/msgPayloadDefC/PowerStorageStatusMsgPayload.h"
 struct PowerStorageStatusMsg_C;
+%include "architecture/msgPayloadDefC/PowerStorageFaultMsgPayload.h"
+struct PowerStorageFaultMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/simulation/power/simpleBattery/simpleBattery.rst
+++ b/src/simulation/power/simpleBattery/simpleBattery.rst
@@ -36,3 +36,10 @@ The next step is to attach one or more :ref:`PowerNodeUsageMsgPayload` instances
 
 
 For more information on how to set up and use this module, see the simple power system example :ref:`scenarioPowerDemo`.
+
+Users may configure the fault message to simulate a battery capacity fault that reduces the actual storage capacity while the ``storageCapacity`` value remains unchanged. The faulted battery capacity is determined using the ``faultCapacityRatio``, calculated as (actual capacity) / (set capacity). ::
+
+   faultMsg = messaging.PowerStorageFaultMsgPayload()
+   faultMsg.faultCapacityRatio = 0.3 # Actual capacity is 30% of the nominal capacity
+   faultStatusMsg = messaging.PowerStorageFaultMsg().write(faultMsg)
+   battery.batteryFaultInMsg.subscribeTo(faultStatusMsg)


### PR DESCRIPTION
* **Tickets addressed:** bsk-877
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Squash and Merge  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
This added the capability to simulate a fault in the `simpleBattery` module that reduces the actual storage capacity without directly altering the stated capacity.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
Added unit test to verify that 
1. Check if the battery capacity matches its nominal value when a fault occurs.
2. Verify that the charged capacity does not exceed the faulted capacity or drop below zero.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
Updated rst file associated with simpleBattery module.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None