### PR TITLE
Feature/data residual fills buffer

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -44,6 +44,9 @@ Version |release|
   that the conversion method has a loss of precision in this process.
 - Support including an eclipse message in :ref:`SpacecraftLocation` to more accurately determine illumination.
 - Fixed a bug in :ref:`spiceInterface` where required kernels were being unloaded before they were no longer needed.
+- Fixed an issue where the :ref:`spaceToGroundTransmitter` would check for the amount of data remaining in a different partition than the one being downlinked.
+- Fixed an issue where a high baud rate prevented the :ref:`spaceToGroundTransmitter` from downlinking data from the :ref:`simpleStorageUnit` or :ref:`partitionedStorageUnit`.
+
 
 Version 2.7.0 (April 20, 2025)
 ------------------------------

--- a/src/simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.cpp
+++ b/src/simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.cpp
@@ -170,9 +170,11 @@ void DataStorageUnitBase::integrateDataStatus(double currentTime){
        if ((this->storedDataSum + round(it->baudRate * this->currentTimestep) <= this->storageCapacity) || (it->baudRate < 0)) {
            //! - if a dataNode exists in storedData vector, integrate and add to current amount
            if (index != -1) {
-               //! Only perform if this operation will not take the sum below zero
-               if ((this->storedData[(size_t) index].dataInstanceSum + it->baudRate * this->currentTimestep) >= 0) {
-                   this->storedData[(size_t) index].dataInstanceSum += round(it->baudRate * this->currentTimestep);
+               //! If this operation takes the sum below zero, set it to zero
+               if ((this->storedData[(size_t)index].dataInstanceSum + it->baudRate * this->currentTimestep) >= 0) {
+                   this->storedData[(size_t)index].dataInstanceSum += round(it->baudRate * this->currentTimestep);
+               } else {
+                   this->storedData[(size_t)index].dataInstanceSum = 0;
                }
                //! - if a dataNode does not exist in storedData, add it to storedData, integrate baud rate, and add amount
            }

--- a/src/simulation/onboardDataHandling/spaceToGroundTransmitter/_UnitTest/test_spaceToGroundTransmitter.py
+++ b/src/simulation/onboardDataHandling/spaceToGroundTransmitter/_UnitTest/test_spaceToGroundTransmitter.py
@@ -20,6 +20,7 @@ import inspect
 import os
 
 import pytest
+import numpy as np
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -28,39 +29,25 @@ splitPath = path.split(bskName)
 
 # Import all of the modules that we are going to be called in this simulation
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 from Basilisk.simulation import spaceToGroundTransmitter
 from Basilisk.simulation import simpleInstrument
 from Basilisk.simulation import partitionedStorageUnit
+from Basilisk.simulation import simpleStorageUnit
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 
-
-@pytest.mark.parametrize("deviceStatus", [0,1])
-@pytest.mark.parametrize("accessStatus", [0,1])
-def test_module(show_plots, deviceStatus, accessStatus):
+@pytest.mark.parametrize(
+        "deviceStatus, accessStatus",
+        [(0, 0),
+         (1, 1)])
+def test_baudRate(deviceStatus, accessStatus):
     """
     **Validation Test Description**
 
     1. Whether the simpleTransmitter provides the right output message (baudRate) while on;
     2. Whether the simpleTransmitter provides the right output message (baudRate) while off.
     3. Whether the simpleTransmitter provides the right output message (baudRate) while out of access.
-
-    :param show_plots: Not used; no plots to be shown.
-
-    :return:
     """
-
-    default_results, default_message = run(deviceStatus, accessStatus)
-
-    testResults = sum([default_results])
-    testMessage = [default_message]
-
-    assert testResults < 1, testMessage
-
-
-def run(deviceStatus, accessStatus):
-
     expectedValue = deviceStatus * accessStatus
 
     testFailCount = 0                       # zero unit test result counter
@@ -88,7 +75,7 @@ def run(deviceStatus, accessStatus):
     # Create the test module
     testModule = spaceToGroundTransmitter.SpaceToGroundTransmitter()
     testModule.ModelTag = "transmitter"
-    testModule.nodeBaudRate = 9600. # baud
+    testModule.nodeBaudRate = -9600. # baud
     testModule.packetSize = -9600 # bits
     testModule.numBuffers = 1
     testModule.dataStatus = deviceStatus
@@ -122,26 +109,261 @@ def run(deviceStatus, accessStatus):
 
     generatedData = datLog.baudRate
     print(generatedData)
-    accuracy = 1e-16
 
-    trueData = 9600. # Module should be on after enough data is accrued
+    trueData = -9600. # Module should be on after enough data is accrued
     testArray = [0, 0, 0, expectedValue*trueData, expectedValue*trueData, expectedValue*trueData, expectedValue*trueData] # Should go through three iterations of no data downlinked
 
-    testFailCount, testMessages = unitTestSupport.compareDoubleArray(
-        testArray, generatedData, accuracy, "dataOutput",
-        testFailCount, testMessages)
+    np.testing.assert_array_equal(
+        generatedData, testArray,
+        err_msg="Generated data does not match expected values."
+    )
 
-    if testFailCount:
-        print(testMessages)
-    else:
-        print("Passed")
 
-    # each test method requires a single assert method to be called
-    # this check below just makes sure no sub-test failures were found
-    return [testFailCount, ''.join(testMessages)]
+@pytest.mark.parametrize(
+        "partition_data_0s, partition_data_2s, partition_data_5s, packetSize",
+        [
+            (28800, 9600, 0, -9600),
+            (9599, 9599, 9599, -9600),
+            (9601, 1, 1, -9600),
+            (3600, 3600, 3600, -9600),
+            (3600, 0, 0, 0),
+        ]
+)
+def test_downlink(partition_data_0s, partition_data_2s, partition_data_5s, packetSize):
+    """
+    **Validation Test Description**
+
+    1. Whether the packetSize is correctly set in the spaceToGroundTransmitter module;
+    2. Whether the spaceToGroundTransmitter module correctly downlinks data from the simpleStorageUnit;
+    3. Whether the spaceToGroundTransmitter module correctly handles data less than the packet size;
+    """
+    accessStatus = 1  # 1 means the access is granted, 0 means it is denied
+
+    unitTaskName = "unitTask"               # arbitrary name (don't change)
+    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create fake access messages
+    accMsg2 = messaging.AccessMsgPayload()
+    accMsg2.hasAccess = accessStatus
+    acc2Msg = messaging.AccessMsg().write(accMsg2)
+
+    # Create the test module
+    testModule = spaceToGroundTransmitter.SpaceToGroundTransmitter()
+    testModule.ModelTag = "transmitter"
+    testModule.nodeBaudRate = -9600. # baud
+    testModule.packetSize = packetSize # bits
+    testModule.numBuffers = 0
+    testModule.dataStatus = 1
+    testModule.addAccessMsgToTransmitter(acc2Msg)
+    unitTestSim.AddModelToTask(unitTaskName, testModule)
+
+    # Create a partitionedStorageUnit and attach the instrument to it
+    dataMonitor = simpleStorageUnit.SimpleStorageUnit()
+    dataMonitor.ModelTag = "dataMonitor"
+    dataMonitor.storageCapacity = 8E9 # bits (1 GB)
+    dataMonitor.addDataNodeToModel(testModule.nodeDataOutMsg)
+    unitTestSim.AddModelToTask(unitTaskName, dataMonitor)
+
+    testModule.addStorageUnitToTransmitter(dataMonitor.storageUnitDataOutMsg)
+
+    datLog = testModule.nodeDataOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, datLog)
+
+    dataMonitor.setDataBuffer(partition_data_0s)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(2.0))
+    unitTestSim.ExecuteSimulation()
+
+    np.testing.assert_array_equal(
+        dataMonitor.storageUnitDataOutMsg.read().storedData, partition_data_2s,
+        err_msg="Intermediate partition data at 2 seconds does not match expected values."
+    )
+
+    unitTestSim.ConfigureStopTime(macros.sec2nano(5.0))
+    unitTestSim.ExecuteSimulation()
+
+    np.testing.assert_array_equal(
+        dataMonitor.storageUnitDataOutMsg.read().storedData, partition_data_5s,
+        err_msg="Intermediate partition data at 5 seconds does not match expected values."
+    )
+
+
+@pytest.mark.parametrize(
+        "partition_data_0s, partition_data_2s, partition_data_5s, packetSize",
+        [
+            ([0, 19200, 19200], [0, 9600, 9600], [0, 0, 0], -9600),
+            ([0, 9600, 9600], [0, 0, 0], [0, 0, 0], -9600),
+            ([0, 0, 9599], [0, 0, 9599], [0, 0, 9599], -9600),
+            ([0, 0, 9601], [0, 0, 1], [0, 0, 1], -9600),
+            ([1200, 2400, 3600], [1200, 2400, 3600], [1200, 2400, 3600], -9600),
+            ([1200, 2400, 3600], [0, 0, 0], [0, 0, 0], 0),
+            ([1200, 2400, 3600], [0, 0, 0], [0, 0, 0], -1),
+        ]
+)
+def test_downlink_from_partition(partition_data_0s, partition_data_2s, partition_data_5s, packetSize):
+    """
+    **Validation Test Description**
+
+    1. Whether the spaceToGroundTransmitter module correctly downlinks data from the partitionedStorageUnit;
+    2. Whether the spaceToGroundTransmitter module correctly handles data less than the packet size;
+    3. Whether the spaceToGroundTransmitter module completely empties the partitionedStorageUnit after downlinking data.;
+    """
+    accessStatus = 1  # 1 means the access is granted, 0 means it is denied
+
+    unitTaskName = "unitTask"               # arbitrary name (don't change)
+    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create fake access messages
+    accMsg = messaging.AccessMsgPayload()
+    accMsg.hasAccess = accessStatus
+    acc_msg = messaging.AccessMsg().write(accMsg)
+
+    # Create the test module
+    testModule = spaceToGroundTransmitter.SpaceToGroundTransmitter()
+    testModule.ModelTag = "transmitter"
+    testModule.nodeBaudRate = -9600. # baud
+    testModule.packetSize = packetSize # bits
+    testModule.numBuffers = 0
+    testModule.dataStatus = 1
+    testModule.addAccessMsgToTransmitter(acc_msg)
+    unitTestSim.AddModelToTask(unitTaskName, testModule)
+
+    # Create a partitionedStorageUnit and attach the instrument to it
+    dataMonitor = partitionedStorageUnit.PartitionedStorageUnit()
+    dataMonitor.ModelTag = "dataMonitor"
+    dataMonitor.storageCapacity = 8E9 # bits (1 GB)
+    dataMonitor.addDataNodeToModel(testModule.nodeDataOutMsg)
+    unitTestSim.AddModelToTask(unitTaskName, dataMonitor)
+
+    testModule.addStorageUnitToTransmitter(dataMonitor.storageUnitDataOutMsg)
+
+    datLog = testModule.nodeDataOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, datLog)
+
+    data_partition_names = ["P_1", "P_2", "P_3"]
+    dataMonitor.setDataBuffer(data_partition_names, partition_data_0s)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(2.0))
+    unitTestSim.ExecuteSimulation()
+
+    np.testing.assert_array_equal(
+        [data_i for data_i in dataMonitor.storageUnitDataOutMsg.read().storedData], partition_data_2s,
+        err_msg="Partition data at 2 seconds does not match expected values."
+    )
+
+    unitTestSim.ConfigureStopTime(macros.sec2nano(5.0))
+    unitTestSim.ExecuteSimulation()
+
+    np.testing.assert_array_equal(
+        [data_i for data_i in dataMonitor.storageUnitDataOutMsg.read().storedData], partition_data_5s,
+        err_msg="Partition data at 5 seconds does not match expected values."
+    )
+
+
+@pytest.mark.parametrize(
+        "partition_data_0s, partition_data_2s, partition_data_5s, packetSize",
+        [
+            ([0, 0, 38400], [0, 0, 19200], [0, 0, 19200], -38400),
+            ([0, 0, 38400], [0, 0, 19200], [0, 0, 0], 0)
+
+        ]
+)
+def test_downlink_with_disrupted_connection(partition_data_0s, partition_data_2s, partition_data_5s, packetSize):
+    """
+    **Validation Test Description**
+
+    1. Whether the spaceToGroundTransmitter module correctly downlinks data from the partitionedStorageUnit with interrupted connection with ground station;
+    """
+
+    unitTaskName = "unitTask"               # arbitrary name (don't change)
+    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Create fake access messages
+    accMsg = messaging.AccessMsgPayload()
+    accMsg.hasAccess = 1
+    acc_msg = messaging.AccessMsg().write(accMsg)
+
+    # Create the test module
+    testModule = spaceToGroundTransmitter.SpaceToGroundTransmitter()
+    testModule.ModelTag = "transmitter"
+    testModule.nodeBaudRate = -9600. # baud
+    testModule.packetSize = packetSize # bits
+    testModule.numBuffers = 0
+    testModule.dataStatus = 1
+    testModule.addAccessMsgToTransmitter(acc_msg)
+    unitTestSim.AddModelToTask(unitTaskName, testModule)
+
+    # Create a partitionedStorageUnit and attach the instrument to it
+    dataMonitor = partitionedStorageUnit.PartitionedStorageUnit()
+    dataMonitor.ModelTag = "dataMonitor"
+    dataMonitor.storageCapacity = 8E9 # bits (1 GB)
+    dataMonitor.addDataNodeToModel(testModule.nodeDataOutMsg)
+    unitTestSim.AddModelToTask(unitTaskName, dataMonitor)
+
+    testModule.addStorageUnitToTransmitter(dataMonitor.storageUnitDataOutMsg)
+
+    datLog = testModule.nodeDataOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, datLog)
+
+    data_partition_names = ["P_1", "P_2", "P_3"]
+    dataMonitor.setDataBuffer(data_partition_names, partition_data_0s)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(2.0))
+    unitTestSim.ExecuteSimulation()
+
+    np.testing.assert_array_equal(
+        [data_i for data_i in dataMonitor.storageUnitDataOutMsg.read().storedData], partition_data_2s,
+        err_msg="Partition data at 2 seconds does not match expected values."
+    )
+
+    accMsg.hasAccess = 0 # Satellite loses connection with ground station
+    acc_msg.write(accMsg)
+    unitTestSim.ConfigureStopTime(macros.sec2nano(3.0))
+    unitTestSim.ExecuteSimulation()
+
+    accMsg.hasAccess = 1 # Satellite reestablishes connection with ground station
+    acc_msg.write(accMsg)
+    unitTestSim.ConfigureStopTime(macros.sec2nano(5.0))
+    unitTestSim.ExecuteSimulation()
+
+    np.testing.assert_array_equal(
+        [data_i for data_i in dataMonitor.storageUnitDataOutMsg.read().storedData], partition_data_5s,
+        err_msg="Partition data at 5 seconds does not match expected values."
+    )
+
 #
 # This statement below ensures that the unitTestScript can be run as a
 # stand-alone python script
 #
 if __name__ == "__main__":
