### PR TITLE
Misc CI and documentation updates

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9]
     runs-on: ubuntu-20.04
+    timeout-minutes: 75
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,6 +63,7 @@ jobs:
   build-linux-3-10:
     name: Linux 22.04
     runs-on: ubuntu-22.04
+    timeout-minutes: 75
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -96,6 +98,7 @@ jobs:
   build-linux-3-11:
     name: Linux 22.04 All Tests
     runs-on: ubuntu-22.04
+    timeout-minutes: 75
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -135,6 +138,7 @@ jobs:
   build-linux-3-11-pip:
     name: Linux 22.04 pip
     runs-on: ubuntu-22.04
+    timeout-minutes: 75
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -167,6 +171,7 @@ jobs:
   build-windows:
     name: Windows All Tests
     runs-on: windows-2019
+    timeout-minutes: 75
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -234,6 +239,7 @@ jobs:
   build-macOS:
     name: macOS All Tests Docs
     runs-on: macos-14
+    timeout-minutes: 75
     strategy:
       matrix:
         python-version: [ "3.11", "3.12" ]
@@ -281,6 +287,7 @@ jobs:
   build-macOS-no-vizInterface:
     name: macOS no vizInterface
     runs-on: macos-14
+    timeout-minutes: 75
     strategy:
       matrix:
         python-version: [ "3.11" ]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -22,43 +22,6 @@ jobs:
         with:
           extra_args: --files ${{ steps.file_changes.outputs.all_changed_files}}
 
-  build-linux:
-    name: Linux 20.04
-    strategy:
-      matrix:
-        python-version: [3.8, 3.9]
-    runs-on: ubuntu-20.04
-    timeout-minutes: 75
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install build-essential swig cmake -y
-          sudo apt-get install python${{ matrix.python-version }}-venv -y
-      - name: Create virtual environment and install packages
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements_dev.txt
-      - name: Build basilisk
-        run: |
-          source .venv/bin/activate
-          python3 conanfile.py
-      - name: Run Python Tests
-        if: ${{ always() }}
-        run: |
-          source .venv/bin/activate
-          cd src && pytest -n auto -m "not ciSkip" -rs
-      - name: Run C/C++ Tests
-        if: ${{ always() }}
-        working-directory: ./dist3
-        run: ctest
-
 
   build-linux-3-10:
     name: Linux 22.04
@@ -66,7 +29,7 @@ jobs:
     timeout-minutes: 75
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -238,7 +238,7 @@ jobs:
 
   build-macOS:
     name: macOS All Tests Docs
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 75
     strategy:
       matrix:
@@ -286,7 +286,7 @@ jobs:
 
   build-macOS-no-vizInterface:
     name: macOS no vizInterface
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 75
     strategy:
       matrix:

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -11,12 +11,6 @@ Basilisk Release Notes
     folders as well.  Best place to start is to run the integrated tutorial scripts inside the ``basilisk/examples``
     folder, described in :ref:`examples`.  To learn how to use and program Basilisk, see :ref:`learningBasilisk`.
 
-.. Danger::
-
-   This next generation of Basilisk 2.0+ introduces a new messaging system and file architecture.  As a result
-   using BSK2 requires upgrading existing Basilisk 1.x simulation scripts (see :ref:`migratingToBsk2`) and C/C++ modules
-   (see :ref:`migratingModuleToBsk2`) to be used with 2.x and onwards.  All unit test and example scenario scripts
-   are updated and form a good source for examples on how to use the new software framework.
 
 .. sidebar:: In Progress Features
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -27,7 +27,7 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Updated Linux and Windows CI builds to use ``swig`` 4.2.1
-
+- Updated CI scripts to run on latest macOS and no longer use Ubuntu 20.04
 
 
 Version  2.6.0  (Feb. 21, 2025)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,11 @@ Welcome to Basilisk: an Astrodynamics Simulation Framework
        :align: center
        :width: 100%
 
+.. tip::
+
+   This documentation is for the latest release on ``develop``.
+   If you are looking for documenation for prior tagged releases, they can be found at
+   `here <https://hanspeterschaub.info/bskOlderDocs.html>`_.
 
 Architecture
 ------------


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Doing maintenance on the CI scripts and documentation:
- GitHub will no longer support Ubuntu 20.04 after April 1, 2025.  Moving CI scripts to use 22.04
- Make macOS CI tests use latest OS
- Update BSK documentation cover page to explain that this documentation is for the latest `develop` branch.  A link is provided to an external site hosting tagged releases on the `master` branch.


## Verification
Documentation built without issues.  All CI test pass.

## Documentation
Updated release notes

## Future work
None
