### PR TITLE
Generate artifacts on Ubuntu 22.04

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -43,7 +43,7 @@ jobs:
     build-ubuntu-latest-wheels:
       name: Build ubuntu-latest wheels
       needs: wait_for_version_bump
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       strategy:
         matrix:
           python-version: ["3.9", "3.10", "3.11"]
@@ -66,7 +66,7 @@ jobs:
             pip wheel . -v --wheel-dir /tmp/wheelhouse
         - uses: actions/upload-artifact@v4
           with:
-            name: basilisk-wheels_ubuntu-latest_python${{ matrix.python-version }}
+            name: basilisk-wheels_ubuntu-22.04_python${{ matrix.python-version }}
             path: /tmp/wheelhouse/**/Basilisk*.whl
 
 


### PR DESCRIPTION
It appears that this change (https://github.com/actions/runner-images/issues/10636) to the `ubuntu-latest` runner is breaking the artifacts that we use to run tests on BSK-RL. I think that bumping the ubuntu version back to 22.04 should resolve the issue.