### PR TITLE
Vizard 2.2.2 Support

### DIFF
--- a/docs/source/Support/Developer/deprecatingCode.rst
+++ b/docs/source/Support/Developer/deprecatingCode.rst
@@ -238,3 +238,44 @@ This time, we call the macro ``%deprecated_variable``, although always
 before ``%include "example.h"``. In this case, the two first arguments to ``%deprecated_variable``
 are the name of the class that contains the variable, and then the name of the varible.
 The final two arguments are the expected removal date and the message.
+
+If a C++ structure or one of its fields are renamed, an alias can be used to deprecate the entity while retaining support for the old name. This is done using the ``_DeprecatedWrapper`` class defined in ``"swig_deprecated.i"``. Its implementation is detailed below.
+
+.. code-block::
+
+    // example.i
+
+    %module example
+    %{
+        #include "example.h"
+    %}
+
+    %include "swig_deprecated.i"
+    %include example.h
+
+    %pythoncode %{
+    import sys
+
+    mod = sys.modules[__name__]
+
+    mod.ExampleStruct = _DeprecatedWrapper(
+        mod.ExampleStruct,
+        targetName="ExampleStruct",
+        deprecatedFields={"oldField": "newField"},
+        typeConversion="scalarTo3D",
+        removalDate="YYYY/MM/DD"
+    )
+
+    mod.OldStructure = _DeprecatedWrapper(
+        mod.NewStructure,
+        aliasName="OldStructure",
+        targetName="NewStructure",
+        removalDate="YYYY/MM/DD"
+    )
+
+    protectAllClasses(sys.modules[__name__])
+    %}
+
+If a field is renamed, the top chunk creates a wrapper that contains the old field name and handles deprecation warnings and getter/setter behavior. The ``typeConversion`` parameter can be set to ``"scalarTo3D"`` to deprecate a scalar variable and alias to a new 3D variable with repeated values.
+
+If a structure is renamed, the second chunk creates a wrapper that generates an alias using the old structure name for continued support.

--- a/docs/source/Support/Developer/deprecatingCode.rst
+++ b/docs/source/Support/Developer/deprecatingCode.rst
@@ -5,11 +5,11 @@ Deprecating code in Basilisk
 
 Motivation
 ----------
-The nature of a fast evolving software such as Basilisk is that systems are consistently improving, many times making older functionality obsolete. 
-Thus, we face the challenge of handling older code while we move towards the new systems. 
-We cannot simply remove old functionality, as we don't want user code to break overnight. 
-Instead, we enter a phase of deprecation, when we warn users about the use of deprecated code, 
-but otherwise continue to allow it and support it. After enough time has passed for our users to update 
+The nature of a fast evolving software such as Basilisk is that systems are consistently improving, many times making older functionality obsolete.
+Thus, we face the challenge of handling older code while we move towards the new systems.
+We cannot simply remove old functionality, as we don't want user code to break overnight.
+Instead, we enter a phase of deprecation, when we warn users about the use of deprecated code,
+but otherwise continue to allow it and support it. After enough time has passed for our users to update
 their code, the deprecated functionality can be removed.
 
 This support page explains the different mechanisms we have available in Basilisk to mark code as deprecated.
@@ -41,7 +41,7 @@ To illustrate this functionality, let's imagine the following code:
         @property
         def myProperty(self):
             return self._myPropertyInner * 2
-        
+
         @myProperty.setter
         def myProperty(self, value: int):
             self._myPropertyInner = value / 2
@@ -74,7 +74,7 @@ as follows:
 The first argument to ``@deprecated.deprecated`` must be a string with the date when the function is expected
 to be removed (as a rule of thumb, between 6 to 12 months after the release of
 the deprecated code). The second argument is a message that is shown directly
-to users. Here, you may explain why the function is deprecated, alternative functions, 
+to users. Here, you may explain why the function is deprecated, alternative functions,
 links to documentation or scenarios that show how to translate deprecated code...
 
 If you want to deprecate a **class**, then use:
@@ -96,7 +96,7 @@ If you want to deprecate an **attribute**, that is, a class variable, then do:
     from Basilisk.utilities import deprecated
 
     class MyClass:
-        
+
         myAttribute = deprecated.DeprecatedAttribute(
             "2099/05/05", "myAttribute is no longer used in the simulation"
         )
@@ -119,7 +119,7 @@ Finally, if you need to deprecate a **property**, then use:
     from Basilisk.utilities import deprecated
 
     class MyClass:
-        
+
         @property
         def myProperty(self):
             return self.myPropertyInner * 2
@@ -138,7 +138,7 @@ The third argument, however, shold be the name of the property to deprecate.
 
 Deprecating C++ Code Wrapped by SWIG
 ------------------------------------
-This section explains how to deprecate code that is written in C++ and exposed to 
+This section explains how to deprecate code that is written in C++ and exposed to
 Python through a SWIG interface. Note that deprecation warnings will be raised only
 when the Python wrappers to C++ functionality are invoked. Currently, it is not
 possible to emit deprecation warnings when the deprecated functionality is called from
@@ -164,7 +164,7 @@ the deprecated functionality. For example, let's consider we have this C++ code:
 with the following SWIG interface file:
 
 .. code-block::
-    
+
     // example.i
 
     %module example
@@ -178,7 +178,7 @@ If we want to deprecate the **standalone function** and **class function**, then
 would change the SWIG file to:
 
 .. code-block::
-    
+
     // example.i
 
     %module example
@@ -193,7 +193,7 @@ would change the SWIG file to:
     %include "example.h"
 
 In the code above, we have included ``"swig_deprecated.i"``, which makes the
-``%deprecated_function`` macro available. Then, we have called this macro **before we included the header file** 
+``%deprecated_function`` macro available. Then, we have called this macro **before we included the header file**
 ``"example.h"``. The first input to the macro is the SWIG identifier for the function.
 For standalone functions this is simple the function name, but for class functions this is
 ``[CLASS_NAME]::[FUNCTION_NAME]``. The next two arguments are the expected removal date
@@ -202,7 +202,7 @@ and message, as covered in the previous section.
 If we want to deprecate an entire **class**, then the SWIG file ought to change to:
 
 .. code-block::
-    
+
     // example.i
 
     %module example
@@ -221,7 +221,7 @@ we need to target ``[CLASS_NAME]::[CLASS_NAME]``.
 Finally, to deprecate a class variable, the SWIG file would change to:
 
 .. code-block::
-    
+
     // example.i
 
     %module example
@@ -234,7 +234,7 @@ Finally, to deprecate a class variable, the SWIG file would change to:
 
     %include "example.h"
 
-This time, we call the macro ``%deprecated_variable``, although always 
+This time, we call the macro ``%deprecated_variable``, although always
 before ``%include "example.h"``. In this case, the two first arguments to ``%deprecated_variable``
 are the name of the class that contains the variable, and then the name of the varible.
 The final two arguments are the expected removal date and the message.

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -33,6 +33,7 @@ Version |release|
 - Fixed issue where reaction wheels with unlimited torque (``useMaxTorque=False``) would end simulation prematurely
 - Added safety mechanism to limit excessive wheel acceleration and provide warning messages
 - Fixed a bug in the :ref:`SpacecraftLocation` module that prevented proper eclipse calculation in some cases.
+- Added support for Vizard release 2.2.2, including transition from MultiSphere to MultiShape, and SWIG structure deprecation through aliasing.
 
 
 Version  2.6.0  (Feb. 21, 2025)

--- a/docs/source/Vizard/VizardReleaseNotes.rst
+++ b/docs/source/Vizard/VizardReleaseNotes.rst
@@ -19,6 +19,22 @@ Release Notes
     - Continue to refine and improve the interactive information panels
     - Save streamed data to file to avoid unbounded memory usage when viewing live data
 
