### PR TITLE
Fix subMRP() in RigidBodyKinematics python library

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -30,6 +30,9 @@ Version |release|
   the ``-if dist3/conan`` argument is no longer needed.  The Basilisk install location is
   setup with ``conan 2`` arguments inside ``conanfile.py``.
 - :ref:`simIncludeGravBody` set the moon radius in km, not meters, and was thus 1000x too small when visualized.
+- In the python library :ref:`RigidBodyKinematics` the ``subMRP()`` routine didn't compute the expected
+  result if the denominator was small.  This is now corrected.
+
 
 Version 2.5.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -104,6 +104,7 @@ Version  |release|
 - Update CI Linux build with ``opNav`` to use Ubuntu 22.04, not latest (i.e. 24.02).  The latter does not
   support directly Python 3.11, and Basilisk does not support Python 3.13 yet.
 - :ref:`simIncludeGravBody` set the moon equatorial radius in km, not meters.
+- fixed ``subMRP()`` routine in :ref:`RigidBodyKinematics`
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/utilities/RigidBodyKinematics.py
+++ b/src/utilities/RigidBodyKinematics.py
@@ -1578,8 +1578,8 @@ def BdotmatMRP(q, dq):
     """
     BdotmatMRP(Q, dQ)
 
-    	B = BdotmatMRP(Q, dQ) returns the derivative of the 3x3 BmatMRP 
-        matrix, which is used to calculate the second order derivative 
+    	B = BdotmatMRP(Q, dQ) returns the derivative of the 3x3 BmatMRP
+        matrix, which is used to calculate the second order derivative
         of the MRP vector Q.
 
     	(d^2Q)/(dt^2) = 1/4 ( [B(Q)] dw + [Bdot(Q,dQ)] w )
@@ -2835,14 +2835,12 @@ def subMRP(q1, q2):
     	which corresponds to relative rotation from Q2
     	to Q1.
     """
-    q2m = np.linalg.norm(q2)
-    q1m = np.linalg.norm(q1)
 
-    den = 1 + (q1m * q1m) * (q2m * q2m) + 2 * np.dot(q1, q2)
+    den = 1 + np.dot(q1, q1) * np.dot(q2, q2) + 2 * np.dot(q1, q2)
     if den < 1e-5:
         q2 = -q2/np.dot(q2,q2)
-        den = 1 + (q1m * q1m) * (q2m * q2m) + 2 * np.dot(q1, q2)
-    num = (1 - q2m * q2m) * q1 - (1 - q1m * q1m) * q2 + 2 * np.cross(q1, q2)
+        den = 1 + np.dot(q1, q1) * np.dot(q2, q2) + 2 * np.dot(q1, q2)
+    num = (1 - np.dot(q2, q2)) * q1 - (1 - np.dot(q1, q1)) * q2 + 2 * np.cross(q1, q2)
 
     q = num / den
     if np.dot(q,q) > 1:
@@ -4301,4 +4299,3 @@ def v3Tilde(vector):
               ]
 
     return xTilde
-

--- a/src/utilities/tests/test_RigidBodyKinematics.py
+++ b/src/utilities/tests/test_RigidBodyKinematics.py
@@ -1,0 +1,38 @@
+# ISC License
+#
+# Copyright (c) 2024, AVS Laboratory, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import numpy as np
+from Basilisk.utilities import RigidBodyKinematics as rbk
+
+
+def test_subMRP(show_plots):
+    mrp_1 = np.array([1.5, 0.5, 0.5])
+    mrp_2 = np.array([-0.5, 0.25, 0.15])
+    ans = [-0.005376344086021518,0.04301075268817203,-0.4408602150537635]
+    np.testing.assert_allclose(rbk.subMRP(mrp_1, mrp_2), ans, atol=1e-10, err_msg="subtraction failed")
+
+    # should get the same answer if one MRP is switched to shadoe set
+    mrp_2 = rbk.MRPswitch(mrp_2, 0.0)
+    np.testing.assert_allclose(rbk.subMRP(mrp_1, mrp_2), ans, atol=1e-10, err_msg="subtraction after q2 MRP switch failed")
+
+    mrp_1 = np.array([0.0, 0.0, 1.0])
+    mrp_2 = np.array([0.0, 0.0, -1.0])
+    ans = [0.0, 0.0, 0.0]
+    np.testing.assert_allclose(rbk.subMRP(mrp_1, mrp_2), ans, atol=1e-10, err_msg="180 deg case failed")
+
+
+if __name__ == "__main__":
+    test_subMRP(True)


### PR DESCRIPTION
* **Tickets addressed:** bsk-887
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This function wasn't computing the correct result if the denominator was small.

## Verification
A new unit test was created to ensure we are getting the expected results.

## Documentation
Updated release notes and known issues documents.

## Future work
None