### PR TITLE
Bug/1010 reference counting issue spice interface

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -43,7 +43,7 @@ Version |release|
 - Enhance how ``uint64_t`` values are converted to doubles.  BSK now warns if the time value is large enough such
   that the conversion method has a loss of precision in this process.
 - Support including an eclipse message in :ref:`SpacecraftLocation` to more accurately determine illumination.
-
+- Fixed a bug in :ref:`spiceInterface` where required kernels were being unloaded before they were no longer needed.
 
 Version 2.7.0 (April 20, 2025)
 ------------------------------

--- a/src/simulation/environment/spiceInterface/spiceInterface.h
+++ b/src/simulation/environment/spiceInterface/spiceInterface.h
@@ -93,6 +93,7 @@ private:
 
     static std::mutex kernelManipulationMutex; //!< -- Mutex to protect SPICE kernel loading/unloading operations
     static std::unordered_map<std::string, int> kernelReferenceCounter; //!< -- Reference counter for SPICE kernels
+    static int requiredKernelsRefCount;  // Global counter for REQUIRED_KERNELS
     static const std::vector<std::string> REQUIRED_KERNELS; //!< -- List of required SPICE kernels
 };
 


### PR DESCRIPTION
* **Tickets addressed:** issue #1010 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Fixed reference counting issue with SpiceInterface REQUIRED_KERNELS that was causing SPICE(NOLEAPSECONDS) errors in multi-instance scenarios. Added global reference counting for required kernels. Made kernel unloading more robust by using exact filename matching and ensuring required kernels stay loaded as long as any instance needs them.

## Verification
Unit tests pass locally.
Requires further verification with BSK-RL by @Mark2000 

## Documentation
Updated release notes describing fix briefly.

## Future work
Track and resolve any further issues with spiceInterface class.