+**Version 2.2.2 (March 7, 2025)**
+
+- Migrated to Unity 6
+- TargetLines can target LocationMarkers
+- Improved support for scenarios with Locations in the thousands
+- Added support for scaling of Location markers, size can be increased or decreased from Vizard default dynamically per Location
+- MSM Heads Up Display - added support for other primitive shapes (cube, cylinder, capsule, as well as original sphere) which required adding sub-message fields for Shape, Dimensions, and Rotation of each MSM
+- Added effectors visibility at planet scale and solar system scale (effectors correctly scaled and offset relative to parent spacecraft)
+- Added support for “CAPSULE” primitive shape when importing CustomModel
+- Bug fix: if a normal map texture is imported when generating a custom material, the normal map is enabled in the shader
+- Bug fix: if imported model has multiple meshes, apply custom material to all meshes in model
+- Added input field to AdjustModel panel to control normal map height
+- Bug fix: when using buffered playback, chief spacecraft Hill or Velocity matrices are now automatically recalculated after buffer rollover
+- Bug fix: if camera target is a spacecraft on start-up and the settings flag SpacecraftCSon is set to 1, the spacecraft coordinate system will be shown and the cameraTarget CS on toggle will be on under the View Menu.
+- Added support for relative paths for importing custom models and textures (their paths should be relative to the location of the playback .bin file or the directory the scenario is being executed from, if showing a live simulation)
+
 **Version 2.2.1 (January 13, 2025)**
 
 - Added support for loading .glb model files at runtime using the Import Model GUI Panel or using the custom model import VizMessage

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -986,6 +986,11 @@ The following table lists all required and optional arguments that can be provid
       - m
       - No
       - range of the location station, use 0 or negative value (protobuffer default) to use viz default
+    * - ``markerScale``
+      - double
+      -
+      - No
+      - Value will be multiplied by default marker scale, value less than 1.0 will decrease size, greater will increase size
 
 
 Adding Generic Sensor Visualization

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -65,73 +65,81 @@ default setting for that behavior.
     * - Variable
       - Type
       - Description
-    * - ``ambient``
-      - [0,1]
-      - float value to specify the ambient Vizard lighting.
+    * - **Labels**
+      -
+      -
+    * - ``showCSLabels``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the coordinate system labels. Value of 0 (protobuffer default) to use viz default.
+    * - ``showSpacecraftLabels``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the spacecraft labels. Value of 0 (protobuffer default) to use viz default.
+    * - ``showCameraLabels``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the camera labels. Value of 0 (protobuffer default) to use viz default.
+    * - ``showLightLabels``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the light labels. Value of 0 (protobuffer default) to use viz default.
+    * - ``showCelestialBodyLabels``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the celestial body labels. Value of 0 (protobuffer default) to use viz default.
+    * - ``showLocationLabels``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) labels for a celestial body or spacecraft location. Value of 0 (protobuffer default) to use viz default.
+    * - **Coordinate Frame Settings**
+      -
+      -
+    * - ``spacecraftCSon``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the spacecraft coordinate axes. Value of 0 (protobuffer default) to use viz default.
+    * - ``planetCSon``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the planet coordinate axes. Value of 0 (protobuffer default) to use viz default.
+    * - ``showHillFrame``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the orbit Hill frame of the spacecraft camera target. Value of 0 (protobuffer default) to use viz default.
+    * - ``showVelocityFrame``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the orbit velocity frame of the spacecraft camera target. Value of 0 (protobuffer default) to use viz default.
+    * - **Orbit Line Settings**
+      -
+      -
     * - ``orbitLinesOn``
       - (-1,0,1,2)
-      - Toggle to show osculating orbit lines, Value of 0 (protobuffer default) to use viz default,
-        -1 for false, 1 for relative to parent body, 2 for relative to chief spacecraft body
+      - Toggle to show osculating orbit lines. Value of 0 (protobuffer default) to use viz default,
+        -1 for false, 1 for relative to parent body, 2 for relative to chief spacecraft body.
+    * - ``orbitLineSegments``
+      - int
+      - Number of line segments to use when drawing an osculating trajectory. Value of 0 (protobuffer default)
+        to use viz default or any value greater than or equal to 4.
+    * - ``relativeOrbitRange``
+      - int
+      - +/- Angular range in degrees of the osculating trajectory to show. Value of 0 (protobuffer default) to use
+        viz default or any value greater than or equal to 1.
+    * - ``relativeOrbitFrame``
+      - (0,1,2)
+      - Flag to set with respect to which frame the spacecraft relative orbit trajectory is drawn. Value of 0 (protobuffer default) or 1 to use Hill Frame, 2 to use Velocity Frame.
     * - ``trueTrajectoryLinesOn``
-      - (-1,0,1,2)
-      - Toggle to show true orbit lines, Value of 0 (protobuffer default) to use viz default,
-        -1 for false, 1 to use inertial positions, 2 for relative to chief spacecraft body
-    * - ``spacecraftCSon``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the spacecraft coordinate axes
-    * - ``planetCSon``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the planet coordinate axes
-    * - ``skyBox``
-      - String
-      - Used determine what star background should be shown. The empty string "" provides default NASA SVS Starmap,
-        “ESO” shows the ESO Milky Way skybox, “black” provides a black background, or the user can provide a
-        filepath to custom background image file.
-    * - ``viewCameraBoresightHUD``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the camera boresight line
-    * - ``viewCameraConeHUD``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the camera cone
-    * - ``showCSLabels``
-      - (-1,1)
-      - flag to show (1) or hide (-) the coordinate system labels
-    * - ``showCelestialBodyLabels``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the celestial body labels
-    * - ``showSpacecraftLabels``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the spacecraft labels
-    * - ``showCameraLabels``
-      - (-1,1)
-      - flag to show (1) or hide (-1) the camera labels
-    * - ``customGUIScale``
-      - pos. double
-      - GUI scaling factor, default is -1 which uses Vizard default.
-    * - ``defaultSpacecraftSprite``
+      - (-1,0,1,2,3,4,5)
+      - Toggle to show true orbit lines. Value of 0 (protobuffer default) to use viz default, -1 for false, 1 to use inertial positions, 2 for relative to chief spacecraft body, 3 for relative to a celestial body, 4 for rotating frame of two celestial bodies, 5 for fixed frame of spacecraft or celestial body.
+    * - ``truePathRelativeBody``
       - string
-      - Set sprite for ALL spacecraft through shape name and optional int RGB color values [0,255].
-        Possible settings: ``CIRCLE``, ``SQUARE``, ``STAR``, ``TRIANGLE`` or ``bskSat`` for a 2D spacecraft
-        sprite of the bskSat shape.  Default value is empty yielding a white ``CIRCLE``.
-        To set this in python, use the helper function ``vizSupport.setSprite("STAR", color="red")``
-    * - ``showSpacecraftAsSprites``
-      - (-1,1)
-      - Flag to show spacecraft as sprites if their visual size gets too small
-    * - ``showCelestialBodiesAsSprites``
-      - (-1,1)
-      - Flag to show celestial bodies as sprites if their visual size gets too small
-    * - ``show24hrClock``
-      - (-1,1)
-      - Flag to make mission date/time use a 24h clock instead of a 12h clock with am/pm
-    * - ``showDataRateDisplay``
-      - (-1,1)
-      - Flag to show the data frame rate
-    * - ``keyboardAngularRate``
-      - pos. double
-      - [rad/sec] controls the angular rate at which the camera rotates with keyboard hot-keys.
-    * - ``keyboardZoomRate``
-      - pos. double
-      - Non-dimensional speed at which the camera zooms in and out with hot-keys.
+      - String of the celestial body name to plot the true path trajectory line[s] against, empty string to use the spacecraft's primary body.
+    * - ``truePathRotatingFrame``
+      - string
+      - String must contain the names of two distinct celestial bodies, separated by a space, to define the desired rotating frame for plotting true path trajectories.
+    * - ``truePathFixedFrame``
+      - string
+      - String of the spacecraft or celestial body name whose rotation matrix will provide the fixed frame to plot the true path trajectory against.
+    * - **Spacecraft Settings**
+      -
+      -
+    * - ``viewCameraBoresightHUD``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the camera boresight line. Value of 0 (protobuffer default) to use viz default.
+    * - ``viewCameraConeHUD``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the camera cone. Value of 0 (protobuffer default) to use viz default.
     * - ``defaultThrusterColor``
       - int(4)
       - RGBA color values between (0,255).  Default values of -1 makes Vizard use the default thruster plume color
