### PR TITLE
Windows was not running opNav and vizInterface with conan2

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -114,14 +114,14 @@ jobs:
       - name: "Create virtual Environment"
         run: python3 -m venv .venv
       - name: "Install requirements_dev.txt"
-        run: source .venv/bin/activate && pip3 install -r requirements_dev.txt
+        run: source .venv/bin/activate && pip3 install -r requirements_dev.txt pytest-error-for-skips
       - name: "Build basilisk"
         run: source .venv/bin/activate && python3 conanfile.py --opNav True --allOptPkg
 
       - name: "Run Python Tests"
         run: |
           source .venv/bin/activate
-          cd src && pytest -n auto -m "not ciSkip" -rs
+          cd src && pytest -n auto -m "not ciSkip" -rs --error-for-skips
 
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
@@ -189,7 +189,7 @@ jobs:
         shell: pwsh
         run: |
             venv\Scripts\activate
-            pip install -r requirements_dev.txt
+            pip install -r requirements_dev.txt pytest-error-for-skips
       - name: "Add basilisk and cmake path to env path"
         shell: pwsh
         run: |
@@ -207,7 +207,7 @@ jobs:
           Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name MPLBACKEND -Value ${MPLBACKEND}
           venv\Scripts\activate
           cd src
-          pytest -n auto -m "not ciSkip" -rs
+          pytest -n auto -m "not ciSkip" -rs --error-for-skips
           if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}
       - name: "C/C++ Tests"
         if: ${{ always() }}
@@ -241,7 +241,7 @@ jobs:
       - name: "Install requirements_dev.txt"
         run: |
           source .venv/bin/activate
-          pip3 install cmake -r requirements_dev.txt
+          pip3 install cmake -r requirements_dev.txt pytest-error-for-skips
 
       - name: "Build basilisk with OpNav"
         run: source .venv/bin/activate && python3 conanfile.py --opNav True --allOptPkg
@@ -250,7 +250,7 @@ jobs:
         run: |
           source .venv/bin/activate
           cd src
-          pytest -n auto -m "not ciSkip" -rs
+          pytest -n auto -m "not ciSkip" -rs --error-for-skips
         if: ${{ always() }}
       - name: "Run C/C++ Tests"
         working-directory: ./dist3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -116,7 +116,7 @@ jobs:
       - name: "Install requirements_dev.txt"
         run: source .venv/bin/activate && pip3 install -r requirements_dev.txt pytest-error-for-skips
       - name: "Build basilisk"
-        run: source .venv/bin/activate && python3 conanfile.py --opNav True --allOptPkg
+        run: source .venv/bin/activate && python3 conanfile.py --opNav True
 
       - name: "Run Python Tests"
         run: |
@@ -200,7 +200,7 @@ jobs:
         shell: pwsh
         run: |
           venv\Scripts\activate
-          python conanfile.py --opNav True --allOptPkg
+          python conanfile.py --opNav True
       - name: "Run Python Tests"
         shell: pwsh
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ always() }}
         run: |
           source .venv/bin/activate
-          cd src && pytest -n auto -m "not ciSkip"
+          cd src && pytest -n auto -m "not ciSkip" -rs
       - name: Run C/C++ Tests
         if: ${{ always() }}
         working-directory: ./dist3
@@ -85,7 +85,7 @@ jobs:
       - name: "Run Python Tests"
         run: |
           source .venv/bin/activate
-          cd src && pytest -n auto -m "not ciSkip"
+          cd src && pytest -n auto -m "not ciSkip" -rs
 
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
@@ -121,7 +121,7 @@ jobs:
       - name: "Run Python Tests"
         run: |
           source .venv/bin/activate
-          cd src && pytest -n auto -m "not ciSkip"
+          cd src && pytest -n auto -m "not ciSkip" -rs
 
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
@@ -157,7 +157,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install pytest pytest-xdist
-          cd src && pytest -n auto -m "not ciSkip"
+          cd src && pytest -n auto -m "not ciSkip" -rs
 
 
   build-windows:
