### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -222,7 +222,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.11", "3.12" ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docs/source/Install/installOnLinux.rst
+++ b/docs/source/Install/installOnLinux.rst
@@ -13,7 +13,7 @@ Software setup
 In order to run Basilisk, the following software will be necessary. This document outline how to install this support software.
 
 -  `Cmake <https://cmake.org/>`__ 3.14 or higher
--  `Python <https://www.python.org/>`__ 3.8 to 3.11
+-  `Python <https://www.python.org/>`__ 3.8 to 3.12
 -  `SWIG <http://www.swig.org/>`__ (version 4.x)
 -  `GCC <https://gcc.gnu.org/>`__
 -  (Optional) Get the `GitKraken <https://www.gitkraken.com>`__

--- a/docs/source/Install/installOnMacOS.rst
+++ b/docs/source/Install/installOnMacOS.rst
@@ -8,7 +8,7 @@ Setup On macOS
 ==============
 
 These instruction outline how to install Basilisk (BSK) on a clean version of macOS.
-Basilisk requires the use of Python 3.8 to 3.11.
+Basilisk requires the use of Python 3.8 to 3.12.
 
 The following python package dependencies are automatically checked and installed in the steps below.
 

--- a/docs/source/Install/installOnWindows.rst
+++ b/docs/source/Install/installOnWindows.rst
@@ -15,7 +15,7 @@ In order to run Basilisk, the following software will be necessary:
 
 -  `Cmake <https://cmake.org/>`__ 3.14 or higher.  Make sure you can execute this
    program from the command line
--  `Python <https://www.python.org/downloads/windows/>`__ 3.8 to 3.11
+-  `Python <https://www.python.org/downloads/windows/>`__ 3.8 to 3.12
 -  `pip <https://pip.pypa.io/en/stable/installing/>`__
 -  Visual Studios 15 2017 or greater
 -  `Swig <http://www.swig.org/download.html>`__ version 4.X

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -110,6 +110,7 @@ Version  |release|
 - Removed deprecated swig code that allowed still importing `sys_model.h` instead of `sys_model.i`
 - Updated :ref:`groundMapping` to correct behavior if ``maximumRange == -1``
 - Updated scripts to work with ``matplotlib`` version 3.10.x without errors or warnings
+- Add support for Python 3.12
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
 [project]
 name        = 'Basilisk'
 dynamic     = ["version", "dependencies"]
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 
 readme      = "README.md"
 license     = {file = "LICENSE"}

--- a/src/architecture/_GeneralModuleFiles/py_sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/py_sys_model.i
@@ -1,5 +1,5 @@
 
-%module(directors="1") sysModel
+%module(directors="1",threads="1") sysModel
 %{
    #include "sys_model.h"
 %}

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -1,6 +1,4 @@
-#undef SWIGPYTHON_BUILTIN
-
-%module {type}Payload
+%module(threads="1") {type}Payload
 %{{
     #include "{baseDir}/{type}Payload.h"
     #include "architecture/messaging/messaging.h"
@@ -55,4 +53,3 @@ INSTANTIATE_TEMPLATES({type}, {type}Payload, {baseDir})
 %template({type}OutMsgsVector) std::vector<Message<{type}Payload>, std::allocator<Message<{type}Payload>> >;
 %template({type}OutMsgsPtrVector) std::vector<Message<{type}Payload>*, std::allocator<Message<{type}Payload>*> >;
 %template({type}InMsgsVector) std::vector<ReadFunctor<{type}Payload>, std::allocator<ReadFunctor<{type}Payload>> >;
-

--- a/src/architecture/system_model/sim_model.i
+++ b/src/architecture/system_model/sim_model.i
@@ -16,7 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module sim_model
+%module("threads"=1) sim_model
 %{
    #include "sim_model.h"
 %}
@@ -70,7 +70,7 @@ namespace std {
         SWIG_exception(SWIG_RuntimeError, e.what());
     } catch (const std::string& e) {
         SWIG_exception(SWIG_RuntimeError, e.c_str());
-    } 
+    }
 }
 
 %include "sys_model_task.h"

--- a/src/architecture/system_model/sys_model_task.i
+++ b/src/architecture/system_model/sys_model_task.i
@@ -16,7 +16,7 @@
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
  */
-%module sys_model_task
+%module("threads"=1) sys_model_task
 %{
    #include "sys_model_task.h"
 %}


### PR DESCRIPTION
* **Tickets addressed:** #765 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Multithreading was enabled on relevant modules, and the disable of SWIGPYTHON_BUILTIN was removed from messaging.

## Verification
Tested locally on macOS ARM64, Python 3.11 and 3.12.

## Documentation
Any documentation referring to Python version support should be updated.

## Future work
* Evaluate the performance impact of enabling multithreading, considering afaik almost all Basilisk users use a single worker thread. Maybe it would have been better to refactor out multithreading altogether.
* Python 3.13 is on the horizon so hopefully it goes well.
