### PR TITLE
Better initialization and printing of payloads

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
@@ -75,4 +75,28 @@ this method on both C and C++ wrapped message objects::
 
     msgCopy = msg.read()
 
+Message payloads can be printed to visualize their content::
 
+    payload = messaging.AlbedoMsgPayload(
+        AfluxAtInstrument=1.0,
+        AfluxAtInstrumentMax=2.0,
+        albedoAtInstrumentMax=3.0
+    )
+
+    print(payload)
+
+displays::
+
+    AlbedoMsgPayload(AfluxAtInstrument=1.0, AfluxAtInstrumentMax=2.0, albedoAtInstrument=0.0, albedoAtInstrumentMax=3.0)
+
+For large payloads, `pretty-printing <https://docs.python.org/3/library/pprint.html>`_ will perform automatic line breaks::
+
+    from pprint import pprint
+    pprint(payload)
+
+displays::
+
+    AlbedoMsgPayload(AfluxAtInstrument=1.0,
+                     AfluxAtInstrumentMax=2.0,
+                     albedoAtInstrument=0.0,
+                     albedoAtInstrumentMax=3.0)

--- a/docs/source/Learn/bskPrinciples/bskPrinciples-5.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-5.rst
@@ -29,6 +29,10 @@ Essentially this is a python instance of the message structure definition found 
 
     msgData.variable = .....
 
+You may also initalize fields on construction::
+
+    msgData = messaging.someMsgPayload(variable=...)
+
 Next, a message object is created and the message data is written to it.  The message object is created using::
 
     msg = messaging.someMsg()

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -73,6 +73,10 @@ Version |release|
 
     This is a breaking change, see list of known issues for details. Please report any issues
     (at buildtime or runtime) with recorders for custom payloads.
+- Support initialization of fields in the constructor of message payloads (in Python).
+- Improve string representation of message payloads (in Python).
+- Add support for pretty-printing message payloads (in Python).
+- Updated documentation and all scenarios to use new payload constructor format.
 
 
 Version 2.7.0 (April 20, 2025)

--- a/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
+++ b/docs/source/Vizard/vizardAdvanced/vizardSettings.rst
@@ -1581,8 +1581,7 @@ then lists of lists are required::
 
 Next, each light can be connected to the optional device status message of type :ref:`DeviceCmdMsgPayload`::
 
-        lightCmdMsgData = messaging.DeviceCmdMsgPayload()
-        lightCmdMsgData.deviceCmd = 1
+        lightCmdMsgData = messaging.DeviceCmdMsgPayload(deviceCmd = 1)
         lightCmdMsg = messaging.DeviceCmdMsg().write(lightCmdMsgData)
 
         cmdInMsg = messaging.DeviceCmdMsgReader()
@@ -1693,8 +1692,7 @@ a color message of type :ref:`ColorMsgPayload`, you use the argument ``trueOrbit
 and provide it the color message.  This could be the output of a BSK module, or a stand alone message.
 Here is sample code using a stand-alone message::
 
-    colorMsgContent = messaging.ColorMsgPayload()
-    colorMsgContent.colorRGBA = vizSupport.toRGBA255("Yellow")
+    colorMsgContent = messaging.ColorMsgPayload(colorRGBA = vizSupport.toRGBA255("Yellow"))
     colorMsg = messaging.ColorMsg().write(colorMsgContent)
 
     viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject

--- a/docs/source/codeSamples/bsk-5.py
+++ b/docs/source/codeSamples/bsk-5.py
@@ -46,8 +46,7 @@ def run():
     scSim.AddModelToTask("dynamicsTask", mod1)
 
     # create stand-alone input message
-    msgData = messaging.CModuleTemplateMsgPayload()
-    msgData.dataVector = [1., 2., 3.]
+    msgData = messaging.CModuleTemplateMsgPayload(dataVector = [1., 2., 3.])
     msg = messaging.CModuleTemplateMsg().write(msgData)
 
     # connect to stand-alone msg

--- a/examples/BskSim/models/BSK_FormationFsw.py
+++ b/examples/BskSim/models/BSK_FormationFsw.py
@@ -238,8 +238,11 @@ class BSKFswModels():
 
     def SetVehicleConfiguration(self):
         # use the same inertia in the FSW algorithm as in the simulation
-        vcData = messaging.VehicleConfigMsgPayload()
-        vcData.ISCPntB_B = [900.0, 0.0, 0.0, 0.0, 800.0, 0.0, 0.0, 0.0, 600.0]
+        vcData = messaging.VehicleConfigMsgPayload(ISCPntB_B=[
+            900.0, 0.0,   0.0,
+            0.0,   800.0, 0.0,
+            0.0,   0.0,   600.0
+        ])
         self.vcMsg = messaging.VehicleConfigMsg().write(vcData)
 
     def SetMRPFeedbackControl(self):

--- a/examples/BskSim/models/BSK_Fsw.py
+++ b/examples/BskSim/models/BSK_Fsw.py
@@ -324,8 +324,6 @@ class BSKFswModels:
 
     def SetCSSWlsEst(self, SimBase):
         """Set the FSW CSS configuration information """
-        cssConfig = messaging.CSSConfigMsgPayload()
-        totalCSSList = []
         nHat_B_vec = [
             [0.0, 0.707107, 0.707107],
             [0.707107, 0., 0.707107],
@@ -336,14 +334,16 @@ class BSKFswModels:
             [0., 0.258819, -0.965926],
             [0.707107, -0.353553, -0.612372]
         ]
-        for CSSHat in nHat_B_vec:
-            CSSConfigElement = messaging.CSSUnitConfigMsgPayload()
-            CSSConfigElement.CBias = 1.0
-            CSSConfigElement.nHat_B = CSSHat
-            totalCSSList.append(CSSConfigElement)
-        cssConfig.cssVals = totalCSSList
-
-        cssConfig.nCSS = len(nHat_B_vec)
+        cssConfig = messaging.CSSConfigMsgPayload(
+            nCSS = len(nHat_B_vec),
+            cssVals = [
+                messaging.CSSUnitConfigMsgPayload(
+                    CBias=1.0,
+                    nHat_B=CSSHat,
+                )
+                for CSSHat in nHat_B_vec
+            ]
+        )
         self.cssConfigMsg = messaging.CSSConfigMsg().write(cssConfig)
 
         self.cssWlsEst.cssDataInMsg.subscribeTo(SimBase.DynModels.CSSConstellationObject.constellationOutMsg)

--- a/examples/mujoco/scenarioAsteroidLanding.py
+++ b/examples/mujoco/scenarioAsteroidLanding.py
@@ -160,10 +160,8 @@ def run(showPlots: bool = False, visualize: bool = False):
 
     # Set a thruster force of 275 N trying to slowdown our descent
     thrust = 275 # N
-    thrustMsgPayload = messaging.SingleActuatorMsgPayload()
-    thrustMsgPayload.input = thrust
     thrustMsg = messaging.SingleActuatorMsg()
-    thrustMsg.write(thrustMsgPayload)
+    thrustMsg.write(messaging.SingleActuatorMsgPayload(input=thrust))
 
     scene.getSingleActuator("thrust").actuatorInMsg.subscribeTo(thrustMsg)
 
@@ -187,9 +185,7 @@ def run(showPlots: bool = False, visualize: bool = False):
     scSim.ExecuteSimulation()
 
     # Near surface, turn off thrusters and let gravity land us
-    thrustMsgPayload = messaging.SingleActuatorMsgPayload()
-    thrustMsgPayload.input = 0  # N
-    thrustMsg.write(thrustMsgPayload)
+    thrustMsg.write(messaging.SingleActuatorMsgPayload(input=0)) # N
 
     # Run until simulation completion
     scSim.ConfigureStopTime(macros.sec2nano(tf))
@@ -259,8 +255,7 @@ class ConstantGravity(sysModel.SysModel):
         dcm_BN = rbk.MRP2C(frame.sigma_BN)
         force_B = np.dot(dcm_BN, self.force_N)
 
-        payload = messaging.ForceAtSiteMsgPayload()
-        payload.force_S = force_B
+        payload = messaging.ForceAtSiteMsgPayload(force_S=force_B)
         self.forceOutMsg.write(payload, CurrentSimNanos, self.moduleID)
 
 

--- a/examples/mujoco/scenarioDeployPanels.py
+++ b/examples/mujoco/scenarioDeployPanels.py
@@ -441,8 +441,7 @@ class PIDController(StatefulSysModel.StatefulSysModel):
         self.integralErrorState.setDerivative([[stateError]])
 
         # Write the control output to the output message
-        payload = messaging.SingleActuatorMsgPayload()
-        payload.input = control_output
+        payload = messaging.SingleActuatorMsgPayload(input=control_output)
         self.outputOutMsg.write(payload, CurrentSimNanos, self.moduleID)
 
 

--- a/examples/mujoco/scenarioReactionWheel.py
+++ b/examples/mujoco/scenarioReactionWheel.py
@@ -169,10 +169,8 @@ def run(showPlots: bool = False, visualize: bool = False):
     # input to the system. In this case, the actuator is a motor
     # that applies a torque to the 'wheel_1' joint.
     torque = 2 # N*m
-    TorqueAtSiteMsgPayload = messaging.SingleActuatorMsgPayload()
-    TorqueAtSiteMsgPayload.input = torque
     torqueMsg = messaging.SingleActuatorMsg()
-    torqueMsg.write(TorqueAtSiteMsgPayload)
+    torqueMsg.write(messaging.SingleActuatorMsgPayload(input=torque))
 
     # Subscribe the actuator to the torque message.
     scene.getSingleActuator("wheel_1").actuatorInMsg.subscribeTo(torqueMsg)
@@ -210,9 +208,7 @@ def run(showPlots: bool = False, visualize: bool = False):
     scSim.ExecuteSimulation()
 
     # Change the torque to -2 N*m
-    TorqueAtSiteMsgPayload = messaging.SingleActuatorMsgPayload()
-    TorqueAtSiteMsgPayload.input = -torque
-    torqueMsg.write(TorqueAtSiteMsgPayload)
+    torqueMsg.write(messaging.SingleActuatorMsgPayload(input=-torque))
 
     # Run the simulation for another 60 seconds
     scSim.ConfigureStopTime(macros.sec2nano(2 * tf))

--- a/examples/mujoco/scenarioSRPInPanels.py
+++ b/examples/mujoco/scenarioSRPInPanels.py
@@ -364,8 +364,7 @@ class SRPPanel(sysModel.SysModel):
         cosAngle = np.dot(-normalVector_N, self.sunlightDirection_N)
         forceMagnitude = self.srpFactor * cosAngle**2
 
-        payload = messaging.SingleActuatorMsgPayload()
-        payload.input = forceMagnitude
+        payload = messaging.SingleActuatorMsgPayload(input=forceMagnitude)
         self.forceOutMsg.write(payload, CurrentSimNanos, self.moduleID)
 
 