@@ -207,7 +207,7 @@ jobs:
           Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name MPLBACKEND -Value ${MPLBACKEND}
           venv\Scripts\activate
           cd src
-          pytest -n auto -m "not ciSkip"
+          pytest -n auto -m "not ciSkip" -rs
           if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}
       - name: "C/C++ Tests"
         if: ${{ always() }}
@@ -250,7 +250,7 @@ jobs:
         run: |
           source .venv/bin/activate
           cd src
-          pytest -n auto -m "not ciSkip"
+          pytest -n auto -m "not ciSkip" -rs
         if: ${{ always() }}
       - name: "Run C/C++ Tests"
         working-directory: ./dist3
@@ -296,6 +296,6 @@ jobs:
         run: |
           source .venv/bin/activate
           cd src
-          pytest -n auto -m "not ciSkip"
+          pytest -n auto -m "not ciSkip" -rs
 
         if: ${{ always() }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,7 @@ from packaging.requirements import Requirement
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.microsoft import is_msvc
+from conan.tools.files import copy
 from pathlib import Path
 
 sys.path.insert(1, './src/utilities/')
@@ -234,11 +235,6 @@ class BasiliskConan(ConanFile):
             else:
                 self.info.settings.compiler.runtime = "MT/MTd"
 
-    def imports(self):
-        if self.settings.os == "Windows":
-            self.keep_imports = True
-            self.copy("*.dll", "../Basilisk", "bin")
-
     def layout(self):
         cmake_layout(self,
                      src_folder=str(self.options.get_safe("sourceFolder")),
@@ -252,6 +248,11 @@ class BasiliskConan(ConanFile):
         self.folders.build = str(self.options.get_safe("buildFolder"))
 
     def generate(self):
+        if self.settings.os == "Windows":
+            for dep in self.dependencies.values():
+                for libdir in dep.cpp_info.bindirs:
+                    copy(self, "*.dll", libdir, "../Basilisk")
+
         if self.options.get_safe("pathToExternalModules"):
             print(statusColor + "Including External Folder: " + endColor + str(self.options.pathToExternalModules))
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -120,6 +120,7 @@ Version  |release|
 - Support for Vizard release 2.2.1, including rotating frame settings and documentation for support of ``.glb`` shape files
 - ``vizProtobuffer`` upgraded to use latest C++ compiler, ``protobuf`` Python/C++ library upgraded
 - Updated :ref:`installLinux` to discuss installing BSK on Fedora Linux systems.
+- Updated CI scripts to catch cases where tests are skipped that should be.  Windows now builds properly with `conan2`.
 
 
 Version 2.5.0 (Sept. 30, 2024)

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -56,4 +56,3 @@ if ('--report' in sys.argv) and ('pytest-html' not in installed_packages):
 
 if 'pytest-html' in installed_packages:
     exec(open(path + "/reportconf.py").read(), globals())
-


### PR DESCRIPTION
* **Tickets addressed:** bsk-901
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
With the move to `conan2` the Windows build started to skip some test, but the CI script still claimed it completed successfully as no outright error occurred. The issue was that the `vizInterface` and `opNav` related DLL's were not being found with the `conan2` build.  These dependencies were being downloaded and compiled, but then the python script was not able to import any BSK modules that depended on these.  

The unit test scripts using `vizInterface` and `opNav` had safe guards as we also have CI scripts that don't include these dependencies and want to ensure that here these tests are skipped.  Now, the CI scripts for Linux, Windows and macOS that are configured to have all the collected tests pass will throw an error if a test is skipped.  This will reduce the chances for such a regression in the future.

## Verification
Was able to fully build the CI Windows BSK configuration and all tests pass now.  Verified on personal computer running Windows as well.

## Documentation
Added release notes

## Future work
None
