### PR TITLE
Feature/979 mujoco stateful sysmodel

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -70,7 +70,8 @@ Version |release|
 - Added support for showing ``QuadMap`` quadrilateral surface meshes in Vizard, with scenario :ref:`scenarioQuadMaps` detailing usage. Allows users to draw quads on celestial bodies and spacecraft.
 - Added ``fixedframe2lla()`` function in :ref:`vizSupport` which is useful for computing QuadMap mesh interpolations
 - Added QuadMap mesh support functions (:ref:`quadMapSupport`) for displaying camera FOV boxes as projected on the surface of a reference ellipsoid, and drawing rectangular latitude/longitude defined regions.
-
+- :beta:`Mujoco Support`: Added ``StatefulSysModel`` for models in the dynamics task of ``MJScene`` that need to declare
+  continuous-time states. Modified :ref:`scenarioDeployPanels` to illustrate the use of ``StatefulSysModel``.
 
 Version  2.6.0  (Feb. 21, 2025)
 -------------------------------

--- a/src/architecture/_GeneralModuleFiles/py_sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/py_sys_model.i
@@ -1,5 +1,5 @@
 
-%module(directors="1",threads="1") sysModel
+%module(directors="1",threads="1",package="Basilisk.architecture") sysModel
 %{
    #include "sys_model.h"
 %}

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJBody.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJBody.cpp
@@ -207,9 +207,9 @@ void MJBody::writeStateDependentOutputMessages(uint64_t CurrentSimNanos)
     }
 }
 
-void MJBody::registerStates(DynParamManager& paramManager)
+void MJBody::registerStates(DynParamRegisterer paramManager)
 {
-    this->massState = paramManager.registerState(1, 1, "mujocoBodyMass_" + this->name);
+    this->massState = paramManager.registerState(1, 1, "mass");
 }
 
 void MJBody::updateMujocoModelFromMassProps()

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJBody.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJBody.h
@@ -36,6 +36,7 @@
 #include "MJJoint.h"
 #include "MJObject.h"
 #include "MJSite.h"
+#include "StatefulSysModel.h"
 
 /// @cond
 /**
@@ -252,13 +253,13 @@ public:
     void writeStateDependentOutputMessages(uint64_t CurrentSimNanos);
 
     /**
-     * @brief Registers the body's states with a dynamic parameter manager.
+     * @brief Registers the body's states with a dynamic parameter registerer.
      *
      * Currently, only the mass of the body is considered a parameter.
      *
-     * @param paramManager Reference to the dynamic parameter manager.
+     * @param paramManager The dynamic parameter registerer.
      */