--- a/examples/mujoco/scenarioSimpleDocking.py
+++ b/examples/mujoco/scenarioSimpleDocking.py
@@ -66,9 +66,7 @@ def setThrusterForce(
     """Writes the ``input`` argument of the given messages with
     the values in ``thrust``."""
     for msg, val in zip(msgs, thrust):
-        forceMsgPayload = messaging.SingleActuatorMsgPayload()
-        forceMsgPayload.input = val
-        msg.write(forceMsgPayload)
+        msg.write(messaging.SingleActuatorMsgPayload(input=val))
 
 
 def run(showPlots: bool = False, visualize: bool = False):

--- a/examples/mujoco/scenarioUnbalancedThrusters.py
+++ b/examples/mujoco/scenarioUnbalancedThrusters.py
@@ -124,10 +124,8 @@ def run(showPlots: bool = False, visualize: bool = False):
         # to define the force and torque vectors.
         # In this case, the gear is set to "0 0 -1 0 0 0", which
         # means that the force is applied along the negative z-axis.
-        thrustMsgPayload = messaging.SingleActuatorMsgPayload()
-        thrustMsgPayload.input = thrust
         thrustMsg = messaging.SingleActuatorMsg()
-        thrustMsg.write(thrustMsgPayload)
+        thrustMsg.write(messaging.SingleActuatorMsgPayload(input=thrust))
 
         actuatorName = f"tank_{i}_thrust"
 
@@ -141,10 +139,8 @@ def run(showPlots: bool = False, visualize: bool = False):
         # its time derivative. In this case, the mass of the tanks
         # is decreasing linearly with time, with the last tank
         # decreasing at twice the rate of the others.
-        mDotMsgPayload = messaging.SCMassPropsMsgPayload()
-        mDotMsgPayload.massSC = mDot if i < 4 else mDot * 2
         mDotMsg = messaging.SCMassPropsMsg()
-        mDotMsg.write(mDotMsgPayload)
+        mDotMsg.write(messaging.SCMassPropsMsgPayload(massSC=mDot if i < 4 else mDot * 2))
 
         bodyName = f"tank_{i}"
         body = scene.getBody(bodyName)

--- a/examples/scenarioAlbedo.py
+++ b/examples/scenarioAlbedo.py
@@ -185,8 +185,8 @@ def run(show_plots, albedoData, multipleInstrument, multiplePlanet, useEclipse, 
         simulationTimeStep = macros.sec2nano(simTimeStep)
     dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
     # Create sun message
-    sunPositionMsg = messaging.SpicePlanetStateMsgPayload()
-    sunPositionMsg.PositionVector = [-om.AU * 1000., 0.0, 0.0]
+    sunPositionMsg = messaging.SpicePlanetStateMsgPayload(PositionVector=[-om.AU * 1000., 0.0, 0.0])
+
     sunMsg = messaging.SpicePlanetStateMsg().write(sunPositionMsg)
 
     # Create planet message (earth)
@@ -197,18 +197,22 @@ def run(show_plots, albedoData, multipleInstrument, multiplePlanet, useEclipse, 
     planet1.isCentralBody = True  # ensure this is the central gravitational body
     req1 = planet1.radEquator
 
-    planetPositionMsg1 = messaging.SpicePlanetStateMsgPayload()
-    planetPositionMsg1.PositionVector = [0., 0., 0.]
-    planetPositionMsg1.PlanetName = planetCase1
-    planetPositionMsg1.J20002Pfix = np.identity(3)
+    planetPositionMsg1 = messaging.SpicePlanetStateMsgPayload(
+        PositionVector=[0., 0., 0.],
+        PlanetName=planetCase1,
+        J20002Pfix=np.identity(3),
+    )
+
     pl1Msg = messaging.SpicePlanetStateMsg().write(planetPositionMsg1)
     if multiplePlanet:
         # Create planet message (moon)
         planetCase2 = 'moon'
-        planetPositionMsg2 = messaging.SpicePlanetStateMsgPayload()
-        planetPositionMsg2.PositionVector = [0., 384400. * 1000, 0.]
-        planetPositionMsg2.PlanetName = planetCase2
-        planetPositionMsg2.J20002Pfix = np.identity(3)
+        planetPositionMsg2 = messaging.SpicePlanetStateMsgPayload(
+            PositionVector=[0., 384400. * 1000, 0.],
+            PlanetName=planetCase2,
+            J20002Pfix=np.identity(3),
+        )
+
         pl2Msg = messaging.SpicePlanetStateMsg().write(planetPositionMsg2)
 
     #

--- a/examples/scenarioAsteroidArrival.py
+++ b/examples/scenarioAsteroidArrival.py
@@ -427,8 +427,8 @@ def run(show_plots):
     attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
 
     # Create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Set up the MRP Feedback control module
@@ -484,11 +484,13 @@ def run(show_plots):
         scData.transceiverList = vizInterface.TransceiverVector([transceiverHUD])
         scData.genericSensorList = vizInterface.GenericSensorVector([genericSensor])
 
-        thrusterMsgInfo = messaging.THROutputMsgPayload()
-        thrusterMsgInfo.maxThrust = 1  # Newtons
-        thrusterMsgInfo.thrustForce = 0  # Newtons
-        thrusterMsgInfo.thrusterLocation = [0, 0, -1.5]
-        thrusterMsgInfo.thrusterDirection = [0, 0, 1]
+        thrusterMsgInfo = messaging.THROutputMsgPayload(
+            maxThrust=1,
+            thrustForce=0,
+            thrusterLocation=[0, 0, -1.5],
+            thrusterDirection=[0, 0, 1],
+        )
+
         thrMsg = messaging.THROutputMsg().write(thrusterMsgInfo)
         scData.thrInMsgs = messaging.THROutputMsgInMsgsVector([thrMsg.addSubscriber()])
 

--- a/examples/scenarioAttGuideHyperbolic.py
+++ b/examples/scenarioAttGuideHyperbolic.py
@@ -322,8 +322,8 @@ def run(show_plots, useAltBodyFrame):
     attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # setup the MRP Feedback control module

--- a/examples/scenarioAttLocPoint.py
+++ b/examples/scenarioAttLocPoint.py
@@ -284,8 +284,8 @@ def run(show_plots):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg)
 

--- a/examples/scenarioAttitudeConstrainedManeuver.py
+++ b/examples/scenarioAttitudeConstrainedManeuver.py
@@ -23,8 +23,8 @@ Overview
 This script sets up a 6-DOF spacecraft which is orbiting the Earth, in the presence of the Sun.
 The spacecraft is modelled according to the specifics of the Bevo-2 satellite, that has a sensitive
 star tracker aligned with the x body axis and two sun sensors aligned with the y and z body axes.
-In contrast with :ref:`scenarioAttitudeConstraintViolation` the goal of this scenario is to illustrate 
-how to set up a Basilisk simulation using the :ref:`constrainedAttitudeManeuver` module to perform a 
+In contrast with :ref:`scenarioAttitudeConstraintViolation` the goal of this scenario is to illustrate
+how to set up a Basilisk simulation using the :ref:`constrainedAttitudeManeuver` module to perform a
 slew maneuver while ensuring constraint compliance.
 
 The script is found in the folder ``basilisk/examples`` and executed by using::
@@ -32,15 +32,15 @@ The script is found in the folder ``basilisk/examples`` and executed by using::
       python3 scenarioAttitudeConstrainedManeuver.py
 
 This simulation is set up identically to :ref:`scenarioAttitudeConstraintViolation`. The reader is referred
-to this scenario for a detailed description of the setup. The only difference in this scenario is that the 
+to this scenario for a detailed description of the setup. The only difference in this scenario is that the
 constraint-naive :ref:`inertial3D` module for attitude pointing is replaced with the :ref:`constrainedAttitudeManeuver`
 module.
 
 Illustration of Simulation Results
 ----------------------------------
 
-Each run of the script produces 6 figures. Figures 1-4 report, respectively, attitude error, RW motor torque, rate 
-tracking error, and RW speed. These plots are only relevant to the spacecraft / RW dynamics. Figures 5 and 6 
+Each run of the script produces 6 figures. Figures 1-4 report, respectively, attitude error, RW motor torque, rate
+tracking error, and RW speed. These plots are only relevant to the spacecraft / RW dynamics. Figures 5 and 6
 show the angle between the boresight vector of the star tracker and the Sun (fig. 5), and of the sun sensor(s) and
 the Sun (fig. 6). Each plot features a dashed line that represents an angular threshold for that specific instrument.
 
@@ -53,8 +53,8 @@ using :ref:`constrainedAttitudeManeuver`, the constraints are not violated.
 
     show_plots = True, use2SunSensors = False, starTrackerFov = 20, sunSensorFov = 70, attitudeSetCase = 0
 
-This case features the violation of the keep in constraint of the sun sensor only when :ref:`inertial3D` is used. 
-Just for this case, only the sun sensor along the y body axis is considered. Now, the keep in constraint is not violated 
+This case features the violation of the keep in constraint of the sun sensor only when :ref:`inertial3D` is used.
+Just for this case, only the sun sensor along the y body axis is considered. Now, the keep in constraint is not violated
 as the boresight angle never exceeds the 70 def field of view of the instrument.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstrainedManeuver5020700.svg
@@ -67,7 +67,7 @@ as the boresight angle never exceeds the 70 def field of view of the instrument.
 
     show_plots = True, use2SunSensors = True, starTrackerFov = 20, sunSensorFov = 70, attitudeSetCase = 1
 
-In this case, using :ref:`inertial3D`, both the sun sensor boresights exceed the respective thresholds. 
+In this case, using :ref:`inertial3D`, both the sun sensor boresights exceed the respective thresholds.
 In this scenario, however, they do not.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstrainedManeuver5120701.svg
@@ -80,7 +80,7 @@ In this scenario, however, they do not.
 
     show_plots = True, use2SunSensors = True, starTrackerFov = 20, sunSensorFov = 70, attitudeSetCase = 2
 
-In this case, :ref:`inertial3D` violates the keep out constraint of the star tracker, alongside with the keep in 
+In this case, :ref:`inertial3D` violates the keep out constraint of the star tracker, alongside with the keep in
 constraints for both the sun sensors. The following simulation shows how all the constraints are respected.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstrainedManeuver5120702.svg
@@ -127,10 +127,10 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     simulationTime = macros.min2nano(3.5)
     simulationTimeStep = macros.sec2nano(0.01)
     dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
-    
+
     #
     # setup the simulation tasks/objects
-    # 
+    #
 
     # initialize spacecraft object and set properties
     scObject = spacecraft.Spacecraft()
@@ -179,7 +179,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     # sets of initial attitudes that yield the desired constraint violations (attitudeSetCase)
     sigma_BN_start = [ [0.522, -0.065,  0.539],     # to violate one keepIn only
                        [0.314, -0.251,  0.228],     # to violate two keepIn and not keepOut
-                       [-0.378, 0.119, -0.176],     # to violate keepOut and both keepIn 
+                       [-0.378, 0.119, -0.176],     # to violate keepOut and both keepIn
                        [-0.412, 0.044, -0.264] ]    # to violate keepOut only
 
     # To set the spacecraft initial conditions, the following initial position and velocity variables are set:
@@ -187,7 +187,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     scObject.hub.v_CN_NInit = vN  # m/s - v_BN_N
     scObject.hub.sigma_BNInit = sigma_BN_start[attitudeSetCase]  # MRP set to customize initial inertial attitude
     scObject.hub.omega_BN_BInit = [[0.], [0.], [0.]]             # rad/s - omega_CN_B
-    
+
     # define the simulation inertia
     I = [0.02 / 3,  0.,         0.,
          0.,        0.1256 / 3, 0.,
@@ -246,7 +246,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     # sets of initial attitudes that yield the desired constraint violations (attitudeSetCase)
     sigma_BN_target = [ [0.342,  0.223, -0.432],     # to violate one keepIn only
                         [0.326, -0.206, -0.823],     # to violate two keepIn and not keepOut
-                        [0.350,  0.220, -0.440],     # to violate keepOut and both keepIn 
+                        [0.350,  0.220, -0.440],     # to violate keepOut and both keepIn
                         [0.350,  0.220, -0.440] ]    # to violate keepOut only
 
     # setup readManeuver guidance module
@@ -285,7 +285,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     # Make the RW control all three body axes
     controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
-    
+
     # Boresight vector modules.
     stBACObject = boreAngCalc.BoreAngCalc()
     stBACObject.ModelTag = "starTrackerBoresight"
@@ -296,7 +296,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     ssyBACObject.ModelTag = "SunSensorBoresight"
     ssyBACObject.boreVec_B = [0., 1., 0.]  # boresight in body frame
     scSim.AddModelToTask(simTaskName, ssyBACObject)
-    
+
     if use2SunSensors:
         CAM.appendKeepInDirection([0,0,1], sunSensorFov*macros.D2R)
         sszBACObject = boreAngCalc.BoreAngCalc()
@@ -342,8 +342,8 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Setup the FSW RW configuration message.
@@ -365,7 +365,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(fswRwParamMsg)
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mrpControl.cmdTorqueOutMsg)
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
-    
+
     # Boresight modules
     stBACObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
     stBACObject.celBodyInMsg.subscribeTo(spiceObject.planetStateOutMsgs[1])
@@ -411,7 +411,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     dataSSyMissAngle = ssyBACOLog.missAngle
     if use2SunSensors:
         dataSSzMissAngle = sszBACOLog.missAngle
-    
+
     dataRW = []
     for i in range(numRW):
         dataRW.append(rwLogs[i].u_current)
@@ -419,8 +419,8 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     np.set_printoptions(precision=16)
 
 
-    # Displays the plots relative to the S/C attitude, maneuver, RW speeds and torques and boresight angles    
-    
+    # Displays the plots relative to the S/C attitude, maneuver, RW speeds and torques and boresight angles
+
     timeData = rwMotorLog.times() * macros.NANO2MIN
 
     plot_attitude_error(timeData, dataSigmaBR)
@@ -433,7 +433,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     figureList[pltName] = plt.figure(2)
 
     plot_rate_error(timeData, dataOmegaBR)
-    pltName = fileName + "3" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)     
+    pltName = fileName + "3" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)
     figureList[pltName] = plt.figure(3)
 
     plot_rw_speeds(timeData, dataOmegaRW, numRW)
@@ -443,7 +443,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     plot_st_miss_angle(timeData, dataSTMissAngle, starTrackerFov)
     pltName = fileName + "5" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)
     figureList[pltName] = plt.figure(5)
-        
+
     dataSS = [dataSSyMissAngle]
     if use2SunSensors:
         dataSS.append(dataSSzMissAngle)
@@ -451,7 +451,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     pltName = fileName + "6" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)
     figureList[pltName] = plt.figure(6)
 
-    if show_plots:  
+    if show_plots:
         plt.show()
 
     # close the plots being saved off to avoid over-writing old and new figures

--- a/examples/scenarioAttitudeConstraintViolation.py
+++ b/examples/scenarioAttitudeConstraintViolation.py
@@ -24,37 +24,37 @@ Demonstrates how to set up conical keep-in and keep-out constraints for a spacec
 This script sets up a 6-DOF spacecraft which is orbiting the Earth, in the presence of the Sun.
 The spacecraft is modelled according to the specifics of the Bevo-2 satellite, that has a sensitive
 star tracker aligned with the x body axis and two sun sensors aligned with the y and z body axes.
-The goal is to illustrate how to set up a Basilisk simulation to check whether certain slew 
+The goal is to illustrate how to set up a Basilisk simulation to check whether certain slew
 maneuvers cause violations in the positional constraints of the spacecraft.
 
 The script is found in the folder ``basilisk/examples`` and executed by using::
 
       python3 scenarioAttitudeConstraintViolation.py
 
-The main simulation layout is the same as in :ref:`scenarioAttitudeFeedbackRW`, shown in the following illustration.  
-A single simulation process is created which contains both the spacecraft simulation modules, as well as the Flight 
+The main simulation layout is the same as in :ref:`scenarioAttitudeFeedbackRW`, shown in the following illustration.
+A single simulation process is created which contains both the spacecraft simulation modules, as well as the Flight
 Software (FSW) algorithm modules.
 
 .. image:: /_images/static/test_scenarioAttitudeFeedbackRW.svg
    :align: center
 
-The spacecraft mass, inertia, and control gains in this example script have been designed to match the performance 
+The spacecraft mass, inertia, and control gains in this example script have been designed to match the performance
 of the Bevo 2 satellite. To better understand how to add RW to the Spacecraft Simulation to perform slew maneuvers
 from an initial to a final inertially fixed attitude, the reader is redirected to :ref:`scenarioAttitudeFeedbackRW`
 where this process is explained in the details.
 
 This script uses :ref:`simIncludeGravBody` to add Earth and Sun to the simulation. The method ``createSpiceInterface``
 to create Spice modules for the celestial bodies and generate the respective Spice planet state messages.
-The :ref:`boreAngCalc` module is set up for each of the instruments that have geometric angular constraints. This module 
+The :ref:`boreAngCalc` module is set up for each of the instruments that have geometric angular constraints. This module
 subscribes to the :ref:`SCStatesMsgPayload` and :ref:`SpicePlanetStateMsgPayload` of the bright object (the Sun) and
-returns a :ref:`BoreAngleMsgPayload` that contains the angle between the bright object and the direction of the 
+returns a :ref:`BoreAngleMsgPayload` that contains the angle between the bright object and the direction of the
 boresight vector of the instrument.
 
 Illustration of Simulation Results
 ----------------------------------
 
-Each run of the script produces 6 figures. Figures 1-4 report, respectively, attitude error, RW motor torque, rate 
-tracking error, and RW speed. These plots are only relevant to the spacecraft / RW dynamics. Figures 5 and 6 
+Each run of the script produces 6 figures. Figures 1-4 report, respectively, attitude error, RW motor torque, rate
+tracking error, and RW speed. These plots are only relevant to the spacecraft / RW dynamics. Figures 5 and 6
 show the angle between the boresight vector of the star tracker and the Sun (fig. 5), and of the sun sensor(s) and
 the Sun (fig. 6). Each plot features a dashed line that represents an angular threshold for that specific instrument.
 Opaque red zones in each plot represent the portions of each maneuver where that constraint has been violated.
@@ -68,7 +68,7 @@ constraint violation.
     show_plots = True, use2SunSensors = False, starTrackerFov = 20, sunSensorFov = 70, attitudeSetCase = 0
 
 This case features the violation of the keep in constraint of the sun sensor only. Just for this case, only the sun
-sensor along the y body axis is considered. The keep in constraint is violated when the boresight angle exceeds the 
+sensor along the y body axis is considered. The keep in constraint is violated when the boresight angle exceeds the
 70 def field of view of the instrument.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstraintViolation5020700.svg
