### PR TITLE
Make time difference and conversion evaluations safer

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -31,6 +31,12 @@ Version |release|
 - Demo video was added to :ref:`scenarioQuadMaps` documentation
 - Pinned python dependencies to avoid issues with new package versions.
 - Added a new github workflow job ``canary`` to routinely check the compatibility of latest python dependencies with python 3.13 on the latest mac-os.
+- Fixed an issue where DynamicObject classes computed time steps by differencing double values rather
+  than ``uint64_t`` values in nanoseconds.  This could cause micro drifts in the integration process.  See
+  `Issue 993 <https://github.com/AVSLab/basilisk/issues/993>`_ for more info on this issue.  Now the time step is computed
+  using ``uint64_t`` time values and then converted to a double.
+- Enhance how ``uint64_t`` values are converted to doubles.  BSK now warns if the time value is large enough such
+  that the conversion method has a loss of precision in this process.
 
 
 Version 2.7.0 (April 20, 2025)

--- a/examples/scenarioPatchedConics.py
+++ b/examples/scenarioPatchedConics.py
@@ -158,14 +158,16 @@ def run(show_plots):
     # and to discount Jupiter's velocity upon
     # entering Jupiter's Sphere of Influence. This ensures the spacecraft has the correct heliocentric and relative
     # positions and velocities even when the planets are not moving.
+    rEarth = 149598023. * 1000
+    rJupiter = 778298361. * 1000
     earthStateMsg = messaging.SpicePlanetStateMsgPayload()
-    earthStateMsg.PositionVector = [0.0, -149598023 * 1000, 0.0]
+    earthStateMsg.PositionVector = [0.0, -rEarth, 0.0]
     earthStateMsg.VelocityVector = [0.0, 0.0, 0.0]
     earthMsg = messaging.SpicePlanetStateMsg().write(earthStateMsg)
     gravFactory.gravBodies['earth'].planetBodyInMsg.subscribeTo(earthMsg)
 
     jupiterStateMsg = messaging.SpicePlanetStateMsgPayload()
-    jupiterStateMsg.PositionVector = [0.0, 778298361 * 1000, 0.0]
+    jupiterStateMsg.PositionVector = [0.0, rJupiter, 0.0]
     jupiterStateMsg.VelocityVector = [0.0, 0.0, 0.0]
     jupiterMsg = messaging.SpicePlanetStateMsg().write(jupiterStateMsg)
     gravFactory.gravBodies['jupiter barycenter'].planetBodyInMsg.subscribeTo(jupiterMsg)
@@ -194,8 +196,6 @@ def run(show_plots):
     vel_N_Earth = [0.0 * 1000, 0, 0]
 
     # Hohmann transfer calculations
-    rEarth = 149598023. * 1000
-    rJupiter = 778298361. * 1000
     at = (rEarth + rJupiter) * .5
     vPt = np.sqrt(2 * sun.mu / rEarth - sun.mu / at)
     vAt = np.sqrt(2 * sun.mu / rJupiter - sun.mu / at)

--- a/examples/scenarioPatchedConics.py
+++ b/examples/scenarioPatchedConics.py
@@ -241,6 +241,11 @@ def run(show_plots):
     scSim.ConfigureStopTime(simulationTime)
     scSim.ExecuteSimulation()
 
+    # write planet state messages again to avoid long time difference errors in the gravity effector
+    earthMsg.write(earthStateMsg, scSim.TotalSim.CurrentNanos)
+    jupiterMsg.write(jupiterStateMsg, scSim.TotalSim.CurrentNanos)
+    sunMsg.write(sunStateMsg, scSim.TotalSim.CurrentNanos)
+
     posRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubPosition)
     velRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubVelocity)
 
@@ -256,8 +261,14 @@ def run(show_plots):
     velRef.setState(vN)
 
     # run simulation for 2nd chunk
-    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(110000))
+    stopTime = simulationTime + macros.sec2nano(110000)
+    scSim.ConfigureStopTime(stopTime)
     scSim.ExecuteSimulation()
+
+    # write planet state messages again to avoid long time difference errors in the gravity effector
+    earthMsg.write(earthStateMsg, scSim.TotalSim.CurrentNanos)
+    jupiterMsg.write(jupiterStateMsg, scSim.TotalSim.CurrentNanos)
+    sunMsg.write(sunStateMsg, scSim.TotalSim.CurrentNanos)
 
     posData = dataLog.r_BN_N
     velData = dataLog.v_BN_N
@@ -294,8 +305,18 @@ def run(show_plots):
     posRef.setState(rN)
     velRef.setState(vN)
 
-    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(110000) + T2 - oneWeek*1)
-    scSim.ExecuteSimulation()
+    # to avoid the planet message becoming too stale and the resulting loss in time accuracy
+    # we break up the integration into chunks of less than 100 days
+    steps = 20
+    for i in range(steps):
+        stopTime = simulationTime + macros.sec2nano(110000) + T2*(i+1)/steps - oneWeek*1
+        scSim.ConfigureStopTime(stopTime)
+        scSim.ExecuteSimulation()
+
+        # write planet state messages again to avoid long time difference errors in the gravity effector
+        earthMsg.write(earthStateMsg, scSim.TotalSim.CurrentNanos)
+        jupiterMsg.write(jupiterStateMsg, scSim.TotalSim.CurrentNanos)
+        sunMsg.write(sunStateMsg, scSim.TotalSim.CurrentNanos)
 
     hohmann_PosData = dataLog.r_BN_N
     hohmann_VelData = dataLog.v_BN_N
@@ -314,8 +335,14 @@ def run(show_plots):
     simulationTimeStep = macros.sec2nano(500.)
     dynProcess.updateTaskPeriod(simTaskName, simulationTimeStep)
     dataLog.updateTimeInterval(macros.sec2nano(20*60))
