### PR TITLE
Hotfix/Compiler Warnings MuJocO

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,13 +188,16 @@ function(generate_package_libraries INIT_DIRECTORY AllLibs)
     endif()
 
     # Link all necessary libraries
-    target_link_libraries(${LIB_NAME} PUBLIC ArchitectureUtilities)
     target_link_libraries(${LIB_NAME} PRIVATE ModuleIdGenerator)
-    target_link_libraries(${LIB_NAME} PUBLIC cMsgCInterface)
     target_link_libraries(${LIB_NAME} PRIVATE ${PYTHON3_MODULE})
     target_link_libraries(${LIB_NAME} PRIVATE Eigen3::Eigen3)
     if(${PARENT_DIR_NAME} STREQUAL "mujocoDynamics")
       target_link_libraries(${LIB_NAME} PUBLIC dynamicsLib)
+      # dynamicsLib already has ArchitectureUtilities and cMsgCInterface
+      # publicly linked, so no need to add them (again) for mujocoDynamics
+    else()
+      target_link_libraries(${LIB_NAME} PUBLIC ArchitectureUtilities)
+      target_link_libraries(${LIB_NAME} PUBLIC cMsgCInterface)
     endif()
 
     # define build location, IDE generation specifications

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJQPosStateData.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJQPosStateData.h
@@ -50,7 +50,7 @@ public:
      *
      * @return A unique pointer to the cloned `StateData` object.
      */
-    virtual std::unique_ptr<StateData> clone() const;
+    virtual std::unique_ptr<StateData> clone() const override;
 
     /**
      * @brief Configures the state data with the given MuJoCo model.

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.h
@@ -519,7 +519,7 @@ public:
      * @param error The error message.
      */
     template <typename T = std::invalid_argument>
-    void logAndThrow (const std::string& error);
+    [[noreturn]] void logAndThrow (const std::string& error);
 
 public:
     static const int FWD_KINEMATICS_PRIORITY = 10000; ///< Priority for default forward kinematics model.

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJSite.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJSite.cpp
@@ -77,7 +77,7 @@ void MJSite::writeFwdKinematicsMessage(mjModel* model, mjData* data, uint64_t Cu
     mrpd = rot;
 
     double res[6];
-    mj_objectVelocity(model, data, mjOBJ_SITE, this->getId(), res, 0);
+    mj_objectVelocity(model, data, mjOBJ_SITE, static_cast<int>(this->getId()), res, 0);
 
     // TODO: Double check this is right
     std::copy_n(res, 3, payload.omega_BN_B);

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.h
@@ -54,7 +54,7 @@ using mjVFSDeleter = mjDeleter<mjVFS, mj_deleteVFS>;
 
 /** Loggs an error message and then throws an error. */
 template <typename T = std::invalid_argument>
-inline void logAndThrow (const std::string& error, BSKLogger* logger = nullptr)
+[[noreturn]] inline void logAndThrow (const std::string& error, BSKLogger* logger = nullptr)
 {
     if (logger) {
         logger->bskLog(BSK_ERROR, error.c_str());


### PR DESCRIPTION
* **Tickets addressed:** Hotfix
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Some `mujocoDynamics` code was raising compiler warnings. These commits address these.

One of the warnings was due to a missing override keyword.

The other warning was raised because some functions were reaching the control flow end without returning the expected value. However, this is because a `logAndThrow` was being called, which throws an error and thus interrupts normal control flow. By letting the compiler know that this function is ``[[noreturn]]``, it no longer cares about the return on that path of the control flow.

## Verification
I'll check the MacOS build logs for compiler warnings (I'm tagging this PR dont merge until I've done this manual check).