@@ -81,8 +81,8 @@ sensor along the y body axis is considered. The keep in constraint is violated w
 
     show_plots = True, use2SunSensors = True, starTrackerFov = 20, sunSensorFov = 70, attitudeSetCase = 0
 
-This case is identical to the previous one, except for the fact that both sun sensors along the y and z body axes are 
-being used. No constraints are violated, since the keep in condition only needs to be satisfied for at least one sun 
+This case is identical to the previous one, except for the fact that both sun sensors along the y and z body axes are
+being used. No constraints are violated, since the keep in condition only needs to be satisfied for at least one sun
 sensor at  the time.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstraintViolation5120700.svg
@@ -95,7 +95,7 @@ sensor at  the time.
 
     show_plots = True, use2SunSensors = True, starTrackerFov = 20, sunSensorFov = 70, attitudeSetCase = 1
 
-In this case there is a portion of the slew maneuver where both the sun sensor boresights exceed the threshold, 
+In this case there is a portion of the slew maneuver where both the sun sensor boresights exceed the threshold,
 therefore the keep in constraint is violated.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstraintViolation5120701.svg
@@ -121,9 +121,9 @@ for both the sun sensors.
 
     show_plots = True, use2SunSensors = True, starTrackerFov = 30, sunSensorFov = 70, attitudeSetCase = 3
 
-In this last case, only the keep out constraint is violated. Since the fields of view of star tracker and 
-sun sensors for the Bevo 2 are, respectively, 20 deg and 70 deg, and they are mounted 90 deg apart from 
-each other on the spacecraft, this keep-out-only violation would not be possible. In this case it is 
+In this last case, only the keep out constraint is violated. Since the fields of view of star tracker and
+sun sensors for the Bevo 2 are, respectively, 20 deg and 70 deg, and they are mounted 90 deg apart from
+each other on the spacecraft, this keep-out-only violation would not be possible. In this case it is
 obtained by increasing the field of view of the star tracker to 30 deg.
 
 .. image:: /_images/Scenarios/scenarioAttitudeConstraintViolation5130703.svg
@@ -173,10 +173,10 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     simulationTime = macros.min2nano(1.5)
     simulationTimeStep = macros.sec2nano(0.5)
     dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
-    
+
     #
     # setup the simulation tasks/objects
-    # 
+    #
 
     # initialize spacecraft object and set properties
     scObject = spacecraft.Spacecraft()
@@ -224,19 +224,19 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     oe.f = 135 * macros.D2R
     rN, vN = orbitalMotion.elem2rv(mu, oe)
     oe = orbitalMotion.rv2elem(mu, rN, vN)
-	
+
 	# sets of initial attitudes that yield the desired constraint violations (attitudeSetCase)
     sigma_BN_start = [ [0.522, -0.065,  0.539],     # to violate one keepIn only
                        [0.314, -0.251,  0.228],     # to violate two keepIn and not keepOut
-                       [-0.378, 0.119, -0.176],     # to violate keepOut and both keepIn 
+                       [-0.378, 0.119, -0.176],     # to violate keepOut and both keepIn
                        [-0.412, 0.044, -0.264] ]    # to violate keepOut only
 
     # To set the spacecraft initial conditions, the following initial position and velocity variables are set:
     scObject.hub.r_CN_NInit = rN  # m   - r_BN_N
     scObject.hub.v_CN_NInit = vN  # m/s - v_BN_N
-    scObject.hub.sigma_BNInit = sigma_BN_start[attitudeSetCase]   # change this MRP set to customize initial inertial attitude        
+    scObject.hub.sigma_BNInit = sigma_BN_start[attitudeSetCase]   # change this MRP set to customize initial inertial attitude
     scObject.hub.omega_BN_BInit = [[0.], [0.], [0.]]              # rad/s - omega_CN_B
-    
+
     # define the simulation inertia
     I = [0.02 / 3,  0.,         0.,
          0.,        0.1256 / 3, 0.,
@@ -295,9 +295,9 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
   	# sets of initial attitudes that yield the desired constraint violations (attitudeSetCase)
     sigma_BN_target = [ [0.342,  0.223, -0.432],     # to violate one keepIn only
                         [0.326, -0.206, -0.823],     # to violate two keepIn and not keepOut
-                        [0.350,  0.220, -0.440],     # to violate keepOut and both keepIn 
+                        [0.350,  0.220, -0.440],     # to violate keepOut and both keepIn
                         [0.350,  0.220, -0.440] ]    # to violate keepOut only
-	
+
     # setup inertial3D guidance module
     inertial3DObj = inertial3D.inertial3D()
     inertial3DObj.ModelTag = "inertial3D"
@@ -328,7 +328,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     # Make the RW control all three body axes
     controlAxes_B = [1, 0, 0, 0, 1, 0, 0, 0, 1]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
-    
+
     # Boresight vector modules.
     stBACObject = boreAngCalc.BoreAngCalc()
     stBACObject.ModelTag = "starTrackerBoresight"
@@ -339,7 +339,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     ssyBACObject.ModelTag = "SunSensorBoresight"
     ssyBACObject.boreVec_B = [0., 1., 0.]  # boresight in body frame
     scSim.AddModelToTask(simTaskName, ssyBACObject)
-    
+
     if use2SunSensors:
         sszBACObject = boreAngCalc.BoreAngCalc()
         sszBACObject.ModelTag = "SunSensorBoresight"
@@ -380,8 +380,8 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Setup the FSW RW configuration message.
@@ -399,7 +399,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(fswRwParamMsg)
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mrpControl.cmdTorqueOutMsg)
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
-    
+
     # Boresight modules
     stBACObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
     stBACObject.celBodyInMsg.subscribeTo(spiceObject.planetStateOutMsgs[1])
@@ -449,7 +449,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     dataSSyMissAngle = ssyBACOLog.missAngle
     if use2SunSensors:
         dataSSzMissAngle = sszBACOLog.missAngle
-    
+
     dataRW = []
     for i in range(numRW):
         dataRW.append(rwLogs[i].u_current)
@@ -457,8 +457,8 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     np.set_printoptions(precision=16)
 
 
-    # Displays the plots relative to the S/C attitude, maneuver, RW speeds and torques and boresight angles    
-    
+    # Displays the plots relative to the S/C attitude, maneuver, RW speeds and torques and boresight angles
+
     timeData = rwMotorLog.times() * macros.NANO2MIN
 
     plot_attitude_error(timeData, dataSigmaBR)
@@ -471,7 +471,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     figureList[pltName] = plt.figure(2)
 
     plot_rate_error(timeData, dataOmegaBR)
-    pltName = fileName + "3" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)     
+    pltName = fileName + "3" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)
     figureList[pltName] = plt.figure(3)
 
     plot_rw_speeds(timeData, dataOmegaRW, numRW)
@@ -481,7 +481,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     plot_st_miss_angle(timeData, dataSTMissAngle, starTrackerFov)
     pltName = fileName + "5" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)
     figureList[pltName] = plt.figure(5)
-        
+
     dataSS = [dataSSyMissAngle]
     if use2SunSensors:
         dataSS.append(dataSSzMissAngle)
@@ -489,7 +489,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     pltName = fileName + "6" + str(int(use2SunSensors)) + str(starTrackerFov) + str(sunSensorFov) + str(attitudeSetCase)
     figureList[pltName] = plt.figure(6)
 
-    if show_plots:  
+    if show_plots:
         plt.show()
 
     # close the plots being saved off to avoid over-writing old and new figures

--- a/examples/scenarioAttitudeFeedback.py
+++ b/examples/scenarioAttitudeFeedback.py
@@ -302,8 +302,8 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     # The MRP Feedback algorithm requires the vehicle configuration structure. This defines various spacecraft
     # related states such as the inertia tensor and the position vector between the primary Body-fixed frame
     # B origin and the center of mass (defaulted to zero).  The message payload is created through
-    configData = messaging.VehicleConfigMsgPayload()
-    configData.ISCPntB_B = I
+    configData = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
+
     # Two methods are shown to create either a C++ or C wrapped msg object in python.  The
     # preferred method is to just create C++ wrapped messages.
     if not useCMsg:

--- a/examples/scenarioAttitudeFeedback2T.py
+++ b/examples/scenarioAttitudeFeedback2T.py
@@ -278,8 +278,8 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     #
 
     # create the FSW vehicle configuration message
-    configData = messaging.VehicleConfigMsgPayload()
-    configData.ISCPntB_B = I
+    configData = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
+
     configDataMsg = messaging.VehicleConfigMsg().write(configData)
 
     #

--- a/examples/scenarioAttitudeFeedback2T_TH.py
+++ b/examples/scenarioAttitudeFeedback2T_TH.py
@@ -601,8 +601,8 @@ def run(show_plots, useDVThrusters):
 
     # create the FSW vehicle configuration message
 
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # create the FSW Thruster configuration message

--- a/examples/scenarioAttitudeFeedback2T_stateEffTH.py
+++ b/examples/scenarioAttitudeFeedback2T_stateEffTH.py
@@ -511,8 +511,8 @@ def run(show_plots, useDVThrusters):
 
     # create the FSW vehicle configuration message
 
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # create the FSW Thruster configuration message

--- a/examples/scenarioAttitudeFeedbackNoEarth.py
+++ b/examples/scenarioAttitudeFeedbackNoEarth.py
@@ -244,8 +244,8 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # The primary difference is that the gravity body is not included.

--- a/examples/scenarioAttitudeFeedbackRW.py
+++ b/examples/scenarioAttitudeFeedbackRW.py
@@ -558,8 +558,8 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Two options are shown to setup the FSW RW configuration message.

--- a/examples/scenarioAttitudeFeedbackRWPower.py
+++ b/examples/scenarioAttitudeFeedbackRWPower.py
@@ -263,8 +263,8 @@ def run(show_plots, useRwPowerGeneration):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # make the FSW RW configuration message

--- a/examples/scenarioAttitudeGG.py
+++ b/examples/scenarioAttitudeGG.py
@@ -236,8 +236,8 @@ def run(show_plots):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # connect messages

--- a/examples/scenarioAttitudeGuidance.py
+++ b/examples/scenarioAttitudeGuidance.py
@@ -373,8 +373,8 @@ def run(show_plots, useAltBodyFrame):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg)
 

--- a/examples/scenarioAttitudePointing.py
+++ b/examples/scenarioAttitudePointing.py
@@ -219,8 +219,8 @@ def run(show_plots, useLargeTumble):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     #

--- a/examples/scenarioAttitudeSteering.py
+++ b/examples/scenarioAttitudeSteering.py
@@ -416,8 +416,8 @@ def run(show_plots, simCase):
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # FSW RW configuration message

