### PR TITLE
Add ability to specify vizInterface data file name and path

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -55,6 +55,9 @@ Version |release|
 - Improve reading speed of recorded messages by about 75%.
 - Added support for Vizard 2.3.0
 - Redirected MuJoCo errors and warnings to :ref:`bskLogging` instead of printing to file.
+- Update :ref:`vizSupport`  for the ``saveFile`` argument to take an explicit
+  file path and file name and not auto-generate the ``_VizFiles`` sub-folder.  This provides the
+  user more direct control where and how the simulation data is saved.
 - Support calling ``unsubscribe`` on input messages.
 - Fixed an issue where the :ref:`forceTorqueThrForceMapping` module's Reset() function did not zero all thruster settings correctly.
 - Updated ``canary`` workflow to run on all pull requests to the develop branch, providing feedback on compatibility with latest dependencies.

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -226,6 +226,15 @@ void VizInterface::Reset(uint64_t CurrentSimNanos)
     this->FrameNumber=-1;
     if (this->saveFile) {
         this->outputStream = new std::ofstream(this->protoFilename, std::ios::out |std::ios::binary);
+
+        /* check if file could be opened */
+        if (!this->outputStream->is_open()) {
+            this->saveFile = false; // turn off save file flag
+            bskLogger.bskLog(BSK_ERROR, "VizInterface: Unable to open file %s for writing.", this->protoFilename.c_str());
+            return;
+        } else {
+            bskLogger.bskLog(BSK_INFORMATION, "VizInterface: Writing data to %s", this->protoFilename.c_str());
+        }
     }
 
     this->settings.dataFresh = true;        // reset flag to transmit Vizard settings

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -2036,7 +2036,6 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
             vizFileNamePath = filePath + '/_VizFiles/' + fileName + '_UnityViz.bin'
         vizMessenger.saveFile = True
         vizMessenger.protoFilename = vizFileNamePath
-        print("Saving Viz file to " + vizFileNamePath)
 
     if 'liveStream' in kwargs:
         val = kwargs['liveStream']

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -1583,8 +1583,10 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     Keyword Args
     ------------
     saveFile: str
-        can be a single file name, or a full path + file name. In both cases a local results are stored
-        in a local sub-folder.
+        can be a single python file name, or a full path + file name. In both cases a local results are stored
+        in a local sub-folder called ``_VizFiles``.
+        If a data file name is provided directly (i.e. it ends with ``.bin``), then the
+        associated file path and name are used explicitly.
         Default: empty string resulting in the data not being saved to a file
     rwEffectorList: single or list of ``ReactionWheelStateEffector``
         The list must have the same length ``scList``.  Each entry is the :ref:`ReactionWheelStateEffector` instance

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -2012,18 +2012,26 @@ def enableUnityVisualization(scSim, simTaskName, scList, **kwargs):
     vizMessenger.gravBodyInformation = vizInterface.GravBodyInfoVector(planetInfoList)
     vizMessenger.spiceInMsgs = messaging.SpicePlanetStateMsgInMsgsVector(spiceMsgList)
 
-    # note that the following logic can receive a single file name, or a full path + file name.
+    # note that the following logic can receive a single python file name, or a full path + file name.
     # In both cases a local results are stored in a local sub-folder.
+    # If a "*.bin" file is provided, then the provided path and name are used to store the data.
     vizMessenger.saveFile = False
     if 'saveFile' in kwargs:
         fileNamePath = kwargs['saveFile']
-        fileName = os.path.splitext(os.path.basename(fileNamePath))[0]
-        filePath = os.path.dirname(fileNamePath)
-        if filePath == "":
-            filePath = "."
-        if not os.path.isdir(filePath + '/_VizFiles'):
-            os.mkdir(filePath + '/_VizFiles')
-        vizFileNamePath = filePath + '/_VizFiles/' + fileName + '_UnityViz.bin'
+        if os.path.splitext(os.path.basename(fileNamePath))[1].lower()==".bin":
+            # here the provide file path, file name and file extension are used explicitly
+            vizFileNamePath = fileNamePath
+        else:
+            # here the file path and name string are split into file path and a file name
+            # next, the `_VizFiles` folder is created, if needed, and the binary data file
+            # has the name of the provided file name with `_UnityViz.bin` appended
+            fileName = os.path.splitext(os.path.basename(fileNamePath))[0]
+            filePath = os.path.dirname(fileNamePath)
+            if filePath == "":
+                filePath = "."
+            if not os.path.isdir(filePath + '/_VizFiles'):
+                os.mkdir(filePath + '/_VizFiles')
+            vizFileNamePath = filePath + '/_VizFiles/' + fileName + '_UnityViz.bin'
         vizMessenger.saveFile = True
         vizMessenger.protoFilename = vizFileNamePath
         print("Saving Viz file to " + vizFileNamePath)


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The `vizSupport.py` method `enableUnityVisualization()` has a string argument `saveFile`. This string should contain the path and file name to be used.  This was typically the scenario script file that is being passed along.  The script then created a local sub-folder called `_VizFiles` and put a data file in there with the file name and `_UnityViz.bin` added.

Now, if the `saveFile` argument contains a string with path and a binary data file name ending in `.bin`, then this path and file name are used without modification.  

## Verification
Manually Tested the argument and binary data files were created as expected. All unit tests passed.

## Documentation
Update release notes and the method documentation.

## Future work
None