### PR TITLE
Upgrade to VS 17 and GitHub Windows testing image to 2025

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -140,7 +140,7 @@ jobs:
   build-windows:
     name: Windows All Tests
     runs-on: windows-2025
-    timeout-minutes: 75
+    timeout-minutes: 100
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -139,7 +139,7 @@ jobs:
 
   build-windows:
     name: Windows All Tests
-    runs-on: windows-2019
+    runs-on: windows-2025
     timeout-minutes: 75
     strategy:
       matrix:

--- a/conanfile.py
+++ b/conanfile.py
@@ -57,9 +57,6 @@ bskModuleOptionsFlag = {
     "allOptPkg": [[True, False], False]  # TODO: Remove, used only for managePipEnvironment.
 }
 
-# this statement is needed to enable Windows to print ANSI codes in the Terminal
-# see https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python/3332860#3332860
-os.system("")
 
 def is_running_virtual_env():
     return sys.prefix != sys.base_prefix
@@ -228,9 +225,6 @@ class BasiliskConan(ConanFile):
             self.options['opencv'].with_openexr = False  # generate image in EXR format
             self.options['opencv'].with_quirc = False  # QR code lib
             self.options['opencv'].with_webp = False  # raster graphics file format for web
-
-        if is_msvc(self):
-            self.options["*"].shared = True
 
         # Other dependency options
         if self.options.get_safe("vizInterface") or self.options.get_safe("opNav"):

--- a/conanfile.py
+++ b/conanfile.py
@@ -284,7 +284,7 @@ class BasiliskConan(ConanFile):
                 generatorString = "Xcode"
                 tc.generator = generatorString
             elif self.settings.os == "Windows":
-                generatorString = "Visual Studio 16 2019"
+                generatorString = "Visual Studio 17 2022"
                 tc.generator = generatorString
                 self.options["*"].shared = True
             else:

--- a/docs/source/Install/installOnWindows.rst
+++ b/docs/source/Install/installOnWindows.rst
@@ -197,4 +197,4 @@ using:
          :scale: 50%
 
    -  Change the active config to Release instead of debug for solution properties.
-   -  Within Visual Studio now go under `Build menu/Build Solution` to build.
+   -  Within Visual Studio now go under ``Build menu/Build Solution`` to build.

--- a/docs/source/Install/installOnWindows.rst
+++ b/docs/source/Install/installOnWindows.rst
@@ -6,7 +6,7 @@
 Setup On Windows
 ================
 
-The following was developed using Windows 7 and Visual Studio Community 15 2017 or 16 2019.
+The following was developed using Windows 11 and Visual Studio Community 17 2022.
 
 Software setup
 --------------
@@ -16,7 +16,7 @@ In order to run Basilisk, the following software will be necessary:
 -  `Python <https://www.python.org/downloads/windows/>`__ 3.8 to 3.13.
    Version 3.8 is deprecated and will be removed April 2026.
 -  `pip <https://pip.pypa.io/en/stable/installing/>`__
--  Visual Studios 15 2017 or greater
+-  Default compiler is Visual Studios 17 2022
 -  `Swig <http://www.swig.org/download.html>`__ version 4.X
 -  (Optional) A GiT GUI application such as `GitKraken <https://www.gitkraken.com>`__
    to manage your copy of the Basilisk repository
@@ -146,7 +146,7 @@ When all the prerequisite installations are complete, the project can be built a
 
     (.venv) $ python conanfile.py
 
-   This creates the Visual Studio 16 2019 IDE project in ``dist3`` and builds the project.
+   This creates the Visual Studio 17 2022 IDE project in ``dist3`` and builds the project.
    You can also specify the generator directly in this build process and select other versions of Visual Studio.
    For other configure and build options, including running ``cmake`` directly, see :ref:`configureBuild`.
    This process will verify that the minimum required Basilisk python packages are installed, and that
@@ -155,10 +155,9 @@ When all the prerequisite installations are complete, the project can be built a
 
    .. note::
 
-        The default Window compiler is Visual Studio 16.  If you had VS 17 installed and downgraded to VS 16,
-        then the system might still find VS 17 and give an error when running the above command.
-        If you want to compile with latest VS 17, then use
-        ``python conanfile.py --generator "Visual Studio 17 2022"``.
+        The default Window compiler is Visual Studio 17.
+        If you want to compile with VS 16, then use
+        ``python conanfile.py --generator "Visual Studio 16 2019"``.
 
    .. note::
 

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -44,6 +44,12 @@ Version |release|
 - Support including an eclipse message in :ref:`SpacecraftLocation` to more accurately determine illumination.
 - Fixed an issue where the :ref:`spaceToGroundTransmitter` would check for the amount of data remaining in a different partition than the one being downlinked.
 - Fixed an issue where a high baud rate prevented the :ref:`spaceToGroundTransmitter` from downlinking data from the :ref:`simpleStorageUnit` or :ref:`partitionedStorageUnit`.
+- Updated default Windows compiler to be ``Visual Studio 17 2022``.  The CI test build now occurs on Windows 11.
+
+  .. warning::
+
+    If you still want to use Visual Studio 16, then be sure to set the generator
+    using ``python conanfile.py --generator "Visual Studio 16 2019``
 
 
 Version 2.7.0 (April 20, 2025)
@@ -157,7 +163,6 @@ Version  2.6.0  (Feb. 21, 2025)
 
     You have to upgrade your python ``conan`` package to be able to build Basilisk.
     Use ``python install --upgrade conan``.
-
 - Added support for subclassing ``StateData`` and overloading certain methods. This enables support for custom state
   behavior, such as quaternions, which have size 4 but their derivative is size 3. This is done in preparation of
   a future MuJoCo integration. Note the warning below regarding SWIG files for ``dynamicEffector`` and ``stateEffector``.

--- a/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/forceTorqueThrForceMapping.c
+++ b/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/forceTorqueThrForceMapping.c
@@ -183,7 +183,7 @@ void Update_forceTorqueThrForceMapping(forceTorqueThrForceMappingConfig *configD
     }
 
     /* Compute the minimum norm inverse of DG*/
-    double DGT_DGDGT_inv[6*6];
+    double DGT_DGDGT_inv[6*MAX_EFF_CNT];
     mMinimumNormInverse(DG_full, (size_t) 6-numZeroes, (size_t) MAX_EFF_CNT, DGT_DGDGT_inv);
 
     /* Compute the force for each thruster */


### PR DESCRIPTION
* **Tickets addressed:** closes #1019
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Upgraded the default Windows compiler in `conanfile.py` and changed the image being used to run Windows tests.

The VS compiler uncovered a memory-related crash in `forceTorqueThrForceMapping.c` when many thrusters were being used.  An array was not being allocated with enough memory, which caused a stack buffer overflow. Somehow, this error had never surfaced until now. Fixed by allocating the proper amount of memory.

It seems like the Windows action is now taking >75 min to run, which was timing out the action. Increased the timeout to 100 mins for Windows.

## Verification
All tests, including Windows on 2025, pass.

## Documentation
Release notes updated, also the windows install instructions.