### PR TITLE
Change thrusterData to a pointer

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -70,6 +70,7 @@ Version |release|
 - Added support for showing ``QuadMap`` quadrilateral surface meshes in Vizard, with scenario :ref:`scenarioQuadMaps` detailing usage. Allows users to draw quads on celestial bodies and spacecraft.
 - Added ``fixedframe2lla()`` function in :ref:`vizSupport` which is useful for computing QuadMap mesh interpolations
 - Added QuadMap mesh support functions (:ref:`quadMapSupport`) for displaying camera FOV boxes as projected on the surface of a reference ellipsoid, and drawing rectangular latitude/longitude defined regions.
+- Updated ``THRSimConfig`` to use a shared pointer to avoid duplication of configuration data across the simulation and to enable access and updates to the parameters during simulation. This change has been implemented in both the ``thrusterDynamicsEffector`` and ``thrusterStateEffector`` modules.
 - :beta:`Mujoco Support`: Added ``StatefulSysModel`` for models in the dynamics task of ``MJScene`` that need to declare
   continuous-time states. Modified :ref:`scenarioDeployPanels` to illustrate the use of ``StatefulSysModel``.
 

--- a/examples/BskSim/models/BSK_Dynamics.py
+++ b/examples/BskSim/models/BSK_Dynamics.py
@@ -192,6 +192,7 @@ class BSKDynamicModels():
         """Set the 8 ACS thrusters."""
         # Make a fresh TH factory instance, this is critical to run multiple times
         thFactory = simIncludeThruster.thrusterFactory()
+        self.thFactory = thFactory
 
         # 8 thrusters are modeled that act in pairs to provide the desired torque
         thPos = [
@@ -221,7 +222,7 @@ class BSKDynamicModels():
                 , dir_B
             )
         # create thruster object container and tie to spacecraft object
