### PR TITLE
Feature/bsk-1043: Active set allocation and bug fix in forceTorqueThrForceMapping

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -12,6 +12,7 @@ Version |release|
 -----------------
 - pip-based installation in editable mode using ``pip install -e .`` is not currently supported.
   Developers and users alike should continue to use ``python conanfile.py`` installation.
+- The ``Reset()`` function in :ref:`forceTorqueThrForceMapping` was not working properly. This has been addressed in the current release.
 
 
 Version 2.7.0

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -56,6 +56,7 @@ Version |release|
 - Added support for Vizard 2.3.0
 - Redirected MuJoCo errors and warnings to :ref:`bskLogging` instead of printing to file.
 - Support calling ``unsubscribe`` on input messages.
+- Fixed an issue where the :ref:`forceTorqueThrForceMapping` module's Reset() function did not zero all thruster settings correctly.
 
 
 Version 2.7.0 (April 20, 2025)

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,6 +1,6 @@
 breathe==4.36.0
 docutils==0.21.2
 recommonmark==0.7.1
-sphinx>7.0.0,=<8.2.3
+sphinx>7.0.0,<=8.2.3
 sphinx_rtd_theme>=3.0.0,<=3.0.2
 sphinx-copybutton==0.5.2

--- a/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/_UnitTest/test_forceTorqueThrForceMapping.py
+++ b/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/_UnitTest/test_forceTorqueThrForceMapping.py
@@ -60,11 +60,9 @@ def test_forceTorqueThrForceMapping1():
 
     CoM_B = [0.1, 0.1, 0.1]
 
-    truth = np.array([[0.7082, 0.5500, 0.0810, 0.1772, 0.6272, 0.6310, 0., 0.2582]])
-
     [testResults, testMessage] = forceTorqueThrForceMappingTestFunction(rcsLocationData, rcsDirectionData,
                                                                         requested_torque, requested_force, CoM_B,
-                                                                        truth, True)
+                                                                        True)
 
     assert testResults < 1, testMessage
 
@@ -102,11 +100,9 @@ def test_forceTorqueThrForceMapping2():
 
     requested_torque = [0.0, 0.0, 0.0]
 
-    truth = np.array([[0.5340, 0.5807, 0., 0.0588, 0.5088, 0.5500, 0.0307, 0.0840]])
-
     [testResults, testMessage] = forceTorqueThrForceMappingTestFunction(rcsLocationData, rcsDirectionData,
                                                                         requested_torque, requested_force, CoM_B,
-                                                                        truth, True)
+                                                                        True)
 
     assert testResults < 1, testMessage
 
@@ -144,11 +140,9 @@ def test_forceTorqueThrForceMapping3():
 
     requested_torque = [0.0, 0.0, 0.0]
 
-    truth = np.array([[0.5340, 0.5807, 0., 0.0588, 0.5088, 0.5500, 0.0307, 0.0840]])
-
     [testResults, testMessage] = forceTorqueThrForceMappingTestFunction(rcsLocationData, rcsDirectionData,
                                                                         requested_torque, requested_force, CoM_B,
-                                                                        truth, False)
+                                                                        False)
 
     assert testResults < 1, testMessage
 
@@ -192,16 +186,31 @@ def test_forceTorqueThrForceMapping4():
     requested_torque = [0.0, 0.0, 0.0]
     requested_force = [0.9, 1.1, 1.]
 
-    truth = np.array([[0.5050, 0.5550, 0.0300, 0.0300, 0., 0.0600, 0.0050, 0.0550, 0.5300, 0.5100, 0.5500, 0.5300]])
-
     [testResults, testMessage] = forceTorqueThrForceMappingTestFunction(rcsLocationData, rcsDirectionData,
                                                                         requested_torque, requested_force, CoM_B,
-                                                                        truth, True)
+                                                                        True)
     assert testResults < 1, testMessage
 
 
+def calculate_force_torque(thruster_forces, locations, directions, CoM_B):
+    """Calculate the resulting force and torque from thruster forces"""
+    total_force = np.zeros(3)
+    total_torque = np.zeros(3)
+
+    for i, force in enumerate(thruster_forces):
+        # Force contribution
+        force_vector = force * directions[i]
+        total_force += force_vector
+
+        # Torque contribution (r x F)
+        r_rel_com = locations[i] - CoM_B
+        torque_contribution = np.cross(r_rel_com, force_vector)
+        total_torque += torque_contribution
+
+    return total_torque, total_force
+
 def forceTorqueThrForceMappingTestFunction(rcsLocation, rcsDirection, requested_torque, requested_force, CoM_B,
-                                           truth, torqueInMsgFlag):
+                                           torqueInMsgFlag):
     """Test method"""
     testFailCount = 0
     testMessages = []
@@ -257,8 +266,42 @@ def forceTorqueThrForceMappingTestFunction(rcsLocation, rcsDirection, requested_
     unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))
     unitTestSim.ExecuteSimulation()
 