-    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(110000) + T2 - oneWeek*0.5)
+    stopTime = simulationTime + macros.sec2nano(110000) + T2 - oneWeek*0.5
+    scSim.ConfigureStopTime(stopTime)
     scSim.ExecuteSimulation()
+
+    # write planet state messages again to avoid long time difference errors in the gravity effector
+    earthMsg.write(earthStateMsg, scSim.TotalSim.CurrentNanos)
+    jupiterMsg.write(jupiterStateMsg, scSim.TotalSim.CurrentNanos)
+    sunMsg.write(sunStateMsg, scSim.TotalSim.CurrentNanos)
 
     timeSwitch_posData = dataLog.r_BN_N
     endTimeStepSwitchTime = len(timeSwitch_posData)
@@ -354,9 +381,15 @@ def run(show_plots):
     # Setup data logging before the simulation is initialized
 
     # scSim.TotalSim.logThisMessage(scObject.scStateOutMsgName, simulationTimeStep)
-    scSim.ConfigureStopTime(simulationTime + macros.sec2nano(110000) + T2 + oneWeek*6)
-
+    stopTime = simulationTime + macros.sec2nano(110000) + T2 + oneWeek*6
+    scSim.ConfigureStopTime(stopTime)
     scSim.ExecuteSimulation()
+
+    # write planet state messages again to avoid long time difference errors in the gravity effector
+    earthMsg.write(earthStateMsg, scSim.TotalSim.CurrentNanos)
+    jupiterMsg.write(jupiterStateMsg, scSim.TotalSim.CurrentNanos)
+    sunMsg.write(sunStateMsg, scSim.TotalSim.CurrentNanos)
+
     #   retrieve the logged data
     dataPos = dataLog.r_BN_N
     dataVel = dataLog.v_BN_N

--- a/src/architecture/utilities/macroDefinitions.h
+++ b/src/architecture/utilities/macroDefinitions.h
@@ -33,6 +33,53 @@
 #define RECAST2x2       (double (*)[2])
 #define SEC2HOUR        1./3600.
 
+#include <stdint.h>  // For uint64_t
+#include <float.h>   // For DBL_MANT_DIG
+#include <math.h>    // For NAN, fabs()
+#include <stdio.h>
+#include <inttypes.h>
 
+/**
+ * Converts nanoseconds to seconds (double), with basic precision check.
+ * Returns NAN if conversion would lose precision.
+ */
+static inline  double nanoToSec(uint64_t nanos) {
+    // Double precision loses exact integer values past 2^53
+    const uint64_t MAX_SAFE_UINT64_FOR_DOUBLE = (1ULL << DBL_MANT_DIG);  // Usually 2^53
+
+    if (nanos > MAX_SAFE_UINT64_FOR_DOUBLE) {
+        fprintf(stderr,
+            "[nano_to_sec] ERROR: Input %" PRIu64
+            " exceeds safe conversion limit (~%llu). Precision may be lost. Returning NAN.\n",
+            nanos, MAX_SAFE_UINT64_FOR_DOUBLE);
+        return NAN;  // Indicate precision loss
+    }
+
+    return (double)nanos * NANO2SEC;  // Convert to seconds
+}
+
+/**
+ * Converts seconds (double) to nanoseconds (uint64_t).
+ * Returns NAN on error (e.g. negative input or overflow)
+ */
+static inline uint64_t secToNano(double seconds) {
+    if (seconds < 0.0) {
+        fprintf(stderr,
+            "[secToNano] ERROR: Negative time value passed (%.15f seconds). Returning 0.\n",
+            seconds);
+        return 0;
+    }
+
+    double result = seconds * SEC2NANO;
+
+    if (result > (double)UINT64_MAX) {
+        fprintf(stderr,
+            "[secToNano] ERROR: Input time %.15f seconds exceeds uint64_t capacity. Returning 0.\n",
+            seconds);
+        return 0;
+    }
+
+    return (uint64_t)(result + 0.5);  // Round to nearest integer
+}
 
 #endif

--- a/src/architecture/utilities/macroDefinitions.h
+++ b/src/architecture/utilities/macroDefinitions.h
@@ -59,6 +59,23 @@ static inline  double nanoToSec(uint64_t nanos) {
 }
 
 /**
+ * Takes two times in nanoseconds, takes their difference and converts to seconds (double),
+ * with basic precision check.
+ * Returns NAN if conversion would lose precision.
+ */
+static inline  double diffNanoToSec(uint64_t time1Nano, uint64_t time2Nano) {
+    double signedTimeDifference;
+
+    if (time1Nano >= time2Nano) {
+        signedTimeDifference = nanoToSec(time1Nano - time2Nano);
+    } else {
+        signedTimeDifference = -nanoToSec(time2Nano - time1Nano);
+    }
+
+    return signedTimeDifference;
+}
+
+/**
  * Converts seconds (double) to nanoseconds (uint64_t).
  * Returns NAN on error (e.g. negative input or overflow)
  */

--- a/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
+++ b/src/fswAlgorithms/attControl/mrpFeedback/mrpFeedback.c
@@ -149,7 +149,7 @@ void Update_mrpFeedback(mrpFeedbackConfig *configData, uint64_t callTime,
     if (configData->priorTime == 0) {
         dt = 0.0;
     } else {
-        dt = (callTime - configData->priorTime) * NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorTime);
     }
     configData->priorTime = callTime;
 

--- a/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.c
+++ b/src/fswAlgorithms/attControl/rateServoFullNonlinear/rateServoFullNonlinear.c
@@ -135,7 +135,7 @@ void Update_rateServoFullNonlinear(rateServoFullNonlinearConfig *configData, uin
     if (configData->priorTime == 0) {
         dt = 0.0;
     } else {
-        dt = (callTime - configData->priorTime) * NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorTime);
     }
     configData->priorTime = callTime;
 

