### PR TITLE
Fix Moon equatorial radius value

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -29,7 +29,7 @@ Version |release|
 - If configuring and building Basilisk directly with ``conan install`` and ``build`` commands,
   the ``-if dist3/conan`` argument is no longer needed.  The Basilisk install location is
   setup with ``conan 2`` arguments inside ``conanfile.py``.
-
+- :ref:`simIncludeGravBody` set the moon radius in km, not meters, and was thus 1000x too small when visualized.
 
 Version 2.5.0
 -------------

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -103,6 +103,7 @@ Version  |release|
 
 - Update CI Linux build with ``opNav`` to use Ubuntu 22.04, not latest (i.e. 24.02).  The latter does not
   support directly Python 3.11, and Basilisk does not support Python 3.13 yet.
+- :ref:`simIncludeGravBody` set the moon equatorial radius in km, not meters.
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/utilities/simIncludeGravBody.py
+++ b/src/utilities/simIncludeGravBody.py
@@ -115,7 +115,7 @@ BODY_DATA = {
         displayName="moon",
         modelDictionaryKey="",
         mu=astroConstants.MU_MOON*1e9,
-        radEquator=astroConstants.REQ_MOON,
+        radEquator=astroConstants.REQ_MOON*1e3,
         spicePlanetFrame="IAU_moon",
     ),
     "mars": BodyData(


### PR DESCRIPTION
* **Tickets addressed:** bsk-876
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The gravity factory class set the moon equatorial radius in km, not meters, and was thus 1000x too small.  As a result, visualizations using the moon would not be seeing it at the right size.

## Verification
A scenario such as the halo orbit example now shows both Earth and moon with the expected size.

## Documentation
Updated release notes and known issues documents.

## Future work
None.
