### PR TITLE
Latest linux does not directly support Python 3.11

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,8 +94,8 @@ jobs:
 
 
   build-linux-3-11:
-    name: Linux Latest opNav
-    runs-on: ubuntu-latest
+    name: Linux 22.04 opNav
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -101,6 +101,9 @@ Version  |release|
     ``%include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"``. See
     ``src/simulation/dynamics/dragEffector/dragDynamicEffector.i`` for an example.
 
+- Update CI Linux build with ``opNav`` to use Ubuntu 22.04, not latest (i.e. 24.02).  The latter does not
+  support directly Python 3.11, and Basilisk does not support Python 3.13 yet.
+
 
 Version 2.5.0 (Sept. 30, 2024)
 ------------------------------


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The Linux CI build began failing because it was using `ubuntu-latest` which now provides Ubuntu 24.02.  This version no longer provides direct support for python 3.11.  See https://askubuntu.com/questions/1512005/python3-11-install-on-ubuntu-24-04.  

As Basilisk doesn't support python 3.12 yet, the CI build should be using 22.04 for now.

## Verification
CI Linux build with `opNav` built without issues again.

## Documentation
Updated release notes.

## Future work
When BSK supports python 3.12 this build should be tested again on latest Ubuntu.