@@ -139,109 +147,126 @@ default setting for that behavior.
     * - ``defaultThrusterPlumeLifeScalar``
       - double
       - Value of 1.0 or 0.0 to use viz default, values between 0 and 1 will decrease the length of all thruster plumes,
-        >1 will increase lengths of all thruster plumes
-    * - ``orbitLineSegments``
-      - int
-      - Number of line segments to use when drawing an osculating trajectory. Value of 0 (protobuffer default)
-        to use viz default or any value greater than or equal to 4
-    * - ``relativeOrbitRange``
-      - int
-      - +/- angular range in degrees of the osculating trajectory to show.  Value of 0 (protobuffer default) to use
-        viz default or any value greater than or equal to 1
-    * - ``showHillFrame``
-      - int
-      - flag to show the orbit Hill frame of the spacecraft camera target. Value of 0 (protobuffer default)
-        to use viz default, -1 for false, 1 for true
-    * - ``showVelocityFrame``
-      - int
-      - flag to show the orbit velocity frame of the spacecraft camera target. Value of 0 (protobuffer default)
-        to use viz default, -1 for false, 1 for true
-    * - ``relativeOrbitFrame``
-      - int
-      - flag to set with respect to which frame the relative orbit trajectory is drawn.
-        Value of 0 (protobuffer default) or 1 to use Hill Frame, 2 to use Velocity Frame
-    * - ``mainCameraTarget``
+        >1 will increase lengths of all thruster plumes.
+    * - **Sprites**
+      -
+      -
+    * - ``defaultSpacecraftSprite``
       - string
-      - If valid spacecraft or celestial body name is provided, the main camera will be targeted at
-        that body at start
-    * - ``spacecraftShadowBrightness``
-      - double
-      - Control the ambient light specific to spacecraft objects, value between 0 and 1, use negative value
-        to use viz default
+      - Set sprite for ALL spacecraft through shape name and optional int RGB color values [0,255].
+        Possible settings: ``CIRCLE``, ``SQUARE``, ``STAR``, ``TRIANGLE`` or ``bskSat`` for a 2D spacecraft
+        sprite of the bskSat shape.  Default value is empty yielding a white ``CIRCLE``.
+        To set this in python, use the helper function ``vizSupport.setSprite("STAR", color="red")``.
+    * - ``showSpacecraftAsSprites``
+      - (-1,0,1)
+      - Flag to show spacecraft as sprites if their visual size gets too small (1). Value of -1 or 0 (protobuffer default) to use viz default.
+    * - ``showCelestialBodiesAsSprites``
+      - (-1,0,1)
+      - Flag to show celestial bodies as sprites if their visual size gets too small (1). Value of -1 or 0 (protobuffer default) to use viz default.
+    * - **Location Settings**
+      -
+      -
+    * - ``showLocationCones``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) a cone protruding from a celestial body or spacecraft location. Value of 0 (protobuffer default) to use viz default.
+    * - ``showLocationCommLines``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) a line when a spacecraft enters the FOV of a ground station or another spacecraft. Value of 0 (protobuffer default) to use viz default. These can become computationally expensive because they perform ray casting, so if obstruction detection is not necessary it would be easier to use target lines (see live settings table).
+    * - ``useSimpleLocationMarkers``
+      - (-1,0,1)
+      - Flag to use simplified Location markers (no cones, range, or communication lines) when the number of locations is greater than 100 (1), or force use of full-featured Location (-1). Value of 0 (protobuffer default) to use viz default.
+    * - **View Settings**
+      -
+      -
+    * - ``skyBox``
+      - String
+      - Used determine what star background should be shown. The empty string "" provides default NASA SVS Starmap,
+        “ESO” shows the ESO Milky Way skybox, “black” provides a black background, or the user can provide a
+        filepath to custom background image file.
+    * - ``atmospheresOff``
+      - (-1,0,1)
+      - Flag to disable the atmosphere effect on celestial bodies (1). Value of -1 or 0 (protobuffer default) to use viz default.
+    * - ``forceStartAtSpacecraftLocalView``
+      - (-1,0,1)
+      - Flag to force Vizard to initialize in spacecraft-view on start up (1). Value of -1 or 0 (protobuffer default) to use viz default.
     * - ``spacecraftSizeMultiplier``
       - double