--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -216,8 +216,8 @@ def run(show_plots, liveStream, broadcastStream, timeStep, orbitCase, useSpheric
     thrModelTag = "ACSThrusterDynamics"
     thFactory.addToSpacecraft(thrModelTag, thrusterSet, scObject)
 
-    thrMsgData = messaging.THRArrayOnTimeCmdMsgPayload()
-    thrMsgData.OnTimeRequest = [0, 0, 0]
+    thrMsgData = messaging.THRArrayOnTimeCmdMsgPayload(OnTimeRequest=[0, 0, 0])
+
     thrMsg = messaging.THRArrayOnTimeCmdMsg()
     thrMsg.write(thrMsgData)
     thrusterSet.cmdsInMsg.subscribeTo(thrMsg)

--- a/examples/scenarioBskLog.py
+++ b/examples/scenarioBskLog.py
@@ -84,8 +84,8 @@ def run(case):
 
     # Create input message and size it because the regular creator of that message
     # is not part of the test.
-    inputMessageData = messaging.CModuleTemplateMsgPayload()  # Create a structure for the input message
-    inputMessageData.dataVector = [1.0, 1.0, 0.7]  # Set up a list as a 3-vector
+    # Set up a list as a 3-vector
+    inputMessageData = messaging.CModuleTemplateMsgPayload(dataVector=[1.0, 1.0, 0.7])
     dataMsg = messaging.CModuleTemplateMsg().write(inputMessageData)
 
     # Construct algorithm and associated C++ container

--- a/examples/scenarioCSS.py
+++ b/examples/scenarioCSS.py
@@ -242,13 +242,11 @@ def run(show_plots, useCSSConstellation, usePlatform, useEclipse, useKelly):
     #
     # create simulation messages
     #
-    sunPositionMsgData = messaging.SpicePlanetStateMsgPayload()
-    sunPositionMsgData.PositionVector = [0.0, om.AU*1000.0, 0.0]
+    sunPositionMsgData = messaging.SpicePlanetStateMsgPayload(PositionVector=[0.0, om.AU*1000.0, 0.0])
     sunPositionMsg = messaging.SpicePlanetStateMsg().write(sunPositionMsgData)
 
     if useEclipse:
-        eclipseMsgData = messaging.EclipseMsgPayload()
-        eclipseMsgData.shadowFactor = 0.5
+        eclipseMsgData = messaging.EclipseMsgPayload(shadowFactor=0.5)
         eclipseMsg = messaging.EclipseMsg().write(eclipseMsgData)
 
     def setupCSS(CSS):

--- a/examples/scenarioCSSFilters.py
+++ b/examples/scenarioCSSFilters.py
@@ -469,17 +469,16 @@ def run(saveFigures, show_plots, FilterType, simTime):
     #
     #   add the FSW CSS information
     #
-    cssConstVehicle = messaging.CSSConfigMsgPayload()
-
-    totalCSSList = []
-    for CSSHat in CSSOrientationList:
-        newCSS = messaging.CSSUnitConfigMsgPayload()
-        newCSS.nHat_B = CSSHat
-        newCSS.CBias = 1.0
-        totalCSSList.append(newCSS)
-    cssConstVehicle.nCSS = len(CSSOrientationList)
-    cssConstVehicle.cssVals = totalCSSList
-
+    cssConstVehicle = messaging.CSSConfigMsgPayload(
+        nCSS = len(CSSOrientationList),
+        cssVals = [
+            messaging.CSSUnitConfigMsgPayload(
+                nHat_B=CSSHat,
+                CBias=1.0,
+            )
+            for CSSHat in CSSOrientationList
+        ]
+    )
     cssConstMsg = messaging.CSSConfigMsg().write(cssConstVehicle)
 
     #

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -136,12 +136,10 @@ def run(show_plots):
     scSim.AddModelToTask(dynTaskName, scObjectDebris)
 
     # Create VehicleConfig messages including the S/C mass (for etSphericalControl)
-    servicerConfigOutData = messaging.VehicleConfigMsgPayload()
-    servicerConfigOutData.massSC = scObjectServicer.hub.mHub
+    servicerConfigOutData = messaging.VehicleConfigMsgPayload(massSC=scObjectServicer.hub.mHub)
     servicerVehicleConfigMsg = messaging.VehicleConfigMsg().write(servicerConfigOutData)
 
-    debrisConfigOutData = messaging.VehicleConfigMsgPayload()
-    debrisConfigOutData.massSC = scObjectDebris.hub.mHub
+    debrisConfigOutData = messaging.VehicleConfigMsgPayload(massSC=scObjectDebris.hub.mHub)
     debrisVehicleConfigMsg = messaging.VehicleConfigMsg().write(debrisConfigOutData)
 
     # clear prior gravitational body and SPICE setup definitions
@@ -162,12 +160,12 @@ def run(show_plots):
     scSim.AddModelToTask(dynTaskName, MSMmodule)
 
     # define electric potentials
-    voltServicerInMsgData = messaging.VoltMsgPayload()
-    voltServicerInMsgData.voltage = 25000.  # [V] servicer potential
+    voltServicerInMsgData = messaging.VoltMsgPayload(voltage=25000.)
+  # [V] servicer potential
     voltServicerInMsg = messaging.VoltMsg().write(voltServicerInMsgData)
 
-    voltDebrisInMsgData = messaging.VoltMsgPayload()
-    voltDebrisInMsgData.voltage = -25000.  # [V] debris potential
+    voltDebrisInMsgData = messaging.VoltMsgPayload(voltage=-25000.)
+  # [V] debris potential
     voltDebrisInMsg = messaging.VoltMsg().write(voltDebrisInMsgData)
 
     # create a list of sphere body-fixed locations and associated radii

--- a/examples/scenarioDeployingSolarArrays.py
+++ b/examples/scenarioDeployingSolarArrays.py
@@ -453,10 +453,11 @@ def run(show_plots):
         array1MaxRotAccelList2.append(thetaDDotMax)
 
     # Update the array 1 stand-alone element translational state messages
-    array1ElementTranslationMessageData = messaging.PrescribedTranslationMsgPayload()
-    array1ElementTranslationMessageData.r_PM_M = r_PM1_M1Init2  # [m]
-    array1ElementTranslationMessageData.rPrime_PM_M = np.array([0.0, 0.0, 0.0])  # [m/s]
-    array1ElementTranslationMessageData.rPrimePrime_PM_M = np.array([0.0, 0.0, 0.0])  # [m/s^2]
+    array1ElementTranslationMessageData = messaging.PrescribedTranslationMsgPayload(
+        r_PM_M=r_PM1_M1Init2,   # [m]
+        rPrime_PM_M=np.array([0.0, 0.0, 0.0]),  # [m/s]
+        rPrimePrime_PM_M=np.array([0.0, 0.0, 0.0]),  # [m/s^2]
+    )
     array1ElementTranslationMessage = messaging.PrescribedTranslationMsg().write(array1ElementTranslationMessageData)
 
     array1ElementRefMsgList2 = list()
@@ -469,9 +470,10 @@ def run(show_plots):
         array1RotProfilerList[i].setThetaInit(array1ThetaInit2)  # [rad]
         array1RotProfilerList[i].setThetaDDotMax(array1MaxRotAccelList2[i])  # [rad/s^2]
 
-        array1ElementMessageData = messaging.HingedRigidBodyMsgPayload()
-        array1ElementMessageData.theta = (36 * i * macros.D2R) + array1ThetaInit2  # [rad]
-        array1ElementMessageData.thetaDot = 0.0  # [rad/s]
+        array1ElementMessageData = messaging.HingedRigidBodyMsgPayload(
+            theta=(36 * i * macros.D2R) + array1ThetaInit2,  # [rad]
+            thetaDot=0.0,  # [rad/s]
+        )
         array1ElementRefMsgList2.append(messaging.HingedRigidBodyMsg().write(array1ElementMessageData))
 
         array1RotProfilerList[i].spinningBodyInMsg.subscribeTo(array1ElementRefMsgList2[i])
@@ -493,9 +495,10 @@ def run(show_plots):
     for i in range(num_elements):
         array2RotProfilerList[i].setThetaDDotMax(array2MaxRotAccelList2[i])  # [rad/s^2]
 
-        array2ElementMessageData = messaging.HingedRigidBodyMsgPayload()
-        array2ElementMessageData.theta = array2ThetaInit2  # [rad]
-        array2ElementMessageData.thetaDot = 0.0  # [rad/s]
+        array2ElementMessageData = messaging.HingedRigidBodyMsgPayload(
+            theta=array2ThetaInit2,  # [rad]
+            thetaDot=0.0,   # [rad/s]
+        )
         array2ElementRefMsgList2.append(messaging.HingedRigidBodyMsg().write(array2ElementMessageData))
 
         array2RotProfilerList[i].spinningBodyInMsg.subscribeTo(array2ElementRefMsgList2[i])
@@ -514,10 +517,11 @@ def run(show_plots):
         array2MaxRotAccelList3.append(thetaDDotMax)
 
     # Update the array 2 stand-alone element translational state messages
-    array2ElementTranslationMessageData = messaging.PrescribedTranslationMsgPayload()
-    array2ElementTranslationMessageData.r_PM_M = r_PM2_M2Init2  # [m]
-    array2ElementTranslationMessageData.rPrime_PM_M = np.array([0.0, 0.0, 0.0])  # [m/s]
-    array2ElementTranslationMessageData.rPrimePrime_PM_M = np.array([0.0, 0.0, 0.0])  # [m/s^2]
+    array2ElementTranslationMessageData = messaging.PrescribedTranslationMsgPayload(
+        r_PM_M=r_PM2_M2Init2,   # [m]
+        rPrime_PM_M=np.array([0.0, 0.0, 0.0]),   # [m/s]
+        rPrimePrime_PM_M=np.array([0.0, 0.0, 0.0]),   # [m/s^2]
+    )
     array2ElementTranslationMessage = messaging.PrescribedTranslationMsg().write(array2ElementTranslationMessageData)
 
     array2ElementRefMsgList3 = list()
@@ -530,9 +534,10 @@ def run(show_plots):
         array2RotProfilerList[i].setThetaInit(array2ThetaInit2)  # [rad]
         array2RotProfilerList[i].setThetaDDotMax(array2MaxRotAccelList3[i])  # [rad/s^2]
 
-        array2ElementMessageData = messaging.HingedRigidBodyMsgPayload()
-        array2ElementMessageData.theta = (36 * i * macros.D2R) + array2ThetaInit2  # [rad]
-        array2ElementMessageData.thetaDot = 0.0  # [rad/s]
+        array2ElementMessageData = messaging.HingedRigidBodyMsgPayload(
+            theta=(36 * i * macros.D2R) + array2ThetaInit2,   # [rad]
+            thetaDot=0.0,   # [rad/s]
+        )
         array2ElementRefMsgList3.append(messaging.HingedRigidBodyMsg().write(array2ElementMessageData))
 
         array2RotProfilerList[i].spinningBodyInMsg.subscribeTo(array2ElementRefMsgList3[i])

--- a/examples/scenarioDragDeorbit.py
+++ b/examples/scenarioDragDeorbit.py
@@ -201,8 +201,7 @@ def run(show_plots, initialAlt=250, deorbitAlt=100, model="exponential"):
 
         swMsgList = []
         for c, val in enumerate(sw_msg.values()):
-            swMsgData = messaging.SwDataMsgPayload()
-            swMsgData.dataValue = val
+            swMsgData = messaging.SwDataMsgPayload(dataValue=val)
             swMsgList.append(messaging.SwDataMsg().write(swMsgData))
             atmo.swDataInMsgs[c].subscribeTo(swMsgList[-1])
     else:

--- a/examples/scenarioExtendingBoom.py
+++ b/examples/scenarioExtendingBoom.py
@@ -175,9 +175,10 @@ def run(show_plots):
     scSim.AddModelToTask(dynTaskName, profiler2)
     translatingBodyEffector.translatingBodyRefInMsgs[1].subscribeTo(profiler2.linearTranslationRigidBodyOutMsg)
 
-    translatingRigidBodyMsgData = messaging.LinearTranslationRigidBodyMsgPayload()
-    translatingRigidBodyMsgData.rho = scGeometry.heightArm  # [m]
-    translatingRigidBodyMsgData.rhoDot = 0  # [m/s]
+    translatingRigidBodyMsgData = messaging.LinearTranslationRigidBodyMsgPayload(
+        rho=scGeometry.heightArm,   # [m]
+        rhoDot=0,   # [m/s]
+    )
     translatingRigidBodyMsg2 = messaging.LinearTranslationRigidBodyMsg().write(translatingRigidBodyMsgData)
     profiler2.linearTranslationRigidBodyInMsg.subscribeTo(translatingRigidBodyMsg2)
 
@@ -206,9 +207,10 @@ def run(show_plots):
     scSim.AddModelToTask(dynTaskName, profiler3)
     translatingBodyEffector.translatingBodyRefInMsgs[2].subscribeTo(profiler3.linearTranslationRigidBodyOutMsg)
 
-    translatingRigidBodyMsgData = messaging.LinearTranslationRigidBodyMsgPayload()
-    translatingRigidBodyMsgData.rho = scGeometry.heightArm  # [m]
-    translatingRigidBodyMsgData.rhoDot = 0  # [m/s]
+    translatingRigidBodyMsgData = messaging.LinearTranslationRigidBodyMsgPayload(
+        rho=scGeometry.heightArm,  # [m]
+        rhoDot=0,  # [m/s]
+    )
     translatingRigidBodyMsg3 = messaging.LinearTranslationRigidBodyMsg().write(translatingRigidBodyMsgData)
     profiler3.linearTranslationRigidBodyInMsg.subscribeTo(translatingRigidBodyMsg3)
 
@@ -237,9 +239,10 @@ def run(show_plots):
     scSim.AddModelToTask(dynTaskName, profiler4)
     translatingBodyEffector.translatingBodyRefInMsgs[3].subscribeTo(profiler4.linearTranslationRigidBodyOutMsg)
 
-    translatingRigidBodyMsgData = messaging.LinearTranslationRigidBodyMsgPayload()
-    translatingRigidBodyMsgData.rho = scGeometry.heightArm  # [m]
-    translatingRigidBodyMsgData.rhoDot = 0  # [m/s]
+    translatingRigidBodyMsgData = messaging.LinearTranslationRigidBodyMsgPayload(
+        rho=scGeometry.heightArm,   # [m]
+        rhoDot=0,   # [m/s]
+    )
     translatingRigidBodyMsg4 = messaging.LinearTranslationRigidBodyMsg().write(translatingRigidBodyMsgData)
     profiler4.linearTranslationRigidBodyInMsg.subscribeTo(translatingRigidBodyMsg4)
 

--- a/examples/scenarioFlexiblePanel.py
+++ b/examples/scenarioFlexiblePanel.py
@@ -314,8 +314,8 @@ def setUpControl(scSim, extFTObject, attError, scGeometry):
     mrpControl.P = 2 * np.max(IHubPntB_B) / decayTime
     mrpControl.K = (mrpControl.P / xi) ** 2 / np.max(IHubPntB_B)
 
-    configData = messaging.VehicleConfigMsgPayload()
-    configData.IHubPntB_B = list(IHubPntB_B.flatten())
+    configData = messaging.VehicleConfigMsgPayload(IHubPntB_B=list(IHubPntB_B.flatten()))
+
     configDataMsg = messaging.VehicleConfigMsg()
     configDataMsg.write(configData)
 

--- a/examples/scenarioFlybySpice.py
+++ b/examples/scenarioFlybySpice.py
@@ -456,8 +456,8 @@ def run(planetCase):
     attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
 
     # Create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Set up the MRP Feedback control module
@@ -566,9 +566,8 @@ def run(planetCase):
 
     return
 
-    
+
 if __name__ == "__main__":
     run(
         "mars"   # venus, earth, mars
     )
-

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -347,8 +347,8 @@ def run(show_plots):
     attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # create FSW RW parameter msg

--- a/examples/scenarioFormationReconfig.py
+++ b/examples/scenarioFormationReconfig.py
@@ -175,9 +175,10 @@ def run(show_plots, useRefAttitude):
     fswProcess.addTask(scSim.CreateNewTask(fswTaskName, fswTimeStep))
 
     # VehicleConfigFswMsg
-    vehicleConfigOut2 = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut2.ISCPntB_B = I
-    vehicleConfigOut2.massSC = scObject2.hub.mHub
+    vehicleConfigOut2 = messaging.VehicleConfigMsgPayload(
+        ISCPntB_B=I,
+        massSC=scObject2.hub.mHub,
+    )
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut2)
 
     # inertial 3D target attitude

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -378,10 +378,8 @@ def run(show_plots):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = (
-        I  # use the same inertia in the FSW algorithm as in the simulation
-    )
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg)
 

--- a/examples/scenarioGroundMapping.py
+++ b/examples/scenarioGroundMapping.py
@@ -344,10 +344,8 @@ def run(show_plots, useCentral):
     extFTObject.cmdTorqueInMsg.subscribeTo(mrpControl.cmdTorqueOutMsg)
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = (
-        I  # use the same inertia in the FSW algorithm as in the simulation
-    )
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg)
 

--- a/examples/scenarioHelioTransSpice.py
+++ b/examples/scenarioHelioTransSpice.py
@@ -158,8 +158,8 @@ def run():
 
     # Configure Vizard settings
     if vizSupport.vizFound:
-        colorMsgContent = messaging.ColorMsgPayload()
-        colorMsgContent.colorRGBA = vizSupport.toRGBA255("Yellow")
+        colorMsgContent = messaging.ColorMsgPayload(colorRGBA=vizSupport.toRGBA255("Yellow"))
+
         colorMsg = messaging.ColorMsg().write(colorMsgContent)
 
         viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject

--- a/examples/scenarioHohmann.py
+++ b/examples/scenarioHohmann.py
@@ -324,8 +324,8 @@ def run(show_plots, rFirst, rSecond):
     scSim.AddModelToTask(fswTaskName, rwMotorTorqueObj)
 
     # Create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Create the FSW reaction wheel configuration message

--- a/examples/scenarioInertialSpiral.py
+++ b/examples/scenarioInertialSpiral.py
@@ -198,7 +198,7 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, attGuidanceEuler2)
     # Make rotation 2 be 0.0001 rad/s about 2 axis
     attGuidanceEuler2.angleRates = [0.0, 0.0001, 0.0]
-    
+
     # set up the attitude tracking error evaluation module
     attError = attTrackingError.attTrackingError()
     attError.ModelTag = "attError"
@@ -216,8 +216,8 @@ def run(show_plots):
     #
     # create simulation messages
     #
-    configData = messaging.VehicleConfigMsgPayload()
-    configData.ISCPntB_B = I
+    configData = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
+
     configDataMsg = messaging.VehicleConfigMsg().write(configData)
 
     #
@@ -273,7 +273,7 @@ def run(show_plots):
     scSim.ExecuteSimulation()
 
     dataSigmaBN = snAttLog.sigma_BN