-    void registerStates(DynParamManager& paramManager);
+    void registerStates(DynParamRegisterer paramManager);
 
     /**
      * @brief Updates the MuJoCo model from the mass properties of the body.

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
@@ -93,6 +93,19 @@ void MJScene::initializeDynamics()
     if (!recompiled) {
         this->spec.configure();
     }
+
+    // Register the states of the models in the dynamics task
+    for (auto[_, sysModelPtr] : this->dynamicsTask.TaskModels)
+    {
+        if (auto statefulSysModelPtr = dynamic_cast<StatefulSysModel*>(sysModelPtr))
+        {
+            statefulSysModelPtr->registerStates(DynParamRegisterer(
+                this->dynManager,
+                sysModelPtr->ModelTag.empty() ? std::string("model") : sysModelPtr->ModelTag
+                + "_" + std::to_string(sysModelPtr->moduleID) + "_"
+            ));
+        }
+    }
 }
 
 void MJScene::UpdateState(uint64_t CurrentSimNanos)

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
@@ -20,6 +20,7 @@
 #include "MJScene.h"
 
 #include "MJFwdKinematics.h"
+#include "StatefulSysModel.h"
 
 #include "simulation/dynamics/_GeneralModuleFiles/svIntegratorRK4.h"
 #include "architecture/utilities/macroDefinitions.h"
@@ -79,7 +80,10 @@ void MJScene::initializeDynamics()
     this->actState = this->dynManager.registerState(1, 1, "mujocoAct");
 
     for (auto&& body : this->spec.getBodies()) {
-        body.registerStates(this->dynManager);
+        body.registerStates(DynParamRegisterer(
+            this->dynManager,
+            "body_" + body.getName() + "_"
+        ));
     }
 
     // Make sure the spec is compiled

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.h
@@ -1,0 +1,113 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef STATEFUL_SYS_MODEL_H
+#define STATEFUL_SYS_MODEL_H
+
+#include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+
+/**A short-lived class passed to StatefulSysModel for them to register
+ * their states.
+ *
+ * This class serves two purposes. First, it adds a prefix to every state
+ * name before registering it on the actual DynParamManager. This prevents
+ * state name collisions between StatefulSysModel as long as the prefix
+ * are unique. Second, it exponses only the registerState method from
+ * the DynParamManager. This prevents StatefulSysModel from registering
+ * properties or accessing the states of other models, which would allow for
+ * information to flow between models without going through the message system.
+ * If a model needs to access information from another model, it should do so
+ * thorugh a message, not by sharing a state or property.
+ */
+class DynParamRegisterer
+{
+public:
+    /** Constructor */
+    DynParamRegisterer(DynParamManager& manager, std::string stateNamePrefix)
+        : manager(manager)
+        , stateNamePrefix(stateNamePrefix)
+        {}
+
+    /** Creates and returns a new state, which will be managed by the
+     * underlying ``DynParamManager``.
+     *
+     * The state name should be unique: registering two states with the
+     * same name on this class will cause an error. Different StatefulSysModel
+     * are allowed to use the same state name, however.
+     *
+     * This method may optionally be templated to create StateData of
+     * subclasses of StateData.
+     */
+    template <typename StateDataType = StateData,
+              std::enable_if_t<std::is_base_of_v<StateData, StateDataType>, bool> = true>
+    inline StateDataType* registerState(uint32_t nRow, uint32_t nCol, std::string stateName)
+    {
+        return this->manager.registerState<StateDataType>(
+            nRow, nCol, this->stateNamePrefix + stateName
+        );
+    }
+
+protected:
+    DynParamManager& manager; ///< wrapped manager
+    std::string stateNamePrefix; ///< prefix added to all registered state names
+};
+
+/** A SysModel that has continuous-time states.
+ *
+ * StatefulSysModel are added on the dynamics task of an MJScene.
+ * On its UpdateState method, a StatefulSysModel should call each state's
+ * setDerivative method. This value will be used by the integrator to
+ * update the state for the next integrator step.
+ *
+ * The sample code below shows how to get the current value of the state
+ * and how to set its derivative. In this case, ``x`` would follow an
+ * exponential trajectory:
+ * \code{.cpp}
+ * void UpdateState(uint64_t CurrentSimNanos) override {
+ *     auto x = this->xState->getState();
+ *     this->xState->setDerivative( x );
+ * }
+ * \endcode
+ */
+class StatefulSysModel : public SysModel
+{
+public:
+    /** Default constructor */
+    StatefulSysModel() = default;
+
+    /**Used to register states on the given DynParamRegisterer.
+     *
+     * The main purpose of this method is for this class to call
+     * ``registerState`` on the registerer. Note that state names
+     * should not be repeated within the same StatefulSysModel.
+     *
+     * \code{.cpp}
+     * void registerStates(DynParamRegisterer& registerer) override {
+     *     this->posState = registerer.register(3, 1, "pos");
+     *     this->massState = registerer.register(1, 1, "mass");
+     *     // etc.
+     * }
+     * \endcode
+     *
+     */
+    virtual void registerStates(DynParamRegisterer registerer) = 0;
+};
+
+#endif

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_sys_model.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_sys_model.py
@@ -1,0 +1,92 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from Basilisk.utilities import macros
+from Basilisk.utilities import SimulationBaseClass
+
+try:
+    from Basilisk.simulation import mujoco
+    from Basilisk.simulation import StatefulSysModel
+    couldImportMujoco = True
+except:
+    couldImportMujoco = False
+
+import pytest
+import numpy as np
+
+@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
+def test_stateful():
+    """Tests that ``StatefulSysModel`` works as expected.
+
+    We use a simple ``StatefulSysModel`` with a single state. We check
+    that said state is registered with the expected name and that its
+    value evolves as we would expect.
+    """
+
+    # Declared inside, since StatefulSysModel may be undefined if not running with mujoco
+    class ExponentialStateModel(StatefulSysModel.StatefulSysModel):
+        """A simple model with one state, whose derivative is dx/dt = x*t."""
+
+        def registerStates(self, registerer: StatefulSysModel.DynParamRegisterer):
+            """Called once during InitializeSimulation"""
+            self.xState = registerer.registerState(1, 1, "x")
+
+        def UpdateState(self, CurrentSimNanos):
+            """Called at every integrator step"""
+            t = macros.NANO2SEC * CurrentSimNanos
+            x = self.xState.getState()[0][0]
+            self.xState.setDerivative( [[t*x]] )
+
+
+    dt = 0.01 # s
+    tf = 1 # s
+
+    # Create sim, process, and task
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("test")
+    dynProcess.addTask(scSim.CreateNewTask("test", macros.sec2nano(dt)))
+
+    scene = mujoco.MJScene("<mujoco/>") # empty scene, no multi-body dynamics
+    scSim.AddModelToTask("test", scene)
+
+    expState = ExponentialStateModel()
+    expState.ModelTag = "testModel"
+
+    scene.AddModelToDynamicsTask(expState)
+
+    # Run the sim
+    scSim.InitializeSimulation()
+    expState.xState.setState([[1]]) # initialize state to 1
+
+    # Run for tf seconds
+    scSim.ConfigureStopTime(macros.sec2nano(tf))
+    scSim.ExecuteSimulation()
+
+    # Check that the state name has the model tag and ID prepended
+    expected_name = f"{expState.ModelTag}_{expState.moduleID}_x"
+    assert expState.xState.getName() == expected_name, f"{expState.xState.getName()} != {expected_name}"
+
+    # The state follows dx/dt=x*t for x(0) = 1
+    # So we expect x(tf=1) to be e^(tf^2/2)
+    expected = np.exp( tf**2 / 2 )
+    assert expState.xState.getState()[0][0] == pytest.approx(expected)
+
+if __name__ == "__main__":
+    if True:
+        test_stateful()
+    else:
+        pytest.main([__file__])

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/pyStatefulSysModel.i
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/pyStatefulSysModel.i
@@ -1,0 +1,55 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module(directors="1",threads="1") StatefulSysModel
+%{
+   #include "StatefulSysModel.h"
+%}
+
+%pythoncode %{
+import sys
+import traceback
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "architecture/utilities/bskLogging.h"
+%import "architecture/_GeneralModuleFiles/py_sys_model.i"
+
+// We don't need to construct the DynParamRegisterer on the Python side
+%ignore DynParamRegisterer::DynParamRegisterer;
+
+%feature("director") StatefulSysModel;
+%feature("pythonappend") StatefulSysModel::StatefulSysModel %{
+    self.__super_init_called__ = True%}
+%rename("_StatefulSysModel") StatefulSysModel;
+%include "StatefulSysModel.h"
+
+%template(registerState) DynParamRegisterer::registerState<StateData, true>;
+
+%pythoncode %{
+class StatefulSysModel(_StatefulSysModel, metaclass=Basilisk.architecture.sysModel.SuperInitChecker):
+    bskLogger: BSKLogger = None
+
+    def __init_subclass__(cls):
+        # Make it so any exceptions in UpdateState and Reset
+        # print any exceptions before returning control to
+        # C++ (at which point exceptions will crash the program)
+        cls.UpdateState = Basilisk.architecture.sysModel.logError(cls.UpdateState)
+        cls.Reset = Basilisk.architecture.sysModel.logError(cls.Reset)
+        cls.registerStates = Basilisk.architecture.sysModel.logError(cls.registerStates)
+%}


### PR DESCRIPTION
* **Tickets addressed:** Closes #979
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Currently, the `MJScene` dynamic object cannot have continuous states, other than the states of the multi-body. A continuous state is a state whose evolution is given by its time derivative, and thus must be integrated forward in time. `spacecraft` objects use `stateEffector` to declare such states (for example, a fuel tank is modeled as a `stateEffector` whose mass in a continuous state). A similar capability is required for `MJScene`.

To address this, a new class, `StatefulSysModel`, has been added, which inherits from `SysModel` but has an additional virtual method `registerStates`. `MJScene` has an internal "dynamics" task, which contains `SysModel` objects that compute the forces/torques applied on the multi-body system. With `StatefulSysModel`, we make it so that the `SysModel` objects in the "dynamics" task can also declare their own continuous-time states and then compute their derivative on their `UpdateState` method.

`StatefulSysModel` have a new method, `registerStates`, which is called on the `initializeDynamics` function in `MJScene` (the same method where the mujoco multi-body declares its states or `stateEffector` registered their states in `spacecraft`). The main difference with `stateEffector` is that `StatefulSysModel` get a `DynParamRegisterer` objects, instead of a `DynParamManager`. `DynParamRegisterer` wraps an instance of `DynParamManager`, but allows only one function to be called on it: `registerState`. Moreover, it prepends some model-unique string to the state name before registering it on the manager, which prevents state name collision between models (multiple models can register the same state name). 

`DynParamRegisterer` purposefully grants access to only one method `registerState`, because I consider other methods in the manager to be transparent data sharing, which can be harmful to understanding the flow of data in the simulation. Shared state objects and properties allow models to talk to each other and influence each other through a parallel information passing scheme to messages. The message system provides clear model interfaces, functional encapsulation, and ease of testing and logging. Data sharing through states and properties goes against this. If a model wants to share its state information, I believe it should do so through a message. If a model needs to know a "property" of the multi-body (such as its center of mass or gravity acceleration), then a model should compute and properly publish this information as a message. With this new pattern, state objects are managed by a single model, and properties are deprecated.

Moreover, Python `StatefulSysModel` are supported. With this feature, we are able to effectively replicate the `dynamicEffector` and `stateEffector` functionality purely on the Python side, which will enable rapid prototyping.

## Verification
A new test `src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_sys_model.py` has been written. Moreover, a scenario `examples/mujoco/scenarioDeployPanels.py` has been updated to show the use of `StatefulSysModel` (in Python).

## Documentation
No documentation has been added, other than the showcase in `scenarioDeployPanels.py`. Release notes have not been updated, since the previous MuJoCo entry covers this content.