-      - Control the display size of spacecraft in the Planet and Solar System Views, values greater than 0,
-        use negative value to use viz default
-    * - ``spacecraftHelioViewSizeMultiplier``
-      - double
-      - Control the display size of spacecraft in the Solar System View, values greater than 0, use negative
-        value to use viz default
-    * - ``forceStartAtSpacecraftLocalView``
-      - int
-      - Require Vizard to start up in spacecraft-view on start up
-    * - ``showLocationCommLines``
-      - int
-      - Shows a line when a spacecraft enters the FOV of a ground station or another spacecraft. These can become computationally expensive because they perform ray casting, so if obstruction detection is not necessary it would be easier to use target lines (see live settings table). Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-    * - ``showLocationCones``
-      - int
-      - Shows a cone protruding from a celestial body or spacecraft location. Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-    * - ``showLocationLabels``
-      - int
-      - Shows labels for a celestial body or spacecraft location. Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-    * - ``useSimpleLocationMarkers``
-      - int
-      - Value of 0 (protobuffer default) to use simplified Location markers when number
-        of locations is greater than 100, -1 to force use of full-featured Location, 1 to
-        force use of simplified Location (no cones, range, or communication lines)
-    * - ``atmospheresOff``
-      - int
-      - Toggle to disable the atmosphere effect on celestial bodies, Value of 0 (protobuffer default to use
-        viz default, -1 for false, 1 for true.
+      - Control the display size of spacecraft in the Planet View, values greater than 0,
+        use negative value to use viz default.
     * - ``scViewToPlanetViewBoundaryMultiplier``
       - int
       - Multiplier x 1000m to set the boundary at which the spacecraft local view transitions to planet view.
         Valid range from 1 to 10 or 0 to use viz default.
+    * - ``spacecraftHelioViewSizeMultiplier``
+      - double
+      - Control the display size of spacecraft in the Solar System View, values greater than 0, use negative
+        value to use viz default.
     * - ``planetViewToHelioViewBoundaryMultiplier``
       - int
       - Multiplier x (10000 * current planet local scale) at which the planet view transitions to the solar
         system view. Valid range from 1 to 10 or 0 to use viz default.
-    * - ``sunIntensity``
-      - double
-      - Multiplier for the intensity of the light being used as the main light source or sun, value of 0 to use
-        viz default
-    * - ``attenuateSunLightWithDistance``
-      - int
-      - Toggle to reduce brightness of sun lighting with the square of the distance from the sun.
-        Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true.
-    * - ``showLightLabels``
-      - int
-      - Toggle to label spacecraft light elements, Value of 0 (protobuffer default) to use viz
-        default, -1 for false, 1 for true
     * - ``celestialBodyHelioViewSizeMultiplier``
       - double
       - Control the display size of celestial bodies in the Solar System View,
         values greater than 0, use negative value to use viz default.
-        Default value is -1 to use Vizard default value.
-    * - ``showMissionTime``
-      - int
-      - flag to show the mission time instead of the simulation time. Value of 0 (protobuffer default)
-        to use viz default, -1 for false, 1 for true
-    * - ``keyboardLiveInput``
+    * - **Lighting Settings**
+      -
+      -
+    * - ``ambient``
+      - double
+      - Float value between 0.0 and 1.0 to specify the ambient Vizard lighting.
+    * - ``spacecraftShadowBrightness``
+      - double
+      - Control the ambient light specific to spacecraft objects, value between 0 and 1, use negative value
+        to use viz default.
+    * - ``sunIntensity``
+      - double
+      - Multiplier for the intensity of the light being used as the main light source or sun, value of 0 to use viz default.
+    * - ``attenuateSunLightWithDistance``
+      - (-1,0,1)
+      - Flag to reduce brightness of sun lighting with the square of the distance from the sun (1). Value of -1 or 0 (protobuffer default) to use viz default.
+    * - **Main Camera Settings**
+      -
+      -
+    * - ``mainCameraTarget``
       - string
-      - string of alphanumeric key inputs to listen for during 2-way communication
+      - If valid spacecraft or celestial body name is provided, the main camera will be targeted at
+        that body at start.
+    * - ``keyboardAngularRate``
+      - pos. double
+      - Non-dimensional angular rate at which the camera rotates with keyboard hot-keys.
+    * - ``keyboardZoomRate``
+      - pos. double
+      - Non-dimensional speed at which the camera zooms in and out with keyboard hot-keys.
+    * - **Playback Settings**
+      -
+      -
     * - ``messageBufferSize``
       - int
       - [bytes] Maximum size of vizMessages to be loaded into memory at one time,
-        -1 to force loading of entire file into memory, 0 to use viz default
-    * - ``truePathRelativeBody``
+        -1 to force loading of entire file into memory, 0 to use viz default.
+    * - **GUI Settings**
+      -
+      -
+    * - ``customGUIScale``
+      - pos. double
+      - GUI scaling factor, use negative value to use viz default.
+    * - ``show24hrClock``
+      - (-1,0,1)
+      - Flag to make mission date/time use a 24h clock instead of a 12h clock with AM/PM (1). Value of -1 or 0 (protobuffer default) to use viz default.
+    * - ``showDataRateDisplay``
+      - (-1,0,1)
+      - Flag to show (1) or hide (-1) the data rate. Value of 0 (protobuffer default) to use viz default.
+    * - ``showMissionTime``
+      - (-1,0,1)
+      - Flag to show the mission time instead of the simulation time (1). Value of -1 or 0 (protobuffer default)
+        to use viz default.
+    * - **Live Communication Settings**
+      -
+      -
+    * - ``keyboardLiveInput``
       - string
-      - String of the celestial body name to plot the true path trajectory line[s] against, empty string to use the spacecraft's primary body
-    * - ``truePathRotatingFrame``
-      - string
-      - String must contain the names of two distinct celestial bodies, separated by a space, to define the desired rotating frame for plotting true path trajectories
-    * - ``truePathFixedFrame``
-      - string
-      - String of the spacecraft or celestial body name whose rotation matrix will provide the fixed frame to plot the true path trajectory against
+      - String of alphanumeric key inputs to listen for during 2-way communication.
 
 
 While the prior settings are only read once during start up, the following settings are checked
@@ -285,29 +310,29 @@ The following table includes the keyword options for this method.
       - Required
       - Description
     * - ``viewThrusterPanel``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the thruster panel
+      - Show (1) or hide (-1) the thruster panel. Value of 0 (protobuffer default) to use viz default.
     * - ``viewThrusterHUD``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the thruster particle streams
+      - Show (1) or hide (-1) the thruster particle streams. Value of 0 (protobuffer default) to use viz default.
     * - ``showThrusterLabels``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the thruster labels
+      - Show (1) or hide (-1) the thruster labels. Value of 0 (protobuffer default) to use viz default.
     * - ``viewRWPanel``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the reaction wheel panel
+      - Show (1) or hide (-1) the reaction wheel panel. Value of 0 (protobuffer default) to use viz default.
     * - ``viewRWHUD``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the reaction wheel disks configuration outside the spacecraft
+      - Show (1) or hide (-1) the reaction wheel disks configuration outside the spacecraft. Value of 0 (protobuffer default) to use viz default.
     * - ``showRWLabels``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the reaction wheel labels
+      - Show (1) or hide (-1) the reaction wheel labels. Value of 0 (protobuffer default) to use viz default.
     * - ``spacecraftName``
       - string
       - No, sc name default
@@ -333,46 +358,46 @@ The following table includes the keyword options for this method.
       - Required
       - Description
     * - ``viewCSSPanel``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the CSS panel
+      - Show (1) or hide (-1) the CSS panel. Value of 0 (protobuffer default) to use viz default.
     * - ``viewCSSCoverage``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the CSS coverage spheres
+      - Show (1) or hide (-1) the CSS coverage spheres. Value of 0 (protobuffer default) to use viz default.
     * - ``viewCSSBoresight``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the CSS boresight axes
+      - Show (1) or hide (-1) the CSS boresight axes. Value of 0 (protobuffer default) to use viz default.
     * - ``showCSSLabels``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Show the CSS labels
+      - Show (1) or hide (-1) the CSS labels. Value of 0 (protobuffer default) to use viz default.
     * - ``spacecraftName``
       - string
       - No, sc name default
       - Specify which spacecraft should show actuator information. If not provided then
         the ``viz.spacecraftName`` is used.
     * - ``showGenericSensorLabels``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Show (1) or hide (-1) generic sensor labels. Value of 0 (protobuffer default) to use viz default.
     * - ``showTransceiverLabels``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Show (1) or hide (-1) transceiver labels. Value of 0 (protobuffer default) to use viz default.
     * - ``showTransceiverFrustrum``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Show (1) or hide (-1) transceiver frustums. Value of 0 (protobuffer default) to use viz default.
     * - ``showGenericStoragePanel``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Show (1) or hide (-1) generic storage panels. Value of 0 (protobuffer default) to use viz default.
     * - ``showMultiShapeLabels``
-      - Boolean
+      - (-1,0,1)
       - No
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Show (1) or hide (-1) MultiShape labels. Value of 0 (protobuffer default) to use viz default.
 
 
 Defining a Pointing Line

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -780,6 +780,8 @@ This functionality can be controlled by using the ``createCustomModel()`` helper
 	                            modelPath="/Users/hp/Downloads/Topex-Posidon/Topex-Posidon-composite.obj",
 	                            scale=[2, 2, 10])
 
+.. note::
+    The model path can either be defined as an absolute or relative path. When playing back from a saved binary scenario file, the relative model path will be relative to the playback file (which may be in a different location than the scenario itself). Relative paths can be particularly useful when sharing binaries with custom resources. Absolute paths are more robust for live-streaming, or scenarios where both live-streaming and saving playback files are used.
 
 The following table illustrates the arguments for the ``createCustomModel`` method.
 
@@ -796,7 +798,7 @@ The following table illustrates the arguments for the ``createCustomModel`` meth
       - string
       -
       - Yes
-      - Path to model obj -OR- "CUBE", "CYLINDER", "CAPSULE", or "SPHERE" to use a primitive shape
+      - Path to model obj (can be specified as either absolute or relative path) -OR- "CUBE", "CYLINDER", "CAPSULE", or "SPHERE" to use a primitive shape.
     * - ``simBodiesToModify``
       - string
       -

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -369,7 +369,7 @@ The following table includes the keyword options for this method.
       - Boolean
       - No
       - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-    * - ``showMultiSphereLabels``
+    * - ``showMultiShapeLabels``
       - Boolean
       - No
       - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
@@ -771,7 +771,7 @@ The following table illustrates the arguments for the ``createCustomModel`` meth
       - string
       -
       - Yes
-      - Path to model obj -OR- "CUBE", "CYLINDER", or "SPHERE" to use a primitive shape
+      - Path to model obj -OR- "CUBE", "CYLINDER", "CAPSULE", or "SPHERE" to use a primitive shape
     * - ``simBodiesToModify``
       - string
       -
@@ -1767,19 +1767,19 @@ sphere has a spacecraft-fixed location and radius.  Vizard can display such sphe
 and color them using the current sphere charge value.  See :ref:`scenarioDebrisReorbitET`
 for an example of this visualization tool being used.
 
-The MSM information is added using the ``enableUnityVisualization()`` method with the
+There are also applications where it could be useful to display other shape primitives, such as cuboids, cylinders, capsules, or ellipsoids for visualizing electrostatically-charged pads and surfaces. To generalize different shape primitive use cases, the BSK/Vizard support structure is named ``MultiShape``. The MSM information is added using the ``enableUnityVisualization()`` method with the
 keyword ``msmInfoList``.  This information must be provided for each spacecraft in the
-simulation as a list of ``vizInterface.MultiSphereInfo()`` structures.
+simulation as a list of ``vizInterface.MultiShapeInfo()`` structures.
 Each craft can use a different MSM setup.  If the spacecraft has no MSM model then
 use ``None`` in the list for that spacecraft.
 
-The ``MultiSphereInfo`` structure contains the input message ``msmChargeInMsg``
+The ``MultiShapeInfo`` structure contains the input message ``msmChargeInMsg``
 where the spacecraft sphere charge values are read in from.  It also
 contains a vector of MSM configuration information structures of