-    
+
     dataEulerAnglesPitch = list()
     dataEulerAnglesYaw = list()
     dataEulerAnglesRoll = list()
@@ -282,7 +282,7 @@ def run(show_plots):
         dataEulerAnglesPitch.append(eulerAngle[0])
         dataEulerAnglesYaw.append(eulerAngle[1])
         dataEulerAnglesRoll.append(eulerAngle[2])
-        
+
     timeLineSet = attErrorLog.times() * macros.NANO2MIN
     #
     #   plot the results

--- a/examples/scenarioMomentumDumping.py
+++ b/examples/scenarioMomentumDumping.py
@@ -21,29 +21,29 @@ Overview
 --------
 
 This script shows how to perform momentum dumping when the momentum accumulated on the reaction wheels
-is above a user-defined threshold. In this case, such threshold is set at 80 Nms. The dumping is performed 
-by a set of 8 thrusters that can provide control about the three principal axes of the spacecraft. 
+is above a user-defined threshold. In this case, such threshold is set at 80 Nms. The dumping is performed
+by a set of 8 thrusters that can provide control about the three principal axes of the spacecraft.
 To perform the momentum dumping, three concatenated modules are used:
 
-- :ref:`thrMomentumManagement`: computes the amount of momentum to be dumped, based on current stored momentum 
+- :ref:`thrMomentumManagement`: computes the amount of momentum to be dumped, based on current stored momentum
   and the user-defined threshold. It is important to notice that, for the three concatenated modules to work
-  correctly, this first module cannot be run at simulation time :math:`t = 0`. In this script, the method 
-  ``Reset`` is called on :ref:`thrMomentumManagement` at :math:`t = 10` s, which coincides to the time at which 
+  correctly, this first module cannot be run at simulation time :math:`t = 0`. In this script, the method
+  ``Reset`` is called on :ref:`thrMomentumManagement` at :math:`t = 10` s, which coincides to the time at which
   the first desaturating impulse is fired.
 - :ref:`thrForceMapping`: maps the amout of momentum to be dumped into impulses that must be delivered by each
   thruster. This module is originally implemented to map a requested torque into forces imparted by the thrusters,
   but it can be applied in this case as well, because the math is the same. The only caveat is that, in this case,
   the output should not be scaled by the thruster maximum torque capability, since the desired output is an impulse
-  and not a torque. To deactivate the output scaling, the ``angErrThresh`` input variable for this module must be 
+  and not a torque. To deactivate the output scaling, the ``angErrThresh`` input variable for this module must be
   set to a value larger than :math:`\pi`, as specified in the module documentation.
-- :ref:`thrMomentumDumping`: computes the thruster on-times required to deliver the desired impulse. A 
+- :ref:`thrMomentumDumping`: computes the thruster on-times required to deliver the desired impulse. A
   ``maxCounterValue`` of 100 is used in this example to allow the spacecraft to maneuver back to the desired attitude
-  after each time the thrusters fire. 
+  after each time the thrusters fire.
 
-For this script to work as intended, it is necessary to run the flight software and the dynamics at two different 
+For this script to work as intended, it is necessary to run the flight software and the dynamics at two different
 frequencies. In this example, the simulation time step for the flight software is 1 second, whereas for the dynamics
-it is 0.1 seconds. This is necessary because the :ref:`thrMomentumDumping` automatically uses the task time step as 
-control period for the firing. However, if the dynamics is integrated at the same frequency, this does not give 
+it is 0.1 seconds. This is necessary because the :ref:`thrMomentumDumping` automatically uses the task time step as
+control period for the firing. However, if the dynamics is integrated at the same frequency, this does not give
 enough time resolution to appreciate the variation in the momentum.
 
 The script is found in the folder ``basilisk/examples`` and executed by using::
@@ -56,7 +56,7 @@ Illustration of Simulation Results
 In this examples, the spacecraft is already at the desired attitude, but the four reaction wheels are saturated (the total
 angular momentum exceeds the threshold). The desaturation happens at :math:`t = 10` when the :ref:`thrMomentumManagement` is
 reset. Three firings are sufficient to dump the momentum below the set threshold. The following figures illustrate the change
-in momentum for the four wheels :math:`H_i` for :math:`i = 1,...,4` and the total angular momentum :math:`\|H\|`, and the 
+in momentum for the four wheels :math:`H_i` for :math:`i = 1,...,4` and the total angular momentum :math:`\|H\|`, and the
 attitude errors, as functions of time, with respect to the desired target attitude.
 
 .. image:: /_images/Scenarios/scenarioMomentumDumping3.svg
@@ -69,8 +69,8 @@ The plots show that the momentum is dumped below the threshold. Also, the desire
 second firing, and after the third, but between the second and the third there is not enough time for the spacecraft to slew
 back to that attitude.
 
-The next two plots show the amount of impulse [Ns] requested for each thruster, and the times during which each thruster is 
-operational. As expected, 100 control times pass between each firing: because the control time coincides with the flight 
+The next two plots show the amount of impulse [Ns] requested for each thruster, and the times during which each thruster is
+operational. As expected, 100 control times pass between each firing: because the control time coincides with the flight
 software simulation time step of 1 s, this means that firings are 100 seconds apart.
 
 .. image:: /_images/Scenarios/scenarioMomentumDumping5.svg
@@ -120,10 +120,10 @@ def run(show_plots):
     simulationTimeStepDyn = macros.sec2nano(0.1)
     dynProcess.addTask(scSim.CreateNewTask(dynTask, simulationTimeStepDyn))
     dynProcess.addTask(scSim.CreateNewTask(fswTask, simulationTimeStepFsw))
-    
+
     #
     # setup the simulation tasks/objects
-    # 
+    #
 
     # initialize spacecraft object and set properties
     scObject = spacecraft.Spacecraft()
@@ -174,7 +174,7 @@ def run(show_plots):
     scObject.hub.v_CN_NInit = vN                          # m/s - v_BN_N
     scObject.hub.sigma_BNInit = [0, 0., 0.]              # MRP set to customize initial inertial attitude
     scObject.hub.omega_BN_BInit = [[0.], [0.], [0.]]      # rad/s - omega_CN_B
