### PR TITLE
Convert RW raw pointers to smart pointers

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -13,6 +13,8 @@ Version |release|
 - pip-based installation in editable mode using ``pip install -e .`` is not currently supported.
   Developers and users alike should continue to use ``python conanfile.py`` installation.
 - The ``Reset()`` function in :ref:`forceTorqueThrForceMapping` was not working properly. This has been addressed in the current release.
+- The reaction wheel configuration message was moved from C++ messages to the dynamics folder and renamed to :ref:`RWConfigPayload`.
+  The reaction wheel factory was changed accordingly. Users that created the message on their own should now call ``reactionWheelStateEffector.RWConfigPayload`` instead of ``messaging``.
 
 
 Version 2.7.0

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -62,6 +62,7 @@ Version |release|
 - Fixed an issue where the :ref:`forceTorqueThrForceMapping` module's Reset() function did not zero all thruster settings correctly.
 - Updated ``canary`` workflow to run on all pull requests to the develop branch, providing feedback on compatibility with latest dependencies.
 - Added links to published paper in :ref:`oneAxisSolarArrayPoint` documentation.
+- Converted RW data structures in ``reactionWheelStateEffector`` to shared pointers instead of raw pointers.
 
 
 Version 2.7.0 (April 20, 2025)

--- a/src/simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.h
@@ -24,10 +24,10 @@
 #include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
 
 
-/*! @brief Structure used to define the individual RW configuration data message*/
+/*! @brief Structure used to define the individual RW configuration data */
 typedef struct
 //@cond DOXYGEN_IGNORE