-type ``MultiSphere``.  The following list show all ``MultiSphere`` structure
+type ``MultiShape``.  The following list show all ``MultiShape`` structure
 variables.
 
-.. list-table:: ``MultiSphere`` variables
+.. list-table:: ``MultiShape`` variables
     :widths: 20 10 10 10 100
     :header-rows: 1
 
@@ -1803,7 +1803,7 @@ variables.
       - double
       - meter
       - Yes
-      - radius of the sphere
+      - radius of the sphere (deprecated)
     * - ``currentValue``
       - double
       - Coulomb
@@ -1832,6 +1832,21 @@ variables.
       - No
       - desired opacity value between 0 and 255 for when charge is neutral.  Default
         is -1 which yield the Vizard default opacity value.
+    * - ``shape``
+      - string
+      -
+      - No
+      - Set shape to use "CUBE", "CYLINDER", "CAPSULE", or "SPHERE" (default)
+    * - ``dimensions``
+      - double(3)
+      - meters
+      - Yes
+      - Desired dimensions of selected shape in x, y, and z (For cylinder, z is height)
+    * - ``rotation``
+      - double(3)
+      - MRP
+      - Yes
+      - Desired orientation of the MultiShape in the spacecraft body frame
 
 
 The following code illustrates how to add support for visualizing
@@ -1840,16 +1855,16 @@ an :ref:`msmForceTorque` to emulate the charging.  The charge values are read in
 message.  The MSM body-fixed positions are stored in the list ``spPosListDebris``, while
 the MSM radii are stored in the list ``rListDebris``.  The sample code is::
 
-    msmInfoDebris = vizInterface.MultiSphereInfo()
+    msmInfoDebris = vizInterface.MultiShapeInfo()
     msmInfoDebris.msmChargeInMsg.subscribeTo(MSMmodule.chargeMsmOutMsgs[0])
     msmDebrisList = []
     for (pos, rad) in zip(spPosListDebris, rListDebris):
-        msmDebris = vizInterface.MultiSphere()
+        msmDebris = vizInterface.MultiShape()
         msmDebris.position = pos
         msmDebris.radius = rad
         msmDebris.maxValue = 30e-6  # Coulomb
         msmDebrisList.append(msmDebris)
