### PR TITLE
Add Locations using lat/lon/alt

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -54,6 +54,7 @@ Version |release|
 - Add support for python 3.13 by removing the use of ``eval()`` and most ``exec()`` methods,
   rewrote ``methodizeEvent()`` in ``SimulationBaseClass.py``.  If you use python 3.13+ the
   scope of the ``eval()`` method has changed (see https://peps.python.org/pep-0667/).
+- Added ``lla2fixedframe()`` function in :ref:`vizSupport` which provides ability to define Locations on a parent body by providing latitude/longitude/altitude relative to reference ellipsoid.
 
 
 Version  2.6.0  (Feb. 21, 2025)

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -992,7 +992,7 @@ The following table lists all required and optional arguments that can be provid
       - float(3)
       - m
       - Yes
-      - position vector of the location G relatiave to parent body (planet or spacecraft) frame P in P frame components
+      - position vector of the location G relative to parent body (planet or spacecraft) frame P in P frame components
     * - ``lla_GP``
       - float(3)
       - [rad, rad, m]

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -993,6 +993,11 @@ The following table lists all required and optional arguments that can be provid
       - m
       - Yes
       - position vector of the location G relatiave to parent body (planet or spacecraft) frame P in P frame components
+    * - ``lla_GP``
+      - float(3)
+      - [rad, rad, m]
+      - No
+      - position vector of the location G in latitude/longitude/altitude components. Required if ``r_GP_P`` is not specified.
     * - ``gHat_P``
       - float(3)
       -

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -467,7 +467,7 @@ def run(show_plots):
             range=2000.0 * 1000,  # meters
         )
 
-        # Add the Santiago target
+        # Add the Singapore target
         vizSupport.addLocation(
             viz,
             stationName="Singapore Station",

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -461,7 +461,7 @@ def run(show_plots):
             viz,
             stationName="Santiago Target",
             parentBodyName=earth.displayName,
-            r_GP_P=[1761771.6422437236, -5022201.882030934, -3515898.6046771165],
+            lla_GP=[np.deg2rad(-33.4489), np.deg2rad(-70.6693), 569.7],
             fieldOfView=np.radians(160.0),
             color="pink",
             range=2000.0 * 1000,  # meters


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Added framework in vizSupport to allow location definitions using latitude, longitude, altitude rather than just in cartesian body-fixed frame. The LLA coordinates are converted to body-fixed frame before transmission to Vizard.

## Verification
Manual testing. No tests were added as the vizSupport file currently does not have tests set up.

## Documentation
Added new keyword ``lla_GP`` to ``vizSupport.addLocation`` documentation.

## Future work
Potentially add unit testing for vizSupport functions.