--- a/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
+++ b/src/fswAlgorithms/attDetermination/CSSEst/cssWlsEst.c
@@ -186,7 +186,7 @@ void Update_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime,
     if (configData->priorTime == 0) {
         dt = 0.0;
     } else {
-        dt = (callTime - configData->priorTime) * NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorTime);
     }
     configData->priorTime = callTime;
 
@@ -265,7 +265,7 @@ void Update_cssWlsEst(CSSWLSConfig *configData, uint64_t callTime,
     /*! - If the residual fit output message is set, then compute the residuals and stor them in the output message */
     if (SunlineFilterMsg_C_isLinked(&configData->cssWLSFiltResOutMsg)) {
         configData->filtStatus.numObs = (int) configData->numActiveCss;
-        configData->filtStatus.timeTag = (double) (callTime*NANO2SEC);
+        configData->filtStatus.timeTag = callTime*NANO2SEC;
         v3Copy(sunlineOutBuffer.vehSunPntBdy, configData->filtStatus.state);
         SunlineFilterMsg_C_write(&configData->filtStatus, &configData->cssWLSFiltResOutMsg, moduleID, callTime);
 

--- a/src/fswAlgorithms/attGuidance/eulerRotation/eulerRotation.c
+++ b/src/fswAlgorithms/attGuidance/eulerRotation/eulerRotation.c
@@ -143,7 +143,7 @@ void computeTimeStep(eulerRotationConfig *configData, uint64_t callTime)
     {
         configData->dt = 0.0;
     } else {
-        configData->dt = (callTime - configData->priorTime)*NANO2SEC;
+        configData->dt = diffNanoToSec(callTime, configData->priorTime);
     }
 }
 

--- a/src/fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.c
+++ b/src/fswAlgorithms/attGuidance/inertial3DSpin/inertial3DSpin.c
@@ -91,7 +91,7 @@ void Update_inertial3DSpin(inertial3DSpinConfig *configData, uint64_t callTime, 
         dt = 0.0;
         v3Copy(attRefInMsgBuffer.sigma_RN, configData->sigma_RN);
     } else {
-        dt = (callTime - configData->priorTime) * NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorTime);
     }
 
     /*! - Generate inertial 3D Spinning Reference */