-    testFailCount, testMessages = unitTestSupport.compareArray(truth, np.array([module.thrForceCmdOutMsg.read().thrForce[0:len(rcsLocation)]]), 1e-3,
-                                                                 "CompareForces", testFailCount, testMessages)
+    # Get actual thruster forces
+    actual_thruster_forces = np.array(module.thrForceCmdOutMsg.read().thrForce[0:len(rcsLocation)])
+
+    actual_torque, actual_force = calculate_force_torque(
+        actual_thruster_forces,
+        np.array(rcsLocation),
+        np.array(rcsDirection),
+        np.array(CoM_B)
+    )
+
+    # Print detailed comparison
+    print(f"Requested torque: {requested_torque}")
+    print(f"Actual torque:    {actual_torque}")
+    print(f"Torque error:     {actual_torque - requested_torque}")
+    print(f"Requested force:  {requested_force}")
+    print(f"Actual force:     {actual_force}")
+    print(f"Force error:      {actual_force - requested_force}")
+    print(f"Thruster forces:  {actual_thruster_forces}")
+
+    # Validate thruster force constraints (0 <= force <= maxThrust)
+    for i, force in enumerate(actual_thruster_forces):
+        if force < -1e-10:
+            testFailCount += 1
+            testMessages.append(f"FAILED: Thruster {i} has negative force: {force}\n")
+        elif force > maxThrust + 1e-10:
+            testFailCount += 1
+            testMessages.append(f"FAILED: Thruster {i} exceeds max thrust ({maxThrust} N): {force}\n")
+
+    # Test force/torque accuracy using compareVector
+    tolerance = 1e-3
+    requested_torque_force = np.array([requested_torque + requested_force])
+    actual_torque_force = np.array([np.concatenate([actual_torque, actual_force])])
+
+    testFailCount, testMessages = unitTestSupport.compareVector(
+        requested_torque_force, actual_torque_force, tolerance,
+        "Force/Torque accuracy", testFailCount, testMessages)
 
     # First set a non-zero force/torque request
     cmdTorqueInMsgData.torqueRequestBody = [1.0, 0.5, 0.7]
@@ -277,11 +320,11 @@ def forceTorqueThrForceMappingTestFunction(rcsLocation, rcsDirection, requested_
     expectedForce = [0.] * messaging.MAX_EFF_CNT
     testFailCount, testMessages = unitTestSupport.compareVector(np.array(expectedForce),
                                                                 np.array(module.thrForceCmdOutMsg.read().thrForce),
-                                                                1e-3,
+                                                                tolerance,
                                                                 "Reset() zeroed thruster force",
                                                                 testFailCount, testMessages)
 
-    print("Accuracy used: 1e-3")
+    print(f"Accuracy used: {tolerance}")
 
     if testFailCount == 0:
         print("PASSED: " + module.ModelTag)
@@ -293,3 +336,6 @@ def forceTorqueThrForceMappingTestFunction(rcsLocation, rcsDirection, requested_
 
 if __name__ == "__main__":
     test_forceTorqueThrForceMapping1()
+    test_forceTorqueThrForceMapping2()
+    test_forceTorqueThrForceMapping3()
+    test_forceTorqueThrForceMapping4()

--- a/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/forceTorqueThrForceMapping.c
+++ b/src/fswAlgorithms/effectorInterfaces/forceTorqueThrForceMapping/forceTorqueThrForceMapping.c
@@ -159,7 +159,7 @@ void Update_forceTorqueThrForceMapping(forceTorqueThrForceMappingConfig *configD
     vSetZero(zeroVector, configData->numThrusters);
     numZeroes = 0;
     for(uint32_t j = 0; j < 6; j++) {
-        if (vIsEqual(zeroVector, 6, DG[j], 0.0000001)) {
+        if (vIsEqual(zeroVector, configData->numThrusters, DG[j], 0.0000001)) {
             zeroRows[j] = 1;
             numZeroes += 1;
         } else {
@@ -170,15 +170,13 @@ void Update_forceTorqueThrForceMapping(forceTorqueThrForceMappingConfig *configD
     /* Create the DG w/ zero rows removed */
     double DG_full[6*MAX_EFF_CNT];
     vSetZero(DG_full, (size_t) 6*MAX_EFF_CNT);
-    uint32_t zeroesPassed;
-    zeroesPassed = 0;
+    uint32_t row_idx = 0;
     for(uint32_t i = 0; i < 6; i++) {
         if (!zeroRows[i]) {
             for(uint32_t j = 0; j < MAX_EFF_CNT; j++) {
-                DG_full[MXINDEX(MAX_EFF_CNT, i-zeroesPassed, j)] = DG[i][j];
+                DG_full[MXINDEX(MAX_EFF_CNT, row_idx, j)] = DG[i][j];
             }
-        } else {
-            zeroesPassed += 1;
+            row_idx++;
         }
     }
 


### PR DESCRIPTION
* **Tickets addressed:** #1043 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

This PR addresses two issues in the `forceTorqueThrForceMapping` module:

1. **Bug fix:**
   Corrects the check for zero rows in the DG matrix, which previously used a hardcoded value instead of the actual number of thrusters. This ensures thrusters are zeroed out correctly based on the true system configuration.

2. Small code clean-up 

All changes are made in logically organised commits.

## Verification

* Updated the unit tests for `forceTorqueThrForceMapping` to compare the actual net force and torque produced by the allocated thruster forces, rather than checking for specific per-thruster values (since multiple valid allocations can exist).
* Introduced a new helper, `calculate_force_torque()`, to compute the resultant force and torque from the set of thruster outputs using standard physics equations.
* The tests now validate that the allocated solution produces the correct net force and torque (within tolerance), using `unitTestSupport.compareArray()`.
* All tests pass after these updates.

## Documentation

* Inline code comments have been updated for clarity.

## Future work

* Update public documentation to fully reflect the new algorithm and limitations.
* Additional unit tests could be added for edge cases.