### PR TITLE
Remove opNavMode

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -27,7 +27,7 @@ Basilisk Release Notes
 Version |release|
 -----------------
 - Marked the use of python 3.8 as deprecated
-
+- Support for ``opNavMode`` flag within vizSupport was removed, as its deprecation period ended
 
 
 Version 2.7.0 (April 20, 2025)

--- a/docs/source/Vizard/vizardAdvanced/vizardLiveComm.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardLiveComm.rst
@@ -18,9 +18,6 @@ BSK can link with Vizard **live** in three ways:
   messages to Vizard when an image is requested. This is a more efficient OpNav mode, but shows no
   graphical display in Vizard.
 
-.. caution::
-    Legacy ``opNavMode`` has been deprecated. For ``opNavMode = 1``, use ``liveStream`` flag. For ``opNavMode = 2``, use ``noDisplay`` flag.
-
 
 ``liveStream`` Mode
 ===================

--- a/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_LimbAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_LimbAttOD.py
@@ -227,11 +227,10 @@ def run(TheScenario):
     TheScenario.configure_initial_conditions()
 
     TheScenario.get_FswModel().imageProcessing.saveImages = 0
-    TheScenario.get_DynModel().vizInterface.opNavMode = 1
+    TheScenario.get_DynModel().vizInterface.liveStream = True
 
-    mode = ["None", "-directComm", "-noDisplay"]
     vizard = subprocess.Popen(
-        [TheScenario.vizPath, "--args", mode[TheScenario.get_DynModel().vizInterface.opNavMode],
+        [TheScenario.vizPath, "--args", "-directComm",
          "tcp://localhost:5556"], stdout=subprocess.DEVNULL)
     print("Vizard spawned with PID = " + str(vizard.pid))
 

--- a/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_OpNavAttODMC.py
+++ b/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_OpNavAttODMC.py
@@ -118,11 +118,10 @@ def run(TheScenario):
     TheScenario.configure_initial_conditions()
 
     TheScenario.get_FswModel().imageProcessing.saveImages = 0
-    TheScenario.get_DynModel().vizInterface.opNavMode = 1
+    TheScenario.get_DynModel().vizInterface.liveStream = True
 
-    mode = ["None", "-directComm", "-noDisplay"]
     vizard = subprocess.Popen(
-        [TheScenario.vizPath, "--args", mode[TheScenario.get_DynModel().vizInterface.opNavMode], "tcp://localhost:5556"], stdout=subprocess.DEVNULL)
+        [TheScenario.vizPath, "--args", "-directComm", "tcp://localhost:5556"], stdout=subprocess.DEVNULL)
     print("Vizard spawned with PID = " + str(vizard.pid))
 
     # Configure FSW mode

--- a/src/simulation/vizard/vizInterface/vizInterface.h
+++ b/src/simulation/vizard/vizInterface/vizInterface.h
@@ -63,8 +63,6 @@ public:
     std::vector<QuadMap *> quadMaps;               //!< vector of QuadMap regions
     std::vector<GravBodyInfo> gravBodyInformation; //!< vector of gravitational body info
     std::vector<Message<CameraImageMsgPayload>*> opnavImageOutMsgs;    //!< vector of vizard instrument camera output messages
-    int opNavMode;                                 /*!< [int] Set non-zero positive value  if Unity/Viz couple in direct
-                                                    communication. (1 - regular opNav, 2 - performance opNav) */
     bool saveFile;                                 //!< [Bool] Set True if Vizard should save a file of the data.
 
     bool liveStream;                               //!< [Bool] Set True if Vizard should receive a live stream of BSK data.

--- a/src/simulation/vizard/vizInterface/vizInterface.i
+++ b/src/simulation/vizard/vizInterface/vizInterface.i
@@ -22,7 +22,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 %}
 
 %include "swig_deprecated.i"
-%deprecated_variable(VizInterface, opNavMode, "2025/04/17", "opNavMode is deprecated. Use liveStream and noDisplay flags instead.")
 
 %pythoncode %{
 from Basilisk.architecture.swig_common_model import *

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -1562,8 +1562,6 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     genericSensorCmdInMsgs:
         list of lists of :ref:`DeviceCmdMsgPayload` sensor state messages.  The outer list length must
         match ``scList``.  If the spacecraft has no sensor command msg, then use ``None``.
-    opNavMode: bool
-        flag if opNavMode should be used [DEPRECATED]
     liveStream: bool
         flag if live data streaming to Vizard should be used
     broadcastStream: bool
@@ -1609,7 +1607,7 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     global firstSpacecraftName
 
     unitTestSupport.checkMethodKeyword(
-        ['saveFile', 'opNavMode', 'rwEffectorList', 'thrEffectorList', 'thrColors', 'cssList', 'liveStream', 'broadcastStream',
+        ['saveFile', 'rwEffectorList', 'thrEffectorList', 'thrColors', 'cssList', 'liveStream', 'broadcastStream',
          'noDisplay', 'genericSensorList', 'transceiverList', 'genericStorageList', 'lightList', 'spriteList',
          'modelDictionaryKeyList', 'oscOrbitColorList', 'trueOrbitColorList', 'logoTextureList',
          'msmInfoList', 'ellipsoidList', 'trueOrbitColorInMsgList'],
@@ -2012,25 +2010,4 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
             exit(1)
         vizMessenger.noDisplay = val
 
-    if 'opNavMode' in kwargs:
-        deprecateOpNav()
-        val = kwargs['opNavMode']
-        if not isinstance(val, int):
-            print('ERROR: vizSupport: opNavMode must be 0 (off), 1 (regular opNav) or 2 (high performance opNav)')
-            exit(1)
-        if val < 0 or val > 2:
-            print('ERROR: vizSupport: opNavMode must be 0 (off), 1 (regular opNav) or 2 (high performance opNav)')
-            exit(1)
-        if val == 1:
-            vizMessenger.liveStream = True
-        if val == 2:
-            if vizMessenger.liveStream or vizMessenger.broadcastStream:
-                print("ERROR: vizSupport: noDisplay mode cannot be used with liveStream or broadcastStream.")
-            else:
-                vizMessenger.noDisplay = True
-
     return vizMessenger
-
-@deprecated.deprecated("2025/04/17", "opNavMode has been deprecated. Use 'liveStream' or 'noDisplay' flags instead.")
-def deprecateOpNav():
-    return


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
Removed all instances of opNavMode within vizInterface and vizSupport, as the 1-year deprecation ended on 4/17/25.

## Verification
None

## Documentation
Mentioned removal in release notes. Alternate flags are documented.

## Future work
None