### PR TITLE
Feature/750 scenario sep momentum management updates

### DIFF
--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -56,9 +56,10 @@ Illustration of Simulation Results
 The most interesting result of this analysis is shown comparing RW speeds with and without continuous momentum
 management. In the first plot, the thruster is fired through the system's center of mass and therefore the thrust is not
 used to perform momentum management. Exact knowledge of the system's CM location is used here. The wheel speeds increase
-linearly over time, eventually needing momentum dumping. In the second plot, the thruster is used to perform continuous
-momentum management, and the CM location is sequentially estimated. Wheel speeds oscillate in the beginning when the CM
-location is still poorly known, until finally settling once the estimate becomes accurate.
+linearly over time to compensate for the solar radiation pressure, eventually needing momentum dumping. In the second plot,
+the thruster is used to perform continuous momentum management, and the CM location is sequentially estimated. Wheel speeds
+oscillate during the initial transients when the CM estimate is bad, as a result of the thruster torque acting on the system.
+When the CM becomes good, the RW speeds settle without diverging. The value at which each wheel settles depends on the transients.
 
 .. image:: /_images/Scenarios/scenarioSepMomentumManagement300.svg
    :align: center
@@ -79,18 +80,19 @@ true CM.
    :align: center
 
 The final two plots show the net external torques about the CM, projected on the plane orthogonal to the thrust vector
-:math:`\boldsymbol{t}`. In the second plot, because the thruster is fired through the CM, the only contribution is given
-by the SRP torque. In the first plot, when the thruster is fired through the equilibrium point :math:`C^*`, the thruster
-torque exactly counters the action of the SRP torque according to:
+:math:`\boldsymbol{t}`. In the first plot, because the thruster is fired through the CM, the only contribution is given
+by the SRP torque. In the second plot, the net torque goes to zero as the CM location becomes more accurate and the
+thruster is fired through the equilibrium point :math:`C^*`. In this situation the thruster torque exactly counters the
+action of the SRP torque according to:
 
 .. math::
-    \boldsymbol{L} = \boldsymbol{L}_\text{SRP} - (\boldsymbol{L}_\text{SRP} \cdot \boldsymbol{\hat{t}})\boldsymbol{\hat{t}} +
+    \boldsymbol{L}_\text{net} = \boldsymbol{L}_\text{SRP} - (\boldsymbol{L}_\text{SRP} \cdot \boldsymbol{\hat{t}})\boldsymbol{\hat{t}} +
     \boldsymbol{r}_{C^*/C} \times \boldsymbol{t} = 0.
 
-.. image:: /_images/Scenarios/scenarioSepMomentumManagement1000.svg
+.. image:: /_images/Scenarios/scenarioSepMomentumManagement900.svg
    :align: center
 