-    msmInfoDebris.msmList = vizInterface.MultiSphereVector(msmDebrisList)
+    msmInfoDebris.msmList = vizInterface.MultiShapeVector(msmDebrisList)
 
     viz = vizSupport.enableUnityVisualization(scSim, dynTaskName, [scObjectDebris]
                                               , saveFile=fileName

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -181,13 +181,13 @@ default setting for that behavior.
       - Require Vizard to start up in spacecraft-view on start up
     * - ``showLocationCommLines``
       - int
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Shows a line when a spacecraft enters the FOV of a ground station or another spacecraft. These can become computationally expensive because they perform ray casting, so if obstruction detection is not necessary it would be easier to use target lines (see live settings table). Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
     * - ``showLocationCones``
       - int
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Shows a cone protruding from a celestial body or spacecraft location. Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
     * - ``showLocationLabels``
       - int
-      - Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+      - Shows labels for a celestial body or spacecraft location. Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
     * - ``useSimpleLocationMarkers``
       - int
       - Value of 0 (protobuffer default) to use simplified Location markers when number

--- a/examples/scenarioCustomGravBody.py
+++ b/examples/scenarioCustomGravBody.py
@@ -211,7 +211,10 @@ def run(show_plots):
         viz.settings.showSpacecraftLabels = 1
         # load CAD for custom gravity model
         vizSupport.createCustomModel(viz,
-                                     modelPath=os.path.join(path, "dataForExamples", "Itokawa", "ItokawaHayabusa.obj"),
+                                     # Specifying relative model path is useful for sharing scenarios and resources:
+                                     modelPath=os.path.join("..", "dataForExamples", "Itokawa", "ItokawaHayabusa.obj"),
+                                     # Specifying absolute model path is preferable for live-streaming:
+                                     # modelPath=os.path.join(path, "dataForExamples", "Itokawa", "ItokawaHayabusa.obj"),
                                      shader=1,
                                      simBodiesToModify=['Itokawa'],
                                      scale=[962, 962, 962])

--- a/examples/scenarioDataToViz.py
+++ b/examples/scenarioDataToViz.py
@@ -178,14 +178,20 @@ def run(show_plots, attType):
         viz.settings.spacecraftShadowBrightness = 0.2
         # load CAD for target spacecraft
         vizSupport.createCustomModel(viz,
-                                     modelPath=os.path.join(path, "dataForExamples", "Aura_27.obj"),
+                                     # Specifying relative model path is useful for sharing scenarios and resources:
+                                     modelPath=os.path.join("..", "dataForExamples", "Aura_27.obj"),
+                                     # Specifying absolute model path is preferable for live-streaming:
+                                     # modelPath=os.path.join(path, "dataForExamples", "Aura_27.obj"),
                                      shader=1,
                                      simBodiesToModify=[scList[1].ModelTag],
                                      rotation=[180. * macros.D2R, 0.0 * macros.D2R, -90. * macros.D2R],
                                      scale=[1, 1, 1])
         # load CAD for servicer spacecraft
         vizSupport.createCustomModel(viz,
-                                     modelPath=os.path.join(path, "dataForExamples", "Loral-1300Com-main.obj"),
+                                     # Specifying relative model path is useful for sharing scenarios and resources:
+                                     modelPath=os.path.join("..", "dataForExamples", "Loral-1300Com-main.obj"),
+                                     # Specifying absolute model path is preferable for live-streaming:
+                                     # modelPath=os.path.join(path, "dataForExamples", "Loral-1300Com-main.obj"),
                                      simBodiesToModify=[scList[0].ModelTag],
                                      rotation=[0. * macros.D2R, -90.0 * macros.D2R, 0. * macros.D2R],
                                      scale=[0.09, 0.09, 0.09])

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -172,9 +172,9 @@ def run(show_plots):
 
     # create a list of sphere body-fixed locations and associated radii
     spPosListServicer = [[0., 0., 0.]]  # one sphere located at origin of body frame
-    rListServicer = [2.]  # radius of sphere is 2m
+    rListServicer = [5.]  # radius of sphere is 5m
     spPosListDebris = [[0., 0., 0.]]  # one sphere located at origin of body frame
-    rListDebris = [3.]  # radius of sphere is 3m
+    rListDebris = [4.]  # radius of sphere is 4m
 
     # add spacecraft to state
     MSMmodule.addSpacecraftToModel(scObjectServicer.scStateOutMsg, messaging.DoubleVector(rListServicer),

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -67,6 +67,7 @@ Illustration of Simulation Results
 #
 
 import os
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -75,7 +76,7 @@ from Basilisk.fswAlgorithms import etSphericalControl
 from Basilisk.simulation import simpleNav, spacecraft, extForceTorque, msmForceTorque
 from Basilisk.utilities import (SimulationBaseClass, macros,
                                 orbitalMotion, simIncludeGravBody,
-                                unitTestSupport, vizSupport)
+                                unitTestSupport, vizSupport, deprecated)
 
 try:
     from Basilisk.simulation import vizInterface
@@ -301,32 +302,38 @@ def run(show_plots):
     # to save the BSK data to a file, uncomment the saveFile line below
     if vizSupport.vizFound:
         # setup MSM information
-        msmInfoServicer = vizInterface.MultiSphereInfo()
+        msmInfoServicer = vizInterface.MultiShapeInfo()
         msmInfoServicer.msmChargeInMsg.subscribeTo(MSMmodule.chargeMsmOutMsgs[0])
         msmServicerList = []
         for (pos, rad) in zip(spPosListServicer, rListServicer):
-            msmServicer = vizInterface.MultiSphere()
+            msmServicer = vizInterface.MultiShape()
             msmServicer.position = pos
-            msmServicer.radius = rad
+            msmServicer.dimensions = [rad, rad, rad]
             msmServicer.isOn = 1
             msmServicer.maxValue = 30e-6  # Coulomb
             msmServicer.currentValue = 4e-6  # Coulomb
             msmServicerList.append(msmServicer)
-        msmInfoServicer.msmList = vizInterface.MultiSphereVector(msmServicerList)
+        msmInfoServicer.msmList = vizInterface.MultiShapeVector(msmServicerList)
 
-        msmInfoDebris = vizInterface.MultiSphereInfo()
+        msmInfoDebris = vizInterface.MultiShapeInfo()
         msmInfoDebris.msmChargeInMsg.subscribeTo(MSMmodule.chargeMsmOutMsgs[1])
         msmDebrisList = []
         for (pos, rad) in zip(spPosListDebris, rListDebris):
-            msmDebris = vizInterface.MultiSphere()
+            msmDebris = vizInterface.MultiShape()
             msmDebris.position = pos
-            msmDebris.radius = rad
+            msmDebris.dimensions = [rad, rad, rad]
             msmDebris.isOn = 1
             msmDebris.maxValue = 30e-6  # Coulomb
             msmDebris.currentValue = 4e-6  # Coulomb
             msmDebris.neutralOpacity = 50  # opacity value between 0 and 255
             msmDebrisList.append(msmDebris)
-        msmInfoDebris.msmList = vizInterface.MultiSphereVector(msmDebrisList)
+        msmInfoDebris.msmList = vizInterface.MultiShapeVector(msmDebrisList)
+
+        # Check MultiSphere deprecation
+        warnings.simplefilter("ignore", deprecated.BSKDeprecationWarning)
+        vizInterface.MultiSphere().radius = 0
+        vizInterface.MultiSphereInfo()
+        vizInterface.MultiSphereVector()
 
         viz = vizSupport.enableUnityVisualization(scSim, dynTaskName, [scObjectServicer, scObjectDebris]
                                                   # , saveFile=fileName

--- a/examples/scenarioDeployingSolarArrays.py
+++ b/examples/scenarioDeployingSolarArrays.py
@@ -190,7 +190,7 @@ def run(show_plots):
     r_M1S1_B = [0.0, 0.0, 0.0]  # [m]
     r_M2S2_B = [0.0, 0.0, 0.0]  # [m]
 
-    # Position vector of solar array frame origin points with respect to hub frame origin point B 
+    # Position vector of solar array frame origin points with respect to hub frame origin point B
     # expressed in B frame components
     rArray1SB_B = np.array([2.0, 0.0, 0.0])   # [m]
     rArray2SB_B = np.array([-2.0, 0.0, 0.0])   # [m]
@@ -216,7 +216,7 @@ def run(show_plots):
     IElement_PntFc_F = [[I_element_11, 0.0, 0.0],
                         [0.0, I_element_22, 0.0],
                         [0.0, 0.0, I_element_33]]  # [kg m^2] (Elements approximated as rectangular prisms)
-    
+
     # Deployment temporal information
     ramp_duration = 2.0  # [s]
     init_deploy_duration = 5.0 * 60.0  # [s]
@@ -346,7 +346,7 @@ def run(show_plots):
         array2RotProfilerList[i].setThetaDDotMax(array2MaxRotAccelList1[i])  # [rad/s^2]
         array1RotProfilerList[i].setThetaInit(array1ThetaInit1)  # [rad]
         array2RotProfilerList[i].setThetaInit(array2ThetaInit1)  # [rad]
-    
+
         scSim.AddModelToTask(fswTaskName, array1RotProfilerList[i])
         scSim.AddModelToTask(fswTaskName, array2RotProfilerList[i])
         array1RotProfilerList[i].spinningBodyInMsg.subscribeTo(array1ElementRefMsgList1[i])
@@ -378,7 +378,7 @@ def run(show_plots):
     array2Element8PrescribedDataLog = array2RotProfilerList[7].spinningBodyOutMsg.recorder(dataRecRate)
     array2Element9PrescribedDataLog = array2RotProfilerList[8].spinningBodyOutMsg.recorder(dataRecRate)
     array2Element10PrescribedDataLog = array2RotProfilerList[9].spinningBodyOutMsg.recorder(dataRecRate)
-    
+
     scSim.AddModelToTask(fswTaskName, scStateData)
     scSim.AddModelToTask(fswTaskName, array1Element1PrescribedDataLog)
     scSim.AddModelToTask(fswTaskName, array1Element2PrescribedDataLog)
@@ -499,7 +499,7 @@ def run(show_plots):
         array2ElementRefMsgList2.append(messaging.HingedRigidBodyMsg().write(array2ElementMessageData))
 
         array2RotProfilerList[i].spinningBodyInMsg.subscribeTo(array2ElementRefMsgList2[i])
-        
+
     simTime3 = init_deploy_duration + 10  # [s]
     scSim.ConfigureStopTime(macros.sec2nano(simTime1 + simTime2 + simTime3))
     scSim.ExecuteSimulation()
@@ -739,4 +739,3 @@ if __name__ == "__main__":
     run(
         True,   # show_plots
     )
-    

--- a/examples/scenarioDeployingSolarArrays.py
+++ b/examples/scenarioDeployingSolarArrays.py
@@ -421,13 +421,19 @@ def run(show_plots):
         for i in range(num_elements):
             vizSupport.createCustomModel(viz,
                                          simBodiesToModify=["Array1Element" + str(i+1)],
-                                         modelPath=path + "/dataForExamples/triangularPanel.obj",
+                                         # Specifying relative model path is useful for sharing scenarios and resources:
+                                         modelPath=os.path.join("..", "dataForExamples", "triangularPanel.obj"),
+                                         # Specifying absolute model path is preferable for live-streaming:
+                                         # modelPath=os.path.join(path, "dataForExamples", "triangularPanel.obj"),
                                          rotation=[-np.pi/2, 0, np.pi/2],
                                          scale=[1.3, 1.3, 1.3],
                                          color=vizSupport.toRGBA255("green"))
             vizSupport.createCustomModel(viz,
                                          simBodiesToModify=["Array2Element" + str(i+1)],
-                                         modelPath=path + "/dataForExamples/triangularPanel.obj",
+                                         # Specifying relative model path is useful for sharing scenarios and resources:
+                                         modelPath=os.path.join("..", "dataForExamples", "triangularPanel.obj"),
+                                         # Specifying absolute model path is preferable for live-streaming:
+                                         # modelPath=os.path.join(path, "dataForExamples", "triangularPanel.obj"),
                                          rotation=[-np.pi/2, 0, np.pi/2],
                                          scale=[1.3, 1.3, 1.3],
                                          color=vizSupport.toRGBA255("blue"))

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -610,7 +610,10 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
         viz.settings.ambient = 0.7  # increase ambient light to make the shaded spacecraft more visible
         viz.settings.orbitLinesOn = -1  # turn off osculating orbit line
         current_path = os.path.dirname(os.path.abspath(__file__))
-        texture_path = os.path.join(current_path, 'dataForExamples', 'texture')
+        # Specifying relative model path is useful for sharing scenarios and resources:
+        texture_path = os.path.join('..', 'dataForExamples', 'texture')
+        # Specifying absolute model path is preferable for live-streaming:
+        # texture_path = os.path.join(current_path, 'dataForExamples', 'texture')
         vizSupport.createCustomModel(viz
                                      , simBodiesToModify=[sc_body_list[0].ModelTag]
                                      , modelPath="CUBE"

--- a/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
+++ b/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
@@ -124,7 +124,7 @@ InstrumentGuiSettings
     int showTransceiverLabels=0;    //!< [int] Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
     int showTransceiverFrustrum=0;  //!< [int] Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
     int showGenericStoragePanel=0;  //!< [int] Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-    int showMultiSphereLabels=0;    //!< [int] Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+    int showMultiShapeLabels=0;    //!< [int] Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
 }InstrumentGuiSettings;
 
 /*! Structure defining a custom CAD model to load to represent a simulation object.
@@ -225,11 +225,11 @@ Light
 
 
 
-/*! Structure defining Multi-Sphere-Method (MSM) sphere configurations
+/*! Structure defining Multi-Shape-Method (MSM) configurations
  */
 typedef struct
 //@cond DOXYGEN_IGNORE
-MultiSphere
+MultiShape
 //@endcond
 {
     int isOn=0;                         //!< Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
@@ -240,18 +240,22 @@ MultiSphere
     std::vector<int> positiveColor;     //!< (optional) Send desired RGBA as values between 0 and 255, default is green
     std::vector<int> negativeColor;     //!< (optional) Send desired RGBA as values between 0 and 255, default is red
     int neutralOpacity=-1;              //!< (optional) Send desired opacity value between 0 and 255 for when charge is neutral
-}MultiSphere;
+    std::string shape = "";             //!< (optional) Set shape to use "CUBE", "CYLINDER", or "SPHERE" (default)
+    double dimensions[3];               //!< [m] Desired dimensions of selected shape in x, y, and z (For cylinder, z is height)
+    double rotation[3];                 //!< [MRP] Desired orientation of the Multi Shape in the spacecraft body frame
+}MultiShape;
 
-/*! Structure defining Multi-Sphere-Method (MSM) information
+
+/*! Structure defining Multi-Shape-Method (MSM) information
  */
 typedef struct
 //@cond DOXYGEN_IGNORE
-MultiSphereInfo
+MultiShapeInfo
 //@endcond
 {
-    std::vector<MultiSphere *> msmList;                     //!< list of MSM configuration information
+    std::vector<MultiShape *> msmList;                      //!< list of MSM configuration information
     ReadFunctor<ChargeMsmMsgPayload> msmChargeInMsg;        //!< input message to read current MSM charges.  If not connected, currentValue can be set directly from python
-}MultiSphereInfo;
+}MultiShapeInfo;
 
 
 
