### PR TITLE
maximumRange not properly considered in groundMapping module

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -32,6 +32,7 @@ Version |release|
 - :ref:`simIncludeGravBody` set the moon radius in km, not meters, and was thus 1000x too small when visualized.
 - In the python library :ref:`RigidBodyKinematics` the ``subMRP()`` routine didn't compute the expected
   result if the denominator was small.  This is now corrected.
+- :ref:`groundLocation` was not respecting the case where ``maximumRange == -1.0`` in the method ``checkInstrumentFOV``.
 
 
 Version 2.5.0

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -108,6 +108,7 @@ Version  |release|
 - Updated :ref:`solarArrayReference` to correct the wrong assumption of reflective solar arrays for momentum management pointing mode.
 - Updated the CI build that includes the documentation to fail if a doxygen warning happens
 - Removed deprecated swig code that allowed still importing `sys_model.h` instead of `sys_model.i`
+- Updated :ref:`groundMapping` to correct behavior if ``maximumRange == -1``
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/simulation/environment/groundMapping/_UnitTest/test_groundMapping.py
+++ b/src/simulation/environment/groundMapping/_UnitTest/test_groundMapping.py
@@ -1,12 +1,12 @@
-# 
+#
 #  ISC License
-# 
+#
 #  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado Boulder
-# 
+#
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
 #  copyright notice and this permission notice appear in all copies.
-# 
+#
 #  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 #  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 #  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,8 +14,8 @@
 #  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-# 
-# 
+#
+#
 
 import math
 
@@ -26,8 +26,11 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport
 
+import pytest
 
-def test_groundMapping():
+@pytest.mark.parametrize("maxRange", [1e-12, 0.001, -1.0])
+
+def test_groundMapping(maxRange):
     r"""
     This test checks two points to determine if they are accessible for mapping or not. One point should be mapped,
     and one point should not be mapped.
@@ -39,11 +42,11 @@ def test_groundMapping():
     not accessible because the spacecraft is not within the point's visibility cone and the point is not within the
     spacecraft's visibility cone.
     """
-    [testResults, testMessage] = groundMappingTestFunction()
+    [testResults, testMessage] = groundMappingTestFunction(maxRange)
     assert testResults < 1, testMessage
 
 
-def groundMappingTestFunction():
+def groundMappingTestFunction(maxRange):
     """Test method"""
     testFailCount = 0
     testMessages = []
@@ -72,7 +75,8 @@ def groundMappingTestFunction():
     groundMap.addPointToModel([0., -0.1, 0.])
     groundMap.addPointToModel([0., 0., math.tan(np.radians(22.5))+0.1])
     groundMap.minimumElevation = np.radians(45.)
-    groundMap.maximumRange = 1e9
+    if maxRange > 0.0:
+        groundMap.maximumRange = maxRange
     groundMap.cameraPos_B = [0, 0, 0]
     groundMap.nHat_B = [0, 1, 0]
     groundMap.halfFieldOfView = np.radians(22.5)
@@ -103,7 +107,7 @@ def groundMappingTestFunction():
             map_access[idx] = 1
 
     # If the first target is not mapped, failure
-    if not map_access[0]:
+    if not map_access[0] and (maxRange > 1.0 or maxRange < 0.0) :
         testFailCount += 1
 
     # If the second target is mapped, failure
@@ -119,4 +123,4 @@ def groundMappingTestFunction():
 
 
 if __name__ == "__main__":
-    test_groundMapping()
+    test_groundMapping(1e9)

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -185,7 +185,7 @@ uint64_t GroundMapping::checkInstrumentFOV(){
     double boresightNormalProj = ((this->r_LP_N - (this->r_BP_N + this->dcm_NB*cameraPos_B)).transpose())*(dcm_NB*this->nHat_B);
 
     /* Check that the normal projection is within the maximum range*/
-    if ((boresightNormalProj >= 0) && (boresightNormalProj <= this->maximumRange)){
+    if ((boresightNormalProj >= 0) && (boresightNormalProj <= this->maximumRange || this->maximumRange < 0)){
         /* Compute the radius of the instrument's cone at the projection distance */
         double coneRadius = boresightNormalProj*tan(this->halfFieldOfView);
         double orthDistance = (this->r_LP_N - (this->r_BP_N + this->dcm_NB*cameraPos_B)  - boresightNormalProj*dcm_NB*this->nHat_B).norm();


### PR DESCRIPTION
* **Tickets addressed:** bsk-878
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The method ``checkInstrumentFOV()`` was not properly respecting the default value of ``maximumRange`` being -1.0 which should result in the range not being considered. This branch corrects this issue.

## Verification
The unit test is updated to check if the target is in range by setting ``maximumRange`` to default value (-1), a very small value (no target in range) and a very large maximum range value.

## Documentation
Updated release notes.

## Future work
None