-.. image:: /_images/Scenarios/scenarioSepMomentumManagement1011.svg
+.. image:: /_images/Scenarios/scenarioSepMomentumManagement911.svg
    :align: center
 
 """
@@ -831,30 +833,28 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
     plot_thruster_cm_offset(timeData, dataRealCM, dataNu, platform.r_S1B_B, platform.dcm_S10B, thrLoc_F, thrDir_F, figID=6)
     pltName = fileName+"6"+str(int(thrMomManagement))+str(int(cmEstimation))
     figureList[pltName] = plt.figure(6)
-    plot_thrust_to_momentum_angle(timeData, dataOmegaRW, Gs, dataNu, platform.dcm_S10B, thrDir_F, figID=7)
+    plot_external_torque(timeData, dataSRPTorquePntC, yString='SRP', figID=7)
     pltName = fileName+"7"+str(int(thrMomManagement))+str(int(cmEstimation))
     figureList[pltName] = plt.figure(7)
-    plot_external_torque(timeData, dataSRPTorquePntC, yString='SRP', figID=8)
+    plot_thr_torque(timeData, dataRealCM, dataNu, platform.r_S1B_B, platform.dcm_S10B, thrLoc_F, thrVec_F, THRConfig.swirlTorque, figID=8)
     pltName = fileName+"8"+str(int(thrMomManagement))+str(int(cmEstimation))
     figureList[pltName] = plt.figure(8)
-    plot_thr_torque(timeData, dataRealCM, dataNu, platform.r_S1B_B, platform.dcm_S10B, thrLoc_F, thrVec_F, THRConfig.swirlTorque, figID=9)
+    plot_net_torques(timeData, dataRealCM, dataNu, platform.r_S1B_B, platform.dcm_S10B, thrLoc_F, thrVec_F, THRConfig.swirlTorque, dataSRPTorquePntC, figID=9)
     pltName = fileName+"9"+str(int(thrMomManagement))+str(int(cmEstimation))
     figureList[pltName] = plt.figure(9)
-    plot_net_torques(timeData, dataRealCM, dataNu, platform.r_S1B_B, platform.dcm_S10B, thrLoc_F, thrVec_F, THRConfig.swirlTorque, dataSRPTorquePntC, figID=10)
+    plot_solar_array_pointing_error(timeData, dataSAPointing, figID=10)
     pltName = fileName+"10"+str(int(thrMomManagement))+str(int(cmEstimation))
     figureList[pltName] = plt.figure(10)
-    plot_solar_array_pointing_error(timeData, dataSAPointing, figID=11)
+    plot_neg_Y_pointing_error(timeData, dataNegYPointing, figID=11)
     pltName = fileName+"11"+str(int(thrMomManagement))+str(int(cmEstimation))
     figureList[pltName] = plt.figure(11)
-    plot_neg_Y_pointing_error(timeData, dataNegYPointing, figID=12)
-    pltName = fileName+"11"+str(int(thrMomManagement))+str(int(cmEstimation))
-    figureList[pltName] = plt.figure(12)
-    plot_state_errors(timeData, dataStateError, dataCovariance, figID=13)
-    pltName = fileName+"11"+str(int(thrMomManagement))+str(int(cmEstimation))
-    figureList[pltName] = plt.figure(13)
-    plot_residuals(timeData, dataPreFit, dataPostFit, cmEstimator.R0[0][0]**0.5, figID=14)
-    pltName = fileName+"12"+str(int(thrMomManagement))+str(int(cmEstimation))
-    figureList[pltName] = plt.figure(14)
+    if cmEstimation:
+        plot_state_errors(timeData, dataStateError, dataCovariance, figID=12)
+        pltName = fileName+"12"+str(int(thrMomManagement))+str(int(cmEstimation))
+        figureList[pltName] = plt.figure(12)
+        plot_residuals(timeData, dataPreFit, dataPostFit, cmEstimator.R0[0][0]**0.5, figID=13)
+        pltName = fileName+"13"+str(int(thrMomManagement))+str(int(cmEstimation))
+        figureList[pltName] = plt.figure(13)
 
     if showPlots:
         plt.show()
@@ -947,33 +947,6 @@ def plot_thruster_cm_offset(timeData, dataCM, dataNu, dataMB_B, dataM0B, dataThr
     plt.legend(loc='lower right')
     plt.xlabel('Time [hours]')
     plt.ylabel('CM Offset Ang [deg]')
-
-def plot_thrust_to_momentum_angle(timeData, dataOmegaRW, Gs, dataNu, dataM0B, dataThrDir_F, figID=None):
-    """Plot the angle between thrust vector and net momentum on RWs."""
-    dataAngle = []
-    for i in range(len(timeData)):
-        FM0 = rbk.euler1232C([dataNu[0][i], dataNu[1][i], 0.0])
-        FB = np.matmul(FM0, dataM0B)
-        BF = FB.transpose()
-        thrDir_B = np.matmul(BF, dataThrDir_F[i])
-        h_B = np.array([0, 0, 0])
-        for j in range(len(Gs)):
-            h_B = h_B + dataOmegaRW[i][j] * Gs[j]
-        h_B_norm = np.linalg.norm(h_B)
-        if h_B_norm == 0:
-            dataAngle.append(0.0)
-        else:
-            dataAngle.append(np.arccos(min(max(np.dot(h_B, thrDir_B) / np.linalg.norm(h_B), -1), 1)))
-        cross = np.cross(h_B, thrDir_B)
-        if np.arctan2(cross[1], cross[0]) < 0:
-            dataAngle[-1] = -dataAngle[-1]
-
-    dataAngle = np.array(dataAngle) * macros.R2D
-    plt.figure(figID, figsize=(5, 2.75))
-    plt.plot(timeData, dataAngle, color='C3', label=r'$\Delta \phi$')
-    plt.legend(loc='lower right')
-    plt.xlabel('Time [hours]')
-    plt.ylabel('Thr-to-Momentum Angle [deg]')
 
 def plot_external_torque(timeData, dataTorque, yString=None, figID=None):
     """Plot the external torques."""

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -481,7 +481,7 @@ def run(swirlTorque, momentumManagement, cmEstimation, showPlots):
     cmEstimator.attitudeTol = 1e-6
     cmEstimator.r_CB_B = r_CB_B_0 # Real CoM_B location = [0.113244, 0.025605, 1.239834]
     cmEstimator.P0 = [0.0025, 0.0025, 0.0025]
-    cmEstimator.R0 = [4e-8, 4e-8, 4e-8]
+    cmEstimator.R0 = [1e-10, 1e-10, 1e-10]
     scSim.AddModelToTask(fswTask, cmEstimator, None, 29)
 
     # create the FSW vehicle configuration message for CoM

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -578,6 +578,45 @@ def run(momentumManagement, cmEstimation, showPlots):
     # but it receives inputs and provides outputs to modules that run on the main flight software task
     messaging.VehicleConfigMsg_C_addAuthor(cmEstimator.vehConfigOutMsgC, vcMsg_CoM)
 
+    # Uncomment to Enable Vizard
+    # Create the effector lists and dictionaries for Vizard
+    rw_state_effector_list = []
+    sc_body_list = []
+    sc_body_list.append(scObject)
+    rw_state_effector_list.append(rwStateEffector)
+    sc_body_list.append([RSAList[0].ModelTag, RSAList[0].spinningBodyConfigLogOutMsg])
+    sc_body_list.append([RSAList[1].ModelTag, RSAList[1].spinningBodyConfigLogOutMsg])
+
+    if vizSupport.vizFound:
+        viz = vizSupport.enableUnityVisualization(scSim, dynTask, sc_body_list
+                                                  # , saveFile=__file__
+                                                  )
+        viz.settings.ambient = 0.7  # increase ambient light to make the shaded spacecraft more visible
+        viz.settings.orbitLinesOn = -1  # turn off osculating orbit line
+        current_path = os.path.dirname(os.path.abspath(__file__))
+        texture_path = os.path.join(current_path, 'dataForExamples', 'texture')
+        vizSupport.createCustomModel(viz
+                                     , simBodiesToModify=[sc_body_list[0].ModelTag]
+                                     , modelPath="CUBE"
+                                     , customTexturePath=os.path.join(texture_path, 'foil_n.png')
+                                     , offset=[0, 0, 0]
+                                     , scale=[2.5, 2.5, 2.5]
+                                     )
+        vizSupport.createCustomModel(viz
+                                     , simBodiesToModify=[sc_body_list[1][0]]
+                                     , modelPath="CYLINDER"
+                                     , customTexturePath=os.path.join(texture_path, 'panel.jpg')
+                                     , offset=[-0.035, 0.25, -0.087]
+                                     , scale=[7, 7, 0.05]
+                                     )
+        vizSupport.createCustomModel(viz
+                                     , simBodiesToModify=[sc_body_list[2][0]]
+                                     , modelPath="CYLINDER"
+                                     , customTexturePath=os.path.join(texture_path, 'panel.jpg')
+                                     , offset=[0.128, 0.25, -0.087]
+                                     , scale=[7, 7, 0.05]
+                                     )
+
     # Connect messages
     sNavObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
     sNavObject.sunStateInMsg.subscribeTo(gravFactory.spiceObject.planetStateOutMsgs[0])

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -187,12 +187,12 @@ def run(momentumManagement, cmEstimation, showPlots):
 
     # setup the orbit using classical orbit elements
     oe = orbitalMotion.ClassicElements()
-    oe.a = 150e9      # meters
+    oe.a = 100e9      # meters
     oe.e = 0.001
     oe.i = 0.0 * macros.D2R
     oe.Omega = 0.0 * macros.D2R
     oe.omega = 0.0 * macros.D2R
-    oe.f = -135.0 * macros.D2R
+    oe.f = -110.0 * macros.D2R
     rN, vN = orbitalMotion.elem2rv(mu, oe)
 
     # To set the spacecraft initial conditions, the following initial position and velocity variables are set:

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -424,8 +424,8 @@ def run(momentumManagement, cmEstimation, showPlots):
     facetR_CopB_BList = [facetLoc1, facetLoc2, facetLoc3, facetLoc4, facetLoc5, facetLoc6, facetLoc7, facetLoc8, facetLoc9, facetLoc10]
 
     # Define the facet optical coefficients
-    facetSpecularCoeffList = np.array([0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9])
-    facetDiffuseCoeffList = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
+    facetSpecularCoeffList = np.array([0.336, 0.336, 0.336, 0.336, 0.336, 0.336, 0.16, 0.00, 0.16, 0.00])
+    facetDiffuseCoeffList = np.array([0.139, 0.139, 0.139, 0.139, 0.139, 0.139, 0.16, 0.56, 0.16, 0.56])
 
     # Populate the scGeometry structure with the facet information
     for i in range(len(facetAreaList)):

--- a/src/tests/test_scenarioSepMomentumManagement.py
+++ b/src/tests/test_scenarioSepMomentumManagement.py
@@ -60,11 +60,14 @@ def test_sepMomentumManagement(withFunction):
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty array to store test log messages
 
-    withMomentumManagement = withFunction
+    withSwirlTorque = False
+    withThrMomManagement = withFunction
+    withSaMomManagement = False
     withCmEstimation = withFunction
 
     try:
-        figureList = scenarioSepMomentumManagement.run(withMomentumManagement, withCmEstimation, False)
+        figureList = scenarioSepMomentumManagement.run(withSwirlTorque, withThrMomManagement,
+                                                       withSaMomManagement, withCmEstimation, False)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
             unitTestSupport.saveScenarioFigure(pltName, plt, path)
@@ -83,4 +86,3 @@ def test_sepMomentumManagement(withFunction):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-


### PR DESCRIPTION
* **Tickets addressed:** bsk-750
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This script is updated to reflect the latest additions presented in Riccardo Calaon's dissertation, and to correct minor imperfections in the previous iteration of the scenario. Commit 1 updates the optical coefficients of the solar arrays to the same value as the arrays of the Lucy spacecraft. Commit 2 lowers the semimajor axis to Venusian orbit to more effectively show the effects of SRP. Commit 3 sets up boresigh modules used to plot alignment accuracies. Commit 4 sets up vizInterface as commented code. Commit 5 adds the option to model the thruster swirl torque via an input variable to the scenario. Commit 6 changes the measurement noise covariance to reflect noise in the PID control torque. Commit 7 changes the array reference frames to equivalent, more intuitive frames. Moreover, the option is added, via input flag, to implement the solar array momentum management technique via differential solar array articulation. Commit 8 refactors the plotting functions, removing uninteresting plots and fixing the numeration; documentation about the scenario is also improved. Commit 9 fixes the test file used to generate the figures included in the documentation.

## Verification
The changes implemented match the results shown in Riccardo Calaon's dissertation "Guidance, Control and Momentum Management of Spacecraft with Multiple Pointing Constraints]".

## Documentation
Documentation is updated to reflect the changes.

## Future work
No future work is currently foreseen.