-    
+
     # define the simulation inertia
     I = [1700,  0.,    0.,
          0.,    1700,  0.,
@@ -306,7 +306,7 @@ def run(show_plots):
     thrDesatControl = thrMomentumManagement.thrMomentumManagement()
     thrDesatControl.ModelTag = "thrMomentumManagement"
     scSim.AddModelToTask(fswTask, thrDesatControl)
-    thrDesatControl.hs_min = 80   # Nms  :  maximum wheel momentum 
+    thrDesatControl.hs_min = 80   # Nms  :  maximum wheel momentum
 
     # setup the thruster force mapping module
     thrForceMappingObj = thrForceMapping.thrForceMapping()
@@ -328,8 +328,8 @@ def run(show_plots):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # if this scenario is to interface with the BSK Viz, uncomment the following lines
@@ -441,8 +441,8 @@ def run(show_plots):
     np.set_printoptions(precision=16)
 
 
-    # Displays the plots relative to the S/C attitude and rates errors, wheel momenta, thruster impulses, on times, and thruster firing intervals  
-    
+    # Displays the plots relative to the S/C attitude and rates errors, wheel momenta, thruster impulses, on times, and thruster firing intervals
+
     timeData = rwMotorLog.times() * macros.NANO2SEC
 
     plot_attitude_error(timeData, dataSigmaBR)
@@ -451,7 +451,7 @@ def run(show_plots):
     figureList[pltName] = plt.figure(1)
 
     plot_rate_error(timeData, dataOmegaBR)
-    pltName = fileName + "2"    
+    pltName = fileName + "2"
     figureList[pltName] = plt.figure(2)
 
     plot_rw_momenta(timeData, dataOmegaRW, RW, numRW)
@@ -474,7 +474,7 @@ def run(show_plots):
     pltName = fileName + "7"
     figureList[pltName] = plt.figure(7)
 
-    if show_plots:  
+    if show_plots:
         plt.show()
 
     # close the plots being saved off to avoid over-writing old and new figures

--- a/examples/scenarioMonteCarloAttRW.py
+++ b/examples/scenarioMonteCarloAttRW.py
@@ -580,8 +580,8 @@ def createScenarioAttitudeFeedbackRW():
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # FSW RW configuration message

--- a/examples/scenarioMtbMomentumManagement.py
+++ b/examples/scenarioMtbMomentumManagement.py
@@ -124,7 +124,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     plt.xlabel('Time [min]')
     plt.ylabel('RW Motor Torque [Nm]')
     plt.grid(True)
-    
+
 def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     """Plot the RW actual motor torques."""
     plt.figure(2)
@@ -152,7 +152,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.xlabel('Time [min]')
     plt.ylabel('Rate Tracking Error [rad/s] ')
     plt.grid(True)
-    
+
 def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     """Plot the RW spin rates."""
     plt.figure(4)
@@ -164,7 +164,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.xlabel('Time [min]')
     plt.ylabel('RW Speed [RPM] ')
     plt.grid(True)
-    
+
 def plot_magnetic_field(timeData, dataMagField):
     """Plot the magnetic field."""
     plt.figure(5)
@@ -188,7 +188,7 @@ def plot_data_tam(timeData, dataTam):
     plt.xlabel('Time [min]')
     plt.ylabel('Magnetic Field [nT]')
     plt.grid(True)
-    
+
 def plot_data_tam_comm(timeData, dataTamComm):
     """Plot the magnetic field."""
     plt.figure(7)
@@ -200,7 +200,7 @@ def plot_data_tam_comm(timeData, dataTamComm):
     plt.xlabel('Time [min]')
     plt.ylabel('Magnetic Field [nT]')
     plt.grid(True)
-    
+
 def plot_data_mtb_momentum_management(timeData, dataMtbMomentumManegement, numMTB):
     """Plot the magnetic field."""
     plt.figure(8)
@@ -212,7 +212,7 @@ def plot_data_mtb_momentum_management(timeData, dataMtbMomentumManegement, numMT
     plt.xlabel('Time [min]')
     plt.ylabel('Torque Rod Dipoles [A-m2]')
     plt.grid(True)
-    
+
 
 def plot_data_rw_motor_torque_desired(dataUsReq, tauRequested_W, numRW):
     """Plot the RW desired motor torques."""
@@ -225,7 +225,7 @@ def plot_data_rw_motor_torque_desired(dataUsReq, tauRequested_W, numRW):
     plt.xlabel('Time [min]')
     plt.ylabel('RW Motor Torque (Nm)')
     plt.grid(True)
-    
+
 def run(show_plots):
     """
     The scenarios can be run with the followings setups parameters:
@@ -310,11 +310,11 @@ def run(show_plots):
     RW3 = rwFactory.create('BCT_RWP015', Gs[:, 2], Omega_max=5000.  # RPM
                            , RWModel=varRWModel, useRWfriction=False,
                            )
-    
+
     RW4 = rwFactory.create('BCT_RWP015', Gs[:, 3], Omega_max=5000.  # RPM
                            , RWModel=varRWModel, useRWfriction=False,
                            )
-    
+
     # In this simulation the RW objects RW1, RW2 or RW3 are not modified further.  However, you can over-ride
     # any values generate in the `.create()` process using for example RW1.Omega_max = 100. to change the
     # maximum wheel speed.
@@ -345,14 +345,14 @@ def run(show_plots):
     magModule.epochInMsg.subscribeTo(epochMsg)
     magModule.addSpacecraftToModel(scObject.scStateOutMsg)  # this command can be repeated if multiple
     scSim.AddModelToTask(simTaskName, magModule)
-    
+
     # add magnetic torque bar effector
     mtbEff = MtbEffector.MtbEffector()
     mtbEff.ModelTag = "MtbEff"
     scObject.addDynamicEffector(mtbEff)
     scSim.AddModelToTask(simTaskName, mtbEff)
-    
-    
+
+
     #
     #   setup the FSW algorithm tasks
     #
@@ -372,7 +372,7 @@ def run(show_plots):
     mrpControl = mrpFeedback.mrpFeedback()
     mrpControl.ModelTag = "mrpFeedback"
     scSim.AddModelToTask(simTaskName, mrpControl)
-    
+
     mrpControl.Ki = -1  # make value negative to turn off integral feedback
     mrpControl.K = 0.0001
     mrpControl.P = 0.002
@@ -396,26 +396,26 @@ def run(show_plots):
     TAM.scaleFactor = 1.0
     TAM.senNoiseStd = [0.0,  0.0, 0.0]
     scSim.AddModelToTask(simTaskName, TAM)
-    
+
     # setup tamComm module
     tamCommObj = tamComm.tamComm()
     tamCommObj.dcm_BS = [1., 0., 0., 0., 1., 0., 0., 0., 1.]
     tamCommObj.ModelTag = "tamComm"
     scSim.AddModelToTask(simTaskName, tamCommObj)
-    
+
     # setup mtbMomentumManagement module
     mtbMomentumManagementObj = mtbMomentumManagement.mtbMomentumManagement()
     # setting the optional RW biases
     mtbMomentumManagementObj.wheelSpeedBiases = [800. * macros.rpm2radsec, 600. * macros.rpm2radsec,
                                                     400. * macros.rpm2radsec, 200. * macros.rpm2radsec]
     mtbMomentumManagementObj.cGain = 0.003
-    mtbMomentumManagementObj.ModelTag = "mtbMomentumManagement"          
+    mtbMomentumManagementObj.ModelTag = "mtbMomentumManagement"
     scSim.AddModelToTask(simTaskName, mtbMomentumManagementObj)
-    
+
     # mtbConfigData message
     mtbConfigParams = messaging.MTBArrayConfigMsgPayload()
     mtbConfigParams.numMTB = 4
-    
+
     # row major toque bar alignments
     mtbConfigParams.GtMatrix_B =[
         1., 0., 0., 0.70710678,
@@ -424,7 +424,7 @@ def run(show_plots):
     maxDipole = 0.1
     mtbConfigParams.maxMtbDipoles = [maxDipole]*mtbConfigParams.numMTB
     mtbParamsInMsg = messaging.MTBArrayConfigMsg().write(mtbConfigParams)
-    
+
     #
     #   Setup data logging before the simulation is initialized
     #
@@ -436,18 +436,18 @@ def run(show_plots):
     tamLog = TAM.tamDataOutMsg.recorder(samplingTime)
     tamCommLog = tamCommObj.tamOutMsg.recorder(samplingTime)
     mtbDipoleCmdsLog = mtbMomentumManagementObj.mtbCmdOutMsg.recorder(samplingTime)
-    
+
     scSim.AddModelToTask(simTaskName, rwMotorLog)
     scSim.AddModelToTask(simTaskName, attErrorLog)
     scSim.AddModelToTask(simTaskName, magLog)
     scSim.AddModelToTask(simTaskName, tamLog)
     scSim.AddModelToTask(simTaskName, tamCommLog)
     scSim.AddModelToTask(simTaskName, mtbDipoleCmdsLog)
-    
+
     # To log the RW information, the following code is used:
     mrpLog = rwStateEffector.rwSpeedOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, mrpLog)
-    
+
     # A message is created that stores an array of the \f$\Omega\f$ wheel speeds.  This is logged
     # here to be plotted later on.  However, RW specific messages are also being created which
     # contain a wealth of information.  The vector of messages is ordered as they were added.  This
@@ -456,14 +456,14 @@ def run(show_plots):
     for item in range(numRW):
         rwLogs.append(rwStateEffector.rwOutMsgs[item].recorder(samplingTime))
         scSim.AddModelToTask(simTaskName, rwLogs[item])
-        
+
     #
     # create simulation messages
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Setup the FSW RW configuration to be the same as the simulated RW configuration
@@ -504,22 +504,22 @@ def run(show_plots):
     TAM.stateInMsg.subscribeTo(scObject.scStateOutMsg)
     TAM.magInMsg.subscribeTo(magModule.envOutMsgs[0])
     tamCommObj.tamInMsg.subscribeTo(TAM.tamDataOutMsg)
-    
+
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(fswRwParamMsg)
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mrpControl.cmdTorqueOutMsg)
-    
+
     mtbMomentumManagementObj.rwParamsInMsg.subscribeTo(fswRwParamMsg)
     mtbMomentumManagementObj.mtbParamsInMsg.subscribeTo(mtbParamsInMsg)
     mtbMomentumManagementObj.tamSensorBodyInMsg.subscribeTo(tamCommObj.tamOutMsg)
     mtbMomentumManagementObj.rwSpeedsInMsg.subscribeTo(rwStateEffector.rwSpeedOutMsg)
     mtbMomentumManagementObj.rwMotorTorqueInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
-    
+
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(mtbMomentumManagementObj.rwMotorTorqueOutMsg)
 
     mtbEff.mtbCmdInMsg.subscribeTo(mtbMomentumManagementObj.mtbCmdOutMsg)
     mtbEff.mtbParamsInMsg.subscribeTo(mtbParamsInMsg)
     mtbEff.magInMsg.subscribeTo(magModule.envOutMsgs[0])
-    
+
     # initialize configure and execute sim
     scSim.InitializeSimulation()
     scSim.ConfigureStopTime(simulationTime)
@@ -537,7 +537,7 @@ def run(show_plots):
     dataTam = tamLog.tam_S
     dataTamComm = tamCommLog.tam_B
     dataMtbDipoleCmds = mtbDipoleCmdsLog.mtbDipoleCmds
-    
+
     np.set_printoptions(precision=16)
 
     #   plot the results
@@ -561,15 +561,15 @@ def run(show_plots):
     plot_magnetic_field(timeData, dataMagField)
     pltName = fileName + "4"
     figureList[pltName] = plt.figure(5)
-    
+
     plot_data_tam(timeData, dataTam)
     pltName = fileName + "5"
     figureList[pltName] = plt.figure(6)
-    
+
     plot_data_tam_comm(timeData, dataTamComm)
     pltName = fileName + "6"
     figureList[pltName] = plt.figure(7)
-    
+
     plot_data_mtb_momentum_management(timeData, dataMtbDipoleCmds, mtbConfigParams.numMTB)
     pltName = fileName + "7"
     figureList[pltName] = plt.figure(8)

--- a/examples/scenarioMtbMomentumManagementSimple.py
+++ b/examples/scenarioMtbMomentumManagementSimple.py
@@ -133,7 +133,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     plt.xlabel('Time [min]')
     plt.ylabel('RW Motor Torque [Nm]')
     plt.grid(True)
-    
+
 def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     """Plot the RW actual motor torques."""
     plt.figure(2)
@@ -161,7 +161,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.xlabel('Time [min]')
     plt.ylabel('Rate Tracking Error [rad/s] ')
     plt.grid(True)
-    
+
 def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     """Plot the RW spin rates."""
     plt.figure(4)
@@ -173,7 +173,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.xlabel('Time [min]')
     plt.ylabel('RW Speed [RPM] ')
     plt.grid(True)
-    
+
 def plot_magnetic_field(timeData, dataMagField):
     """Plot the magnetic field."""
     plt.figure(5)
@@ -197,7 +197,7 @@ def plot_data_tam(timeData, dataTam):
     plt.xlabel('Time [min]')
     plt.ylabel('Magnetic Field [nT]')
     plt.grid(True)
-    
+
 def plot_data_tam_comm(timeData, dataTamComm):
     """Plot the magnetic field."""
     plt.figure(7)
@@ -209,7 +209,7 @@ def plot_data_tam_comm(timeData, dataTamComm):
     plt.xlabel('Time [min]')
     plt.ylabel('Magnetic Field [nT]')
     plt.grid(True)
-    
+
 def plot_data_mtb_momentum_management(timeData, dataMtbMomentumManegement, numMTB):
     """Plot the magnetic field."""
     plt.figure(8)
@@ -221,7 +221,7 @@ def plot_data_mtb_momentum_management(timeData, dataMtbMomentumManegement, numMT
     plt.xlabel('Time [min]')
     plt.ylabel('Torque Rod Dipoles [A-m2]')
     plt.grid(True)
-    
+
 
 def plot_data_rw_motor_torque_desired(dataUsReq, tauRequested_W, numRW):
     """Plot the RW desired motor torques."""
@@ -234,7 +234,7 @@ def plot_data_rw_motor_torque_desired(dataUsReq, tauRequested_W, numRW):
     plt.xlabel('Time [min]')
     plt.ylabel('RW Motor Torque (Nm)')
     plt.grid(True)
-    
+
 def run(show_plots):
     """
     The scenarios can be run with the followings setups parameters:
@@ -317,11 +317,11 @@ def run(show_plots):
     RW3 = rwFactory.create('BCT_RWP015', Gs[:, 2], Omega_max=5000.  # RPM
                            , RWModel=varRWModel, useRWfriction=False,
                            )
-    
+
     RW4 = rwFactory.create('BCT_RWP015', Gs[:, 3], Omega_max=5000.  # RPM
                            , RWModel=varRWModel, useRWfriction=False,
                            )
-    
+
     # In this simulation the RW objects RW1, RW2 or RW3 are not modified further.  However, you can over-ride
     # any values generate in the `.create()` process using for example RW1.Omega_max = 100. to change the
     # maximum wheel speed.
@@ -352,14 +352,14 @@ def run(show_plots):
     magModule.epochInMsg.subscribeTo(epochMsg)
     magModule.addSpacecraftToModel(scObject.scStateOutMsg)  # this command can be repeated if multiple
     scSim.AddModelToTask(simTaskName, magModule)
-    
+
     # add magnetic torque bar effector
     mtbEff = MtbEffector.MtbEffector()
     mtbEff.ModelTag = "MtbEff"
     scObject.addDynamicEffector(mtbEff)
     scSim.AddModelToTask(simTaskName, mtbEff)
-    
-    
+
+
     #
     #   setup the FSW algorithm tasks
     #
@@ -379,13 +379,13 @@ def run(show_plots):
     mrpControl = mrpFeedback.mrpFeedback()
     mrpControl.ModelTag = "mrpFeedback"
     scSim.AddModelToTask(simTaskName, mrpControl)
-    
+
     mrpControl.Ki = -1  # make value negative to turn off integral feedback
     mrpControl.K = 0.0001
     mrpControl.P = 0.002
     mrpControl.integralLimit = 2. / mrpControl.Ki * 0.1
 
-    
+
     # create the minimal TAM module
     TAM = magnetometer.Magnetometer()
     TAM.ModelTag = "TAM_sensor"
@@ -393,28 +393,28 @@ def run(show_plots):
     TAM.scaleFactor = 1.0
     TAM.senNoiseStd = [0.0,  0.0, 0.0]
     scSim.AddModelToTask(simTaskName, TAM)
-    
+
     # setup tamComm module
     tamCommObj = tamComm.tamComm()
     tamCommObj.dcm_BS = [1., 0., 0., 0., 1., 0., 0., 0., 1.]
     tamCommObj.ModelTag = "tamComm"
     scSim.AddModelToTask(simTaskName, tamCommObj)
-    
+
     # setup mtbMomentumManagement module
     mtbMomentumManagementSimpleObj = mtbMomentumManagementSimple.mtbMomentumManagementSimple()
     mtbMomentumManagementSimpleObj.Kp = 0.003
-    mtbMomentumManagementSimpleObj.ModelTag = "mtbMomentumManagementSimple"          
+    mtbMomentumManagementSimpleObj.ModelTag = "mtbMomentumManagementSimple"
     scSim.AddModelToTask(simTaskName, mtbMomentumManagementSimpleObj)
-    
+
     # setup torque2Dipole module
     torque2DipoleObj = torque2Dipole.torque2Dipole()
     torque2DipoleObj.ModelTag = "torque2Dipole"
     scSim.AddModelToTask(simTaskName, torque2DipoleObj)
-    
+
     # mtbConfigData message
     mtbConfigParams = messaging.MTBArrayConfigMsgPayload()
     mtbConfigParams.numMTB = 4
-    
+
     # row major toque bar alignments
     mtbConfigParams.GtMatrix_B =[
         1., 0., 0., 0.70710678,
@@ -423,10 +423,10 @@ def run(show_plots):
     maxDipole = 0.1
     mtbConfigParams.maxMtbDipoles = [maxDipole]*mtbConfigParams.numMTB
     mtbParamsInMsg = messaging.MTBArrayConfigMsg().write(mtbConfigParams)
-    
+
     # setup dipoleMapping module
     dipoleMappingObj = dipoleMapping.dipoleMapping()
-    
+
     # row major toque bar alignment inverse
     dipoleMappingObj.steeringMatrix = [0.75, -0.25, 0.,
                                           -0.25, 0.75, 0.,
@@ -434,12 +434,12 @@ def run(show_plots):
                                            0.35355339, 0.35355339, 0.]
     dipoleMappingObj.ModelTag = "dipoelMapping"
     scSim.AddModelToTask(simTaskName, dipoleMappingObj)
-    
+
     # setup mtbFeedforward module
     mtbFeedforwardObj = mtbFeedforward.mtbFeedforward()
     mtbFeedforwardObj.ModelTag = "mtbFeedforward"
     scSim.AddModelToTask(simTaskName, mtbFeedforwardObj)
-    
+
     # add module that maps the Lr control torque into the RW motor torques
     rwMotorTorqueObj = rwMotorTorque.rwMotorTorque()
     rwMotorTorqueObj.ModelTag = "rwMotorTorque"
@@ -450,46 +450,33 @@ def run(show_plots):
         1, 0, 0, 0, 1, 0, 0, 0, 1
     ]
     rwMotorTorqueObj.controlAxes_B = controlAxes_B
-    
+
     # setup rwNullSpace module
     rwNullSpaceObj = rwNullSpace.rwNullSpace()
     rwNullSpaceObj.OmegaGain = 0.0000003
     rwNullSpaceObj.ModelTag = "rwNullSpace"
     scSim.AddModelToTask(simTaskName, rwNullSpaceObj)
-    
+
     # setup RWConstellationMsgPayload
-    rwConstellationConfig = messaging.RWConstellationMsgPayload()
-    rwConstellationConfig.numRW = numRW
-    rwConfigElementList = list()
-    rwConfigElementMsg1 = messaging.RWConfigElementMsgPayload()
-    rwConfigElementMsg1.gsHat_B = Gs[:, 0]
-    rwConfigElementMsg1.Js = RW1.Js
-    rwConfigElementMsg1.uMax = RW1.u_max
-    rwConfigElementList.append(rwConfigElementMsg1)
-    rwConfigElementMsg2 = messaging.RWConfigElementMsgPayload()
-    rwConfigElementMsg2.gsHat_B = Gs[:, 1]
-    rwConfigElementMsg2.Js = RW2.Js
-    rwConfigElementMsg2.uMax = RW2.u_max
-    rwConfigElementList.append(rwConfigElementMsg2)
-    rwConfigElementMsg3 = messaging.RWConfigElementMsgPayload()
-    rwConfigElementMsg3.gsHat_B = Gs[:, 2]
-    rwConfigElementMsg3.Js = RW3.Js
-    rwConfigElementMsg3.uMax = RW3.u_max
-    rwConfigElementList.append(rwConfigElementMsg3)
-    rwConfigElementMsg4 = messaging.RWConfigElementMsgPayload()
-    rwConfigElementMsg4.gsHat_B = Gs[:, 3]
-    rwConfigElementMsg4.Js = RW4.Js
-    rwConfigElementMsg4.uMax = RW4.u_max
-    rwConfigElementList.append(rwConfigElementMsg4)
-    rwConstellationConfig.reactionWheels = rwConfigElementList
+    rwConstellationConfig = messaging.RWConstellationMsgPayload(
+        numRW=numRW,
+        reactionWheels = [
+            messaging.RWConfigElementMsgPayload(
+                gsHat_B=Gs[:, i],
+                Js=RW.Js,
+                uMax=RW.u_max,
+            )
+            for i, RW in enumerate((RW1, RW2, RW3, RW4))
+        ]
+    )
     rwConstellationConfigInMsg = messaging.RWConstellationMsg().write(rwConstellationConfig)
-    
+
     # setup RWSpeedMsgPayload for the rwNullSpace
     desiredOmega = [1000 * macros.rpm2radsec]*numRW
-    rwNullSpaceWheelSpeedBias = messaging.RWSpeedMsgPayload()
-    rwNullSpaceWheelSpeedBias.wheelSpeeds = desiredOmega
+    rwNullSpaceWheelSpeedBias = messaging.RWSpeedMsgPayload(wheelSpeeds=desiredOmega)
+
     rwNullSpaceWheelSpeedBiasInMsg = messaging.RWSpeedMsg().write(rwNullSpaceWheelSpeedBias)
-    
+
     #
     #   Setup data logging before the simulation is initialized
     #
@@ -501,18 +488,18 @@ def run(show_plots):
     tamLog = TAM.tamDataOutMsg.recorder(samplingTime)
     tamCommLog = tamCommObj.tamOutMsg.recorder(samplingTime)
     mtbDipoleCmdsLog = dipoleMappingObj.dipoleRequestMtbOutMsg.recorder(samplingTime)
-    
+
     scSim.AddModelToTask(simTaskName, rwMotorLog)
     scSim.AddModelToTask(simTaskName, attErrorLog)
     scSim.AddModelToTask(simTaskName, magLog)
     scSim.AddModelToTask(simTaskName, tamLog)
     scSim.AddModelToTask(simTaskName, tamCommLog)
     scSim.AddModelToTask(simTaskName, mtbDipoleCmdsLog)
-    
+
     # To log the RW information, the following code is used:
     mrpLog = rwStateEffector.rwSpeedOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, mrpLog)
-    
+
     # A message is created that stores an array of the \f$\Omega\f$ wheel speeds.  This is logged
     # here to be plotted later on.  However, RW specific messages are also being created which
     # contain a wealth of information.  The vector of messages is ordered as they were added.  This
@@ -521,14 +508,14 @@ def run(show_plots):
     for item in range(numRW):
         rwLogs.append(rwStateEffector.rwOutMsgs[item].recorder(samplingTime))
         scSim.AddModelToTask(simTaskName, rwLogs[item])
-        
+
     #
     # create simulation messages
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Setup the FSW RW configuration to be the same as the simulated RW configuration
@@ -569,36 +556,36 @@ def run(show_plots):
     TAM.stateInMsg.subscribeTo(scObject.scStateOutMsg)
     TAM.magInMsg.subscribeTo(magModule.envOutMsgs[0])
     tamCommObj.tamInMsg.subscribeTo(TAM.tamDataOutMsg)
-    
+
     mtbMomentumManagementSimpleObj.rwParamsInMsg.subscribeTo(fswRwParamMsg)
     mtbMomentumManagementSimpleObj.rwSpeedsInMsg.subscribeTo(rwStateEffector.rwSpeedOutMsg)
-    
+
     torque2DipoleObj.tauRequestInMsg.subscribeTo(mtbMomentumManagementSimpleObj.tauMtbRequestOutMsg)
     torque2DipoleObj.tamSensorBodyInMsg.subscribeTo(tamCommObj.tamOutMsg)
-    
+
     dipoleMappingObj.dipoleRequestBodyInMsg.subscribeTo(torque2DipoleObj.dipoleRequestOutMsg)
     dipoleMappingObj.mtbArrayConfigParamsInMsg.subscribeTo(mtbParamsInMsg)
-    
+
     mtbFeedforwardObj.vehControlInMsg.subscribeTo(mrpControl.cmdTorqueOutMsg)
     mtbFeedforwardObj.dipoleRequestMtbInMsg.subscribeTo(dipoleMappingObj.dipoleRequestMtbOutMsg)
     mtbFeedforwardObj.tamSensorBodyInMsg.subscribeTo(tamCommObj.tamOutMsg)
     mtbFeedforwardObj.mtbArrayConfigParamsInMsg.subscribeTo(mtbParamsInMsg)
-    
+
     rwMotorTorqueObj.rwParamsInMsg.subscribeTo(fswRwParamMsg)
     rwMotorTorqueObj.vehControlInMsg.subscribeTo(mtbFeedforwardObj.vehControlOutMsg)
-    
+
     rwNullSpaceObj.rwMotorTorqueInMsg.subscribeTo(rwMotorTorqueObj.rwMotorTorqueOutMsg)
     rwNullSpaceObj.rwSpeedsInMsg.subscribeTo(rwStateEffector.rwSpeedOutMsg)
     rwNullSpaceObj.rwConfigInMsg.subscribeTo(rwConstellationConfigInMsg)
     rwNullSpaceObj.rwDesiredSpeedsInMsg.subscribeTo(rwNullSpaceWheelSpeedBiasInMsg)
-    
+
     rwStateEffector.rwMotorCmdInMsg.subscribeTo(rwNullSpaceObj.rwMotorTorqueOutMsg)
-    
+
     mtbEff.mtbCmdInMsg.subscribeTo(dipoleMappingObj.dipoleRequestMtbOutMsg)
     mtbEff.mtbParamsInMsg.subscribeTo(mtbParamsInMsg)
     mtbEff.magInMsg.subscribeTo(magModule.envOutMsgs[0])
-    
-    
+
+
     # initialize configure and execute sim
     scSim.InitializeSimulation()
     scSim.ConfigureStopTime(simulationTime)
@@ -616,7 +603,7 @@ def run(show_plots):
     dataTam = tamLog.tam_S
     dataTamComm = tamCommLog.tam_B
     dataMtbDipoleCmds = mtbDipoleCmdsLog.mtbDipoleCmds
-    
+
     np.set_printoptions(precision=16)
 
     #   plot the results
@@ -640,15 +627,15 @@ def run(show_plots):
     plot_magnetic_field(timeData, dataMagField)
     pltName = fileName + "4"
     figureList[pltName] = plt.figure(5)
-    
+
     plot_data_tam(timeData, dataTam)
     pltName = fileName + "5"
     figureList[pltName] = plt.figure(6)
-    
+
     plot_data_tam_comm(timeData, dataTamComm)
     pltName = fileName + "6"
     figureList[pltName] = plt.figure(7)
-    
+
     plot_data_mtb_momentum_management(timeData, dataMtbDipoleCmds, mtbConfigParams.numMTB)
     pltName = fileName + "7"
     figureList[pltName] = plt.figure(8)

--- a/examples/scenarioOrbitManeuverTH.py
+++ b/examples/scenarioOrbitManeuverTH.py
@@ -228,8 +228,8 @@ def run(show_plots):
     thFactory.addToSpacecraft(thrModelTag, thrusterSet, scObject)
 
     # Configure thruster on-time message
-    ThrOnTimeMsgData = messaging.THRArrayOnTimeCmdMsgPayload()
-    ThrOnTimeMsgData.OnTimeRequest = [0, 0]
+    ThrOnTimeMsgData = messaging.THRArrayOnTimeCmdMsgPayload(OnTimeRequest=[0, 0])
+
     thrOnTimeMsg = messaging.THRArrayOnTimeCmdMsg().write(ThrOnTimeMsgData)
 
     #
@@ -285,8 +285,8 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, snTransLog)
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # connect messages