-RWConfigMsgPayload
+RWConfigPayload
 //@endcond
 {
     Eigen::Vector3d rWB_B;      //!< [m], position vector of the RW relative to the spacecraft body frame
@@ -69,7 +69,7 @@ RWConfigMsgPayload
     Eigen::Vector3d w2Hat_B;            //!< unit vector
     Eigen::Vector3d w3Hat_B;            //!< unit vector
     char label[10];             //!< [-], label name of the RW device being simulated
-}RWConfigMsgPayload;
+}RWConfigPayload;
 
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.i
+++ b/src/simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.i
@@ -1,0 +1,28 @@
+/*
+ ISC License
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+%module(package="Basilisk.simulation") RWConfigPayload
+%{
+    #include "simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.h"
+    #include <memory>
+%}
+
+%include "swig_common_model.i"
+
+%include <std_shared_ptr.i>
+%shared_ptr(RWConfigPayload)
+
+%include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
+%include "simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.h"

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_ConfigureRWRequests.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_ConfigureRWRequests.py
@@ -56,7 +56,7 @@ def writeNewRWCmds(self, u_cmd, numRW):
 
 
 def defaultReactionWheel():
-    RW = messaging.RWConfigMsgPayload()
+    RW = reactionWheelStateEffector.RWConfigPayload()
     RW.rWB_B = [[0.], [0.], [0.]]
     RW.gsHat_B = [[1.], [0.], [0.]]
     RW.w2Hat0_B = [[0.], [1.], [0.]]

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -65,7 +65,7 @@ void ReactionWheelStateEffector::registerStates(DynParamManager& states)
     //! zero the RW Omega and theta values (is there I should do this?)
     Eigen::MatrixXd omegasForInit(this->ReactionWheelData.size(),1);
 
-    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         const auto& rw = *ReactionWheelData[i];
         if (rw.RWModel == JitterSimple || rw.RWModel == JitterFullyCoupled) {
@@ -99,7 +99,7 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.IEffPrimePntB_B.setZero();
 
     int thetaCount = 0;
-    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
 		rw.Omega = this->OmegasState->getState()(i, 0);
@@ -287,7 +287,7 @@ void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vec
 	rDDotBNLoc_B = dcm_BN*rDDotBNLoc_N;
 
 	//! - Compute Derivatives
-    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
         if(rw.RWModel == JitterFullyCoupled || rw.RWModel == JitterSimple) {
@@ -407,7 +407,7 @@ void ReactionWheelStateEffector::Reset(uint64_t CurrenSimNanos)
  */
 void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
 {
-    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
         if (numRWJitter > 0) {
@@ -443,7 +443,7 @@ void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
  */
 void ReactionWheelStateEffector::writeOutputStateMessages(uint64_t integTimeNanos)
 {
-    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
         if (numRWJitter > 0) {
@@ -490,7 +490,7 @@ void ReactionWheelStateEffector::ReadInputs()
  */
 void ReactionWheelStateEffector::ConfigureRWRequests(double CurrentTime)
 {
-    for (int i = 0; i < NewRWCmds.size(); ++i)
+    for (std::size_t i = 0; i < NewRWCmds.size(); ++i)
 	{
         auto& cmd = NewRWCmds[i];
 		// Torque saturation

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -62,17 +62,16 @@ void ReactionWheelStateEffector::registerStates(DynParamManager& states)
     //! - Find number of RWs and number of RWs with jitter
     this->numRWJitter = 0;
     this->numRW = 0;
-    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
-    std::shared_ptr<RWConfigPayload> RWIt;
     //! zero the RW Omega and theta values (is there I should do this?)
     Eigen::MatrixXd omegasForInit(this->ReactionWheelData.size(),1);
 
-    for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++) {
-        RWIt = *RWItp;
-        if (RWIt->RWModel == JitterSimple || RWIt->RWModel == JitterFullyCoupled) {
+    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    {
+        const auto& rw = *ReactionWheelData[i];
+        if (rw.RWModel == JitterSimple || rw.RWModel == JitterFullyCoupled) {
             this->numRWJitter++;
         }
-        omegasForInit(RWItp - this->ReactionWheelData.begin(), 0) = RWIt->Omega;
+        omegasForInit(i, 0) = rw.Omega;
         this->numRW++;
     }
 
@@ -100,61 +99,60 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.IEffPrimePntB_B.setZero();
 
     int thetaCount = 0;
-    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
-    std::shared_ptr<RWConfigPayload>RWIt;
-	for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
-	{
-        RWIt = *RWItp;
-		RWIt->Omega = this->OmegasState->getState()(RWItp - ReactionWheelData.begin(), 0);
-		if (RWIt->RWModel == JitterFullyCoupled) {
-			RWIt->theta = this->thetasState->getState()(thetaCount, 0);
-			Eigen::Matrix3d dcm_WW0 = eigenM1(RWIt->theta);
+    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    {
+        auto& rw = *ReactionWheelData[i];
+		rw.Omega = this->OmegasState->getState()(i, 0);
+
+		if (rw.RWModel == JitterFullyCoupled) {
+			rw.theta = this->thetasState->getState()(thetaCount, 0);
+			Eigen::Matrix3d dcm_WW0 = eigenM1(rw.theta);
 			Eigen::Matrix3d dcm_BW0;
-			dcm_BW0.col(0) = RWIt->gsHat_B;
-			dcm_BW0.col(1) = RWIt->w2Hat0_B;
-			dcm_BW0.col(2) = RWIt->w3Hat0_B;
+			dcm_BW0.col(0) = rw.gsHat_B;
+			dcm_BW0.col(1) = rw.w2Hat0_B;
+			dcm_BW0.col(2) = rw.w3Hat0_B;
 			Eigen::Matrix3d dcm_BW = dcm_BW0 * dcm_WW0.transpose();
-			RWIt->w2Hat_B = dcm_BW.col(1);
-			RWIt->w3Hat_B = dcm_BW.col(2);
+			rw.w2Hat_B = dcm_BW.col(1);
+			rw.w3Hat_B = dcm_BW.col(2);
 
 			//! wheel inertia tensor about wheel center of mass represented in B frame
 			Eigen::Matrix3d IRWPntWc_W;
-			IRWPntWc_W << RWIt->Js, 0., RWIt->J13, \
-								0., RWIt->Jt, 0., \
-								RWIt->J13, 0., RWIt->Jg;
-			RWIt->IRWPntWc_B = dcm_BW * IRWPntWc_W * dcm_BW.transpose();
+			IRWPntWc_W << rw.Js, 0., rw.J13, \
+								0., rw.Jt, 0., \
+								rw.J13, 0., rw.Jg;
+			rw.IRWPntWc_B = dcm_BW * IRWPntWc_W * dcm_BW.transpose();
 
 			//! wheel inertia tensor body frame derivative about wheel center of mass represented in B frame
 			Eigen::Matrix3d IPrimeRWPntWc_W;
-			IPrimeRWPntWc_W << 0., -RWIt->J13, 0., \
-								-RWIt->J13, 0., 0., \
+			IPrimeRWPntWc_W << 0., -rw.J13, 0., \
+								-rw.J13, 0., 0., \
 								0., 0., 0.;
-			IPrimeRWPntWc_W *= RWIt->Omega;
-			RWIt->IPrimeRWPntWc_B = dcm_BW * IPrimeRWPntWc_W * dcm_BW.transpose();
+			IPrimeRWPntWc_W *= rw.Omega;
+			rw.IPrimeRWPntWc_B = dcm_BW * IPrimeRWPntWc_W * dcm_BW.transpose();
 
 			//! wheel center of mass location
-			RWIt->rWcB_B = RWIt->rWB_B + RWIt->d*RWIt->w2Hat_B;
-			RWIt->rTildeWcB_B = eigenTilde(RWIt->rWcB_B);
-			RWIt->rPrimeWcB_B = RWIt->d*RWIt->Omega*RWIt->w3Hat_B;
-			Eigen::Matrix3d rPrimeTildeWcB_B = eigenTilde(RWIt->rPrimeWcB_B);
+			rw.rWcB_B = rw.rWB_B + rw.d*rw.w2Hat_B;
+			rw.rTildeWcB_B = eigenTilde(rw.rWcB_B);
+			rw.rPrimeWcB_B = rw.d*rw.Omega*rw.w3Hat_B;
+			Eigen::Matrix3d rPrimeTildeWcB_B = eigenTilde(rw.rPrimeWcB_B);
 
 			//! - Give the mass of the reaction wheel to the effProps mass
-			this->effProps.mEff += RWIt->mass;
-			this->effProps.rEff_CB_B += RWIt->mass*RWIt->rWcB_B;
-			this->effProps.IEffPntB_B += RWIt->IRWPntWc_B + RWIt->mass*RWIt->rTildeWcB_B*RWIt->rTildeWcB_B.transpose();
-			this->effProps.rEffPrime_CB_B += RWIt->mass*RWIt->rPrimeWcB_B;
-			this->effProps.IEffPrimePntB_B += RWIt->IPrimeRWPntWc_B + RWIt->mass*rPrimeTildeWcB_B*RWIt->rTildeWcB_B.transpose() + RWIt->mass*RWIt->rTildeWcB_B*rPrimeTildeWcB_B.transpose();
+			this->effProps.mEff += rw.mass;
+			this->effProps.rEff_CB_B += rw.mass*rw.rWcB_B;
+			this->effProps.IEffPntB_B += rw.IRWPntWc_B + rw.mass*rw.rTildeWcB_B*rw.rTildeWcB_B.transpose();
+			this->effProps.rEffPrime_CB_B += rw.mass*rw.rPrimeWcB_B;
+			this->effProps.IEffPrimePntB_B += rw.IPrimeRWPntWc_B + rw.mass*rPrimeTildeWcB_B*rw.rTildeWcB_B.transpose() + rw.mass*rw.rTildeWcB_B*rPrimeTildeWcB_B.transpose();
             thetaCount++;
-		} else if (RWIt->RWModel == JitterSimple) {
-			RWIt->theta = this->thetasState->getState()(thetaCount, 0);
-			Eigen::Matrix3d dcm_WW0 = eigenM1(RWIt->theta);
+		} else if (rw.RWModel == JitterSimple) {
+			rw.theta = this->thetasState->getState()(thetaCount, 0);
+			Eigen::Matrix3d dcm_WW0 = eigenM1(rw.theta);
 			Eigen::Matrix3d dcm_BW0;
-			dcm_BW0.col(0) = RWIt->gsHat_B;
-			dcm_BW0.col(1) = RWIt->w2Hat0_B;
-			dcm_BW0.col(2) = RWIt->w3Hat0_B;
+			dcm_BW0.col(0) = rw.gsHat_B;
+			dcm_BW0.col(1) = rw.w2Hat0_B;
+			dcm_BW0.col(2) = rw.w3Hat0_B;
 			Eigen::Matrix3d dcm_BW = dcm_BW0 * dcm_WW0.transpose();
-			RWIt->w2Hat_B = dcm_BW.col(1);
-			RWIt->w3Hat_B = dcm_BW.col(2);
+			rw.w2Hat_B = dcm_BW.col(1);
+			rw.w3Hat_B = dcm_BW.col(2);
 			thetaCount++;
 		}
 	}
@@ -192,80 +190,78 @@ void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMa
 
 	omegaLoc_BN_B = omega_BN_B;
 
-    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
-    std::shared_ptr<RWConfigPayload> RWIt;
-	for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
-	{
-        RWIt = *RWItp;
-		OmegaSquared = RWIt->Omega * RWIt->Omega;
+    for (const auto & rwPtr : ReactionWheelData)
+    {
+        auto & rw = *rwPtr;
+		OmegaSquared = rw.Omega * rw.Omega;
 
         // Determine which friction model to use (if starting from zero include stribeck)
-        if (fabs(RWIt->Omega) < 0.10*RWIt->omegaLimitCycle && RWIt->betaStatic > 0) {
-            RWIt->frictionStribeck = 1;
+        if (fabs(rw.Omega) < 0.10*rw.omegaLimitCycle && rw.betaStatic > 0) {
+            rw.frictionStribeck = 1;
         }
-        double signOfOmega = ((RWIt->Omega > 0) - (RWIt->Omega < 0));
-        double omegaDot = RWIt->Omega - RWIt->omegaBefore;
+        double signOfOmega = ((rw.Omega > 0) - (rw.Omega < 0));
+        double omegaDot = rw.Omega - rw.omegaBefore;
         double signOfOmegaDot = ((omegaDot > 0) - (omegaDot < 0));
-        if (RWIt->frictionStribeck == 1 && abs(signOfOmega - signOfOmegaDot) < 2 && RWIt->betaStatic > 0) {
-            RWIt->frictionStribeck = 1;
+        if (rw.frictionStribeck == 1 && abs(signOfOmega - signOfOmegaDot) < 2 && rw.betaStatic > 0) {
+            rw.frictionStribeck = 1;
         } else {
-            RWIt->frictionStribeck = 0;
+            rw.frictionStribeck = 0;
         }
 
         double frictionForce;
         double frictionForceAtLimitCycle;
         // Friction model which uses static, stribeck, coulomb, and viscous friction models
-        if (RWIt->frictionStribeck == 1) {
-            frictionForce = sqrt(2.0*exp(1.0))*(RWIt->fStatic - RWIt->fCoulomb)*exp(-(RWIt->Omega/RWIt->betaStatic)*(RWIt->Omega/RWIt->betaStatic)/2.0)*RWIt->Omega/(RWIt->betaStatic*sqrt(2.0)) + RWIt->fCoulomb*tanh(RWIt->Omega*10.0/RWIt->betaStatic) + RWIt->cViscous*RWIt->Omega;
-            frictionForceAtLimitCycle = sqrt(2.0*exp(1.0))*(RWIt->fStatic - RWIt->fCoulomb)*exp(-(RWIt->omegaLimitCycle/RWIt->betaStatic)*(RWIt->omegaLimitCycle/RWIt->betaStatic)/2.0)*RWIt->omegaLimitCycle/(RWIt->betaStatic*sqrt(2.0)) + RWIt->fCoulomb*tanh(RWIt->omegaLimitCycle*10.0/RWIt->betaStatic) + RWIt->cViscous*RWIt->omegaLimitCycle;
+        if (rw.frictionStribeck == 1) {
+            frictionForce = sqrt(2.0*exp(1.0))*(rw.fStatic - rw.fCoulomb)*exp(-(rw.Omega/rw.betaStatic)*(rw.Omega/rw.betaStatic)/2.0)*rw.Omega/(rw.betaStatic*sqrt(2.0)) + rw.fCoulomb*tanh(rw.Omega*10.0/rw.betaStatic) + rw.cViscous*rw.Omega;
+            frictionForceAtLimitCycle = sqrt(2.0*exp(1.0))*(rw.fStatic - rw.fCoulomb)*exp(-(rw.omegaLimitCycle/rw.betaStatic)*(rw.omegaLimitCycle/rw.betaStatic)/2.0)*rw.omegaLimitCycle/(rw.betaStatic*sqrt(2.0)) + rw.fCoulomb*tanh(rw.omegaLimitCycle*10.0/rw.betaStatic) + rw.cViscous*rw.omegaLimitCycle;
         } else {
-            frictionForce = signOfOmega*RWIt->fCoulomb + RWIt->cViscous*RWIt->Omega;
-            frictionForceAtLimitCycle = RWIt->fCoulomb + RWIt->cViscous*RWIt->omegaLimitCycle;
+            frictionForce = signOfOmega*rw.fCoulomb + rw.cViscous*rw.Omega;
+            frictionForceAtLimitCycle = rw.fCoulomb + rw.cViscous*rw.omegaLimitCycle;
         }
 
         // This line avoids the limit cycle that can occur with friction
-        if (fabs(RWIt->Omega) < RWIt->omegaLimitCycle) {
-            frictionForce = frictionForceAtLimitCycle/RWIt->omegaLimitCycle*RWIt->Omega;
+        if (fabs(rw.Omega) < rw.omegaLimitCycle) {
+            frictionForce = frictionForceAtLimitCycle/rw.omegaLimitCycle*rw.Omega;
         }
 
         // Set friction force
-        RWIt->frictionTorque = -frictionForce;
+        rw.frictionTorque = -frictionForce;
 
-		if (RWIt->RWModel == BalancedWheels || RWIt->RWModel == JitterSimple) {
-			backSubContr.matrixD -= RWIt->Js * RWIt->gsHat_B * RWIt->gsHat_B.transpose();
-			backSubContr.vecRot -= RWIt->gsHat_B * (RWIt->u_current + RWIt->frictionTorque) + RWIt->Js*RWIt->Omega*omegaLoc_BN_B.cross(RWIt->gsHat_B);
+		if (rw.RWModel == BalancedWheels || rw.RWModel == JitterSimple) {
+			backSubContr.matrixD -= rw.Js * rw.gsHat_B * rw.gsHat_B.transpose();
+			backSubContr.vecRot -= rw.gsHat_B * (rw.u_current + rw.frictionTorque) + rw.Js*rw.Omega*omegaLoc_BN_B.cross(rw.gsHat_B);
 
 			//! imbalance torque (simplified external)
-			if (RWIt->RWModel == JitterSimple) {
+			if (rw.RWModel == JitterSimple) {
 				/* Fs = Us * Omega^2 */ // static imbalance force
-				tempF = RWIt->U_s * OmegaSquared * RWIt->w2Hat_B;
+				tempF = rw.U_s * OmegaSquared * rw.w2Hat_B;
 				backSubContr.vecTrans += tempF;
 
 				//! add in dynamic imbalance torque
 				/* tau_s = cross(r_B,Fs) */ // static imbalance torque
 				/* tau_d = Ud * Omega^2 */ // dynamic imbalance torque
-				backSubContr.vecRot += ( RWIt->rWB_B.cross(tempF) ) + ( RWIt->U_d*OmegaSquared * RWIt->w2Hat_B );
+				backSubContr.vecRot += ( rw.rWB_B.cross(tempF) ) + ( rw.U_d*OmegaSquared * rw.w2Hat_B );
 			}
-        } else if (RWIt->RWModel == JitterFullyCoupled) {
+        } else if (rw.RWModel == JitterFullyCoupled) {
 
-			omegas = RWIt->gsHat_B.transpose()*omegaLoc_BN_B;
-			omegaw2 = RWIt->w2Hat_B.transpose()*omegaLoc_BN_B;
-			omegaw3 = RWIt->w3Hat_B.transpose()*omegaLoc_BN_B;
+			omegas = rw.gsHat_B.transpose()*omegaLoc_BN_B;
+			omegaw2 = rw.w2Hat_B.transpose()*omegaLoc_BN_B;
+			omegaw3 = rw.w3Hat_B.transpose()*omegaLoc_BN_B;
 
-            gravityTorquePntW_B = RWIt->d*RWIt->w2Hat_B.cross(RWIt->mass*g_B);
+            gravityTorquePntW_B = rw.d*rw.w2Hat_B.cross(rw.mass*g_B);
 
-			dSquared = RWIt->d * RWIt->d;
+			dSquared = rw.d * rw.d;
 
-			RWIt->aOmega = -RWIt->mass*RWIt->d/(RWIt->Js + RWIt->mass*dSquared) * RWIt->w3Hat_B;
-			RWIt->bOmega = -1.0/(RWIt->Js + RWIt->mass*dSquared)*((RWIt->Js+RWIt->mass*dSquared)*RWIt->gsHat_B + RWIt->J13*RWIt->w3Hat_B + RWIt->mass*RWIt->d*RWIt->rWB_B.cross(RWIt->w3Hat_B));
-			RWIt->cOmega = 1.0/(RWIt->Js + RWIt->mass*dSquared)*(omegaw2*omegaw3*(-RWIt->mass*dSquared)-RWIt->J13*omegaw2*omegas-RWIt->mass*RWIt->d*RWIt->w3Hat_B.transpose()*omegaLoc_BN_B.cross(omegaLoc_BN_B.cross(RWIt->rWB_B))+(RWIt->u_current + RWIt->frictionTorque) + RWIt->gsHat_B.dot(gravityTorquePntW_B));
+			rw.aOmega = -rw.mass*rw.d/(rw.Js + rw.mass*dSquared) * rw.w3Hat_B;
+			rw.bOmega = -1.0/(rw.Js + rw.mass*dSquared)*((rw.Js+rw.mass*dSquared)*rw.gsHat_B + rw.J13*rw.w3Hat_B + rw.mass*rw.d*rw.rWB_B.cross(rw.w3Hat_B));
+			rw.cOmega = 1.0/(rw.Js + rw.mass*dSquared)*(omegaw2*omegaw3*(-rw.mass*dSquared)-rw.J13*omegaw2*omegas-rw.mass*rw.d*rw.w3Hat_B.transpose()*omegaLoc_BN_B.cross(omegaLoc_BN_B.cross(rw.rWB_B))+(rw.u_current + rw.frictionTorque) + rw.gsHat_B.dot(gravityTorquePntW_B));
 
-			backSubContr.matrixA += RWIt->mass * RWIt->d * RWIt->w3Hat_B * RWIt->aOmega.transpose();
-			backSubContr.matrixB += RWIt->mass * RWIt->d * RWIt->w3Hat_B * RWIt->bOmega.transpose();
-			backSubContr.matrixC += (RWIt->IRWPntWc_B*RWIt->gsHat_B + RWIt->mass*RWIt->d*RWIt->rWcB_B.cross(RWIt->w3Hat_B))*RWIt->aOmega.transpose();
-			backSubContr.matrixD += (RWIt->IRWPntWc_B*RWIt->gsHat_B + RWIt->mass*RWIt->d*RWIt->rWcB_B.cross(RWIt->w3Hat_B))*RWIt->bOmega.transpose();
-			backSubContr.vecTrans += RWIt->mass*RWIt->d*(OmegaSquared*RWIt->w2Hat_B - RWIt->cOmega*RWIt->w3Hat_B);
-			backSubContr.vecRot += RWIt->mass*RWIt->d*OmegaSquared*RWIt->rWcB_B.cross(RWIt->w2Hat_B) - RWIt->IPrimeRWPntWc_B*RWIt->Omega*RWIt->gsHat_B - omegaLoc_BN_B.cross(RWIt->IRWPntWc_B*RWIt->Omega*RWIt->gsHat_B+RWIt->mass*RWIt->rWcB_B.cross(RWIt->rPrimeWcB_B)) - (RWIt->IRWPntWc_B*RWIt->gsHat_B+RWIt->mass*RWIt->d*RWIt->rWcB_B.cross(RWIt->w3Hat_B))*RWIt->cOmega;
+			backSubContr.matrixA += rw.mass * rw.d * rw.w3Hat_B * rw.aOmega.transpose();
+			backSubContr.matrixB += rw.mass * rw.d * rw.w3Hat_B * rw.bOmega.transpose();
+			backSubContr.matrixC += (rw.IRWPntWc_B*rw.gsHat_B + rw.mass*rw.d*rw.rWcB_B.cross(rw.w3Hat_B))*rw.aOmega.transpose();
+			backSubContr.matrixD += (rw.IRWPntWc_B*rw.gsHat_B + rw.mass*rw.d*rw.rWcB_B.cross(rw.w3Hat_B))*rw.bOmega.transpose();
+			backSubContr.vecTrans += rw.mass*rw.d*(OmegaSquared*rw.w2Hat_B - rw.cOmega*rw.w3Hat_B);
+			backSubContr.vecRot += rw.mass*rw.d*OmegaSquared*rw.rWcB_B.cross(rw.w2Hat_B) - rw.IPrimeRWPntWc_B*rw.Omega*rw.gsHat_B - omegaLoc_BN_B.cross(rw.IRWPntWc_B*rw.Omega*rw.gsHat_B+rw.mass*rw.rWcB_B.cross(rw.rPrimeWcB_B)) - (rw.IRWPntWc_B*rw.gsHat_B+rw.mass*rw.d*rw.rWcB_B.cross(rw.w3Hat_B))*rw.cOmega;
 		}
 	}
 }
@@ -280,10 +276,7 @@ void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vec
 	Eigen::Matrix3d dcm_NB;                        /*! direction cosine matrix from B to N */
 	Eigen::Vector3d rDDotBNLoc_N;                  /*! second time derivative of rBN in N frame */
 	Eigen::Vector3d rDDotBNLoc_B;                  /*! second time derivative of rBN in B frame */
-	int RWi = 0;
     int thetaCount = 0;
-	std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
-    std::shared_ptr<RWConfigPayload>RWIt;
 
 	//! Grab necessarry values from manager
 	omegaDotBNLoc_B = omegaDot_BN_B;
@@ -294,40 +287,39 @@ void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vec
 	rDDotBNLoc_B = dcm_BN*rDDotBNLoc_N;
 
 	//! - Compute Derivatives
-	for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
-	{
-        RWIt = *RWItp;
-        if(RWIt->RWModel == JitterFullyCoupled || RWIt->RWModel == JitterSimple) {
+    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    {
+        auto& rw = *ReactionWheelData[i];
+        if(rw.RWModel == JitterFullyCoupled || rw.RWModel == JitterSimple) {
             // - Set trivial kinemetic derivative
-            thetasDot(thetaCount,0) = RWIt->Omega;
+            thetasDot(thetaCount,0) = rw.Omega;
             thetaCount++;
         }
-		if (RWIt->RWModel == BalancedWheels || RWIt->RWModel == JitterSimple) {
-			OmegasDot(RWi,0) = (RWIt->u_current + RWIt->frictionTorque)/RWIt->Js - RWIt->gsHat_B.transpose()*omegaDotBNLoc_B;
+		if (rw.RWModel == BalancedWheels || rw.RWModel == JitterSimple) {
+			OmegasDot(i,0) = (rw.u_current + rw.frictionTorque)/rw.Js - rw.gsHat_B.transpose()*omegaDotBNLoc_B;
 
             // Check for numerical instability due to excessive wheel acceleration
-            if (std::abs(OmegasDot(RWi,0)) > this->maxWheelAcceleration) {
-                bskLogger.bskLog(BSK_ERROR, "Excessive reaction wheel acceleration detected (%.2e rad/s^2). This may be caused by using unlimited torque (useMaxTorque=False) with a small spacecraft inertia. Consider using torque limits or increasing spacecraft inertia.", std::abs(OmegasDot(RWi,0)));
+            if (std::abs(OmegasDot(i,0)) > this->maxWheelAcceleration) {
+                bskLogger.bskLog(BSK_ERROR, "Excessive reaction wheel acceleration detected (%.2e rad/s^2). This may be caused by using unlimited torque (useMaxTorque=False) with a small spacecraft inertia. Consider using torque limits or increasing spacecraft inertia.", std::abs(OmegasDot(i,0)));
 
                 // Safety mechanism: limit the wheel acceleration to prevent numerical instability
-                OmegasDot(RWi,0) = std::copysign(this->maxWheelAcceleration, OmegasDot(RWi,0));
+                OmegasDot(i,0) = std::copysign(this->maxWheelAcceleration, OmegasDot(i,0));
 
                 // Recalculate the effective torque for consistency
-                double effectiveTorque = OmegasDot(RWi,0) * RWIt->Js + RWIt->gsHat_B.transpose()*omegaDotBNLoc_B;
-                RWIt->u_current = effectiveTorque - RWIt->frictionTorque;
+                double effectiveTorque = OmegasDot(i,0) * rw.Js + rw.gsHat_B.transpose()*omegaDotBNLoc_B;
+                rw.u_current = effectiveTorque - rw.frictionTorque;
             }
-        } else if(RWIt->RWModel == JitterFullyCoupled) {
-			OmegasDot(RWi,0) = RWIt->aOmega.dot(rDDotBNLoc_B) + RWIt->bOmega.dot(omegaDotBNLoc_B) + RWIt->cOmega;
+        } else if(rw.RWModel == JitterFullyCoupled) {
+			OmegasDot(i,0) = rw.aOmega.dot(rDDotBNLoc_B) + rw.bOmega.dot(omegaDotBNLoc_B) + rw.cOmega;
 
             // Check for numerical instability in fully coupled model as well
-            if (std::abs(OmegasDot(RWi,0)) > this->maxWheelAcceleration) {
-                bskLogger.bskLog(BSK_ERROR, "Excessive reaction wheel acceleration detected (%.2e rad/s^2). This may be caused by using unlimited torque (useMaxTorque=False) with a small spacecraft inertia. Consider using torque limits or increasing spacecraft inertia.", std::abs(OmegasDot(RWi,0)));
+            if (std::abs(OmegasDot(i,0)) > this->maxWheelAcceleration) {
+                bskLogger.bskLog(BSK_ERROR, "Excessive reaction wheel acceleration detected (%.2e rad/s^2). This may be caused by using unlimited torque (useMaxTorque=False) with a small spacecraft inertia. Consider using torque limits or increasing spacecraft inertia.", std::abs(OmegasDot(i,0)));
 
                 // Safety mechanism: limit the wheel acceleration to prevent numerical instability
-                OmegasDot(RWi,0) = std::copysign(this->maxWheelAcceleration, OmegasDot(RWi,0));
+                OmegasDot(i,0) = std::copysign(this->maxWheelAcceleration, OmegasDot(i,0));
             }
 		}
-		RWi++;
 	}
 
 	OmegasState->setDerivative(OmegasDot);
@@ -346,21 +338,19 @@ void ReactionWheelStateEffector::updateEnergyMomContributions(double integTime, 
 
     //! - Compute energy and momentum contribution of each wheel
     rotAngMomPntCContr_B.setZero();
-    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
-    std::shared_ptr<RWConfigPayload>RWIt;
-    for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
+    for (const auto & rwPtr : ReactionWheelData)
     {
-        RWIt = *RWItp;
-		if (RWIt->RWModel == BalancedWheels || RWIt->RWModel == JitterSimple) {
-			rotAngMomPntCContr_B += RWIt->Js*RWIt->gsHat_B*RWIt->Omega;
-            rotEnergyContr += 1.0/2.0*RWIt->Js*RWIt->Omega*RWIt->Omega + RWIt->Js*RWIt->Omega*RWIt->gsHat_B.dot(omegaLoc_BN_B);
-		} else if (RWIt->RWModel == JitterFullyCoupled) {
-			Eigen::Vector3d omega_WN_B = omegaLoc_BN_B + RWIt->Omega*RWIt->gsHat_B;
-			Eigen::Vector3d r_WcB_B = RWIt->rWcB_B;
-			Eigen::Vector3d rDot_WcB_B = RWIt->d*RWIt->Omega*RWIt->w3Hat_B + omegaLoc_BN_B.cross(RWIt->rWcB_B);
+        auto const& rw = *rwPtr;
+		if (rw.RWModel == BalancedWheels || rw.RWModel == JitterSimple) {
+			rotAngMomPntCContr_B += rw.Js*rw.gsHat_B*rw.Omega;
+            rotEnergyContr += 1.0/2.0*rw.Js*rw.Omega*rw.Omega + rw.Js*rw.Omega*rw.gsHat_B.dot(omegaLoc_BN_B);
+		} else if (rw.RWModel == JitterFullyCoupled) {
+			Eigen::Vector3d omega_WN_B = omegaLoc_BN_B + rw.Omega*rw.gsHat_B;
+			Eigen::Vector3d r_WcB_B = rw.rWcB_B;
+			Eigen::Vector3d rDot_WcB_B = rw.d*rw.Omega*rw.w3Hat_B + omegaLoc_BN_B.cross(rw.rWcB_B);
 
-			rotEnergyContr += 0.5*omega_WN_B.transpose()*RWIt->IRWPntWc_B*omega_WN_B + 0.5*RWIt->mass*rDot_WcB_B.dot(rDot_WcB_B);
-			rotAngMomPntCContr_B += RWIt->IRWPntWc_B*omega_WN_B + RWIt->mass*r_WcB_B.cross(rDot_WcB_B);
+			rotEnergyContr += 0.5*omega_WN_B.transpose()*rw.IRWPntWc_B*omega_WN_B + 0.5*rw.mass*rDot_WcB_B.dot(rDot_WcB_B);
+			rotAngMomPntCContr_B += rw.IRWPntWc_B*omega_WN_B + rw.mass*r_WcB_B.cross(rDot_WcB_B);
 		}
     }
 }
@@ -389,23 +379,20 @@ void ReactionWheelStateEffector::Reset(uint64_t CurrenSimNanos)
 
     //! - Clear out any currently firing RWs and re-init cmd array
     this->NewRWCmds.clear();
-    for (long unsigned int i=0; i<this->ReactionWheelData.size(); i++) {
-        this->NewRWCmds.push_back(RWCmdInitializer);
-    }
 
-    std::vector<std::shared_ptr<RWConfigPayload>>::iterator itp;
-    std::shared_ptr<RWConfigPayload>it;
-    for (itp = ReactionWheelData.begin(); itp != ReactionWheelData.end(); itp++)
+    for (const auto & rwPtr : ReactionWheelData)
     {
-        it = *itp;
-        if (it->betaStatic == 0.0)
+        this->NewRWCmds.push_back(RWCmdInitializer);
+
+        auto & rw = *rwPtr;
+        if (rw.betaStatic == 0.0)
         {
             bskLogger.bskLog(BSK_WARNING, "Stribeck coefficent currently zero and should be positive to active this friction model, or negative to turn it off!");
         }
         //! Define CoM offset d and off-diagonal inertia J13 if using fully coupled model
-        if (it->RWModel == JitterFullyCoupled) {
-            it->d = it->U_s/it->mass; //!< determine CoM offset from static imbalance parameter
-            it->J13 = it->U_d; //!< off-diagonal inertia is equal to dynamic imbalance parameter
+        if (rw.RWModel == JitterFullyCoupled) {
+            rw.d = rw.U_s/rw.mass; //!< determine CoM offset from static imbalance parameter
+            rw.J13 = rw.U_d; //!< off-diagonal inertia is equal to dynamic imbalance parameter
         }
     }
 
@@ -420,38 +407,32 @@ void ReactionWheelStateEffector::Reset(uint64_t CurrenSimNanos)
  */
 void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
 {
-    RWConfigPayload test;
-	RWConfigLogMsgPayload tmpRW;
-	std::vector<std::shared_ptr<RWConfigPayload>>::iterator itp;
-    std::shared_ptr<RWConfigPayload>it;
-    int c = 0;
-    for (itp = ReactionWheelData.begin(); itp != ReactionWheelData.end(); itp++)
-	{
-        it = *itp;
+    for (int i = 0; i < ReactionWheelData.size(); ++i)
+    {
+        auto& rw = *ReactionWheelData[i];
         if (numRWJitter > 0) {
-            it->theta = this->thetasState->getState()(itp - ReactionWheelData.begin(), 0);
+            rw.theta = this->thetasState->getState()(i, 0);
         }
-        it->Omega = this->OmegasState->getState()(itp - ReactionWheelData.begin(), 0);
+        rw.Omega = this->OmegasState->getState()(i, 0);
 
-        tmpRW = this->rwOutMsgs[c]->zeroMsgPayload;
-		tmpRW.theta = it->theta;
-		tmpRW.u_current = it->u_current;
-        tmpRW.frictionTorque = it->frictionTorque;
-		tmpRW.u_max = it->u_max;
-		tmpRW.u_min = it->u_min;
-		tmpRW.u_f = it->fCoulomb;
-		tmpRW.Omega = it->Omega;
-		tmpRW.Omega_max = it->Omega_max;
-		tmpRW.Js = it->Js;
-		tmpRW.U_s = it->U_s;
-		tmpRW.U_d = it->U_d;
-		tmpRW.RWModel = it->RWModel;
-        tmpRW.P_max = it->P_max;
-        eigenVector3d2CArray(it->gsHat_B, tmpRW.gsHat_B);
-        eigenVector3d2CArray(it->rWB_B, tmpRW.rWB_B);
-		// Write out config data for eachreaction wheel
-        this->rwOutMsgs[c]->write(&tmpRW, this->moduleID, CurrentClock);
-        c++;
+        RWConfigLogMsgPayload tmpRW = this->rwOutMsgs[i]->zeroMsgPayload;
+		tmpRW.theta = rw.theta;
+		tmpRW.u_current = rw.u_current;
+        tmpRW.frictionTorque = rw.frictionTorque;
+		tmpRW.u_max = rw.u_max;
+		tmpRW.u_min = rw.u_min;
+		tmpRW.u_f = rw.fCoulomb;
+		tmpRW.Omega = rw.Omega;
+		tmpRW.Omega_max = rw.Omega_max;
+		tmpRW.Js = rw.Js;
+		tmpRW.U_s = rw.U_s;
+		tmpRW.U_d = rw.U_d;
+		tmpRW.RWModel = rw.RWModel;
+        tmpRW.P_max = rw.P_max;
+        eigenVector3d2CArray(rw.gsHat_B, tmpRW.gsHat_B);
+        eigenVector3d2CArray(rw.rWB_B, tmpRW.rWB_B);
+		// Write out config data for each reaction wheel
+        this->rwOutMsgs[i]->write(&tmpRW, this->moduleID, CurrentClock);
 	}
 }
 
@@ -462,17 +443,15 @@ void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
  */
 void ReactionWheelStateEffector::writeOutputStateMessages(uint64_t integTimeNanos)
 {
-    std::vector<std::shared_ptr<RWConfigPayload>>::iterator itp;
-    std::shared_ptr<RWConfigPayload>it;
-    for (itp = ReactionWheelData.begin(); itp != ReactionWheelData.end(); itp++)
+    for (int i = 0; i < ReactionWheelData.size(); ++i)
     {
-        it = *itp;
+        auto& rw = *ReactionWheelData[i];
         if (numRWJitter > 0) {
-            it->theta = this->thetasState->getState()(itp - ReactionWheelData.begin(), 0);
-            this->rwSpeedMsgBuffer.wheelThetas[itp - ReactionWheelData.begin()] = it->theta;
+            rw.theta = this->thetasState->getState()(i, 0);
+            this->rwSpeedMsgBuffer.wheelThetas[i] = rw.theta;
         }
-        it->Omega = this->OmegasState->getState()(itp - ReactionWheelData.begin(), 0);
-        this->rwSpeedMsgBuffer.wheelSpeeds[itp - ReactionWheelData.begin()] = it->Omega;
+        rw.Omega = this->OmegasState->getState()(i, 0);
+        this->rwSpeedMsgBuffer.wheelSpeeds[i] = rw.Omega;
     }
 
     // Write this message once for all reaction wheels
@@ -511,55 +490,49 @@ void ReactionWheelStateEffector::ReadInputs()
  */
 void ReactionWheelStateEffector::ConfigureRWRequests(double CurrentTime)
 {
-	std::vector<RWCmdMsgPayload>::iterator CmdIt;
-	size_t RWIter = 0;
-
-	// loop through commands
-	for(CmdIt = NewRWCmds.begin(); CmdIt != NewRWCmds.end(); CmdIt++)
+    for (int i = 0; i < NewRWCmds.size(); ++i)
 	{
+        auto& cmd = NewRWCmds[i];
 		// Torque saturation
-		if (this->ReactionWheelData[RWIter]->u_max > 0) {
-			if(CmdIt->u_cmd > this->ReactionWheelData[RWIter]->u_max) {
-				CmdIt->u_cmd = this->ReactionWheelData[RWIter]->u_max;
-			} else if(CmdIt->u_cmd < -this->ReactionWheelData[RWIter]->u_max) {
-				CmdIt->u_cmd = -this->ReactionWheelData[RWIter]->u_max;
+		if (this->ReactionWheelData[i]->u_max > 0) {
+			if(cmd.u_cmd > this->ReactionWheelData[i]->u_max) {
+				cmd.u_cmd = this->ReactionWheelData[i]->u_max;
+			} else if(cmd.u_cmd < -this->ReactionWheelData[i]->u_max) {
+				cmd.u_cmd = -this->ReactionWheelData[i]->u_max;
 			}
 		} else {
             // Warning for unlimited torque with potentially small spacecraft
             static bool warningIssued = false;
-            if (!warningIssued && std::abs(CmdIt->u_cmd) > this->largeTorqueThreshold) {  // Threshold for "large" torque
+            if (!warningIssued && std::abs(cmd.u_cmd) > this->largeTorqueThreshold) {  // Threshold for "large" torque
                 bskLogger.bskLog(BSK_WARNING, "Using unlimited reaction wheel torque (u_max <= 0). This can cause numerical instability with small spacecraft inertia. Consider setting useMaxTorque=True or increasing spacecraft inertia.");
                 warningIssued = true;
             }
         }
 
 		// minimum torque
-		if (std::abs(CmdIt->u_cmd) < this->ReactionWheelData[RWIter]->u_min) {
-			CmdIt->u_cmd = 0.0;
+		if (std::abs(cmd.u_cmd) < this->ReactionWheelData[i]->u_min) {
+			cmd.u_cmd = 0.0;
 		}
 
         // Power saturation
-        if (this->ReactionWheelData[RWIter]->P_max > 0) {
-            if (std::abs(CmdIt->u_cmd * this->ReactionWheelData[RWIter]->Omega) >= this->ReactionWheelData[RWIter]->P_max) {
-                CmdIt->u_cmd = std::copysign(this->ReactionWheelData[RWIter]->P_max / this->ReactionWheelData[RWIter]->Omega, CmdIt->u_cmd);
+        if (this->ReactionWheelData[i]->P_max > 0) {
+            if (std::abs(cmd.u_cmd * this->ReactionWheelData[i]->Omega) >= this->ReactionWheelData[i]->P_max) {
+                cmd.u_cmd = std::copysign(this->ReactionWheelData[i]->P_max / this->ReactionWheelData[i]->Omega, cmd.u_cmd);
             }
         }
 
         // Speed saturation
-        if (std::abs(this->ReactionWheelData[RWIter]->Omega) >= this->ReactionWheelData[RWIter]->Omega_max
-            && this->ReactionWheelData[RWIter]->Omega_max > 0.0 /* negative Omega_max turns of wheel saturation modeling */
-            && this->ReactionWheelData[RWIter]->Omega * CmdIt->u_cmd >= 0.0 // check if torque would accelerate wheel speed beyond Omega_max
+        if (std::abs(this->ReactionWheelData[i]->Omega) >= this->ReactionWheelData[i]->Omega_max
+            && this->ReactionWheelData[i]->Omega_max > 0.0 /* negative Omega_max turns of wheel saturation modeling */
+            && this->ReactionWheelData[i]->Omega * cmd.u_cmd >= 0.0 // check if torque would accelerate wheel speed beyond Omega_max
             ) {
-            CmdIt->u_cmd = 0.0;
+            cmd.u_cmd = 0.0;
         }
 
-		this->ReactionWheelData[RWIter]->u_current = CmdIt->u_cmd; // save actual torque for reaction wheel motor
+		this->ReactionWheelData[i]->u_current = cmd.u_cmd; // save actual torque for reaction wheel motor
 
         // Save the previous omega for next time
-        this->ReactionWheelData[RWIter]->omegaBefore = this->ReactionWheelData[RWIter]->Omega;
-
-		RWIter++;
-
+        this->ReactionWheelData[i]->omegaBefore = this->ReactionWheelData[i]->Omega;
 	}
 }
 

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -33,8 +33,6 @@ ReactionWheelStateEffector::ReactionWheelStateEffector()
 
     this->nameOfReactionWheelOmegasState = "reactionWheelOmegas";
     this->nameOfReactionWheelThetasState = "reactionWheelThetas";
-
-    return;
 }
 
 
@@ -57,8 +55,6 @@ void ReactionWheelStateEffector::linkInStates(DynParamManager& statesIn)
 {
 	//! - Get access to the hub states
     this->g_N = statesIn.getPropertyReference(this->propName_vehicleGravity);
-
-	return;
 }
 
 void ReactionWheelStateEffector::registerStates(DynParamManager& states)
@@ -92,8 +88,6 @@ void ReactionWheelStateEffector::registerStates(DynParamManager& states)
         thetasForZeroing.setZero();
         this->thetasState->setState(thetasForZeroing);
     }
-
-    return;
 }
 
 void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
@@ -170,8 +164,6 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
         this->effProps.rEff_CB_B /= this->effProps.mEff;
         this->effProps.rEffPrime_CB_B /= this->effProps.mEff;
     }
-
-	return;
 }
 
 void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
@@ -276,7 +268,6 @@ void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMa
 			backSubContr.vecRot += RWIt->mass*RWIt->d*OmegaSquared*RWIt->rWcB_B.cross(RWIt->w2Hat_B) - RWIt->IPrimeRWPntWc_B*RWIt->Omega*RWIt->gsHat_B - omegaLoc_BN_B.cross(RWIt->IRWPntWc_B*RWIt->Omega*RWIt->gsHat_B+RWIt->mass*RWIt->rWcB_B.cross(RWIt->rPrimeWcB_B)) - (RWIt->IRWPntWc_B*RWIt->gsHat_B+RWIt->mass*RWIt->d*RWIt->rWcB_B.cross(RWIt->w3Hat_B))*RWIt->cOmega;
 		}
 	}
-	return;
 }
 
 void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
@@ -372,8 +363,6 @@ void ReactionWheelStateEffector::updateEnergyMomContributions(double integTime, 
 			rotAngMomPntCContr_B += RWIt->IRWPntWc_B*omega_WN_B + RWIt->mass*r_WcB_B.cross(rDot_WcB_B);
 		}
     }
-
-    return;
 }
 
 /*! add a RW data object to the reactionWheelStateEffector
@@ -464,8 +453,6 @@ void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
         this->rwOutMsgs[c]->write(&tmpRW, this->moduleID, CurrentClock);
         c++;
 	}
-
-    return;
 }
 
 /*! This method is here to write the output message structure into the specified

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -66,8 +66,8 @@ void ReactionWheelStateEffector::registerStates(DynParamManager& states)
     //! - Find number of RWs and number of RWs with jitter
     this->numRWJitter = 0;
     this->numRW = 0;
-    std::vector<RWConfigMsgPayload *>::iterator RWItp;
-    RWConfigMsgPayload * RWIt;
+    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
+    std::shared_ptr<RWConfigPayload> RWIt;
     //! zero the RW Omega and theta values (is there I should do this?)
     Eigen::MatrixXd omegasForInit(this->ReactionWheelData.size(),1);
 
@@ -106,8 +106,8 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.IEffPrimePntB_B.setZero();
 
     int thetaCount = 0;
-    std::vector<RWConfigMsgPayload *>::iterator RWItp;
-    RWConfigMsgPayload *RWIt;
+    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
+    std::shared_ptr<RWConfigPayload>RWIt;
 	for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
 	{
         RWIt = *RWItp;
@@ -200,8 +200,8 @@ void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMa
 
 	omegaLoc_BN_B = omega_BN_B;
 
-    std::vector<RWConfigMsgPayload *>::iterator RWItp;
-    RWConfigMsgPayload * RWIt;
+    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
+    std::shared_ptr<RWConfigPayload> RWIt;
 	for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
 	{
         RWIt = *RWItp;
@@ -291,8 +291,8 @@ void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vec
 	Eigen::Vector3d rDDotBNLoc_B;                  /*! second time derivative of rBN in B frame */
 	int RWi = 0;
     int thetaCount = 0;
-	std::vector<RWConfigMsgPayload *>::iterator RWItp;
-    RWConfigMsgPayload *RWIt;
+	std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
+    std::shared_ptr<RWConfigPayload>RWIt;
 
 	//! Grab necessarry values from manager
 	omegaDotBNLoc_B = omegaDot_BN_B;
@@ -355,8 +355,8 @@ void ReactionWheelStateEffector::updateEnergyMomContributions(double integTime, 
 
     //! - Compute energy and momentum contribution of each wheel
     rotAngMomPntCContr_B.setZero();
-    std::vector<RWConfigMsgPayload *>::iterator RWItp;
-    RWConfigMsgPayload *RWIt;
+    std::vector<std::shared_ptr<RWConfigPayload>>::iterator RWItp;
+    std::shared_ptr<RWConfigPayload>RWIt;
     for(RWItp=ReactionWheelData.begin(); RWItp!=ReactionWheelData.end(); RWItp++)
     {
         RWIt = *RWItp;
@@ -378,7 +378,7 @@ void ReactionWheelStateEffector::updateEnergyMomContributions(double integTime, 
 
 /*! add a RW data object to the reactionWheelStateEffector
  */
-void ReactionWheelStateEffector::addReactionWheel(RWConfigMsgPayload *NewRW)
+void ReactionWheelStateEffector::addReactionWheel(std::shared_ptr<RWConfigPayload> NewRW)
 {
     /* store the RW information */
     this->ReactionWheelData.push_back(NewRW);
@@ -404,8 +404,8 @@ void ReactionWheelStateEffector::Reset(uint64_t CurrenSimNanos)
         this->NewRWCmds.push_back(RWCmdInitializer);
     }
 
-    std::vector<RWConfigMsgPayload *>::iterator itp;
-    RWConfigMsgPayload *it;
+    std::vector<std::shared_ptr<RWConfigPayload>>::iterator itp;
+    std::shared_ptr<RWConfigPayload>it;
     for (itp = ReactionWheelData.begin(); itp != ReactionWheelData.end(); itp++)
     {
         it = *itp;
@@ -431,10 +431,10 @@ void ReactionWheelStateEffector::Reset(uint64_t CurrenSimNanos)
  */
 void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
 {
-    RWConfigMsgPayload test;
+    RWConfigPayload test;
 	RWConfigLogMsgPayload tmpRW;
-	std::vector<RWConfigMsgPayload *>::iterator itp;
-    RWConfigMsgPayload *it;
+	std::vector<std::shared_ptr<RWConfigPayload>>::iterator itp;
+    std::shared_ptr<RWConfigPayload>it;
     int c = 0;
     for (itp = ReactionWheelData.begin(); itp != ReactionWheelData.end(); itp++)
 	{
@@ -475,8 +475,8 @@ void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
  */
 void ReactionWheelStateEffector::writeOutputStateMessages(uint64_t integTimeNanos)
 {
-    std::vector<RWConfigMsgPayload *>::iterator itp;
-    RWConfigMsgPayload *it;
+    std::vector<std::shared_ptr<RWConfigPayload>>::iterator itp;
+    std::shared_ptr<RWConfigPayload>it;
     for (itp = ReactionWheelData.begin(); itp != ReactionWheelData.end(); itp++)
     {
         it = *itp;

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
@@ -31,7 +31,7 @@
 
 #include "architecture/msgPayloadDefC/RWSpeedMsgPayload.h"
 #include "architecture/msgPayloadDefC/RWCmdMsgPayload.h"
-#include "architecture/msgPayloadDefCpp/RWConfigMsgPayload.h"
+#include "simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.h"
 #include "architecture/msgPayloadDefC/RWConfigLogMsgPayload.h"
 #include "architecture/msgPayloadDefC/ArrayMotorTorqueMsgPayload.h"
 
@@ -57,14 +57,14 @@ public:
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
     void Reset(uint64_t CurrentSimNanos);
-    void addReactionWheel(RWConfigMsgPayload *NewRW);
+    void addReactionWheel(std::shared_ptr<RWConfigPayload> NewRW);
 	void UpdateState(uint64_t CurrentSimNanos);
 	void WriteOutputMessages(uint64_t CurrentClock);
 	void ReadInputs();
 	void ConfigureRWRequests(double CurrentTime);
 
 public:
-	std::vector<RWConfigMsgPayload *> ReactionWheelData;          //!< -- RW information
+	std::vector<std::shared_ptr<RWConfigPayload>> ReactionWheelData;          //!< -- RW information
 
 	ReadFunctor<ArrayMotorTorqueMsgPayload> rwMotorCmdInMsg;    //!< -- RW motor torque array cmd input message
 	Message<RWSpeedMsgPayload> rwSpeedOutMsg;                   //!< -- RW speed array output message

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.i
@@ -17,10 +17,8 @@
 
  */
 %module reactionWheelStateEffector
-
-
 %{
-   #include "reactionWheelStateEffector.h"
+    #include "reactionWheelStateEffector.h"
 %}
 
 %pythoncode %{
@@ -30,11 +28,18 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
 
+// Instantiate templates used by example
+%include "std_vector.i"
+namespace std {
+        %template(RWConfigVector) vector<std::shared_ptr<RWConfigPayload>>;
+}
+
 %include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 %include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"
+%import "simulation/dynamics/_GeneralModuleFiles/RWConfigPayload.i"
 %include "reactionWheelStateEffector.h"
 %include "architecture/utilities/macroDefinitions.h"
 
@@ -42,16 +47,14 @@ from Basilisk.architecture.swig_common_model import *
 struct RWSpeedMsg_C;
 %include "architecture/msgPayloadDefC/RWCmdMsgPayload.h"
 struct RWCmdMsg_C;
-%include "architecture/msgPayloadDefCpp/RWConfigMsgPayload.h"
 %include "architecture/msgPayloadDefC/RWConfigLogMsgPayload.h"
 struct RWConfigLogMsg_C;
 %include "architecture/msgPayloadDefC/ArrayMotorTorqueMsgPayload.h"
 struct ArrayMotorTorqueMsg_C;
 
-%include "std_vector.i"
-namespace std {
-    %template(RWConfigPointerVector) vector<RWConfigMsgPayload *, allocator<RWConfigMsgPayload *> >;
-}
+%pythoncode %{
+from Basilisk.simulation.RWConfigPayload import RWConfigPayload as RWConfigPayload
+%}
 
 %pythoncode %{
 import sys

--- a/src/simulation/thermal/motorThermal/_UnitTest/test_motorThermal.py
+++ b/src/simulation/thermal/motorThermal/_UnitTest/test_motorThermal.py
@@ -218,16 +218,6 @@ def motorThermalTest(show_plots, accuracy):
     unitTestSim.ExecuteSimulation()
     numTests += 1
 
-    # change the test conditions
-    thermalModel.currentTemperature = 20
-    thermalModel.ambientTemperature = 0
-    RW.useRWfriction = True
-
-    # run the second test (motor is hotter than ambient and friction is used)
-    unitTestSim.ConfigureStopTime(4*simulationTime)
-    unitTestSim.ExecuteSimulation()
-    numTests += 1
-
     #
     # retrieve the logged data
     #
@@ -238,13 +228,12 @@ def motorThermalTest(show_plots, accuracy):
     # set the truth vectors
     #
 
-    trueTemp = np.array([0.83985244, 1.67941113, 2.51867637, 3.35764846, 4.19632769,
-                         5.03471435, 5.87280873, 6.71061112, 7.54812182, 8.38534113, 0.86531353,
-                         1.73030786, 2.59498331, 3.45934019, 4.32337882, 5.18709952, 6.05050261,
-                         6.91358841, 7.77635723, 8.6388094, 20.83077463, 21.6612646, 22.49147018,
-                         23.32139167, 24.15102935, 24.9803835, 25.8094544, 26.63824235, 27.46674761,
-                         28.29497048, 20.83623573, 21.67218133, 22.50783709, 23.34320331, 24.17828028,
-                         25.01306827, 25.84756759, 26.68177852, 27.51570134, 28.34933636])
+    trueTemp = np.array([0.83985244, 1.67941113, 2.51867637, 3.35764846, 4.19632769, 5.03471435, 5.87280873,
+                         6.71061112, 7.54812182, 8.38534113,
+                         0.86531353, 1.73030786, 2.59498331, 3.45934019, 4.32337882, 5.18709952, 6.05050261,
+                         6.91358841, 7.77635723, 8.6388094,
+                         20.83077463, 21.6612646, 22.49147018, 23.32139167, 24.15102935, 24.9803835, 25.8094544,
+                         26.63824235, 27.46674761, 28.29497048])
 
     #
     # compare the module results to the true values

--- a/src/utilities/makeDraftModule.py
+++ b/src/utilities/makeDraftModule.py
@@ -697,7 +697,7 @@ def fillCppInfo(module):
     outMsgList = list()
     outMsgList.append({'type': 'AttRefMsg', 'var': 'some2OutMsg', 'desc': 'output msg description', 'wrap': 'C'})
     outMsgList.append({'type': 'SCStatesMsg', 'var': 'someOutMsg', 'desc': 'output msg description', 'wrap': 'C'})
-    outMsgList.append({'type': 'RWConfigMsg', 'var': 'anotherCppOutMsg', 'desc': 'output msg description', 'wrap': 'C++'})
+    outMsgList.append({'type': 'DataStorageStatusMsg', 'var': 'anotherCppOutMsg', 'desc': 'output msg description', 'wrap': 'C++'})
     module.outMsgList = outMsgList
 
     # provide list of module variables

--- a/src/utilities/simIncludeRW.py
+++ b/src/utilities/simIncludeRW.py
@@ -26,6 +26,7 @@ from collections import OrderedDict
 import numpy
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
+from Basilisk.simulation import reactionWheelStateEffector
 
 
 class rwFactory(object):
@@ -89,7 +90,7 @@ class rwFactory(object):
         """
 
         # create the blank RW object
-        RW = messaging.RWConfigMsgPayload()
+        RW = reactionWheelStateEffector.RWConfigPayload()
 
         # process optional input arguments
         if 'RWModel' in kwargs:


### PR DESCRIPTION
* **Tickets addressed:** #1065
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- What approach was taken to satisfy the ticket being addressed? What should reviewers be aware of? How are your
commits organized? -->
A while back the RW effectors were upgraded such that the RW configuration data could be changed on the fly in python.  This was doing by passing a raw pointer of the python-created structure to the C code.  This also mean the user had to ensure this python configuration structure remained in memory. With the thruster effector upgrade the use of smart-pointers was explored successfully.  This branch upgrades the RW effectors to now also use smart-pointers. 

The first commit changes raw pointers to shared pointers in the ``.h`` and ``.cpp`` files. The second commit makes sure SWIG wraps the structures as shared pointers and not raw pointers. The third commit fixes errors in Python where raw pointers were used. The last commit adds release notes.

## Verification
<!-- How were the changes validated? Were any automated tests added, updated, removed, or re-baselined? If you didn't 
add or update any tests justify this choice. -->
RW unit tests were converted accordingly. All tests should be passing.

## Documentation
<!-- What documentation was invalidated by these changes? Which artifacts should reviewers check for accuracy and 
completeness? -->
N/A.

## Future work
<!-- What next steps can we anticipate from here, if any? -->
N/A.