@@ -335,7 +339,7 @@ VizSpacecraftData
     std::vector<int> oscOrbitLineColor;                         //!< (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
     std::vector<int>  trueTrajectoryLineColor;                  //!< (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
     ReadFunctor<ColorMsgPayload> trueTrajectoryLineColorInMsg;  //!< (Optional) Messages specifying true trajectory orbit line RGBA colors.  If connected, this replaces the values set in trueTrajectoryLineColor
-    MultiSphereInfo msmInfo;                                    //!< (Optional) MSM configuration information
+    MultiShapeInfo msmInfo;                                     //!< (Optional) MSM configuration information
     std::vector<Ellipsoid *> ellipsoidList;                     //!< (Optional) ellipsoid about the spacecraft location
 }VizSpacecraftData;
 

--- a/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
+++ b/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
@@ -159,6 +159,7 @@ LocationPbMsg
     double fieldOfView = -1;            //!< [rad] Edge-to-Edge, -1 -> use default, values between 0.0001deg and 179.9999deg valid
     int color[4] = {-1};                //!< Send desired RGBA as values between 0 and 255, -1 -> use default
     double range = 0;                   //!< [m] range of the ground location, use 0 (protobuffer default) to use viz default
+    double markerScale = 0;             //!< (Optional) Value will be multiplied by default marker scale, value less than 1.0 will decrease size, greater will increase size
 }LocationPbMsg;
 
 /*! Structure defining generic sensor information

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -811,6 +811,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
         for (int i=0; i<4; i++) {
             glp->add_color((*glIt)->color[i]);
         }
+        glp->set_markerscale((*glIt)->markerScale);
     }
 
     std::vector<VizSpacecraftData>::iterator scIt;

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -687,7 +687,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             il->set_showtransceiverlabels(this->settings.instrumentGuiSettingsList[idx].showTransceiverLabels);
             il->set_showtransceiverfrustrum(this->settings.instrumentGuiSettingsList[idx].showTransceiverFrustrum);
             il->set_showgenericstoragepanel(this->settings.instrumentGuiSettingsList[idx].showGenericStoragePanel);
-            il->set_showmultispherelabels(this->settings.instrumentGuiSettingsList[idx].showMultiSphereLabels);
+            il->set_showmultishapelabels(this->settings.instrumentGuiSettingsList[idx].showMultiShapeLabels);
         }
 
 
@@ -1005,9 +1005,9 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                 scp->add_truetrajectorylinecolor(scIt->trueTrajectoryLineColor[i]);
             }
 
-            // Write Multi-Sphere-Model messages
+            // Write Multi-Shape-Model messages
             for (size_t idx =0; idx < (size_t) scIt->msmInfo.msmList.size(); idx++) {
-                vizProtobufferMessage::VizMessage::MultiSphere* msmp = scp->add_multispheres();
+                vizProtobufferMessage::VizMessage::MultiShape* msmp = scp->add_multishapes();
 
                 msmp->set_ison(scIt->msmInfo.msmList[idx]->isOn);
                 for (uint64_t j=0; j<3; j++) {
@@ -1023,6 +1023,13 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                     msmp->add_negativecolor(scIt->msmInfo.msmList[idx]->negativeColor[j]);
                 }
                 msmp->set_neutralopacity(scIt->msmInfo.msmList[idx]->neutralOpacity);
+                msmp->set_shape(scIt->msmInfo.msmList[idx]->shape);
+                for (int j=0; j<3; j++) {
+                    msmp->add_dimensions(scIt->msmInfo.msmList[idx]->dimensions[j]);
+                }
+                for (int j=0; j<3; j++) {
+                    msmp->add_rotation(scIt->msmInfo.msmList[idx]->rotation[j]);
+                }
             }
 
         }

--- a/src/simulation/vizard/vizInterface/vizInterface.i
+++ b/src/simulation/vizard/vizInterface/vizInterface.i
@@ -50,7 +50,7 @@ namespace std {
     %template(LightVector) vector<Light *>;
     %template(TransceiverVector) vector<Transceiver *>;
     %template(GenericStorageVector) vector<GenericStorage *>;
-    %template(MultiSphereVector) vector<MultiSphere *>;
+    %template(MultiShapeVector) vector<MultiShape *>;
     %template(EllipsoidVector) vector<Ellipsoid *>;
     %template(VizEventDialogVector) vector<VizEventDialog *>;
     %template(VizEventReplyVector) vector<VizEventReply>;
@@ -91,5 +91,37 @@ struct EpochMsg_C;
 
 %pythoncode %{
 import sys
+
+mod = sys.modules[__name__]
+
+# ------ Deprecated variable/structure list ------ #
+# Remove from here when support is expired.
+mod.MultiShape = _DeprecatedWrapper(
+    mod.MultiShape,
+    targetName="MultiShape",
+    deprecatedFields={"radius": "dimensions"},
+    typeConversion="scalarTo3D",
+    removalDate="2026/03/07"
+)
+
+mod.MultiSphere = _DeprecatedWrapper(
+    mod.MultiShape,
+    aliasName="MultiSphere",
+    targetName="MultiShape",
+    removalDate="2026/03/07"
+)
+mod.MultiSphereInfo = _DeprecatedWrapper(
+    mod.MultiShapeInfo,
+    aliasName="MultiSphereInfo",
+    targetName="MultiShapeInfo",
+    removalDate="2026/03/07"
+)
+mod.MultiSphereVector = _DeprecatedWrapper(
+    mod.MultiShapeVector,
+    aliasName="MultiSphereVector",
+    targetName="MultiShapeVector",
+    removalDate="2026/03/07"
+)
+
 protectAllClasses(sys.modules[__name__])
 %}

--- a/src/utilities/vizProtobuffer/vizMessage.proto
+++ b/src/utilities/vizProtobuffer/vizMessage.proto
@@ -69,7 +69,7 @@ message VizMessage{
         string modelDictionaryKey = 13;               // ""  or "bskSat" will result in the default BSKSat model, "6USat" to use a built-in 6U model, "3USat" to use a built-in 3U model
         repeated int32 oscOrbitLineColor = 14;        // (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
         repeated int32 trueTrajectoryLineColor = 15;  // (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
-        string logoTexture = 16;                      // Path to image texture to be used to customize built-in spacecraft models
+        string logoTexture = 16;                      // (Optional) Path to image texture to be used to customize built-in spacecraft models
         repeated MultiShape multiShapes = 17;         // (Optional) Multi-Shape-Model (MSM)
         repeated Ellipsoid ellipsoids = 18;           // (Optional) Ellipsoid Heads Up Displays
         string parentSpacecraftName = 19;             // Name of the main spacecraft body that this spacecraft object should be considered a component of. Required if this spacecraft object is a subcomponent of a larger craft (i.e. deployable solar panel)

--- a/src/utilities/vizProtobuffer/vizMessage.proto
+++ b/src/utilities/vizProtobuffer/vizMessage.proto
@@ -70,7 +70,7 @@ message VizMessage{
         repeated int32 oscOrbitLineColor = 14;        // (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
         repeated int32 trueTrajectoryLineColor = 15;  // (Optional) Send desired RGBA as values between 0 and 255, color can be changed at any time step
         string logoTexture = 16;                      // Path to image texture to be used to customize built-in spacecraft models
-        repeated MultiSphere multiSpheres = 17;       // (Optional) Multi-Sphere-Model (MSM) charging model information
+        repeated MultiShape multiShapes = 17;         // (Optional) Multi-Shape-Model (MSM)
         repeated Ellipsoid ellipsoids = 18;           // (Optional) Ellipsoid Heads Up Displays
         string parentSpacecraftName = 19;             // Name of the main spacecraft body that this spacecraft object should be considered a component of. Required if this spacecraft object is a subcomponent of a larger craft (i.e. deployable solar panel)
 }
@@ -247,12 +247,12 @@ message VizMessage{
         int32 showTransceiverLabels = 7;   // Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
         int32 showTransceiverFrustrum = 8; // Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
         int32 showGenericStoragePanel = 9; // Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-        int32 showMultiSphereLabels = 10;  // Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
+        int32 showMultiShapeLabels = 10;   // Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
     }
 
     message CustomModel{
         // ALL FIELDS CHECKED ONLY IN FIRST MESSAGE, ONLY NEEDED IF A CUSTOM MODEL IS BEING APPLIED
-        string modelPath = 1;                  // Path to model obj -OR- "CUBE", "CYLINDER", or "SPHERE" to use a primitive shape or "HI_DEF_SPHERE" to use the high vertex count icosphere
+        string modelPath = 1;                  // Path to model obj -OR- "CUBE", "CYLINDER", "CAPSULE", or "SPHERE" to use a primitive shape or "HI_DEF_SPHERE" to use the high vertex count icosphere
         repeated string simBodiesToModify = 2; // Which bodies in scene to replace with this model, use "ALL_SPACECRAFT" in the first string to apply custom model to all spacecraft in simulation
         repeated double offset = 3;            // meters
         repeated double rotation = 4;          // degrees, euler rotation about x, y, z axes in spacecraft CS
@@ -330,18 +330,21 @@ message VizMessage{
         string truePathFixedFrame = 56;                     // string of the spacecraft or celestial body name whose rotation matrix will provide the fixed frame to plot the true path trajectory against
     }
 
-    message MultiSphere{ //ONLY NEEDED IF MSM DESIRED
-        //FIELDS 2,3, 5 CHECKED FIRST MESSAGE ONLY
+    message MultiShape{ //ONLY NEEDED IF MSM DESIRED
+        //FIELDS 2,3,5,10,11 CHECKED FIRST MESSAGE ONLY
         //FIELD 1,4 CHECKED EVERY MESSAGE
-        //FIELDS 6, 7,8  OPTIONAL, CHECKED FIRST MESSAGE ONLY
+        //FIELDS 6,7,8,9  OPTIONAL, CHECKED FIRST MESSAGE ONLY
         int32 isOn = 1;                   // Value of 0 (protobuffer default) to use viz default, -1 for false, 1 for true
-        repeated double position = 2;     // [m] position in the body frame
-        double radius = 3;                // [m] radius of the sphere
-        double currentValue = 4;          // [Coulomb] current sphere charge value
-        double maxValue = 5;              // [Coulomb] maximum sphere charge value
+        repeated double position = 2;     // [m] position in the spacecraft body frame
+        double radius = 3;                // DEPRECATED - USE DIMENSIONS [m] radius of the sphere or cylinder, width of cube
+        double currentValue = 4;          // [Coulomb] current charge value
+        double maxValue = 5;              // [Coulomb] maximum charge value
         repeated int32 positiveColor = 6; // (optional) Send desired RGBA as values between 0 and 255, default is green
         repeated int32 negativeColor = 7; // (optional) Send desired RGBA as values between 0 and 255, default is red
         int32 neutralOpacity = 8;         // (optional) Send desired opacity value between 0 and 255 for when charge is neutral, negative value yields default
+        string shape = 9;                 // (optional) Set shape to use "CUBE", "CYLINDER", "CAPSULE", or "SPHERE" (default)
+        repeated double dimensions = 10;  // [m] Desired dimensions of selected shape in x, y, and z (For cylinder, z is height)
+        repeated double rotation = 11;    // [MRP] Desired orientation of the Multi Shape in the spacecraft body frame
     }
 
     message Location{ //ONLY NEEDED IF LOCATION DESIRED

--- a/src/utilities/vizProtobuffer/vizMessage.proto
+++ b/src/utilities/vizProtobuffer/vizMessage.proto
@@ -356,6 +356,7 @@ message VizMessage{
         double fieldOfView = 5;      // [deg] angle is measured edge-to-edge, -1 -> use default, values between 0.0001 and 179.9999 valid
         repeated int32 color = 6;    // Send desired RGBA as values between 0 and 255, default is white
         double range = 7;            // [m] Value of 0 (protobuffer default) to use viz default
+        double markerScale = 8;      // (optional) Value will be multiplied by default marker scale, values less than 1.0 will decrease size, greater will increase
     }
 
     message Ellipsoid{ //ONLY NEEDED IF ELLIPSOID DESIRED

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -547,7 +547,7 @@ def setInstrumentGuiSetting(viz, **kwargs):
     showGenericStoragePanel: int
         flag if the generic sensor labels should be shown (1) or hidden (-1)
         Default: 0 - if not provided, then the Vizard default settings are used
-    showMultiSphereLabels: int
+    showMultiShapeLabels: int
         flag if the generic sensor labels should be shown (1) or hidden (-1)
         Default: 0 - if not provided, then the Vizard default settings are used
     """
@@ -561,7 +561,7 @@ def setInstrumentGuiSetting(viz, **kwargs):
     unitTestSupport.checkMethodKeyword(
         ['spacecraftName', 'viewCSSPanel', 'viewCSSCoverage', 'viewCSSBoresight', 'showCSSLabels',
          'showGenericSensorLabels', 'showTransceiverLabels', 'showTransceiverFrustrum',
-         'showGenericStoragePanel', 'showMultiSphereLabels'],
+         'showGenericStoragePanel', 'showMultiShapeLabels'],
         kwargs)
 
     if 'spacecraftName' in kwargs:
@@ -670,17 +670,17 @@ def setInstrumentGuiSetting(viz, **kwargs):
             exit(1)
         vizElement.showGenericStoragePanel = setting
 
-    if 'showMultiSphereLabels' in kwargs:
-        setting = kwargs['showMultiSphereLabels']
+    if 'showMultiShapeLabels' in kwargs:
+        setting = kwargs['showMultiShapeLabels']
         if not isinstance(setting, int):
-            print('ERROR: vizSupport: showMultiSphereLabels must be  -1 (Off), 0 (default) or 1 (On)')
+            print('ERROR: vizSupport: showMultiShapeLabels must be  -1 (Off), 0 (default) or 1 (On)')
             exit(1)
         if setting is False:
             setting = -1
         if setting*setting > 1:
-            print('ERROR: vizSupport: showMultiSphereLabels must be -1 (Off), 0 (default) or 1 (On)')
+            print('ERROR: vizSupport: showMultiShapeLabels must be -1 (Off), 0 (default) or 1 (On)')
             exit(1)
-        vizElement.showMultiSphereLabels = setting
+        vizElement.showMultiShapeLabels = setting
 
     instrumentGuiSettingList.append(vizElement)
     del viz.settings.instrumentGuiSettingsList[:]  # clear settings list to replace it with updated list


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
Support for Vizard release 2.2.2 including:
- MultiSphere deprecation, replaced with MultiShape. New fields include: shape, dimensions, rotation
- General alias deprecation added in swig_deprecated.i
- Cleaned up vizSettings documentation
- Switch from absolute to relative paths for custom model loading

## Verification
No tests added

## Documentation
All changes documented in dedicated commits

## Future work
Add example scenario implementing new MultiShape settings
