### PR TITLE
Deprecate Python 3.8

### DIFF
--- a/docs/source/Install/installOnLinux.rst
+++ b/docs/source/Install/installOnLinux.rst
@@ -12,7 +12,7 @@ Software setup
 
 In order to run Basilisk, the following software will be necessary. This document outline how to install this support software.
 
--  `Python <https://www.python.org/>`__ 3.8 to 3.13
+-  `Python <https://www.python.org/>`__ 3.8 to 3.13.  Version 3.8 is deprecated and will be removed April 2026.
 -  `SWIG <http://www.swig.org/>`__ (version 4.x)
 -  `GCC <https://gcc.gnu.org/>`__
 -  (Optional) Get the `GitKraken <https://www.gitkraken.com>`__

--- a/docs/source/Install/installOnMacOS.rst
+++ b/docs/source/Install/installOnMacOS.rst
@@ -8,7 +8,7 @@ Setup On macOS
 ==============
 
 These instruction outline how to install Basilisk (BSK) on a clean version of macOS.
-Basilisk requires the use of Python 3.8 to 3.13.
+Basilisk requires the use of Python 3.8 to 3.13.   Version 3.8 is deprecated and will be removed April 2026.
 
 The following python package dependencies are automatically checked and installed in the steps below.
 

--- a/docs/source/Install/installOnWindows.rst
+++ b/docs/source/Install/installOnWindows.rst
@@ -13,7 +13,8 @@ Software setup
 
 In order to run Basilisk, the following software will be necessary:
 
--  `Python <https://www.python.org/downloads/windows/>`__ 3.8 to 3.13
+-  `Python <https://www.python.org/downloads/windows/>`__ 3.8 to 3.13.
+   Version 3.8 is deprecated and will be removed April 2026.
 -  `pip <https://pip.pypa.io/en/stable/installing/>`__
 -  Visual Studios 15 2017 or greater
 -  `Swig <http://www.swig.org/download.html>`__ version 4.X

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -26,7 +26,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
-- text here
+- Marked the use of python 3.8 as deprecated
 
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,11 @@ include(bskTargetExcludeBuildOptions)
 # Find necessary packages
 find_package(Python3 ${PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development.Module OPTIONAL_COMPONENTS Development.SABIModule)
 
+# check for deprecated python 3.8
+if(Python3_VERSION VERSION_LESS "3.9")
+    message(WARNING "You are using Python ${Python3_VERSION}, but support for Python < 3.9 is deprecated and will be removed in April 2026.")
+endif()
+
 if((${Python3_VERSION} VERSION_GREATER_EQUAL 3.12))
   message(WARNING "Basilisk on Python 3.12+ (found version ${Python3_VERSION}) requires SWIG 4.2.0+.")
   find_package(SWIG 4.2...<5 REQUIRED COMPONENTS python)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,20 @@ if(Python3_VERSION VERSION_LESS "3.9")
     message(WARNING "You are using Python ${Python3_VERSION}, but support for Python < 3.9 is deprecated and will be removed in April 2026.")
 endif()
 
-if((${Python3_VERSION} VERSION_GREATER_EQUAL 3.12))
-  message(WARNING "Basilisk on Python 3.12+ (found version ${Python3_VERSION}) requires SWIG 4.2.0+.")
+# Find SWIG early (no version requirement yet)
+find_package(SWIG REQUIRED COMPONENTS python)
+
+# Check both versions
+if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
+  if(SWIG_VERSION VERSION_LESS "4.2.0")
+    message(FATAL_ERROR
+      "Python ${Python3_VERSION} requires SWIG 4.2.0 or newer, but found SWIG ${SWIG_VERSION}."
+    )
+  endif()
+endif()
+
+# Now safely require SWIG in the appropriate version range
+if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
   find_package(SWIG 4.2...<5 REQUIRED COMPONENTS python)
 else()
   find_package(SWIG 4.0...<5 REQUIRED COMPONENTS python)


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Python 3.8 is getting very old now and is limiting some features that don't work with this version.  The use of 3.8 is now deprecated and will be removed in April 2026.

## Verification
Did a clean build and test of the documentation. No issues.

## Documentation
Updated release notes

## Future work
None