### PR TITLE
Implement VSCMG Velocity Steering module

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -32,6 +32,7 @@ Version |release|
 - Pinned python dependencies to avoid issues with new package versions.
 - Updated :ref:`vscmgStateEffector` documentation.
 - Added a new :ref:`vscmgGimbalRateServo` module that computes the VSCMG wheel motor torque and gimbal motor torque.
+- Added a new :ref:`vscmgVelocitySteering` module that computes the desired VSCMG wheel accelerations and gimbal rates.
 - Added a new github workflow job ``canary`` to routinely check the compatibility of latest python dependencies with python 3.13 on the latest mac-os.
 - Deprecated :ref:`SpacecraftSystem`.  It was never completed and we have other ways to connect spacecraft components
 - Allow event conditions and effects to be defined by functions. This is preferred over the old string-based method, as it

--- a/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/_UnitTest/test_vscmgVelocitySteering.py
+++ b/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/_UnitTest/test_vscmgVelocitySteering.py
@@ -1,0 +1,327 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+#
+import inspect
+import os
+
+import numpy as np
+import math
+import pytest
+
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import fswSetupVSCMGs
+from Basilisk.architecture import messaging
+from Basilisk.utilities import macros
+from Basilisk.fswAlgorithms import vscmgVelocitySteering
+
+def defaultVSCMG():
+    VSCMG = messaging.VSCMGConfigMsgPayload()
+
+    VSCMG.rGB_B = [[0.],[0.],[0.]]
+    VSCMG.gsHat0_B = [[0.],[0.],[0.]]
+    VSCMG.gtHat0_B = [[0.],[0.],[0.]]
+    VSCMG.ggHat_B = [[0.],[0.],[0.]]
+    VSCMG.u_s_max = -1
+    VSCMG.u_s_min = -1
+    VSCMG.u_s_f = 0.
+    VSCMG.wheelLinearFrictionRatio = -1
+    VSCMG.u_g_current = 0.
+    VSCMG.u_g_max = -1
+    VSCMG.u_g_min = -1
+    VSCMG.u_g_f = 0.
+    VSCMG.gimbalLinearFrictionRatio = -1
+    VSCMG.Omega = 14.4
+    VSCMG.gamma = 0.
+    VSCMG.gammaDot = 0.
+    VSCMG.Omega_max = 6000. * macros.RPM
+    VSCMG.gammaDot_max = -1
+    VSCMG.IW1 = 0.1
+    VSCMG.IW2 = 0.04
+    VSCMG.IW3 = 0.03
+    VSCMG.IG1 = 0.03
+    VSCMG.IG2 = 0.
+    VSCMG.IG3 = 0.
+    VSCMG.U_s = 0.
+    VSCMG.U_d = 0.
+    VSCMG.l = 0.
+    VSCMG.L = 0.
+    VSCMG.rGcG_G = [[0.],[0.],[0.]]
+    VSCMG.massW = 0.
+    VSCMG.massG = 0.
+    VSCMG.VSCMGModel = 0
+    return VSCMG
+
+def setupVSCMGs(numVSCMGs):
+    VSCMGs = []
+
+    ang = 54.75 * np.pi/180
+
+    VSCMGs.append(defaultVSCMG())
+    VSCMGs[0].ggHat_B = [[math.cos(ang)], [0.0], [math.sin(ang)]]
+    VSCMGs[0].gsHat0_B = [[0.0], [1.0], [0.0]]
+    VSCMGs[0].gtHat0_B = np.cross(np.array([math.cos(ang), 0.0, math.sin(ang)]),np.array([0.0, 1.0, 0.0]))
+
+    if numVSCMGs > 1:
+        VSCMGs.append(defaultVSCMG())
+        VSCMGs[1].gsHat0_B = [[0.0], [-1.0], [0.0]]
+        VSCMGs[1].ggHat_B = [[-math.cos(ang)], [0.0], [math.sin(ang)]]
+        VSCMGs[1].gtHat0_B = np.cross(np.array([-math.cos(ang), 0.0, math.sin(ang)]),np.array([0.0, -1.0, 0.0]))
+
+        if numVSCMGs == 4:
+            VSCMGs.append(defaultVSCMG())
+            VSCMGs[2].gamma = np.deg2rad(90.0)
+            gsHat2_t0_B = np.array([1.0, 0.0, 0.0])
+            ggHat2_B = np.array([0.0, math.cos(ang), math.sin(ang)])
+            gtHat2_t0_B = np.cross(ggHat2_B, gsHat2_t0_B)
+            gtHat2_t0_B /= np.linalg.norm(gtHat2_t0_B)
+            BG2 = np.column_stack([gsHat2_t0_B,
+                            gtHat2_t0_B,
+                            ggHat2_B])
+            GG02 = np.array([
+                [-math.cos(VSCMGs[2].gamma), math.sin(VSCMGs[2].gamma), 0.0],
+                [-math.sin(VSCMGs[2].gamma),  -math.cos(VSCMGs[2].gamma), 0.0],
+                [0.0,             0.0,          1.0]
+                ])
+            BG02 = BG2 @ GG02
+            VSCMGs[2].gsHat0_B = [[BG02[0][0]], [BG02[1][0]], [BG02[2][0]]]
+            VSCMGs[2].gtHat0_B = [[BG02[0][1]], [BG02[1][1]], [BG02[2][1]]]
+            VSCMGs[2].ggHat_B = [[BG02[0][2]], [BG02[1][2]], [BG02[2][2]]]
+
+            VSCMGs.append(defaultVSCMG())
+            VSCMGs[3].gamma = -np.deg2rad(90.0)
+            gsHat3_t0_B = np.array([-1.0, 0.0, 0.0])
+            ggHat3_B = np.array([0.0, -math.cos(ang), math.sin(ang)])
+            gtHat3_t0_B = np.cross(ggHat3_B, gsHat3_t0_B)
+            gtHat3_t0_B /= np.linalg.norm(gtHat3_t0_B)
+            BG3 = np.column_stack([gsHat3_t0_B,
+                            gtHat3_t0_B,
+                            ggHat3_B])
+            GG03 = np.array([
+                [-math.cos(VSCMGs[3].gamma), math.sin(VSCMGs[3].gamma), 0.0],
+                [-math.sin(VSCMGs[3].gamma),  -math.cos(VSCMGs[3].gamma), 0.0],
+                [0.0,             0.0,          1.0]
+                ])
+            BG03 = BG3 @ GG03
+            VSCMGs[3].gsHat0_B = [[BG03[0][0]], [BG03[1][0]], [BG03[2][0]]]
+            VSCMGs[3].gtHat0_B = [[BG03[0][1]], [BG03[1][1]], [BG03[2][1]]]
+            VSCMGs[3].ggHat_B = [[BG03[0][2]], [BG03[1][2]], [BG03[2][2]]]
+
+    return VSCMGs
+
+def etaDot(VSCMGs,numVSCMGs, omega_BN_B, omega_RN_B, mu, W0_s, W_g, Lr):
+
+    h_bar = np.zeros(numVSCMGs)
+    # Calculate the D matrices
+    D0 = np.zeros((3, numVSCMGs))
+    D1 = np.zeros((3, numVSCMGs))
+    D2 = np.zeros((3, numVSCMGs))
+    D3 = np.zeros((3, numVSCMGs))
+    D4 = np.zeros((3, numVSCMGs))
+    for i in range(numVSCMGs):
+        BG0 = np.column_stack((
+            np.array(VSCMGs[i].gsHat0_B).flatten(),
+            np.array(VSCMGs[i].gtHat0_B).flatten(),
+            np.array(VSCMGs[i].ggHat_B).flatten()
+        ))
+        GG0 = np.identity(3)
+        GG0[0,0] = np.cos(VSCMGs[i].gamma)
+        GG0[0,1] = np.sin(VSCMGs[i].gamma)
+        GG0[1,0] = -GG0[0,1]
+        GG0[1,1] = GG0[0,0]
+        BG = BG0 @ GG0.T
+        gsHat = BG[:, 0]
+        gtHat = BG[:, 1]
+
+        Js = VSCMGs[i].IG1 + VSCMGs[i].IW1
+        Jt = VSCMGs[i].IG2 + VSCMGs[i].IW2
+        Jg = VSCMGs[i].IG3 + VSCMGs[i].IW3
+        Iws = VSCMGs[i].IW1
+
+        omega_BN = np.array(omega_BN_B).flatten()
+        omega_RN = np.array(omega_RN_B).flatten()
+        omega_s = float(gsHat @ omega_BN)
+        omega_t = float(gtHat @ omega_BN)
+
+        Omega = VSCMGs[i].Omega
+
+        D0[:,i] = gsHat*Iws
+        D1[:,i] = (Iws*Omega + Js/2*omega_s)*gtHat + Js/2*omega_t*gsHat
+        D2[:,i] = 1/2*Jt*(omega_t*gsHat + omega_s*gtHat)
+        D3[:,i] = Jg*(omega_t*gsHat - omega_s*gtHat)
+        D4[:,i] = 1/2*(Js-Jt)*(np.outer(gsHat,gtHat) @ omega_RN + np.outer(gtHat,gsHat) @ omega_RN)
+
+        h_bar[i] = Js*Omega
+
+    D = D1-D2+D3+D4
+    Q = np.column_stack([D0,D])
+
+    mean_h_bar = np.mean(h_bar)
+    h_bar_squared = mean_h_bar**2
+    delta = np.linalg.det(1/h_bar_squared * (D1 @ D1.T))
+
+    W = np.zeros((2*numVSCMGs, 2*numVSCMGs))
+    for i in range(numVSCMGs):
+        W_si = W0_s[i] * np.exp(-mu*delta)
+        W[i,i] = W_si
+        W[numVSCMGs+i,numVSCMGs+i] = W_g[i]
+
+    QWQT = Q @ W @ Q.T
+    etaDot = W @ Q.T @ np.linalg.solve(QWQT, -np.array(Lr))
+
+    return etaDot
+
+@pytest.mark.parametrize("numVSCMGs", [2,4])
+
+def test_vscmgVelocitySteering(show_plots, numVSCMGs):
+   """Module Unit Test"""
+   [testResults, testMessage] = vscmgVelocitySteeringTest(show_plots, numVSCMGs)
+   assert testResults < 1, testMessage
+
+def vscmgVelocitySteeringTest(show_plots, numVSCMGs):
+    r"""
+    **Validation Test Description**
+
+    Compose a general description of what is being tested in this unit test script.
+
+    **Test Parameters**
+
+    Discuss the test parameters used.
+
+    Args:
+        numVSCMGs (int): number of VSCMGs for this parameterized unit test
+
+    **Description of Variables Being Tested**
+
+    In this file we are checking that the VSCMG Velocity Steering module produces the desired
+    wheel accelerations and gimbal rates.
+    Therefore, the output accelerations and rates are checked against their expected values
+    """
+    testFailCount = 0
+    testMessages = []
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProcessRate = macros.sec2nano(0.1)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # setup module to be tested
+    module = vscmgVelocitySteering.VscmgVelocitySteering()
+    module.ModelTag = "vscmgVelocitySteeringTag"
+    mu = 1e-9
+    module.setMu(mu)
+    W0_s = [200.0] * numVSCMGs
+    W_g = [1.0] * numVSCMGs
+    module.setW0_s(W0_s)
+    module.setW_g(W_g)
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # setup hub angular velocity
+    omega_BN_B = [0.01, -0.01, 0.005]
+    attIn = messaging.NavAttMsgPayload()
+    attIn.omega_BN_B = omega_BN_B
+
+    # setup hub reference angular velocity
+    omega_RN_B = [ 0.00649856, -0.01231292, -0.01172612]
+    guideIn = messaging.AttGuidMsgPayload()
+    guideIn.omega_RN_B = omega_RN_B
+
+    # setup VSCMGs
+    VSCMGs = setupVSCMGs(numVSCMGs)
+    fswSetupVSCMGs.clearSetup()
+    for i in range(numVSCMGs):
+        fswSetupVSCMGs.create(
+            VSCMGs[i].gsHat0_B, VSCMGs[i].gtHat0_B, VSCMGs[i].ggHat_B,
+            VSCMGs[i].IG1, VSCMGs[i].IG2, VSCMGs[i].IG3,
+            VSCMGs[i].IW1, VSCMGs[i].IW2, VSCMGs[i].IW3,
+            VSCMGs[i].Omega, VSCMGs[i].gamma, VSCMGs[i].gammaDot)
+
+    # setup speeds message
+    speedsArray = messaging.VSCMGSpeedMsgPayload()
+    gimbalAngles = []
+    gimbalRates = []
+    wheelSpeeds = []
+    for i in range(numVSCMGs):
+        gimbalAngles.append(VSCMGs[i].gamma)
+        gimbalRates.append(VSCMGs[i].gammaDot)
+        wheelSpeeds.append(VSCMGs[i].Omega)
+    speedsArray.gimbalAngles = gimbalAngles
+    speedsArray.gimbalRates = gimbalRates
+    speedsArray.wheelSpeeds = wheelSpeeds
+
+    # setup control torque
+    Lr = [-0.42470656, -0.82132484, -1.76165287]
+    vehControlIn = messaging.CmdTorqueBodyMsgPayload()
+    vehControlIn.torqueRequestBody = Lr
+
+    # write messages
+    vscmgParamMsg = fswSetupVSCMGs.writeConfigMessage()
+    attInMsg = messaging.NavAttMsg().write(attIn)
+    guideInMsg = messaging.AttGuidMsg().write(guideIn)
+    speedsInMsg = messaging.VSCMGSpeedMsg().write(speedsArray)
+    vehControlInMsg = messaging.CmdTorqueBodyMsg().write(vehControlIn)
+
+    # subscribe input messages to module
+    module.vscmgParamsInMsg.subscribeTo(vscmgParamMsg)
+    module.vehControlInMsg.subscribeTo(vehControlInMsg)
+    module.attNavInMsg.subscribeTo(attInMsg)
+    module.attGuideInMsg.subscribeTo(guideInMsg)
+    module.speedsInMsg.subscribeTo(speedsInMsg)
+
+    # setup logging for the output message
+    dataLog = module.vscmgRefStatesOutMsg.recorder()
+    dataLogC = module.vscmgRefStatesOutMsgC.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    unitTestSim.AddModelToTask(unitTaskName, dataLogC)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.1))
+    unitTestSim.ExecuteSimulation()
+
+    # pull module data and make sure it is correct
+    wheelAccels = dataLog.wheelAccels[0,:numVSCMGs]
+    gimbalRates = dataLog.gimbalRates[0,:numVSCMGs]
+    wheelAccelsC = dataLogC.wheelAccels[0,:numVSCMGs]
+    gimbalRatesC = dataLogC.gimbalRates[0,:numVSCMGs]
+
+    moduleOutputs = np.concatenate((wheelAccels, gimbalRates))
+    moduleOutputsC = np.concatenate((wheelAccelsC, gimbalRatesC))
+
+    # set the output truth values
+    trueOutputs = etaDot(VSCMGs,numVSCMGs, omega_BN_B, omega_RN_B, mu, W0_s, W_g, Lr)
+
+    # compare the module output values to the truth values
+    accuracy = 1e-12
+    testFailCount, testMessages = unitTestSupport.compareArrayND([trueOutputs], [moduleOutputs], accuracy, "VSCMGDesiredStates",
+                                                                 2*numVSCMGs, testFailCount, testMessages)
+
+    testFailCount, testMessages = unitTestSupport.compareArrayND([moduleOutputs], [moduleOutputsC], accuracy, "cMsgTorques",
+                                                                 2 * numVSCMGs, testFailCount, testMessages)
+
+    if testFailCount == 0:
+        print("PASSED: " + module.ModelTag)
+    else:
+        print(testMessages)
+
+    return [testFailCount, "".join(testMessages)]
+
+
+if __name__ == "__main__":
+    test_vscmgVelocitySteering(False, 4)