--- a/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
+++ b/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
@@ -182,7 +182,7 @@ void Update_locationPointing(locationPointingConfig *configData, uint64_t callTi
     /* use sigma_BR to compute d(sigma_BR)/dt if at least two data points */
     if (configData->init < 1) {
         // module update time
-        time_diff = (callTime - configData->time_old)*NANO2SEC;
+        time_diff = diffNanoToSec(callTime, configData->time_old);
 
         // calculate d(sigma_BR)/dt
         v3Subtract(sigma_BR, configData->sigma_BR_old, difference);

--- a/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.c
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/mrpRotation.c
@@ -147,7 +147,7 @@ void computeTimeStep(mrpRotationConfig *configData, uint64_t callTime)
     {
         configData->dt = 0.0;
     } else {
-        configData->dt = (callTime - configData->priorTime)*NANO2SEC;
+        configData->dt = diffNanoToSec(callTime, configData->priorTime);
     }
 }
 

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/oneAxisSolarArrayPoint.c
@@ -218,7 +218,7 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
     }
     // if second update call, derivatives are computed with first order finite differences
     else if (configData->updateCallCount == 1) {
-        T1Seconds = (configData->T1NanoSeconds - callTime) * NANO2SEC;
+        T1Seconds = diffNanoToSec(configData->T1NanoSeconds, callTime);
         for (int j = 0; j < 3; j++) {
             sigmaDot_RN[j] = (sigma_RN_1[j] - sigma_RN[j]) / T1Seconds;
         }
@@ -231,8 +231,8 @@ void Update_oneAxisSolarArrayPoint(OneAxisSolarArrayPointConfig *configData, uin
     }
     // if third update call or higher, derivatives are computed with second order finite differences
     else {
-        T1Seconds = (configData->T1NanoSeconds - callTime) * NANO2SEC;
-        T2Seconds = (configData->T2NanoSeconds - callTime) * NANO2SEC;
+        T1Seconds = diffNanoToSec(configData->T1NanoSeconds, callTime);
+        T2Seconds = diffNanoToSec(configData->T2NanoSeconds, callTime);
         for (int j = 0; j < 3; j++) {
             sigmaDot_RN[j] = ((sigma_RN_1[j]*T2Seconds*T2Seconds - sigma_RN_2[j]*T1Seconds*T1Seconds) / (T2Seconds - T1Seconds) - sigma_RN[j] * (T2Seconds + T1Seconds)) / T1Seconds / T2Seconds;
             sigmaDDot_RN[j] = 2 * ((sigma_RN_1[j]*T2Seconds - sigma_RN_2[j]*T1Seconds) / (T1Seconds - T2Seconds) + sigma_RN[j]) / T1Seconds / T2Seconds;

--- a/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.c
+++ b/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.c
@@ -86,8 +86,8 @@ void Update_dvGuidance(dvGuidanceConfig *configData, uint64_t callTime,
     v3Cross(dcm_BubN[0], dcm_BubN[1], dcm_BubN[2]);
     v3Normalize(dcm_BubN[2], dcm_BubN[2]);
 
-    /*! - evaluate the time since the burn start time */
-    burnTime = ((int64_t) callTime - (int64_t) localBurnData.burnStartTime)*NANO2SEC;
+    /*! - evaluate the time since the burn start time, negative burn time is allowed */
+    burnTime = diffNanoToSec(callTime, localBurnData.burnStartTime);
 
     /*! - evaluate the DCM from inertial to the current Burn frame.
      The current frame differs from the base burn frame via a constant 3-axis rotation */

--- a/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.rst
+++ b/src/fswAlgorithms/dvGuidance/dvAttGuidance/dvGuidance.rst
@@ -3,7 +3,7 @@ Executive Summary
 
 This module creates a time varying attitude reference frame message that allows the orbit correction burn direction to rotate at a constant rate.
 
-A message is read in containing the base \f$\Delta\mathbf{v}\f$ direction, the burn duration, as well as a nominal rotation axis.  A base burn frame is created relative to which a constant rotation about the 3rd frame axis is performed.  The output message contains the full reference frame states including the constant angular velocity vector and a zero angular acceleration vector. More information can be found in the
+A message is read in containing the base :math:`\Delta\mathbf{v}` direction, the burn duration, as well as a nominal rotation axis.  A base burn frame is created relative to which a constant rotation about the 3rd frame axis is performed.  The output message contains the full reference frame states including the constant angular velocity vector and a zero angular acceleration vector. More information can be found in the
 :download:`PDF Description </../../src/fswAlgorithms/dvGuidance/dvAttGuidance/_Documentation/Basilisk-dvGuidance-2019-03-28.pdf>`.
 
 Message Connection Descriptions

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/hingedRigidBodyPIDMotor.c
@@ -84,7 +84,7 @@ void Update_hingedRigidBodyPIDMotor(hingedRigidBodyPIDMotorConfig *configData, u
     /*! compute integral term */
     double dt;
     if (callTime != 0) {
-        dt = (callTime - configData->priorTime) * NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorTime);
         configData->intError += (thetaError + configData->priorThetaError) * dt / 2;
     }
 

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.c
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/rwMotorVoltage.c
@@ -110,7 +110,7 @@ void Update_rwMotorVoltage(rwMotorVoltageConfig *configData, uint64_t callTime, 
     if (RWSpeedMsg_C_isLinked(&configData->rwSpeedInMsg)) {
         /* make sure the clock didn't just initialize, or the module was recently reset */
         if (configData->priorTime != 0) {
-            double dt = (callTime - configData->priorTime) * NANO2SEC; /*!< [s]   control update period */
+            double dt = diffNanoToSec(callTime, configData->priorTime); /*!< [s]   control update period */
             double              OmegaDot[MAX_EFF_CNT];     /*!< [r/s^2] RW angular acceleration */
             for (int i=0; i<configData->rwConfigParams.numRW; i++) {
                 if (rwAvailability.wheelAvailability[i] == AVAILABLE && configData->resetFlag == BOOL_FALSE) {

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/solarArrayReference.c
@@ -209,7 +209,7 @@ void Update_solarArrayReference(solarArrayReferenceConfig *configData, uint64_t 
         hingedRigidBodyRefOut.thetaDot = 0;
     }
     else {
-        dt = (double) (callTime - configData->priorT) * NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorT);
         hingedRigidBodyRefOut.thetaDot = (hingedRigidBodyRefOut.theta - configData->priorThetaR) / dt;
     }
     // update stored variables

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/thrFiringRemainder.c
@@ -113,7 +113,7 @@ void Update_thrFiringRemainder(thrFiringRemainderConfig *configData, uint64_t ca
 	}
 
     /*! - compute control time period Delta_t */
-	controlPeriod = ((double)(callTime - configData->prevCallTime)) * NANO2SEC;
+    controlPeriod = diffNanoToSec(callTime, configData->prevCallTime); /*!< [s] control period */
 	configData->prevCallTime = callTime;
 
 	/*! - Read the input thruster force message */

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/thrFiringSchmitt.c
@@ -116,7 +116,7 @@ void Update_thrFiringSchmitt(thrFiringSchmittConfig *configData, uint64_t callTi
 	}
 
     /*! - compute control time period Delta_t */
-	controlPeriod = ((double)(callTime - configData->prevCallTime)) * NANO2SEC;
+	controlPeriod = diffNanoToSec(callTime, configData->prevCallTime);
 	configData->prevCallTime = callTime;
 
     /*! - read the input thruster force message */

--- a/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/thrMomentumDumping.c
@@ -126,7 +126,7 @@ void Update_thrMomentumDumping(thrMomentumDumpingConfig *configData, uint64_t ca
     if (configData->priorTime != 0) {       /* don't compute dt if this is the first call after a reset */
 
         /* - compute control update time */
-        dt = (callTime - configData->priorTime)*NANO2SEC;
+        dt = diffNanoToSec(callTime, configData->priorTime);
         if (dt < 0.0) {dt = 0.0;}             /* ensure no negative numbers are used */
 
         /*! - Read the requester thruster impulse input message */

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/thrusterPlatformReference.c
@@ -138,7 +138,7 @@ void Update_thrusterPlatformReference(ThrusterPlatformReferenceConfig *configDat
         /*! update integral term */
         double DeltaHsInt_M[3];
         v3Add(configData->priorHs_M, hs_M, DeltaHsInt_M);
-        double dt = (callTime - configData->priorTime) * NANO2SEC;
+        double dt = diffNanoToSec(callTime, configData->priorTime);
         v3Scale(0.5*dt, DeltaHsInt_M, DeltaHsInt_M);
         v3Add(configData->hsInt_M, DeltaHsInt_M, configData->hsInt_M);
         v3Copy(hs_M, configData->priorHs_M);

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.c
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/torqueScheduler.c
@@ -73,7 +73,7 @@ void Update_torqueScheduler(torqueSchedulerConfig *configData, uint64_t callTime
     ArrayEffectorLockMsgPayload effectorLockOut = ArrayEffectorLockMsg_C_zeroMsgPayload();
 
     /*! compute current time from Reset call */
-    double t = ((callTime - configData->t0) * NANO2SEC);
+    double t = diffNanoToSec(callTime, configData->t0);
 
     /*! populate output torque msg */
     motorTorqueOut.motorTorque[0] = motorTorque1In.motorTorque[0];

--- a/src/fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftPointing/spacecraftPointing.c
@@ -159,7 +159,7 @@ void Update_spacecraftPointing(spacecraftPointingConfig *configData, uint64_t ca
         }
 
     /* Find the timestep of the simulation. */
-    dt = (callTime - configData->priorTime) * NANO2SEC;
+    dt = diffNanoToSec(callTime, configData->priorTime);
     configData->priorTime = callTime;
 
     /* sigma_dot_RN is calculated by dividing the difference in sigma by the timestep. */

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/spacecraftReconfig.c
@@ -108,7 +108,7 @@ void Update_spacecraftReconfig(spacecraftReconfigConfig *configData, uint64_t ca
 		configData->prevCallTime = callTime; // initialize
 	}
     // calculate elapsed time from last module updated time
-    double elapsed_time = ((double)(callTime - configData->prevCallTime)) * NANO2SEC;
+    double elapsed_time = diffNanoToSec(callTime, configData->prevCallTime);
     configData->tCurrent = configData->tCurrent + elapsed_time;
 	configData->prevCallTime = callTime;
 

--- a/src/fswAlgorithms/transDetermination/dvAccumulation/dvAccumulation.c
+++ b/src/fswAlgorithms/transDetermination/dvAccumulation/dvAccumulation.c
@@ -191,7 +191,7 @@ void Update_dvAccumulation(DVAccumulationData *configData, uint64_t callTime, in
         /*! - see if data is newer than last data time stamp */
         if(inputAccData.accPkts[i].measTime > configData->previousTime)
         {
-            dt = (inputAccData.accPkts[i].measTime - configData->previousTime)*NANO2SEC;
+            dt = diffNanoToSec(inputAccData.accPkts[i].measTime, configData->previousTime);
             v3Scale(dt, inputAccData.accPkts[i].accel_B, frameDV_B);
             v3Add(configData->vehAccumDV_B, frameDV_B, configData->vehAccumDV_B);
             configData->previousTime = inputAccData.accPkts[i].measTime;

--- a/src/simulation/deviceInterface/encoder/encoder.cpp
+++ b/src/simulation/deviceInterface/encoder/encoder.cpp
@@ -112,7 +112,7 @@ void Encoder::encode(uint64_t CurrentSimNanos)
     clicksPerRadian = this->clicksPerRotation / (2 * M_PI);
 
     // set the time step
-    timeStep = (CurrentSimNanos - this->prevTime) * NANO2SEC;
+    timeStep = diffNanoToSec(CurrentSimNanos, this->prevTime);
 
     // at the beginning of the simulation, the encoder simply outputs the true RW speeds
     if (timeStep == 0.0)

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "dynamicObject.h"
+#include "architecture/utilities/macroDefinitions.h"
 
 void DynamicObject::setIntegrator(StateVecIntegrator* newIntegrator)
 {
@@ -58,17 +59,17 @@ void DynamicObject::syncDynamicsIntegration(DynamicObject* dynPtr)
     dynPtr->isDynamicsSynced = true;
 }
 
-void DynamicObject::integrateState(double integrateToThisTime)
+void DynamicObject::integrateState(uint64_t integrateToThisTimeNanos)
 {
     if (this->isDynamicsSynced) return;
 
     for (const auto& dynPtr : this->integrator->dynPtrs) {
-        dynPtr->preIntegration(integrateToThisTime);
+        dynPtr->preIntegration(integrateToThisTimeNanos);
     }
 
     this->integrator->integrate(this->timeBefore, this->timeStep);
 
     for (const auto& dynPtr : this->integrator->dynPtrs) {
-        dynPtr->postIntegration(integrateToThisTime);
+        dynPtr->postIntegration(integrateToThisTimeNanos);
     }
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynamicObject.h
@@ -51,10 +51,10 @@ class DynamicObject : public SysModel {
     virtual void equationsOfMotion(double t, double timeStep) = 0;
 
     /** Performs pre-integration steps */
-    virtual void preIntegration(double callTime) = 0;
+    virtual void preIntegration(uint64_t callTimeNanos) = 0;
 
     /** Performs post-integration steps */
-    virtual void postIntegration(double callTime) = 0;
+    virtual void postIntegration(uint64_t callTimeNanos) = 0;
 
     /** Initializes the dynamics and variables */
     virtual void initializeDynamics(){};
@@ -67,7 +67,7 @@ class DynamicObject : public SysModel {
      *
      * This is only done if the DynamicObject integration is not sync'd to another DynamicObject
      */
-    void integrateState(double t);
+    void integrateState(uint64_t t);
 
     /** Sets a new integrator in use */
     void setIntegrator(StateVecIntegrator* newIntegrator);
@@ -78,8 +78,9 @@ class DynamicObject : public SysModel {
   public:
     /** flag indicating that another spacecraft object is controlling the integration */
     bool isDynamicsSynced = false;
-    double timeStep;   /**< [s] integration time step */
-    double timeBefore; /**< [s] prior time value */
+    double timeStep = 0.0;   /**< [s] integration time step */
+    double timeBefore = 0.0; /**< [s] prior time value */
+    uint64_t timeBeforeNanos = 0; /**< [ns] prior time value */
 };
 
 #endif /* DYNAMICOBJECT_H */

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -470,7 +470,7 @@ void Spacecraft::preIntegration(double integrateToThisTime) {
 
     // - Integrate the state from the last time (timeBefore) to the integrateToThisTime
     this->hub.matchGravitytoVelocityState(oldV_CN_N); // Set gravity velocity to base velocity for DV estimation
-    this->timeBefore = integrateToThisTime - this->timeStep;
+    this->timeBefore = this->timePrevious;
 }
 
 /*! Perform post-integration steps

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -40,8 +40,6 @@ Spacecraft::Spacecraft()
 
     // - Set values to either zero or default values
     this->currTimeStep = 0.0;
-    this->timeBefore = 0.0;
-    this->simTimePrevious = 0;
     this->dvAccum_CN_B.setZero();
     this->dvAccum_BN_B.setZero();
     this->dvAccum_CN_N.setZero();
@@ -186,7 +184,6 @@ void Spacecraft::UpdateState(uint64_t CurrentSimNanos)
         // - Call writeOutputStateMessages for stateEffectors
         (*it)->writeOutputStateMessages(CurrentSimNanos);
     }
-    this->simTimePrevious = CurrentSimNanos;
 }
 
 /*! This method allows the spacecraft to have access to the current state of the hub for MRP switching, writing
@@ -337,7 +334,8 @@ void Spacecraft::updateSCMassProps(double time)
 void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
 {
     // - Update time to the current time
-    uint64_t integTimeNanos = this->simTimePrevious + secToNano(integTimeSeconds-this->timeBefore);
+    uint64_t integTimeNanos = secToNano(integTimeSeconds);
+
     (*this->sysTime) << (double) integTimeNanos, integTimeSeconds;
 
     // - Zero all Matrices and vectors for back-sub and the dynamics

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -39,7 +39,6 @@ Spacecraft::Spacecraft()
     this->propName_centerOfMassDotSC = "centerOfMassDotSC";
 
     // - Set values to either zero or default values
-    this->currTimeStep = 0.0;
     this->dvAccum_CN_B.setZero();
     this->dvAccum_BN_B.setZero();
     this->dvAccum_CN_N.setZero();

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -40,7 +40,7 @@ Spacecraft::Spacecraft()
 
     // - Set values to either zero or default values
     this->currTimeStep = 0.0;
-    this->timePrevious = 0.0;
+    this->timeBefore = 0.0;
     this->simTimePrevious = 0;
     this->dvAccum_CN_B.setZero();
     this->dvAccum_BN_B.setZero();
@@ -337,7 +337,7 @@ void Spacecraft::updateSCMassProps(double time)
 void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
 {
     // - Update time to the current time
-    uint64_t integTimeNanos = this->simTimePrevious + secToNano(integTimeSeconds-this->timePrevious);
+    uint64_t integTimeNanos = this->simTimePrevious + secToNano(integTimeSeconds-this->timeBefore);
     (*this->sysTime) << (double) integTimeNanos, integTimeSeconds;
 
     // - Zero all Matrices and vectors for back-sub and the dynamics
@@ -453,7 +453,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
  @param integrateToThisTime Time to integrate to
  */
 void Spacecraft::preIntegration(double integrateToThisTime) {
-    this->timeStep = integrateToThisTime - this->timePrevious;
+    this->timeStep = integrateToThisTime - this->timeBefore;
 
     // - Find v_CN_N before integration for accumulated DV
     Eigen::Vector3d oldV_BN_N = this->hubV_N->getState();  // - V_BN_N before integration
@@ -470,14 +470,13 @@ void Spacecraft::preIntegration(double integrateToThisTime) {
 
     // - Integrate the state from the last time (timeBefore) to the integrateToThisTime
     this->hub.matchGravitytoVelocityState(oldV_CN_N); // Set gravity velocity to base velocity for DV estimation
-    this->timeBefore = this->timePrevious;
 }
 
 /*! Perform post-integration steps
  @param integrateToThisTime Time to integrate to
  */
 void Spacecraft::postIntegration(double integrateToThisTime) {
-    this->timePrevious = integrateToThisTime;     // - copy the current time into previous time for next integrate state call
+    this->timeBefore = integrateToThisTime;     // - copy the current time into previous time for next integrate state call
 
     // - Call mass properties to get current info on the mass props of the spacecraft
     this->updateSCMassProps(integrateToThisTime);

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -337,7 +337,7 @@ void Spacecraft::updateSCMassProps(double time)
 void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
 {
     // - Update time to the current time
-    uint64_t integTimeNanos = this->simTimePrevious + (uint64_t) ((integTimeSeconds-this->timePrevious)/NANO2SEC);
+    uint64_t integTimeNanos = this->simTimePrevious + secToNano(integTimeSeconds-this->timePrevious);
     (*this->sysTime) << (double) integTimeNanos, integTimeSeconds;
 
     // - Zero all Matrices and vectors for back-sub and the dynamics

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -88,8 +88,8 @@ public:
     void equationsOfMotion(double integTimeSeconds, double timeStep);    //!< This method computes the equations of motion for the whole system
     void addStateEffector(StateEffector *newSateEffector);  //!< Attaches a stateEffector to the system
     void addDynamicEffector(DynamicEffector *newDynamicEffector);  //!< Attaches a dynamicEffector
-    void preIntegration(double callTime) final;       //!< method to perform pre-integration steps
-    void postIntegration(double callTime) final;      //!< method to perform post-integration steps
+    void preIntegration(uint64_t callTimeNanos) final;       //!< method to perform pre-integration steps
+    void postIntegration(uint64_t callTimeNanos) final;      //!< method to perform post-integration steps
 
 private:
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -44,7 +44,6 @@
 /*! @brief spacecraft dynamic effector */
 class Spacecraft : public DynamicObject{
 public:
-    uint64_t simTimePrevious;            //!< Previous simulation time
     std::string sysTimePropertyName;     //!< Name of the system time property
     ReadFunctor<AttRefMsgPayload> attRefInMsg; //!< (optional) reference attitude input message name
     ReadFunctor<TransRefMsgPayload> transRefInMsg; //!< (optional) reference translation input message name

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -53,7 +53,6 @@ public:
     double rotEnergyContr;               //!< [J] Contribution of stateEffector to total rotational energy
     double orbPotentialEnergyContr;      //!< [J] Contribution of stateEffector to total rotational energy
     double currTimeStep;                 //!< [s] Time after integration, used for dvAccum calculation
-    double timePrevious;                 //!< [s] Time before integration, used for dvAccum calculation
     BackSubMatrices backSubContributions;//!< class variable
     Eigen::Vector3d sumForceExternal_N;  //!< [N] Sum of forces given in the inertial frame
     Eigen::Vector3d sumForceExternal_B;  //!< [N] Sum of forces given in the body frame

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -51,7 +51,6 @@ public:
     double totRotEnergy;                 //!< [J] Total rotational energy
     double rotEnergyContr;               //!< [J] Contribution of stateEffector to total rotational energy
     double orbPotentialEnergyContr;      //!< [J] Contribution of stateEffector to total rotational energy
-    double currTimeStep;                 //!< [s] Time after integration, used for dvAccum calculation
     BackSubMatrices backSubContributions;//!< class variable
     Eigen::Vector3d sumForceExternal_N;  //!< [N] Sum of forces given in the inertial frame
     Eigen::Vector3d sumForceExternal_B;  //!< [N] Sum of forces given in the body frame

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -221,7 +221,7 @@ SpacecraftSystem::SpacecraftSystem()
 
     // - Set values to either zero or default values
     this->currTimeStep = 0.0;
-    this->timePrevious = 0.0;
+    this->timeBefore = 0.0;
     this->simTimePrevious = 0;
     this->numOutMsgBuffers = 2;
 
@@ -625,7 +625,7 @@ void SpacecraftSystem::initializeSCPosVelocity(SpacecraftUnit &spacecraft)
 void SpacecraftSystem::equationsOfMotion(double integTimeSeconds, double timeStep)
 {
     // - Update time to the current time
-    uint64_t integTimeNanos = this->simTimePrevious + (uint64_t) ((integTimeSeconds-this->timePrevious)/NANO2SEC);
+    uint64_t integTimeNanos = this->simTimePrevious + (uint64_t) ((integTimeSeconds-this->timeBefore)/NANO2SEC);
     (*this->sysTime) << (double)integTimeNanos, integTimeSeconds;
 
     this->equationsOfMotionSystem(integTimeSeconds, timeStep);
@@ -1215,7 +1215,7 @@ void SpacecraftSystem::computeEnergyMomentumSystem(double time)
 void SpacecraftSystem::preIntegration(double integrateToThisTime) {
 
     // - Find the time step
-    this->timeStep = integrateToThisTime - this->timePrevious;
+    this->timeStep = integrateToThisTime - this->timeBefore;
 
     this->findPriorStateInformation(this->primaryCentralSpacecraft);
 
@@ -1237,7 +1237,7 @@ void SpacecraftSystem::preIntegration(double integrateToThisTime) {
 void SpacecraftSystem::postIntegration(double integrateToThisTime) {
     std::vector<SpacecraftUnit*>::iterator spacecraftUnConnectedIt;
 
-    this->timePrevious = integrateToThisTime;     // - copy the current time into previous time for next integrate state call
+    this->timeBefore = integrateToThisTime;     // - copy the current time into previous time for next integrate state call
 
     // - Calculate the states of the attached spacecraft from the primary spacecraft
     this->determineAttachedSCStates();

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -221,8 +221,6 @@ SpacecraftSystem::SpacecraftSystem()
 
     // - Set values to either zero or default values
     this->currTimeStep = 0.0;
-    this->timeBefore = 0.0;
-    this->simTimePrevious = 0;
     this->numOutMsgBuffers = 2;
 
     // - Set integrator as RK4 by default
@@ -418,7 +416,6 @@ void SpacecraftSystem::UpdateState(uint64_t CurrentSimNanos)
 
     // - Write the state of the vehicle into messages
     this->writeOutputMessages(CurrentSimNanos);
-    this->simTimePrevious = CurrentSimNanos;
 
     return;
 }
@@ -626,7 +623,7 @@ void SpacecraftSystem::initializeSCPosVelocity(SpacecraftUnit &spacecraft)
 void SpacecraftSystem::equationsOfMotion(double integTimeSeconds, double timeStep)
 {
     // - Update time to the current time
-    uint64_t integTimeNanos = this->simTimePrevious + (uint64_t) ((integTimeSeconds-this->timeBefore)/NANO2SEC);
+    uint64_t integTimeNanos = secToNano(integTimeSeconds);
     (*this->sysTime) << (double)integTimeNanos, integTimeSeconds;
 
     this->equationsOfMotionSystem(integTimeSeconds, timeStep);

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -220,7 +220,6 @@ SpacecraftSystem::SpacecraftSystem()
     this->sysTimePropertyName = "systemTime";
 
     // - Set values to either zero or default values
-    this->currTimeStep = 0.0;
     this->numOutMsgBuffers = 2;
 
     // - Set integrator as RK4 by default

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
@@ -204,8 +204,8 @@ public:
     void attachSpacecraftToPrimary(SpacecraftUnit *newSpacecraft, std::string dockingPortNameOfNewSpacecraft, std::string dockingToPortName);  //!< Attaches a spacecraft to the primary spacecraft chain
     void addSpacecraftUndocked(SpacecraftUnit *newSpacecraft);  //!< Attaches a spacecraft to the primary spacecraft chain
     void determineAttachedSCStates();  //!< class method
-    void preIntegration(double callTime) final;  //!< pre-integration steps
-    void postIntegration(double callTime) final;  //!< post-integration steps
+    void preIntegration(uint64_t callTime) final;  //!< pre-integration steps
+    void postIntegration(uint64_t callTime) final;  //!< post-integration steps
 
 private:
     Eigen::MatrixXd *sysTime;            //!< [s] System time

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
@@ -175,7 +175,6 @@ public:
 
     uint64_t numOutMsgBuffers;           //!< Number of output message buffers for I/O
     std::string sysTimePropertyName;     //!< Name of the system time property
-    double currTimeStep;                 //!< [s] Time after integration, used for dvAccum calculation
     SpacecraftUnit primaryCentralSpacecraft;   //!< Primary spacecraft in which other spacecraft can attach/detach to/from
     std::vector<SpacecraftUnit*> spacecraftDockedToPrimary; //!< vector of spacecraft currently docked with primary spacecraft
     std::vector<SpacecraftUnit*> unDockedSpacecraft; //!< vector of spacecraft currently detached from all other spacecraft

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
@@ -177,7 +177,6 @@ public:
     uint64_t numOutMsgBuffers;           //!< Number of output message buffers for I/O
     std::string sysTimePropertyName;     //!< Name of the system time property
     double currTimeStep;                 //!< [s] Time after integration, used for dvAccum calculation
-    double timePrevious;                 //!< [s] Time before integration, used for dvAccum calculation
     SpacecraftUnit primaryCentralSpacecraft;   //!< Primary spacecraft in which other spacecraft can attach/detach to/from
     std::vector<SpacecraftUnit*> spacecraftDockedToPrimary; //!< vector of spacecraft currently docked with primary spacecraft
     std::vector<SpacecraftUnit*> unDockedSpacecraft; //!< vector of spacecraft currently detached from all other spacecraft

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.h
@@ -173,7 +173,6 @@ private:
 class SpacecraftSystem : public DynamicObject{
 public:
 
-    uint64_t simTimePrevious;            //!< Previous simulation time
     uint64_t numOutMsgBuffers;           //!< Number of output message buffers for I/O
     std::string sysTimePropertyName;     //!< Name of the system time property
     double currTimeStep;                 //!< [s] Time after integration, used for dvAccum calculation

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
@@ -110,8 +110,7 @@ void MJScene::initializeDynamics()
 
 void MJScene::UpdateState(uint64_t CurrentSimNanos)
 {
-    double t = CurrentSimNanos * NANO2SEC;
-    this->integrateState(t);
+    this->integrateState(CurrentSimNanos);
     this->writeOutputStateMessages(CurrentSimNanos);
     for (auto&& body : this->spec.getBodies()) {
         body.writeStateDependentOutputMessages(CurrentSimNanos);
@@ -206,11 +205,13 @@ void MJScene::equationsOfMotion(double t, double timeStep)
     }
 }
 
-void MJScene::preIntegration(double callTime) { this->timeStep = callTime - this->timeBefore; }
+void MJScene::preIntegration(uint64_t callTimeNanos) { this->timeStep = diffNanoToSec(callTimeNanos, this->timeBeforeNanos); }
 
-void MJScene::postIntegration(double callTime)
+void MJScene::postIntegration(uint64_t callTimeNanos)
 {
-    this->timeBefore = callTime;
+    this->timeBefore = callTimeNanos * NANO2SEC;
+    this->timeBeforeNanos = callTimeNanos;
+    double callTime = callTimeNanos * NANO2SEC;
 
     // Copy data from Basilisk state objects to MuJoCo structs
     updateMujocoArraysFromStates();

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.h
@@ -375,9 +375,9 @@ public:
     /**
      * @brief Prepares the system before actual integration.
      *
-     * @param callTime The current simulation time.
+     * @param callTimeNanos The current simulation time.
      */
-    void preIntegration(double callTime) override;
+    void preIntegration(uint64_t callTimeNanos) override;
 
     /**
      * @brief Finalizes the system after integration.
@@ -389,9 +389,9 @@ public:
      * that are computed during the dynamics task depending
      * on the final state.
      *
-     * @param callTime The current simulation time.
+     * @param callTimeNanos The current simulation time.
      */
-    void postIntegration(double callTime) override;
+    void postIntegration(uint64_t callTimeNanos) override;
 
     /**
      * @brief Marks the model as needing recompilation.

--- a/src/simulation/simSynch/simSynch.cpp
+++ b/src/simulation/simSynch/simSynch.cpp
@@ -110,8 +110,7 @@ void ClockSynch::UpdateState(uint64_t currentSimNanos)
 	}
 
     //! - Save off the output message information for analysis
-    this->outputData.finalTimeDelta = (double) (simTimeNano - realTimeNano - sleepAmountNano);
-    this->outputData.finalTimeDelta *= NANO2SEC;
+    this->outputData.finalTimeDelta = diffNanoToSec(simTimeNano, realTimeNano + sleepAmountNano);
 
     //! - Write the composite information into the output synch message.
     this->clockOutMsg.write(&this->outputData, this->moduleID, currentSimNanos);


### PR DESCRIPTION
* **Tickets addressed:** bsk-993
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
See issue #993.  This PR changes computing the time difference via `double` values and now uses `uint64_t` values instead.  This leads to precise time step evaluations.  

Added safe `uint64_t` to `double` and back conversion method that are used in places.  In the end it is up to the module develop to know what time accuracy is required.  For example, magnetic field models often only require time to within an hour and doing a direct conversion from `uint64_t` to `double` is fine.

Working on this branch I cleaned up some legacy time variables and simplified the associated logic.

## Verification
All tests pass again.  The original drifts cause by the time step calculation were minor and the tests still pass.

## Documentation
Updated release notes and documentation built without issue.

## Future work
None for now.