### PR TITLE
JPL NAIF servers back online

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -386,12 +386,9 @@ endfunction()
 
 # Define download URLs and target paths
 set(SPICE_FILES
-#    "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/de430.bsp"
-#    "https://naif.jpl.nasa.gov/pub/naif/HST/kernels/spk/hst_edited.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/hst_edited.bsp"
-#   "https://naif.jpl.nasa.gov/pub/naif/pds/data/nh-j_p_ss-spice-6-v1.0/nhsp_1000/data/spk/nh_pred_od077.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/nh_pred_od077.bsp"
-    "https://hanspeterschaub.info/bskFiles/Spice/de430.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/de430.bsp"
-    "https://hanspeterschaub.info/bskFiles/Spice/hst_edited.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/hst_edited.bsp"
-    "https://hanspeterschaub.info/bskFiles/Spice/nh_pred_od077.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/nh_pred_od077.bsp"
+    "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/de430.bsp"
+    "https://naif.jpl.nasa.gov/pub/naif/HST/kernels/spk/hst_edited.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/hst_edited.bsp"
+    "https://naif.jpl.nasa.gov/pub/naif/pds/data/nh-j_p_ss-spice-6-v1.0/nhsp_1000/data/spk/nh_pred_od077.bsp::${CMAKE_SOURCE_DIR}/../supportData/EphemerisData/nh_pred_od077.bsp"
 )
 
 # Process each large data file

--- a/src/utilities/bskLargeData.py
+++ b/src/utilities/bskLargeData.py
@@ -92,13 +92,13 @@ def main():
 
     # Step 2: Define the download URLs and destination paths
     files_to_download = {
-        "https://hanspeterschaub.info/bskFiles/Spice/de430.bsp": os.path.join(
+        "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de430.bsp": os.path.join(
             basilisk_path, "supportData", "EphemerisData", "de430.bsp"
         ),
-        "https://hanspeterschaub.info/bskFiles/Spice/hst_edited.bsp": os.path.join(
+        "https://naif.jpl.nasa.gov/pub/naif/HST/kernels/spk/hst_edited.bsp": os.path.join(
             basilisk_path, "supportData", "EphemerisData", "hst_edited.bsp"
         ),
-        "https://hanspeterschaub.info/bskFiles/Spice/nh_pred_od077.bsp": os.path.join(
+        "https://naif.jpl.nasa.gov/pub/naif/pds/data/nh-j_p_ss-spice-6-v1.0/nhsp_1000/data/spk/nh_pred_od077.bsp": os.path.join(
             basilisk_path, "supportData", "EphemerisData", "nh_pred_od077.bsp"
         ),
     }


### PR DESCRIPTION
* **Tickets addressed:** bsk-897
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
JPL NAIF servers are back online again.  Reverse earlier patch to download large Spice `*.bsp` files from NAIF servers again.

## Verification
Did test builds across the platforms and all worked as expected.

## Documentation
None

## Future work
None, I hope these horrendous LA wildfires are a once in a lifetime event.