### PR TITLE
Add six to build system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools>=70.1.0,<=78.1.0",   # Required for "bdist_wheel" to work correctly.
     "setuptools-scm>=8.0,<=8.2.1",  # Automatically include all Git-controlled files in sdist
     "packaging>=22,<=24.2",        # Due to incompatibility: https://github.com/pypa/setuptools/issues/4483
-
+    "six>=1.17.0",
     # Requirements for building Basilisk through conanfile
     "conan>=2.0.5,<=2.15.1",
     "cmake>=3.26,<4.0",


### PR DESCRIPTION
* **Tickets addressed:** bsk-1030
* **Review:** By commit 
* **Merge strategy:** Merge (no squash) 

## Description
Fixes a small bug encountered when installing this package via pip, ie `pip install git+https://github.com/AVSLab/basilisk.git`. The installation/build requires `six`, but this package is not declared in `build-system.requires`.

## Verification
Manual verification that this satisfies installation via `pip`.

The following command should successfully install basilisk into the current python environment:

`pip install git+https://github.com/jaypalm/basilisk.git@feature/bsk-1030--add-six-to-build-system.requires`

## Documentation
N/A

## Future work
This may assist continued efforts to simplify installation of this package, and adding it to PyPI