--- a/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.cpp
@@ -1,0 +1,211 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+#include "fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.h"
+#include <cstring>
+#include <iostream>
+
+/*! Initialize C-wrapped output messages */
+void
+VscmgVelocitySteering::SelfInit(){
+    VSCMGRefStatesMsg_C_init(&this->vscmgRefStatesOutMsgC);
+}
+
+/*! This is the constructor for the module class.  It sets default variable
+    values and initializes the various parts of the model */
+VscmgVelocitySteering::VscmgVelocitySteering()
+{
+    // initialize module variables
+    this->mu = 0.0;
+    this->W0_s = std::vector<double>(MAX_EFF_CNT, 0.0);
+    this->W_g = std::vector<double>(MAX_EFF_CNT, 0.0);
+    this->h_bar = std::vector<double>(MAX_EFF_CNT, 0.0);
+}
+
+/*! This method is used to reset the module, checks that required input messages are connected, and initializes internal
+ * states.
+ */
+void
+VscmgVelocitySteering::Reset(uint64_t CurrentSimNanos)
+{
+    // check that required input messages are connected
+    if (!this->vscmgParamsInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "VscmgVelocitySteering.vscmgParamsInMsg was not linked.");
+    }
+    if (!this->vehControlInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "VscmgVelocitySteering.vehControlInMsg was not linked.");
+    }
+    if (!this->attNavInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "VscmgVelocitySteering.attNavInMsg was not linked.");
+    }
+    if (!this->attGuideInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "VscmgVelocitySteering.attGuideInMsg was not linked.");
+    }
+    if (!this->speedsInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "VscmgVelocitySteering.speedsInMsg was not linked.");
+    }
+
+    this->vscmgConfigParams = this->vscmgParamsInMsg();
+
+    for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
+        this->h_bar[i] = vscmgConfigParams.JsList[i] * vscmgConfigParams.Omega0List[i];
+    }
+    Eigen::VectorXd h_bar_vec = Eigen::Map<Eigen::VectorXd>(this->h_bar.data(), this->h_bar.size());
+    double mean_h_bar = 0.0;
+    for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
+        mean_h_bar += h_bar_vec[i];
+    }
+    mean_h_bar /= vscmgConfigParams.numVSCMG;
+    this->h_bar_squared = mean_h_bar * mean_h_bar;
+}
+
+/*! This is the main method that gets called every time the module is updated.  Provide an appropriate description.
+ */
+void
+VscmgVelocitySteering::UpdateState(uint64_t CurrentSimNanos)
+{
+    double omegas;                                          /*![rad/s] projection of body angular velocity onto gsHat axis*/
+    double omegat;                                          /*![rad/s] projection of body angular velocity onto gtHat axis*/
+    double delta;                                           /*![-] proximity to CMG singularity*/
+    double W_si;                                            /*![-] RW mode weight*/
+    Eigen::Vector3d omega_BN_B;                             /*![rad/s] angular velocity of the body frame relative to the inertial frame*/
+    Eigen::Vector3d omega_RN_B;                             /*![rad/s] angular velocity of the reference frame relative to the inertial frame*/
+    Eigen::Vector3d gsHat0_B;                               /*![-] first gimbal unit axis when rotation angle is 0*/
+    Eigen::Vector3d gtHat0_B;                               /*![-] second gimbal unit axis when rotation angle is 0*/
+    Eigen::Vector3d ggHat_B;                                /*![-] third gimbal unit axis*/
+    Eigen::VectorXd etaDot(2 * vscmgConfigParams.numVSCMG); /*![rad/s^2] and [rad/s] desired RW accelerations and gimbal rates*/
+    Eigen::Matrix3d BG0;                                    /*![-] DCM between body frame and gimbal frame when rotation angle is zero */
+    Eigen::Matrix3d GG0;                                    /*![-] DCM between gimbal frame and gimbal frame when rotation angle is zero */
+    Eigen::Matrix3d BG;                                     /*![-] DCM between body frame and gimbal frame */
+    Eigen::Matrix3d QWQT;
+    Eigen::MatrixXd D0(3, vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd D1(3, vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd D2(3, vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd D3(3, vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd D4(3, vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd D(3, vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd Q(3, 2 * vscmgConfigParams.numVSCMG);
+    Eigen::MatrixXd W(2 * vscmgConfigParams.numVSCMG, 2 * vscmgConfigParams.numVSCMG);
+    CmdTorqueBodyMsgPayload Lr;
+    NavAttMsgPayload hubAttState;
+    AttGuidMsgPayload hubGuideState;
+    VSCMGSpeedMsgPayload VSCMGSpeeds;
+
+    D0.setZero();
+    D1.setZero();
+    D2.setZero();
+    D3.setZero();
+    D4.setZero();
+    D.setZero();
+    Q.setZero();
+    W.setZero();
+
+    this->outputRefStates = this->vscmgRefStatesOutMsg.zeroMsgPayload;
+    Lr = this->vehControlInMsg();
+    hubAttState = this->attNavInMsg();
+    hubGuideState = this->attGuideInMsg();
+
+    if (!this->speedsInMsg.isWritten()) {
+        for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
+            VSCMGSpeeds.wheelSpeeds[i] = vscmgConfigParams.Omega0List[i];
+            VSCMGSpeeds.gimbalAngles[i] = vscmgConfigParams.gamma0List[i];
+            VSCMGSpeeds.gimbalRates[i] = vscmgConfigParams.gammaDot0List[i];
+        }
+    } else {
+        VSCMGSpeeds = this->speedsInMsg();
+    }
+
+    omega_BN_B = Eigen::Vector3d(hubAttState.omega_BN_B[0], hubAttState.omega_BN_B[1], hubAttState.omega_BN_B[2]);
+    omega_RN_B = Eigen::Vector3d(hubGuideState.omega_RN_B[0], hubGuideState.omega_RN_B[1], hubGuideState.omega_RN_B[2]);
+
+    for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
+        gsHat0_B = Eigen::Map<const Eigen::Vector3d>(&vscmgConfigParams.Gs0Matrix_B[3 * i]);
+        gtHat0_B = Eigen::Map<const Eigen::Vector3d>(&vscmgConfigParams.Gt0Matrix_B[3 * i]);
+        ggHat_B = Eigen::Map<const Eigen::Vector3d>(&vscmgConfigParams.GgMatrix_B[3 * i]);
+
+        BG0.col(0) = gsHat0_B;
+        BG0.col(1) = gtHat0_B;
+        BG0.col(2) = ggHat_B;
+
+        GG0 = eigenM3(VSCMGSpeeds.gimbalAngles[i]);
+        BG = BG0 * GG0.transpose();
+
+        omegas = BG.col(0).transpose() * omega_BN_B;
+        omegat = BG.col(1).transpose() * omega_BN_B;
+
+        D0.col(i) = BG.col(0) * vscmgConfigParams.IwsList[i];
+        D1.col(i) =
+          (vscmgConfigParams.IwsList[i] * VSCMGSpeeds.wheelSpeeds[i] + 0.5 * vscmgConfigParams.JsList[i] * omegas) *
+            BG.col(1) +
+          0.5 * vscmgConfigParams.JsList[i] * omegat * BG.col(0);
+        D2.col(i) = 0.5 * vscmgConfigParams.JtList[i] * (omegat * BG.col(0) + omegas * BG.col(1));
+        D3.col(i) = vscmgConfigParams.JgList[i] * (omegat * BG.col(0) - omegas * BG.col(1));
+        D4.col(i) = 0.5 * (vscmgConfigParams.JsList[i] - vscmgConfigParams.JtList[i]) *
+                    (BG.col(0) * BG.col(1).transpose() * omega_RN_B + BG.col(1) * BG.col(0).transpose() * omega_RN_B);
+    }
+
+    D = D1 - D2 + D3 + D4;
+
+    Q.block(0, 0, 3, vscmgConfigParams.numVSCMG) = D0;
+    Q.block(0, vscmgConfigParams.numVSCMG, 3, vscmgConfigParams.numVSCMG) = D;
+
+    delta = ((1.0 / this->h_bar_squared) * (D1 * D1.transpose())).determinant();
+
+    for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
+        W_si = this->W0_s[i] * exp(-this->mu * delta);
+        W(i, i) = W_si;
+        W(i + vscmgConfigParams.numVSCMG, i + vscmgConfigParams.numVSCMG) = this->W_g[i];
+    }
+
+    Eigen::Vector3d torqueVec = Eigen::Map<const Eigen::Vector3d>(Lr.torqueRequestBody);
+    QWQT = Q * W * Q.transpose();
+    etaDot = W * Q.transpose() * QWQT.ldlt().solve(-torqueVec);
+
+    for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
+        this->outputRefStates.wheelAccels[i] = etaDot(i);
+        this->outputRefStates.gimbalRates[i] = etaDot(i + vscmgConfigParams.numVSCMG);
+    }
+
+    // Write the output message for the VSCMG reference states
+    this->vscmgRefStatesOutMsg.write(&outputRefStates, this->moduleID, CurrentSimNanos);
+    // Write the C-wrapped output message for the VSCMG torques
+    VSCMGRefStatesMsg_C_write(&this->outputRefStates, &this->vscmgRefStatesOutMsgC, this->moduleID, CurrentSimNanos);
+}
+
+void
+VscmgVelocitySteering::setMu(double var)
+{
+    this->mu = var;
+}
+
+void
+VscmgVelocitySteering::setW0_s(std::vector<double> var)
+{
+    for (size_t i = 0; i < var.size() && i < MAX_EFF_CNT; ++i) {
+        this->W0_s[i] = var[i];
+    }
+}
+
+void
+VscmgVelocitySteering::setW_g(std::vector<double> var)
+{
+    for (size_t i = 0; i < var.size() && i < MAX_EFF_CNT; ++i) {
+        this->W_g[i] = var[i];
+    }
+}

--- a/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.h
+++ b/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.h
@@ -1,0 +1,81 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+
+#ifndef VSCMG_VELOCITY_STEERING_H
+#define VSCMG_VELOCITY_STEERING_H
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/msgPayloadDefC/VSCMGArrayConfigMsgPayload.h"
+#include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
+#include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+#include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+#include "architecture/msgPayloadDefC/VSCMGSpeedMsgPayload.h"
+#include "cMsgCInterface/VSCMGRefStatesMsg_C.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/messaging/messaging.h"
+#include <Eigen/Dense>
+#include "architecture/utilities/avsEigenSupport.h"
+
+/*! @brief Mapping desired control torque vector to gimbal rates and RW wheel accelerations
+ */
+class VscmgVelocitySteering: public SysModel {
+public:
+    VscmgVelocitySteering();
+    ~VscmgVelocitySteering() = default;
+    void SelfInit();
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+
+public:
+    ReadFunctor<VSCMGArrayConfigMsgPayload> vscmgParamsInMsg;  //!< [-] VSCMG array configuration input message
+    ReadFunctor<CmdTorqueBodyMsgPayload> vehControlInMsg;  //!< [-] vehicle control (Lr) input message
+    ReadFunctor<NavAttMsgPayload> attNavInMsg;  //!< [-] attitude navigation input message
+    ReadFunctor<AttGuidMsgPayload> attGuideInMsg;  //!< [-] attitude guidance input message
+    ReadFunctor<VSCMGSpeedMsgPayload> speedsInMsg;  //!< [-] VSCMG speeds input message
+    Message<VSCMGRefStatesMsgPayload> vscmgRefStatesOutMsg;  //!< [-] reference VSCMG states C++ output message
+    VSCMGRefStatesMsg_C               vscmgRefStatesOutMsgC = {};  //!< [-] reference VSCMG states C output message
+    BSKLogger bskLogger;              //!< BSK Logging
+
+    /** setter for `mu` property */
+    void setMu(double);
+    /** getter for `mu` property */
+    double getMu() const {return this->mu;}
+    /** setter for `W0_s` property */
+    void setW0_s(std::vector<double>);
+    /** getter for `W0_s` property */
+    std::vector<double> getW0_s() const {return this->W0_s;}
+    /** setter for `W_g` property */
+    void setW_g(std::vector<double>);
+    /** getter for `W_g` property */
+    std::vector<double> getW_g() const {return this->W_g;}
+
+private:
+    double mu;  //!< [-] control parameter for wheel weights
+    double h_bar_squared;  //!< [kg^2-m^4/s^4] square of nominal RW angular momentums
+    std::vector<double> W0_s;  //!< [-] vector of static wheel weights
+    std::vector<double> W_g;  //!< [-] vector of gimbal wheel weights
+    std::vector<double> h_bar;  //!< [kg-m^2/s] vector of nominal RW angular momentums
+    VSCMGRefStatesMsgPayload outputRefStates;  //!< [-] output reference states for the VSCMGs
+    VSCMGArrayConfigMsgPayload vscmgConfigParams;  //!< [-] struct to store message containing VSCMG config parameters in body B frame
+
+};
+
+
+#endif

--- a/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.i
+++ b/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.i
@@ -1,0 +1,57 @@
+/*
+ ISC License
+
+ Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+*/
+
+%module vscmgVelocitySteering
+
+%include "architecture/utilities/bskException.swg"
+%default_bsk_exception();
+
+%{
+    #include "vscmgVelocitySteering.h"
+%}
+
+%include "std_vector.i"
+%template(DoubleVector) std::vector<double>;
+
+%pythoncode %{
+    from Basilisk.architecture.swig_common_model import *
+%}
+%include "std_string.i"
+%include "swig_conly_data.i"
+
+%include "sys_model.i"
+%include "vscmgVelocitySteering.h"
+
+%include "architecture/msgPayloadDefC/VSCMGArrayConfigMsgPayload.h"
+struct VSCMGArrayConfigMsg_C;
+%include "architecture/msgPayloadDefC/CmdTorqueBodyMsgPayload.h"
+struct CmdTorqueBodyMsg_C;
+%include "architecture/msgPayloadDefC/NavAttMsgPayload.h"
+struct NavAttMsg_C;
+%include "architecture/msgPayloadDefC/AttGuidMsgPayload.h"
+struct AttGuidMsg_C;
+%include "architecture/msgPayloadDefC/VSCMGSpeedMsgPayload.h"
+struct VSCMGSpeedMsg_C;
+%include "architecture/msgPayloadDefC/VSCMGRefStatesMsgPayload.h"
+struct VSCMGRefStatesMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.rst
+++ b/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.rst
@@ -1,0 +1,138 @@
+Executive Summary
+-----------------
+The ``vscmgVelocitySteering`` module maps the required spacecraft control torque vector (:math:`\boldsymbol{L}_r`) to a corresponding reference wheel acceleration and gimbal rate for each VSCMG.
+
+Message Connection Descriptions
+-------------------------------
+The following table lists all the module input and output messages. The module msg connection is set by the user from python. The msg type contains a link to the message structure definition, while the description provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - vscmgParamsInMsg
+      - :ref:`VSCMGArrayConfigMsgPayload`
+      - VSCMG array configuration input message
+    * - vehControlInMsg
+      - :ref:`CmdTorqueBodyMsgPayload`
+      - vehicle control (Lr) input message
+    * - attNavInMsg
+      - :ref:`NavAttMsgPayload`
+      - attitude navigation input message
+    * - attGuideInMsg
+      - :ref:`AttGuidMsgPayload`
+      - attitude guidance input message
+    * - speedsInMsg
+      - :ref:`VSCMGSpeedMsgPayload`
+      - VSCMG speeds input message
+    * - vscmgRefStatesOutMsg
+      - :ref:`VSCMGRefStatesMsgPayload`
+      - reference VSCMG states output message
+
+
+Detailed Module Description
+---------------------------
+General Function
+^^^^^^^^^^^^^^^^
+the `vscmgVelocitySteering` module creates the VSCMG reference state vector :math:`\dot{\boldsymbol{\eta}}` developed in chapter 8 of `Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__.
+
+Algorithm
+^^^^^^^^^
+This module employs the Velocity-Based VSCMG Steering Law of Section (8.8.2) of `Analytical Mechanics of Space Systems <http://doi.org/10.2514/4.105210>`__.  Use of the :math:`2N\times1` state vector :math:`{\boldsymbol{\eta}}`
+
+.. math:: \boldsymbol{\eta} = \begin{bmatrix} \boldsymbol{\Omega} \\ \boldsymbol{\gamma} \end{bmatrix}
+    :label: eq:vscmgEta
+
+and :math:`3\times2N` matrix :math:`[Q]`
+
+.. math:: [Q] = \begin{bmatrix} D_0 & D \end{bmatrix}
+    :label: eq:vscmgQ
+
+allow for the compact expression
+
+.. math:: [Q]\dot{\boldsymbol{\eta}} = -\boldsymbol{L}_r
+    :label: eq:vscmgControl
+
+where :math:`\boldsymbol{L}_r` is the required spacecraft control torque vector, :math:`N` is the number of VSCMGs, :math:`\boldsymbol{\Omega}` is the vector of RW spin rates, and :math:`\boldsymbol{\gamma}` is the vector of gimbal angles. The matrices :math:`[D_0]` and :math:`[D]` are defined with all components in the spacecraft body frame :math:`\mathcal{B}` as
+
+.. math:: [D_0] = \begin{bmatrix} \cdots \hat{\boldsymbol{g}}_{s_{i}}I_{W_{s_{i}}} \cdots \end{bmatrix}
+    :label: eq:vscmgD0
+
+.. math:: [D_1] = \begin{bmatrix} \cdots \left(I_{W_{s_{i}}}\Omega_{i} + \frac{J_{s_{i}}}{2}\omega_{s_{i}} \right)\hat{\boldsymbol{g}}_{t_{i}} + \frac{J_{s_{i}}}{2}\omega_{t_{i}}\hat{\boldsymbol{g}}_{s_{i}} \cdots \end{bmatrix}
+    :label: eq:vscmgD1
+
+.. math:: [D_2] = \begin{bmatrix} \cdots \frac{1}{2}J_{t_{i}}(\omega_{t_{i}}\hat{\boldsymbol{g}}_{s_{i}}+\omega_{s_{i}}\hat{\boldsymbol{g}}_{t_{i}}) \cdots \end{bmatrix}
+    :label: eq:vscmgD2
+
+.. math:: [D_3] = \begin{bmatrix} \cdots J_{g_{i}}(\omega_{t_{i}}\hat{\boldsymbol{g}}_{s_{i}}-\omega_{s_{i}}\hat{\boldsymbol{g}}_{t_{i}}) \cdots \end{bmatrix}
+    :label: eq:vscmgD3
+
+.. math:: [D_4] = \begin{bmatrix} \cdots \frac{1}{2}(J_{s_{i}}-J_{t_{i}})(\hat{\boldsymbol{g}}_{s_{i}}\hat{\boldsymbol{g}}_{t_{i}}^{T}\boldsymbol{\omega}_{r} + \hat{\boldsymbol{g}}_{t_{i}}\hat{\boldsymbol{g}}_{s_{i}}^{T}\boldsymbol{\omega}_{r}) \cdots \end{bmatrix}
+    :label: eq:vscmgD4
+
+.. math:: [D] = ([D_1] - [D_2] + [D_3] + [D_4])
+    :label: eq:vscmgD
+
+where
+
+.. math:: {\boldsymbol{ \omega}} = \omega_{s_{i}}\hat{\boldsymbol{ g}}_{s_{i}} + \omega_{t_{i}}\hat{\boldsymbol{ g}}_{t_{i}} + \omega_{g_{i}}\hat{\boldsymbol{ g}}_{g_{i}}
+    :label: eq:omegaComponents
+
+and :math:`\hat{\boldsymbol{g}}_{s_{i}}`, :math:`\hat{\boldsymbol{g}}_{t_{i}}`, and :math:`\hat{\boldsymbol{g}}_{g_{i}}` are the unit vectors in the direction of the first, second and third axis of the ith gimbal wheel system respectively, :math:`J_{s_{i}}`, :math:`J_{t_{i}}`, :math:`J_{g_{i}}` are the inertias for the ith gimbal wheel system for the first, second and third axis, :math:`I_{w_{s_{i}}}` is the ith RW spin axis inertia, and :math:`\boldsymbol{\omega}_{r}` is the reference angular velocity for the spacecraft.
+
+Defining the :math:`2N\times2N` diagonal weighting matrix :math:`[W]`
+
+.. math:: [W] = \text{diag}\{W_{s_{1}},\cdots,W_{s_{N}},W_{g_{1}},\cdots,W_{g_{N}}\}
+    :label: eq:vscmgWeights
+
+where :math:`W_{s_{i}}` and :math:`W_{g_{i}}` are the weights associated with the ith VSCMG RW and CMG respectively. The desired :math:`\dot{\boldsymbol{\eta}}` can be found through
+
+.. math:: \dot{\boldsymbol{\eta}} = [W][Q]^{T}([Q][W][Q]^{T})^{-1}(-\boldsymbol{L}_{r})
+    :label: eq:vscmgEtaDot
+
+The weights are defined to be dependant on proximity to a CMG singularity through the use of the non-dimensional scalar
+
+.. math:: \delta = \text{det}\frac{1}{\overline{h}^{2}}([D_{1}][D_{1}]^{T})
+    :label: eq:vscmgDelta
+
+where :math:`\overline{h}` is the nominal RW angular momentum found through
+
+.. math:: \overline{h} = \frac{1}{N}\sum_{i=1}^{N}I_{w_{s_{i}}}\Omega_{i_{0}}
+    :label: eq:vscmgHbar
+
+where :math:`\Omega_{i_{0}}` is the nominal spin rate of the ith RW. As the CMG approaches a singularity :math:`\delta` goes to zero. The weights :math:`W_{s_{i}}` can be defined as
+
+.. math:: W_{s_{i}} = W_{s_{i}}^{0}e^{(-\mu\delta)}
+    :label: eq:vscmgWs
+
+with :math:`W_{s_{i}}^{0}` and :math:`\mu` being positive scalars. The weights :math:`W_{g_{i}}` are held constant. This allows for the weights on the RW mode to be small when far from the CMG singularity but still allow the control to produce :math:`\boldsymbol{L}_{r}` if a singularity is reached.
+
+User Guide
+----------
+This section is to outline the steps needed to setup the VSCMG velocity steering module in Python using Basilisk.
+
+#. Import the vscmgVelocitySteering class::
+
+    from Basilisk.fswAlgorithms import vscmgVelocitySteering
+
+#. Create an instance of the vscmgVelocitySteering class::
+
+    vscmgSteering = vscmgVelocitySteering.VscmgVelocitySteering()
+
+#. Set the module parameters::
+
+    mu = 1e-9
+    vscmgSteering.setMu(mu)
+    W0_s = [200.0] * numVSCMGs
+    W_g = [1.0] * numVSCMGs
+    vscmgSteering.setW0_s(W0_s)
+    vscmgSteering.setW_g(W_g)
+
+#. The VSCMG reference states output message is ``vscmgRefStatesOutMsg``.
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, vscmgSteering)


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge

## Description
This PR adds the ability to take a requested spacecraft control torque vector and convert it to a reference state (wheel acceleration and gimbal rate) for a set of VSCMGs that can be used by the vscmgGimbalRateServo module. This enables spacecraft control through use of VSCMGs.

## Verification
A new unit test ``test_vscmgVelocitySteering.py`` was created which verifies the output reference states for a given control torque.

## Documentation
New documentation was made for the ``vscmgVelocitySteering`` module. Release notes were updated to include the new module.

## Future work
N/A