--- a/examples/scenarioPatchedConics.py
+++ b/examples/scenarioPatchedConics.py
@@ -160,21 +160,24 @@ def run(show_plots):
     # positions and velocities even when the planets are not moving.
     rEarth = 149598023. * 1000
     rJupiter = 778298361. * 1000
-    earthStateMsg = messaging.SpicePlanetStateMsgPayload()
-    earthStateMsg.PositionVector = [0.0, -rEarth, 0.0]
-    earthStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    earthStateMsg = messaging.SpicePlanetStateMsgPayload(
+        PositionVector=[0.0, -rEarth, 0.0],
+        VelocityVector=[0.0, 0.0, 0.0],
+    )
     earthMsg = messaging.SpicePlanetStateMsg().write(earthStateMsg)
     gravFactory.gravBodies['earth'].planetBodyInMsg.subscribeTo(earthMsg)
 
-    jupiterStateMsg = messaging.SpicePlanetStateMsgPayload()
-    jupiterStateMsg.PositionVector = [0.0, rJupiter, 0.0]
-    jupiterStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    jupiterStateMsg = messaging.SpicePlanetStateMsgPayload(
+        PositionVector=[0.0, rJupiter, 0.0],
+        VelocityVector=[0.0, 0.0, 0.0],
+    )
     jupiterMsg = messaging.SpicePlanetStateMsg().write(jupiterStateMsg)
     gravFactory.gravBodies['jupiter barycenter'].planetBodyInMsg.subscribeTo(jupiterMsg)
 
-    sunStateMsg = messaging.SpicePlanetStateMsgPayload()
-    sunStateMsg.PositionVector = [0.0, 0.0, 0.0]
-    sunStateMsg.VelocityVector = [0.0, 0.0, 0.0]
+    sunStateMsg = messaging.SpicePlanetStateMsgPayload(
+        PositionVector=[0.0, 0.0, 0.0],
+        VelocityVector=[0.0, 0.0, 0.0],
+    )
     sunMsg = messaging.SpicePlanetStateMsg().write(sunStateMsg)
     gravFactory.gravBodies['sun'].planetBodyInMsg.subscribeTo(sunMsg)
 

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -342,8 +342,8 @@ def run(show_plots):
     attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # create FSW RW parameter msg

--- a/examples/scenarioRoboticArm.py
+++ b/examples/scenarioRoboticArm.py
@@ -174,9 +174,10 @@ def createFirstLink(scSim, spinningBodyEffector, scGeometry):
     scSim.AddModelToTask(scSim.dynTaskName, profiler)
     spinningBodyEffector.spinningBodyRefInMsgs[0].subscribeTo(profiler.spinningBodyOutMsg)
 
-    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
-    hingedRigidBodyMessageData.theta = -30 * macros.D2R  # [rad]
-    hingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
+    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload(
+        theta=-30 * macros.D2R,  # [rad]
+        thetaDot=0.0,  # [rad/s]
+    )
     hingedRigidBodyMessage1 = messaging.HingedRigidBodyMsg().write(hingedRigidBodyMessageData)
     profiler.spinningBodyInMsg.subscribeTo(hingedRigidBodyMessage1)
 
@@ -203,9 +204,10 @@ def createFirstLink(scSim, spinningBodyEffector, scGeometry):
     scSim.AddModelToTask(scSim.dynTaskName, profiler)
     spinningBodyEffector.spinningBodyRefInMsgs[1].subscribeTo(profiler.spinningBodyOutMsg)
 
-    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
-    hingedRigidBodyMessageData.theta = 45 * macros.D2R  # [rad]
-    hingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
+    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload(
+        theta=45 * macros.D2R,  # [rad]
+        thetaDot=0.0,  # [rad/s]
+    )
     hingedRigidBodyMessage2 = messaging.HingedRigidBodyMsg().write(hingedRigidBodyMessageData)
     profiler.spinningBodyInMsg.subscribeTo(hingedRigidBodyMessage2)
 
@@ -232,9 +234,10 @@ def createSecondLink(scSim, spinningBodyEffector, scGeometry):
     scSim.AddModelToTask(scSim.dynTaskName, profiler)
     spinningBodyEffector.spinningBodyRefInMsgs[2].subscribeTo(profiler.spinningBodyOutMsg)
 
-    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
-    hingedRigidBodyMessageData.theta = 90 * macros.D2R  # [rad]
-    hingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
+    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload(
+        theta=90 * macros.D2R,  # [rad]
+        thetaDot=0.0,  # [rad/s]
+    )
     hingedRigidBodyMessage1 = messaging.HingedRigidBodyMsg().write(hingedRigidBodyMessageData)
     profiler.spinningBodyInMsg.subscribeTo(hingedRigidBodyMessage1)
 
@@ -261,9 +264,10 @@ def createSecondLink(scSim, spinningBodyEffector, scGeometry):
     scSim.AddModelToTask(scSim.dynTaskName, profiler)
     spinningBodyEffector.spinningBodyRefInMsgs[3].subscribeTo(profiler.spinningBodyOutMsg)
 
-    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload()
-    hingedRigidBodyMessageData.theta = -20 * macros.D2R  # [rad]
-    hingedRigidBodyMessageData.thetaDot = 0.0  # [rad/s]
+    hingedRigidBodyMessageData = messaging.HingedRigidBodyMsgPayload(
+        theta=-20 * macros.D2R, # [rad]
+        thetaDot=0.0, # [rad/s]
+    )
     hingedRigidBodyMessage2 = messaging.HingedRigidBodyMsg().write(hingedRigidBodyMessageData)
     profiler.spinningBodyInMsg.subscribeTo(hingedRigidBodyMessage2)
 

--- a/examples/scenarioRotatingPanel.py
+++ b/examples/scenarioRotatingPanel.py
@@ -148,9 +148,10 @@ def run(show_plots):
     gravFactory.addBodiesTo(scObject)
 
     # create sun position message
-    sunMessage = messaging.SpicePlanetStateMsgPayload()
-    sunMessage.PlanetName = "Sun"
-    sunMessage.PositionVector = [0, orbitalMotion.AU*1000, 0]
+    sunMessage = messaging.SpicePlanetStateMsgPayload(
+        PlanetName="Sun",
+        PositionVector=[0, orbitalMotion.AU*1000, 0],
+    )
     sunStateMsg = messaging.SpicePlanetStateMsg().write(sunMessage)
 
     # setup the orbit using classical orbit elements

--- a/examples/scenarioSensorThermal.py
+++ b/examples/scenarioSensorThermal.py
@@ -235,10 +235,8 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, tempLog)
 
     # Create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = (
-        I  # use the same inertia in the FSW algorithm as in the simulation
-    )
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg)
 

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -338,11 +338,12 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
     # Write THR Config Msg
     r_TF_F = [0, 0, 0]  # Thruster application point in F frame coordinates
     tHat_F = [0, 0, 1]  # Thrust unit direction vector in F frame coordinates
-    THRConfig = messaging.THRConfigMsgPayload()
-    THRConfig.rThrust_B = r_TF_F
-    THRConfig.tHatThrust_B = tHat_F
-    THRConfig.maxThrust = 0.27
-    THRConfig.swirlTorque = 0
+    THRConfig = messaging.THRConfigMsgPayload(
+        rThrust_B=r_TF_F,
+        tHatThrust_B=tHat_F,
+        maxThrust=0.27,
+        swirlTorque=0,
+    )
     if swirlTorque:
         THRConfig.swirlTorque = 1.0e-3 * THRConfig.maxThrust
     thrConfigFMsg = messaging.THRConfigMsg().write(THRConfig)
@@ -490,14 +491,14 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
     scSim.AddModelToTask(fswTask, cmEstimator, None, 29)
 
     # create the FSW vehicle configuration message for CoM
-    vehicleConfigData = messaging.VehicleConfigMsgPayload()
-    vehicleConfigData.CoM_B = r_CB_B_0    # use the same initial CoM guess as the cmEstimator module
+    # use the same initial CoM guess as the cmEstimator module
+    vehicleConfigData = messaging.VehicleConfigMsgPayload(CoM_B=r_CB_B_0)
     vcMsg_CoM = messaging.VehicleConfigMsg_C()
     vcMsg_CoM.write(vehicleConfigData)
 
     # create the FSW vehicle configuration message for inertias
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I       # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg_I = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Set up platform reference module
@@ -585,8 +586,7 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
     scSim.AddModelToTask(fswTask, rwMotorTorqueObj, 20)
 
     # Configure thruster on-time message
-    thrOnTimeMsgData = messaging.THRArrayOnTimeCmdMsgPayload()
-    thrOnTimeMsgData.OnTimeRequest = [3600*24*7]
+    thrOnTimeMsgData = messaging.THRArrayOnTimeCmdMsgPayload(OnTimeRequest=[3600*24*7])
     thrOnTimeMsg = messaging.THRArrayOnTimeCmdMsg().write(thrOnTimeMsgData)
 
     # Write cmEstimator output msg to the standalone message vcMsg_CoM

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -410,9 +410,10 @@ def run(show_plots):
     trackingError.attRefInMsg.subscribeTo(inertialPoint.attRefOutMsg)
 
     # Specify the vehicle configuration message to tell things what the vehicle inertia is
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I
-    vehicleConfigOut.CoM_B = [0.0, 0.0, 0.0]
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(
+        ISCPntB_B=I,
+        CoM_B=[0.0, 0.0, 0.0],
+    )
     vcConfigMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # Attitude controller configuration

