### PR TITLE
Bug/272 reaction wheel no max torque ends sim no error

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -30,6 +30,9 @@ Version |release|
 - Updated CI scripts to run on latest macOS and no longer use Ubuntu 20.04
 - Updated :ref:`makeDraftModule` to remove redundant comments and implementation of the destructor,
   using only a header-defaulted destructor with ``= default;`` syntax.
+- Fixed issue where reaction wheels with unlimited torque (``useMaxTorque=False``) would end simulation prematurely
+- Added safety mechanism to limit excessive wheel acceleration and provide warning messages
+
 
 Version  2.6.0  (Feb. 21, 2025)
 -------------------------------

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
@@ -86,6 +86,30 @@ private:
 	StateData *thetasState;                                     //!< class variable
     Eigen::MatrixXd *g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
 
+    double maxWheelAcceleration = 1.0e6;    //!< [rad/s^2] Maximum allowed wheel acceleration to prevent numerical instability
+    double largeTorqueThreshold = 10.0;     //!< [Nm] Threshold for warning about large torque with unlimited torque setting
+
+public:
+    /*! @brief Get the maximum wheel acceleration threshold
+     * @return Maximum wheel acceleration in rad/s^2
+     */
+    double getMaxWheelAcceleration() const { return maxWheelAcceleration; }
+
+    /*! @brief Set the maximum wheel acceleration threshold
+     * @param val New maximum wheel acceleration value in rad/s^2
+     */
+    void setMaxWheelAcceleration(double val) { maxWheelAcceleration = val; }
+
+    /*! @brief Get the large torque threshold for unlimited torque warning
+     * @return Large torque threshold in Nm
+     */
+    double getLargeTorqueThreshold() const { return largeTorqueThreshold; }
+
+    /*! @brief Set the large torque threshold for unlimited torque warning
+     * @param val New large torque threshold value in Nm
+     */
+    void setLargeTorqueThreshold(double val) { largeTorqueThreshold = val; }
+
 };
 
 

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
@@ -34,16 +34,33 @@ provides information on what this message is used for.
       - :ref:`RWConfigLogMsgPayload`
       - vector of RW log output messages
 
+User Guide
+-----------
 
+The reaction wheel state effector module provides functionality for simulating reaction wheels in a spacecraft.
+It includes safety mechanisms to prevent numerical instability that can occur with excessive wheel acceleration
+or when using unlimited torque with small spacecraft inertia.
 
+Threshold Parameters
+~~~~~~~~~~~~~~~~~~~~
 
+The module includes two configurable threshold parameters:
 
+* ``maxWheelAcceleration``: Maximum allowed wheel acceleration to prevent numerical instability. Default value is 1.0e6 rad/s^2.
+* ``largeTorqueThreshold``: Threshold for warning about large torque with unlimited torque setting. Default value is 10.0 Nm.
 
+These parameters can be accessed and modified using the following getter and setter methods:
 
+.. code-block:: python
 
+    # Get the current maximum wheel acceleration threshold
+    current_max_accel = reactionWheelStateEffector.getMaxWheelAcceleration()
 
+    # Set a new maximum wheel acceleration threshold
+    reactionWheelStateEffector.setMaxWheelAcceleration(2.0e6)  # rad/s^2
 
+    # Get the current large torque threshold
+    current_torque_threshold = reactionWheelStateEffector.getLargeTorqueThreshold()
 
-
-
-
+    # Set a new large torque threshold
+    reactionWheelStateEffector.setLargeTorqueThreshold(15.0)  # Nm


### PR DESCRIPTION
* **Tickets addressed:** #272 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The issue addressed in ticket #272 involved premature simulation termination when using reaction wheels with unlimited torque (`useMaxTorque=False`), particularly with small spacecraft inertia. The simulation would end at approximately 1.4 minutes instead of the expected 10 minutes without any error messages.

My approach was to:
1. Modify the `reactionWheelStateEffector.cpp` file to detect excessive wheel acceleration
2. Implement a safety mechanism that limits acceleration when it exceeds reasonable thresholds
3. Add warning messages to alert users when unlimited torque is used with small spacecraft inertia

## Verification
1. Testing the modified code with the scenario described in the issue (`scenarioAttitudeFeedbackRW.py` with a 1 kg satellite using Honeywell 16 reaction wheels)
3. Verifying that the simulation now throws a BSK_ERROR under conditions that reproduce original user issue
![Screenshot 2025-02-27 at 1 02 22 AM](https://github.com/user-attachments/assets/b9a37109-5a62-4ad2-a9a2-4d2d7d5b2a48)

No automated tests were added as this was a fix for a specific edge case in the simulation behavior. The existing tests continue to pass with these changes.

## Documentation
The release notes were updated to document this fix.

## Future work
Potentially:
1. Adding more comprehensive parameter validation in the reaction wheel configuration to prevent similar issues
2. Implementing additional safety checks for other effectors
