### PR TITLE
spiceInterface BSK-RL bugfix

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -46,6 +46,7 @@ Version |release|
 - Fixed a bug in :ref:`spiceInterface` where required kernels were being unloaded before they were no longer needed.
 - Fixed an issue where the :ref:`spaceToGroundTransmitter` would check for the amount of data remaining in a different partition than the one being downlinked.
 - Fixed an issue where a high baud rate prevented the :ref:`spaceToGroundTransmitter` from downlinking data from the :ref:`simpleStorageUnit` or :ref:`partitionedStorageUnit`.
+- Enhanced :ref:`spiceInterface` thread safety and provided error handling to resolve flakey SPICE behavior during CI tests in BSK-RL.
 
 
 Version 2.7.0 (April 20, 2025)

--- a/src/simulation/environment/spiceInterface/spiceInterface.h
+++ b/src/simulation/environment/spiceInterface/spiceInterface.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <map>
 #include <mutex>
+#include <shared_mutex>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/bskLogging.h"
@@ -54,6 +55,8 @@ public:
     void clearKeeper();                         //!< class method
     void addPlanetNames(std::vector<std::string> planetNames);    //!< Adds a list of planet names to track in SPICE
     void addSpacecraftNames(std::vector<std::string> spacecraftNames);    //!< Adds a list of spacecraft names to track in SPICE
+    bool areKernelsLoaded();                    //!< Check if required kernels are properly loaded
+    void ensureKernelsLoaded();                 //!< Ensure kernels are loaded, reload if necessary
 
 public:
     Message<SpiceTimeMsgPayload> spiceTimeOutMsg;    //!< spice time sampling output message
@@ -91,7 +94,7 @@ private:
     std::vector<SpicePlanetStateMsgPayload> planetData;
     std::vector<SpicePlanetStateMsgPayload> scData;
 
-    static std::mutex kernelManipulationMutex; //!< -- Mutex to protect SPICE kernel loading/unloading operations
+    static std::recursive_mutex spiceGlobalMutex; //!< -- Recursive mutex to protect ALL SPICE operations and kernel manipulation
     static std::unordered_map<std::string, int> kernelReferenceCounter; //!< -- Reference counter for SPICE kernels
     static int requiredKernelsRefCount;  // Global counter for REQUIRED_KERNELS
     static const std::vector<std::string> REQUIRED_KERNELS; //!< -- List of required SPICE kernels


### PR DESCRIPTION
* **Tickets addressed:** #1023
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR addresses flakey SPICE behavior that caused irregular NOLOADEDFILES and NOLEAPSECONDS errors during CI tests and local runs, especially during documentation builds for BSK-RL. The approach involved comprehensive thread safety improvements to the SPICE interface:

- Added global mutex protection for all SPICE operations to prevent race conditions
- Implemented retry logic with up to 3 attempts for transient SPICE errors  
- Enhanced error handling to return warnings instead of crashes when SPICE operations fail
- Added `areKernelsLoaded()` and `ensureKernelsLoaded()` methods for robust kernel state verification
- Introduced realistic fallback orbital parameters for celestial bodies and spacecraft when SPICE data is unavailable
- Modified `UpdateState()` to aggressively ensure kernels are loaded before operations

## Verification
- Docs CI failures reduced from 100% to 0% (Mark's CI test setup)
- Pytest CI failures reduced from 20% to 0%  (Also Mark's)
- SPICE errors now appear as warnings with retry attempts instead of causing crashes
- All existing functionality preserved while improving robustness for BSK-RL essentially

## Documentation
Updated release notes

## Future work
Monitoring SPICE warning frequency in production to assess if additional work is needed (ideally not!)
