### PR TITLE
Fix CI wheel saving

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -69,7 +69,7 @@ jobs:
         - uses: actions/upload-artifact@v4
           with:
             name: basilisk-wheels_ubuntu-22.04_python${{ matrix.python-version }}
-            path: /tmp/wheelhouse/**/Basilisk*.whl
+            path: /tmp/wheelhouse/**/*asilisk*.whl
 
 
     build_documentation:


### PR DESCRIPTION
The CI system broke since it started producing wheels with lowercase `basilisk` in the name instead of `Basilisk`. This should make it agnostic to case.