--- a/examples/scenarioSmallBodyLandmarks.py
+++ b/examples/scenarioSmallBodyLandmarks.py
@@ -428,8 +428,8 @@ def run(show_plots, useBatch):
         scSim.AddModelToTask(simTaskName, landmarkLog[i])
 
     # Create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg)
 

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -629,8 +629,7 @@ def run(show_plots):
     trackingError.attRefInMsg.subscribeTo(sunPoint.attRefOutMsg)
 
     # Specify the vehicle configuration message to tell things what the vehicle inertia is
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcConfigMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     #   Attitude controller configuration

--- a/examples/scenarioSpacecraftLocation.py
+++ b/examples/scenarioSpacecraftLocation.py
@@ -174,8 +174,8 @@ def run(show_plots):
     attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # setup the MRP Feedback control module

--- a/examples/scenarioSpiceSpacecraft.py
+++ b/examples/scenarioSpiceSpacecraft.py
@@ -220,8 +220,7 @@ def run(show_plots):
     # The MRP Feedback algorithm requires the vehicle configuration structure. This defines various spacecraft
     # related states such as the inertia tensor and the position vector between the primary Body-fixed frame
     # B origin and the center of mass (defaulted to zero).  The message payload is created through
-    configData = messaging.VehicleConfigMsgPayload()
-    configData.ISCPntB_B = I
+    configData = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(configData)
 
     #

--- a/examples/scenarioSweepingSpacecraft.py
+++ b/examples/scenarioSweepingSpacecraft.py
@@ -288,8 +288,7 @@ def run (show_plots, useAltBodyFrame, angle_rate_command, time_command):
     mrpControl.ModelTag = "mrpFeedback"
     scSim.AddModelToTask(simTaskName, mrpControl)
     mrpControl.guidInMsg.subscribeTo(attError.attGuidOutMsg)
-    configData = messaging.VehicleConfigMsgPayload()
-    configData.ISCPntB_B = I
+    configData = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     configDataMsg = messaging.VehicleConfigMsg().write(configData)
     mrpControl.vehConfigInMsg.subscribeTo(configDataMsg) # The MRP feedback algorithm requires the vehicle configuration structure.
     mrpControl.K = 3.5

--- a/examples/scenarioTempMeasurementAttitude.py
+++ b/examples/scenarioTempMeasurementAttitude.py
@@ -273,14 +273,14 @@ def run(show_plots):
     numDataPoints = 100
     samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
 
-    # A message is created that stores an array of the true temperature and temperature measurement. 
+    # A message is created that stores an array of the true temperature and temperature measurement.
     # This is logged here to be plotted later on.
     rwTempLogs = []
     tempMeasLogs = []
     for item in range(numRW):
         rwTempLogs.append(rwTempList[item].temperatureOutMsg.recorder(samplingTime))
         scSim.AddModelToTask(simTaskName, rwTempLogs[item])
-        
+
         tempMeasLogs.append(tempMeasList[item].tempOutMsg.recorder(samplingTime))
         scSim.AddModelToTask(simTaskName, tempMeasLogs[item])
 
@@ -289,8 +289,8 @@ def run(show_plots):
     #
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # set up the FSW RW configuration message.
@@ -352,7 +352,7 @@ def run(show_plots):
     #
     #   retrieve the logged data
     #
-    
+
     dataRWTemperature = []
     dataTempMeasurement = []
     for i in range(numRW):
@@ -372,13 +372,13 @@ def run(show_plots):
 
     figureList = {}
     plot_rw_temperature(timeData, dataRWTemperature, numRW)
-    pltName = fileName + "1" 
+    pltName = fileName + "1"
     figureList[pltName] = plt.figure(1)
 
     plot_rw_temp_measurement(timeData, dataTempMeasurement, numRW)
-    pltName = fileName + "2" 
+    pltName = fileName + "2"
     figureList[pltName] = plt.figure(2)
-    
+
     if show_plots:
         plt.show()
 

--- a/examples/scenarioTwoChargedSC.py
+++ b/examples/scenarioTwoChargedSC.py
@@ -143,12 +143,10 @@ def run(show_plots):
     scSim.AddModelToTask(dynTaskName, MSMmodule)
 
     # define electric potentials
-    voltLeaderInMsgData = messaging.VoltMsgPayload()
-    voltLeaderInMsgData.voltage = -500  # [V] servicer potential
+    voltLeaderInMsgData = messaging.VoltMsgPayload(voltage=-500) # [V] servicer potential
     voltLeaderInMsg = messaging.VoltMsg().write(voltLeaderInMsgData)
 
-    voltFollowerInMsgData = messaging.VoltMsgPayload()
-    voltFollowerInMsgData.voltage = 500  # [V] debris potential
+    voltFollowerInMsgData = messaging.VoltMsgPayload(voltage=500) # [V] debris potential
     voltFollowerInMsg = messaging.VoltMsg().write(voltFollowerInMsgData)
 
     # Import multi-sphere model of GOESR bus and read them into an array of strings
@@ -174,8 +172,8 @@ def run(show_plots):
     rListLeader = radii  # radius of each sphere in the leader spacecraft
     spPosListFollower_H = spherelocation  # The location of each sphere for the follower spacecraft
     rListFollower = radii  # radius of each sphere in the follower spacecraft
-            
-            
+
+
 #    If you would like to simulate each spacecraft by a single sphere, uncomment this section (line186 - line189) of
     #    code and comment out the previous section lines (162-181)
 #     create a list of sphere body-fixed locations and associated radii using one sphere for each spacecraft
@@ -242,7 +240,7 @@ def run(show_plots):
     samplingTime = simulationTime // (numDataPoints - 1)
     dataRecL = scObjectLeader.scStateOutMsg.recorder()
     dataRecF = scObjectFollower.scStateOutMsg.recorder()
-    
+
     # Add recorders to the Task
     scSim.AddModelToTask(dynTaskName, dataRecL)
     scSim.AddModelToTask(dynTaskName, dataRecF)
@@ -276,7 +274,7 @@ def run(show_plots):
 
     attDataL_N = dataRecL.sigma_BN
     attDataF_N = dataRecF.sigma_BN
-    
+
     # Calculate relative position vector and magnitude in the inertial frame
     relPosData_N = posDataL_N[:, 0:3] - posDataF_N[:, 0:3]
     relPosMagn = np.linalg.norm(relPosData_N, axis=1)
@@ -317,7 +315,7 @@ def run(show_plots):
     plt.close("all")
 
     return figureList
-    
+
 
 def plotOrbits(timeData, posDataL_N, posDataF_N, relPosMagn, attDataL_N, attDataF_N, P, spPosListLeader_H, rListLeader,
                LeaderSpCharges, spPosListFollower_H, rListFollower, FollowerSpCharges, relXPosData_H, relYPosData_H,

--- a/examples/scenarioVizPoint.py
+++ b/examples/scenarioVizPoint.py
@@ -183,13 +183,14 @@ def run(show_plots, missionType, saveVizardFile):
         spiceObject.zeroBase = 'earth'
         scSim.AddModelToTask(simTaskName, spiceObject)
         # Setup Camera.
-        cameraConfig = messaging.CameraConfigMsgPayload()
-        cameraConfig.cameraID = 1
-        cameraConfig.renderRate = 0
-        cameraConfig.sigma_CB = [-0.333333, 0.333333, -0.333333]
-        cameraConfig.cameraPos_B = [5000. * 1E-3, 0., 0.]  # in meters
-        cameraConfig.fieldOfView = 0.62*macros.D2R  # in degrees
-        cameraConfig.resolution = [2048, 2048]  # in pixels
+        cameraConfig = messaging.CameraConfigMsgPayload(
+            cameraID=1,
+            renderRate=0,
+            sigma_CB=[-0.333333, 0.333333, -0.333333],
+            cameraPos_B=[5000. * 1E-3, 0., 0.], # m
+            fieldOfView=0.62*macros.D2R, # rad
+            resolution=[2048, 2048], # pixels
+        )
     else:
         simulationTime = macros.min2nano(6.25)
         gravFactory = simIncludeGravBody.gravBodyFactory()
@@ -197,13 +198,14 @@ def run(show_plots, missionType, saveVizardFile):
         mars = gravFactory.createMarsBarycenter()
         mars.isCentralBody = True  # ensure this is the central gravitational body
         mu = mars.mu
-        cameraConfig = messaging.CameraConfigMsgPayload()
-        cameraConfig.cameraID = 1
-        cameraConfig.renderRate = 0
-        cameraConfig.sigma_CB = [-0.333333, 0.333333, -0.333333]
-        cameraConfig.cameraPos_B = [5000. * 1E-3, 0., 0.]  # in meters
-        cameraConfig.fieldOfView = 50.*macros.D2R
-        cameraConfig.resolution = [512, 512]  # in pixels
+        cameraConfig = messaging.CameraConfigMsgPayload(
+            cameraID=1,
+            renderRate=0,
+            sigma_CB=[-0.333333, 0.333333, -0.333333],
+            cameraPos_B=[5000. * 1E-3, 0., 0.], # m
+            fieldOfView=50.*macros.D2R, # rad
+            resolution=[512, 512], # pixels
+        )
     camMsg = messaging.CameraConfigMsg().write(cameraConfig)
 
     #
@@ -270,8 +272,8 @@ def run(show_plots, missionType, saveVizardFile):
         earthPoint = np.array([0.,0.,0.1])
 
     # create the FSW vehicle configuration message
-    vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-    vehicleConfigOut.ISCPntB_B = I  # use the same inertia in the FSW algorithm as in the simulation
+    # use the same inertia in the FSW algorithm as in the simulation
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
     vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     # setup inertial3D guidance module

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -44,6 +44,19 @@ import_array();  // Required to initialize NumPy C API
 %}
 %include "folder/messageTypePayload.h"
 
+%feature("shadow") messageTypePayload()
+{
+def __init__(self, **fields):
+    """Constructs a new payload, zero'd by default.
+
+    Keyword arguments can be passed to initialize the fields of
+    this payload.
+    """
+    _ ## messageTypePayload.messageTypePayload ## _swiginit(self, _ ## messageTypePayload.new_ ## messageTypePayload())
+    for field, value in fields.items():
+        setattr(self, field, value)
+}
+
 %extend messageTypePayload {
 %pythoncode %{
     @classmethod

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -17,6 +17,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 %pythoncode %{
     import numpy as np
+    import inspect
     from Basilisk.utilities import deprecated
 %};
 %{
@@ -41,6 +42,30 @@ import_array();  // Required to initialize NumPy C API
 #include "folder/messageTypePayload.h"
 %}
 %include "folder/messageTypePayload.h"
+
+%extend messageTypePayload {
+%pythoncode %{
+    @classmethod
+    def __fields__(cls):
+        """Returns a list with all the payload's fields."""
+        return tuple(
+            name
+            for name, _ in inspect.getmembers(
+                cls,
+                lambda v: isinstance(v, property) and v is not cls.thisown
+            )
+        )
+
+    def __repr__(self):
+        """Formats the content of the payload"""
+        selfType = type(self)
+        fields = [
+            f"{name}={getattr(self, name)!r}"
+            for name in selfType.__fields__()
+        ]
+        return selfType.__qualname__ + "(" + ', '.join(fields) + ")"
+%}
+}
 
 %template(messageType ## Reader) ReadFunctor<messageTypePayload>;
 %extend ReadFunctor<messageTypePayload> {

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -18,6 +18,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 %pythoncode %{
     import numpy as np
     import inspect
+    import pprint
     from Basilisk.utilities import deprecated
 %};
 %{
@@ -66,6 +67,35 @@ import_array();  // Required to initialize NumPy C API
         return selfType.__qualname__ + "(" + ', '.join(fields) + ")"
 %}
 }
+
+%pythoncode %{
+def _pprint_ ## messageTypePayload(pprinter, object, stream, indent, allowance, context, level):
+    """Formatter function to support pretty-printing (with ``pprint``)."""
+    selfType = type(object)
+    cls_name = selfType.__qualname__
+    indent += len(cls_name) + 1
+    fields = [
+        (name, getattr(object, name))
+        for name in selfType.__fields__()
+    ]
+    stream.write(cls_name + '(')
+    if fields:
+        delimnl = ',\n' + ' ' * indent
+        last_index = len(fields) - 1
+        for i, (key, ent) in enumerate(fields):
+            last = i == last_index
+            stream.write(key)
+            stream.write('=')
+            pprinter._format(ent, stream, indent + len(key) + 1,
+                        allowance if last else 1,
+                        context, level)
+            if not last:
+                stream.write(delimnl)
+
+    stream.write(')')
+
+pprint.PrettyPrinter._dispatch[messageTypePayload.__repr__] = _pprint_ ## messageTypePayload
+%}
 
 %template(messageType ## Reader) ReadFunctor<messageTypePayload>;
 %extend ReadFunctor<messageTypePayload> {


### PR DESCRIPTION
* **Tickets addressed:** Closes #1053 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
- Added support for initializing messages like:
```
payload = messaging.GravityGradientMsgPayload(gravityGradientTorque_B=[1,2,3])
```
```
payload = messaging.AlbedoMsgPayload(
    AfluxAtInstrument=1.0, 
    AfluxAtInstrumentMax=2.0, 
    albedoAtInstrumentMax=3.0
)
```
- Added nicer printing of payloads:
```
>>> print(payload)
GravityGradientMsgPayload(gravityGradientTorque_B=[1.0, 2.0, 3.0])
```
- Added support for [pretty-printing](https://docs.python.org/3/library/pprint.html) payloads:
```
>>> pprint.pprint(payload)
AlbedoMsgPayload(AfluxAtInstrument=1.0,
                 AfluxAtInstrumentMax=2.0,
                 albedoAtInstrument=0.0,
                 albedoAtInstrumentMax=3.0)
``` 
- Updated all scenarios to use the new payload constructor format, when appropriate.

## Verification
Many scenarios were changed to use the new syntax, and they all run as expected.

New printing formats have been verified by simple visual inspection. Given that this does not impact functionality, this soft testing was deemed enough.

## Documentation
Updated documentation to showcase the new constructor format when appropriate. The documentation also contains other examples of setting fields after creation, so no information is lost.

## Future work
Improve type-hinting support. Right now, the constructor signature is:
```
def __init__(self, **kwargs):
```
which, while valid at runtime, does not provide any hints to the IDE. Given the changes in #1037 , the field information is already parsed and hardcoded in the SWIG file at compile time, so it wouldn't be impossible to use this information to hardcode the constructor to be:
```
def __init__(self, AfluxAtInstrument = None, AfluxAtInstrumentMax = None, ...)
```
