### PR TITLE
Bug/rerun monte carlo patch

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -34,7 +34,7 @@ Version |release|
 - Added safety mechanism to limit excessive wheel acceleration and provide warning messages
 - Fixed a bug in the :ref:`SpacecraftLocation` module that prevented proper eclipse calculation in some cases.
 - Added support for Vizard release 2.2.2, including transition from MultiSphere to MultiShape, and SWIG structure deprecation through aliasing.
-
+- Fixed scenario name mismatch in :ref:`scenarioRerunMonteCarlo` that prevented rerunning example Monte Carlo simulation scenarios.
 
 Version  2.6.0  (Feb. 21, 2025)
 -------------------------------

--- a/examples/MonteCarloExamples/scenarioRerunMonteCarlo.py
+++ b/examples/MonteCarloExamples/scenarioRerunMonteCarlo.py
@@ -57,23 +57,23 @@ def run(time=None):
     """
 
     # Step 1-3: Change to the relevant scenario
-    scenarioName = "scenario_AttFeedback"
+    scenarioName = "scenario_AttFeedback"  # This is the actual scenario module name
+    mcName = "scenarioBskSimAttFeedbackMC" # This is the MC script name
 
     monteCarlo = Controller()
-    monteCarlo.numProcess = 3 # Specify number of processes to spawn
-    runsList = [1]  # Specify the run numbers to be rerun
+    monteCarlo.numProcess = 3
+    runsList = [1]
 
-    #
-    # # Generic initialization
-    icName = path + "/" + scenarioName + "MC/"
-    newDataDir = path + "/" + scenarioName + "MC/rerun"
+    # Generic initialization
+    icName = path + "/" + mcName  # Use MC script name for directory
+    newDataDir = path + "/" + mcName + "/rerun"
 
-
+    # Import the base scenario module, not the MC script
     exec('import '+ scenarioName)
-    simulationModule = eval(scenarioName + "." + scenarioName) # ex. scenarioMonteCarlo.scenarioMonteCarlo
+    simulationModule = eval(scenarioName + ".scenario_AttFeedback")  # Use the actual scenario function
     if time is not None:
-        exec (scenarioName + '.' + scenarioName + '.simBaseTime = time')  # ex. scenarioMonteCarlo.scenarioMonteCarlo.simBaseTime = time
-    executionModule = eval(scenarioName + ".runScenario") # ex. scenarioMonteCarlo.run
+        exec (scenarioName + '.scenario_AttFeedback.simBaseTime = time')
+    executionModule = eval(scenarioName + ".runScenario")
 
     monteCarlo.setSimulationFunction(simulationModule)
     monteCarlo.setExecutionFunction(executionModule)


### PR DESCRIPTION
* **Tickets addressed:** bsk-000
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Name mismatch caused error when running the example script for rerunning Monte Carlo simulations. This mismatch is corrected and the MC now reruns successfully.

## Verification
The changes were validated by manually running the example script successfully.

## Documentation
Updated release notes

## Future work
No future work/bugs for this scenario. Do note that removing/replacing .eval() will require editing this scenario further.