-    test_module(False, 1, 1)
+    test_baudRate(1, 1)
+    test_downlink(28800, 9600, 0, -9600)
+    test_downlink_from_partition([0, 19200, 19200], [0, 9600, 9600], [0, 0, 0], -9600)
+    test_downlink_with_disrupted_connection([0, 0, 38400], [0, 0, 19200], [0, 0, 19200], -38400)

--- a/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
+++ b/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
@@ -121,10 +121,37 @@ void SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload *dataUs
     // Get the buffer with the most data
     double maxVal = -1.0;
     int maxIndex = -1;
-    for (uint64_t i = 0; i < this->storageUnitMsgsBuffer.back().storedData.size(); i++) {
-        if (this->storageUnitMsgsBuffer.back().storedData[i] > maxVal) {
-            maxVal = this->storageUnitMsgsBuffer.back().storedData[i];
-            maxIndex = (int) i;
+
+    //! - If the transmitted packet size has exceeded the packet size, set packetTransmitted to zero
+    // Both of these variables are negative so the comparison is non-intuitive
+    if (this->packetTransmitted <= this->packetSize) {
+        this->packetTransmitted = 0.0;
+    }
+
+    //! - If transmitted packet data is more than zero, continue downlinking from previous partition
+    if (this->packetTransmitted != 0.0) {
+        // Loop through the storageUnitMsgsBuffer to find the previous partition
+        for (uint64_t i = 0; i <  this->storageUnitMsgsBuffer.back().storedDataName.size(); i++) {
+            if (this->storageUnitMsgsBuffer.back().storedDataName[i] == this->nodeDataName) {
+                maxVal = this->storageUnitMsgsBuffer.back().storedData[i];
+                maxIndex = (int) i;
+            }
+        }
+        // If there is no data in the partition, reset maxVal, maxIndex, and packetTransmitted
+        if (maxVal <= 0.0) {
+            maxIndex = -1;
+            this->packetTransmitted = 0.0;
+            dataUsageSimMsg->baudRate = 0.0;
+        }
+    }
+
+    //! - If there is no previous partition being downlinked, find the partition with the most data to downlink
+    if (this->packetTransmitted == 0.0) {
+        for (uint64_t i = 0; i < this->storageUnitMsgsBuffer.back().storedData.size(); i++) {
+            if (this->storageUnitMsgsBuffer.back().storedData[i] > maxVal) {
+                maxVal = this->storageUnitMsgsBuffer.back().storedData[i];
+                maxIndex = (int) i;
+            }
         }
     }
 
@@ -139,34 +166,38 @@ void SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload *dataUs
                          sizeof(this->nodeDataName));
                  // strncpy nodeDataName to the name of the output message
                  strncpy(dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
-                 this->packetTransmitted += this->nodeBaudRate * (this->currentTimestep);
 
-                 // Check to see if maxVal is less than packet size or if it will downlink more data than is available
-                 // If so, set the output message baudRate to zero
+                 // Check to see if maxVal is less than packet size. If not set the output message baudRate to zero
                  // We do not want to start downlinking until we have enough data for one packet
-                 if ((maxVal < (-1 * (this->packetSize))) ||
-                     ((maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0)) {
-                     dataUsageSimMsg->baudRate = 0;
-                     this->packetTransmitted = 0;
+                 if (maxVal < (-1 * (this->packetSize))) {
+                    dataUsageSimMsg->baudRate = 0;
+                    this->packetTransmitted = 0;
                  }
+                 else {
+                    // If the downlink exceeds the available data, don't downlink
+                    if ((maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0) {
+                        dataUsageSimMsg->baudRate = 0;
+                        this->packetTransmitted = 0;
+                    }
+                    else {
+                        // Otherwise, transmit with the nodeBaudRate
+                        this->packetTransmitted += this->nodeBaudRate * (this->currentTimestep);
+                    }
+                 }
+
+
              } else {
                  strncpy(dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
-                 this->packetTransmitted += this->nodeBaudRate * (this->currentTimestep);
 
-                 // Check to see if maxVal is less than packet size.
-                 // If so, set the output message baudRate to zero
-                 // We do not want to start downlinking until we have enough data for one packet
-                 if ((maxVal < (-1 * (this->packetSize))) ||
-                     ((maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0)) {
-                     dataUsageSimMsg->baudRate = 0;
-                     this->packetTransmitted = 0;
-                 }
-
-                 // If the transmitted packet size has exceeded the packet size, set packetTransmitted to zero
-                 // Both of these variables are negative so the comparison is non-intuitive
-                 if (this->packetTransmitted <= this->packetSize) {
-                     this->packetTransmitted = 0.0;
-                 }
+                // If the downlink exceeds the available data, don't downlink
+                if ((maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0) {
+                    dataUsageSimMsg->baudRate = 0;
+                    this->packetTransmitted = 0;
+                }
+                else {
+                    // Otherwise, transmit with the nodeBaudRate
+                    this->packetTransmitted += this->nodeBaudRate * (this->currentTimestep);
+                }
              }
 
          } else{

--- a/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
+++ b/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
@@ -112,7 +112,9 @@ bool SpaceToGroundTransmitter::customReadMessages(){
  @param dataUsageSimMsg
  @param currentTime
 */
-void SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload *dataUsageSimMsg, double currentTime){
+void
+SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload* dataUsageSimMsg, double currentTime)
+{
 
     this->currentTimestep = currentTime - this->previousTime;
 
@@ -131,10 +133,10 @@ void SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload *dataUs
     //! - If transmitted packet data is more than zero, continue downlinking from previous partition
     if (this->packetTransmitted != 0.0) {
         // Loop through the storageUnitMsgsBuffer to find the previous partition
-        for (uint64_t i = 0; i <  this->storageUnitMsgsBuffer.back().storedDataName.size(); i++) {
+        for (uint64_t i = 0; i < this->storageUnitMsgsBuffer.back().storedDataName.size(); i++) {
             if (this->storageUnitMsgsBuffer.back().storedDataName[i] == this->nodeDataName) {
                 maxVal = this->storageUnitMsgsBuffer.back().storedData[i];
-                maxIndex = (int) i;
+                maxIndex = (int)i;
             }
         }
         // If there is no data in the partition, reset maxVal, maxIndex, and packetTransmitted
@@ -150,63 +152,60 @@ void SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload *dataUs
         for (uint64_t i = 0; i < this->storageUnitMsgsBuffer.back().storedData.size(); i++) {
             if (this->storageUnitMsgsBuffer.back().storedData[i] > maxVal) {
                 maxVal = this->storageUnitMsgsBuffer.back().storedData[i];
-                maxIndex = (int) i;
+                maxIndex = (int)i;
             }
         }
     }
 
     //! - If we have access to any ground location, do the transmission logic
-    if (std::any_of(this->groundLocationAccessMsgs.begin(), this->groundLocationAccessMsgs.end(), [](AccessMsgPayload msg){return msg.hasAccess>0;})){
+    if (std::any_of(this->groundLocationAccessMsgs.begin(),
+                    this->groundLocationAccessMsgs.end(),
+                    [](AccessMsgPayload msg) { return msg.hasAccess > 0; })) {
         // If an index was assigned
         if (maxIndex != -1) {
-             //! - If we have not transmitted any of the packet, we select a new type of data to downlink
-             if (this->packetTransmitted == 0.0) {
-                 // Set nodeDataName to the maximum data name
-                 strncpy(this->nodeDataName, this->storageUnitMsgsBuffer.back().storedDataName[maxIndex].c_str(),
-                         sizeof(this->nodeDataName));
-                 // strncpy nodeDataName to the name of the output message
-                 strncpy(dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
+            //! - If we have not transmitted any of the packet, we select a new type of data to downlink
+            if (this->packetTransmitted == 0.0) {
+                // Set nodeDataName to the maximum data name
+                strncpy(this->nodeDataName,
+                        this->storageUnitMsgsBuffer.back().storedDataName[maxIndex].c_str(),
+                        sizeof(this->nodeDataName));
+                // strncpy nodeDataName to the name of the output message
+                strncpy(dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
 
-                 // Check to see if maxVal is less than packet size. If not set the output message baudRate to zero
-                 // We do not want to start downlinking until we have enough data for one packet
-                 if (maxVal < (-1 * (this->packetSize))) {
+                // Check to see if maxVal is less than packet size. If not set the output message baudRate to zero
+                // We do not want to start downlinking until we have enough data for one packet
+                if (maxVal < (-1 * (this->packetSize))) {
                     dataUsageSimMsg->baudRate = 0;
                     this->packetTransmitted = 0;
-                 }
-                 else {
+                } else {
                     // If the downlink exceeds the available data, don't downlink
                     if ((maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0) {
-                        dataUsageSimMsg->baudRate = 0;
-                        this->packetTransmitted = 0;
-                    }
-                    else {
+                        this->packetTransmitted = -maxVal;
+                    } else {
                         // Otherwise, transmit with the nodeBaudRate
                         this->packetTransmitted += this->nodeBaudRate * (this->currentTimestep);
                     }
-                 }
+                }
 
-
-             } else {
-                 strncpy(dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
+            } else {
+                strncpy(dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
 
                 // If the downlink exceeds the available data, don't downlink
                 if ((maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0) {
-                    dataUsageSimMsg->baudRate = 0;
-                    this->packetTransmitted = 0;
-                }
-                else {
+                    this->packetTransmitted = -maxVal;
+                } else {
                     // Otherwise, transmit with the nodeBaudRate
                     this->packetTransmitted += this->nodeBaudRate * (this->currentTimestep);
                 }
-             }
+            }
 
-         } else{
-             dataUsageSimMsg->baudRate = 0;
-             this->packetTransmitted = 0;
-         }
+        } else {
+            dataUsageSimMsg->baudRate = 0;
+            this->packetTransmitted = 0;
+        }
     }
     // If we don't have access, we can't transmit anything
-    else{
+    else {
         dataUsageSimMsg->baudRate = 0;
         this->packetTransmitted = 0;
     }

--- a/src/simulation/onboardDataHandling/storageUnit/_UnitTest/test_partitionedStorageUnit.py
+++ b/src/simulation/onboardDataHandling/storageUnit/_UnitTest/test_partitionedStorageUnit.py
@@ -35,7 +35,9 @@ from Basilisk.utilities import macros
 
 params_storage_limits = [(1200, 1200, 2400, 2400),
                      (600, 1200, 3600, 3600),
-                     (600, 600, 10000, 6000)]
+                     (600, 600, 10000, 6000),
+                     (-100, 0, 10000, 0),
+                     (-100, -100, 10000, 0),]
 
 @pytest.mark.parametrize("baudRate_1, baudRate_2, storageCapacity, expectedStorage",
                           params_storage_limits)
@@ -43,9 +45,9 @@ def test_storage_limits(baudRate_1, baudRate_2, storageCapacity, expectedStorage
     """
     Tests:
 
-    1. Whether the partitionedStorageUnit can add multiple nodes (core base class 
+    1. Whether the partitionedStorageUnit can add multiple nodes (core base class
         functionality);
-    2. That the partitionedStorageUnit correctly evaluates how much stored data it 
+    2. That the partitionedStorageUnit correctly evaluates how much stored data it
         should have given a pair of baud input messages.
 
     :return:
@@ -105,7 +107,7 @@ def test_storage_limits(baudRate_1, baudRate_2, storageCapacity, expectedStorage
 
     #   Check 3 - is the amount of data more than zero and less than the capacity?
     for ind in range(0,len(storedDataLog)):
-        assert storedDataLog[ind] <= capacityLog[ind] or np.isclose(storedDataLog[ind], 
+        assert storedDataLog[ind] <= capacityLog[ind] or np.isclose(storedDataLog[ind],
             capacityLog[ind]), (
                 "FAILED: PartitionedStorageUnit's stored data exceeded its capacity.")
 
@@ -128,14 +130,14 @@ params_set_data = [(1200, 1200, ['test'], [1200], 2400, 2400),
 @pytest.mark.parametrize(
     "baudRate_1, baudRate_2, partitionName, add_data, storageCapacity, expectedStorage",
     params_set_data)
-def test_set_data_buffer(baudRate_1, baudRate_2, partitionName, 
+def test_set_data_buffer(baudRate_1, baudRate_2, partitionName,
                          add_data, storageCapacity, expectedStorage):
     """
     Tests:
 
-    1. Whether the partitionedStorageUnit properly adds data in different partitions 
+    1. Whether the partitionedStorageUnit properly adds data in different partitions
         using the setDataBuffer method;
-    2. That the partitionedStorageUnit correctly evaluates how much stored data it 
+    2. That the partitionedStorageUnit correctly evaluates how much stored data it
         should have given a pair of input messages and using setDataBuffer.
 
     :return:
@@ -203,7 +205,7 @@ def test_set_data_buffer(baudRate_1, baudRate_2, partitionName,
 
     #   Check 3 - is the amount of data more than zero and less than the capacity?
     for ind in range(0,len(storedDataLog)):
-        assert storedDataLog[ind] <= capacityLog[ind] or np.isclose(storedDataLog[ind], 
+        assert storedDataLog[ind] <= capacityLog[ind] or np.isclose(storedDataLog[ind],
             capacityLog[ind]), (
                 "FAILED: PartitionedStorageUnit's stored data exceeded its capacity.")
 
@@ -222,13 +224,13 @@ params_set_data = [(600, 600, ['test'], [0], 1E4),
 @pytest.mark.parametrize(
     "baudRate_1, baudRate_2, partitionName, add_data, storageCapacity",
     params_set_data)
-def test_set_data_buffer_partition(baudRate_1, baudRate_2, partitionName, 
+def test_set_data_buffer_partition(baudRate_1, baudRate_2, partitionName,
                                    add_data, storageCapacity):
 
     """
     Tests:
 
-    1. Whether the partitionedStorageUnit manages the data in already existing 
+    1. Whether the partitionedStorageUnit manages the data in already existing
         and new partitions correctly;
 
     :return:
@@ -298,10 +300,82 @@ def test_set_data_buffer_partition(baudRate_1, baudRate_2, partitionName,
             baudRate = baudRate_2
 
         # Check 2 - if partition exists, does it added data to the correct partition?
-        np.testing.assert_allclose(dataVec[-1][partIndex], 
-            add_data[dataIndex] + baudRate*sim_time, 
+        np.testing.assert_allclose(dataVec[-1][partIndex],
+            add_data[dataIndex] + baudRate*sim_time,
             err_msg = (
             "FAILED: PartitionedStorageUnit did not use the correct partition."))
+
+
+params_storage_limits = [(-1200, 0, 2400, 4800, 2400),
+                         (-120, 0, 2400, 4800, 4200),
+                         (-1200, -1200, 2400, 4800, 0),]
+
+@pytest.mark.parametrize("baudRate_1, baudRate_2, initialData, storageCapacity, expectedStorage",
+                          params_storage_limits)
+def test_data_removal(baudRate_1, baudRate_2, initialData, storageCapacity, expectedStorage):
+    """
+    Tests:
+
+    1. Whether removing data from the simpleStorageUnit works correctly;
+
+    :return:
+    """
+
+    unitTaskName = "unitTask"               # arbitrary name (don't change)
+    unitProcessName = "TestProcess"         # arbitrary name (don't change)
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.1)     # update process rate update time
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    test_storage_unit = partitionedStorageUnit.PartitionedStorageUnit()
+    test_storage_unit.storageCapacity = storageCapacity # bit capacity.
+
+    dataMsg1 = messaging.DataNodeUsageMsgPayload()
+    dataMsg1.baudRate = baudRate_1 # baud
+    dataMsg1.dataName = "node_1_msg"
+    dat1Msg = messaging.DataNodeUsageMsg().write(dataMsg1)
+
+    dataMsg2 = messaging.DataNodeUsageMsgPayload()
+    dataMsg2.baudRate = baudRate_2 # baud
+    dataMsg2.dataName = "node_2_msg"
+    dat2Msg = messaging.DataNodeUsageMsg().write(dataMsg2)
+
+    # Test the addNodeToStorage method:
+    test_storage_unit.addDataNodeToModel(dat1Msg)
+    test_storage_unit.addDataNodeToModel(dat2Msg)
+
+    unitTestSim.AddModelToTask(unitTaskName, test_storage_unit)
+
+    dataLog = test_storage_unit.storageUnitDataOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    test_storage_unit.setDataBuffer(["node_1_msg", "node_2_msg"], [initialData]*2)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(5.0))
+
+    unitTestSim.ExecuteSimulation()
+
+    storedDataLog = dataLog.storageLevel
+    capacityLog = dataLog.storageCapacity
+
+    #   Check 1 - is used storage space correct?
+    np.testing.assert_allclose(storedDataLog[-1], expectedStorage, atol=1e-4,
+        err_msg=("FAILED: PartitionedStorageUnit did not track integrated data."))
+
+    #   Check 2 - is the amount of data more than zero and less than the capacity?
+    for ind in range(0,len(storedDataLog)):
+        assert storedDataLog[ind] <= capacityLog[ind] or np.isclose(storedDataLog[ind],
+            capacityLog[ind]), (
+                "FAILED: PartitionedStorageUnit's stored data exceeded its capacity.")
+
+        assert storedDataLog[ind] >= 0., (
+            "FAILED: PartitionedStorageUnit's stored data was negative.")
 
 
 if __name__ == "__main__":
@@ -312,8 +386,14 @@ if __name__ == "__main__":
     test_storage_limits(baudRate_1, baudRate_2, storageCapacity, expectedStorage)
     add_data = [1200, 200]
     partitionName = ["test", "node_1_msg"]
-    test_set_data_buffer(baudRate_1, baudRate_2, partitionName, 
+    test_set_data_buffer(baudRate_1, baudRate_2, partitionName,
                          add_data, storageCapacity, expectedStorage)
     storageCapacity = 20000
-    test_set_data_buffer_partition(baudRate_1, baudRate_2, partitionName, 
+    test_set_data_buffer_partition(baudRate_1, baudRate_2, partitionName,
                          add_data, storageCapacity)
+    baudRate_1 = -240
+    baudRate_2 = -240
+    initialData = 1200
+    storageCapacity = 2400
+    expectedStorage = 0
+    test_data_removal(baudRate_1, baudRate_2, initialData, storageCapacity, expectedStorage)

--- a/src/simulation/onboardDataHandling/storageUnit/simpleStorageUnit.cpp
+++ b/src/simulation/onboardDataHandling/storageUnit/simpleStorageUnit.cpp
@@ -64,9 +64,11 @@ void SimpleStorageUnit::integrateDataStatus(double currentTime){
             this->storedData.push_back({{'S','T','O','R','E','D',' ','D','A','T','A'}, 0});
         }
         else if ((this->storedDataSum + round(it->baudRate * this->currentTimestep) < this->storageCapacity) || (it->baudRate <= 0)){
-            //! - Only perform the operation if it will not result in less than 0 data
-            if ((this->storedData[0].dataInstanceSum + it->baudRate * this->currentTimestep) >= 0){
+            //! If this operation takes the sum below zero, set it to zero
+            if ((this->storedData[0].dataInstanceSum + it->baudRate * this->currentTimestep) >= 0) {
                 this->storedData[0].dataInstanceSum += round(it->baudRate * this->currentTimestep);
+            } else {
+                this->storedData[0].dataInstanceSum = 0;
             }
         }
         this->netBaud += it->baudRate;


### PR DESCRIPTION
* **Tickets addressed:** bsk-1012, bsk-1013
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
The `spaceToGroundTransmitter` will check for the correct partition before continuing to downlink data when `packetTransmitted < packetSize` in a given time step. 

Also, the transmitter will attempt to downlink data even when the downlinked data would exceed the amount stored in a given partition (`maxVal + this->nodeBaudRate * (this->currentTimestep)) < 0`). Modules `simpleStorageUnit` and `partitionedStorageUnit` were modified to allow only the remaining amount of data to be remove.

## Verification
Unit tests were expanded to check for the new conditions. Previous tests remain valid.

## Documentation
No documentation was invalidated with these changes. No changes in functionality were made.