-        thFactory.addToSpacecraft("ACS Thrusters",
+        self.thFactory.addToSpacecraft("ACS Thrusters",
                                   self.thrustersDynamicEffector,
                                   self.scObject)
 

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
@@ -419,9 +419,9 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
             rampOffList.append(newElement)
 
         # Set up the ramps
-        thrusterSet.thrusterData[0].ThrusterOnRamp = \
+        thruster1.ThrusterOnRamp = \
             thrusterDynamicEffector.ThrusterTimeVector(rampOnList)
-        thrusterSet.thrusterData[0].ThrusterOffRamp = \
+        thruster1.ThrusterOffRamp = \
             thrusterDynamicEffector.ThrusterTimeVector(rampOffList)
 
         if rampDown == "OFF":

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h
@@ -49,28 +49,28 @@ public:
     void computeForceTorque(double integTime, double timeStep);
     void computeStateContribution(double integTime);
     void Reset(uint64_t CurrentSimNanos);
-    void addThruster(THRSimConfig* newThruster);
-    void addThruster(THRSimConfig* newThruster, Message<SCStatesMsgPayload>* bodyStateMsg);
+    void addThruster(std::shared_ptr<THRSimConfig> newThruster);
+    void addThruster(std::shared_ptr<THRSimConfig> newThruster, Message<SCStatesMsgPayload>* bodyStateMsg);
     void UpdateState(uint64_t CurrentSimNanos);
     void writeOutputMessages(uint64_t CurrentClock);
     bool ReadInputs();
     void ConfigureThrustRequests(double currentTime);
-    void ComputeThrusterFire(THRSimConfig *CurrentThruster, double currentTime);
-    void ComputeThrusterShut(THRSimConfig *CurrentThruster, double currentTime);
+    void ComputeThrusterFire(std::shared_ptr<THRSimConfig> CurrentThruster, double currentTime);
+    void ComputeThrusterShut(std::shared_ptr<THRSimConfig> CurrentThruster, double currentTime);
     void UpdateThrusterProperties();
-    void computeBlowDownDecay(THRSimConfig *CurrentThruster);
+    void computeBlowDownDecay(std::shared_ptr<THRSimConfig> CurrentThruster);
 
 public:
     ReadFunctor<THRArrayOnTimeCmdMsgPayload> cmdsInMsg;  //!< -- input message with thruster commands
     std::vector<Message<THROutputMsgPayload>*> thrusterOutMsgs;  //!< -- output message vector for thruster data
 
     int stepsInRamp;                               //!< class variable
-    std::vector<THRSimConfig> thrusterData; //!< -- Thruster information
+    std::vector<std::shared_ptr<THRSimConfig>> thrusterData; //!< -- Thruster information
     std::vector<double> NewThrustCmds;             //!< -- Incoming thrust commands
     double mDotTotal;                              //!< kg/s Current mass flow rate of thrusters
     double fuelMass;                               //!< kg Current total fuel mass of connected fuel tank
     double prevFireTime;                           //!< s  Previous thruster firing time
-	double thrFactorToTime(THRSimConfig *thrData,
+	double thrFactorToTime(std::shared_ptr<THRSimConfig> thrData,
 		std::vector<THRTimePair> *thrRamp);
 	StateData *hubSigma;                           //!< pointer to the hub attitude states
     StateData *hubOmega;                           //!< pointer to the hub angular velocity states

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.i
@@ -43,13 +43,17 @@ namespace std {
 %include "thrusterDynamicEffector.h"
 
 %include "simulation/dynamics/_GeneralModuleFiles/THRTimePair.h"
-%include "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h"
+%import "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.i"
 
 %include "architecture/msgPayloadDefC/THRArrayOnTimeCmdMsgPayload.h"
 struct THRArrayOnTimeCmdMsg_C;
 %include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 struct SCStatesMsg_C;
+
+%pythoncode %{
+from Basilisk.simulation.THRSimConfig import THRSimConfig as THRSimConfig
+%}
 
 %pythoncode %{
 import sys

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
@@ -57,8 +57,8 @@ public:
     void UpdateState(uint64_t CurrentSimNanos);
 
 
-    void addThruster(THRSimConfig* newThruster); //!< -- Add a new thruster to the thruster set
-    void addThruster(THRSimConfig* newThruster, Message<SCStatesMsgPayload>* bodyStateMsg); //!< -- (overloaded) Add a new thruster to the thruster set connect to a body different than the hub
+    void addThruster(std::shared_ptr<THRSimConfig> newThruster); //!< -- Add a new thruster to the thruster set
+    void addThruster(std::shared_ptr<THRSimConfig> newThruster, Message<SCStatesMsgPayload>* bodyStateMsg); //!< -- (overloaded) Add a new thruster to the thruster set connect to a body different than the hub
     void ConfigureThrustRequests();
     void UpdateThrusterProperties();
 
@@ -66,7 +66,7 @@ public:
     // Input and output messages
     ReadFunctor<THRArrayOnTimeCmdMsgPayload> cmdsInMsg;  //!< -- input message with thruster commands
     std::vector<Message<THROutputMsgPayload>*> thrusterOutMsgs;  //!< -- output message vector for thruster data
-    std::vector<THRSimConfig> thrusterData; //!< -- Thruster information
+    std::vector<std::shared_ptr<THRSimConfig>> thrusterData; //!< -- Thruster information
     std::vector<double> NewThrustCmds;             //!< -- Incoming thrust commands
 
     // State information

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.i
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.i
@@ -31,12 +31,10 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
-%include "std_vector.i"
-
 %include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-%include "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h"
+%import "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.i"
 %include "thrusterStateEffector.h"
 
 %include "architecture/msgPayloadDefC/THRArrayOnTimeCmdMsgPayload.h"
@@ -44,6 +42,10 @@ struct THRArrayOnTimeCmdMsg_C;
 %include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 struct SCStatesMsg_C;
+
+%pythoncode %{
+from Basilisk.simulation.THRSimConfig import THRSimConfig as THRSimConfig
+%}
 
 %pythoncode %{
 import sys

--- a/src/simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h
@@ -30,7 +30,7 @@
 /*! This structure is used to define the overall configuration of an entire
  thruster.  It holds the current operational data for the thruster, the
  ramp/max/min configuration data, and the physical location/orientation data for
- a thruster.*/
+ a thruster. This structure is managed using a `std::shared_ptr` to avoid duplication of configuration data across the simulation and to enable access and updates to the parameters during simulation.*/
 typedef struct
 //@cond DOXYGEN_IGNORE
 THRSimConfig

--- a/src/simulation/dynamics/_GeneralModuleFiles/THRSimConfig.i
+++ b/src/simulation/dynamics/_GeneralModuleFiles/THRSimConfig.i
@@ -1,0 +1,31 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+%module(package="Basilisk.simulation") THRSimConfig
+%{
+#include "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h"
+#include <memory>
+%}
+
+%include "swig_common_model.i"
+
+%include <std_shared_ptr.i>
+%shared_ptr(THRSimConfig)
+
+%include "simulation/dynamics/_GeneralModuleFiles/THRSimConfig.h"


### PR DESCRIPTION
* **Tickets addressed:** bsk-952
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Changed the thruster config message in thrusterDynamicEffector to a pointer, duplication of thruster config messages is avoided, and parameters can be easily modified during simulation.

## Verification
Unit test was done with `test_ThrusterDynamicsUnit.py`

## Documentation
N/A

## Future work
N/A
