### PR TITLE
Log MuJoCo errors through BSKLogger

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -54,6 +54,7 @@ Version |release|
 
 - Improve reading speed of recorded messages by about 75%.
 - Added support for Vizard 2.3.0
+- Redirected MuJoCo errors and warnings to :ref:`bskLogging` instead of printing to file.
 
 
 Version 2.7.0 (April 20, 2025)

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
@@ -38,6 +38,10 @@ MJScene::MJScene(std::string xml, const std::vector<std::string>& files)
 {
     this->AddFwdKinematicsToDynamicsTask(MJScene::FWD_KINEMATICS_PRIORITY);
     this->integrator = new svIntegratorRK4(this);
+
+    // Replace default MuJoCo error/warning handling with our own
+    mju_user_error = MJBasilisk::detail::logMujocoError;
+    mju_user_warning = MJBasilisk::detail::logMujocoWarning;
 }
 
 MJScene MJScene::fromFile(const std::string& fileName)

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.cpp
@@ -19,6 +19,20 @@
 
 #include "MJUtils.h"
 
+using namespace std::string_literals;
+
 namespace MJBasilisk::detail
 {
+void
+logMujocoError(const char* err)
+{
+    logAndThrow<std::runtime_error>("MuJoCo internal error: "s + err);
+}
+
+void
+logMujocoWarning(const char* err)
+{
+    BSKLogger{}.bskLog(BSK_WARNING, ("MuJoCo internal warning: "s + err).c_str());
+}
+
 } // namespace MJBasilisk::detail

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.h
@@ -64,6 +64,18 @@ template <typename T = std::invalid_argument>
     throw T(error);
 }
 
+/** Calls ``logAndThrow<std::runtime_error>`` with the given input
+ *
+ * Meant to be used as an error callback for MuJoCo's ``mju_user_error``.
+*/
+void logMujocoError(const char* err);
+
+/** Calls ``BSKLogger::bskLog`` with the given input
+ *
+ * Meant to be used as an error callback for MuJoCo's ``mju_user_warning``.
+*/
+void logMujocoWarning(const char* err);
+
 } // namespace MJBasilisk::detail
 
 #endif


### PR DESCRIPTION
* **Tickets addressed:** closes #1021 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
Original issue:
> This happens whenever MuJoCo raises a warning or error. This is not ideal, as it contaminates the workspace and Basilisk already has established logging practices. Standard Basilisk logging should be used in place of printing to a file.

To address this, we set the custom error/warning callbacks in MuJoCo to call `BSKLogger::bskLog`. For the case of the error callback, we also throw an exception (as the program is expected to be interrupted).

## Verification
Manually triggered erroneous behavior and asserted that no log file is created, but rather the logger is used. Feature is considered non-critical and small enough to not require a regtest.

## Documentation
Release notes updated.
