### PR TITLE
[hotfix] Forward conan_args matrix values to build step

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: ./.github/actions/build
         with:
           python-version: ${{ matrix.python }}
-          conan-args: --opNav True --mujoco True --mujocoReplay True --recorderPropertyRollback True
+          conan-args: ${{ matrix.conan_args }}
       - name: Pytest
         working-directory: src
         run: |


### PR DESCRIPTION
* **Tickets addressed:** bsk-1084
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The build step that passes the conan_args still had the old hard coded value. This hot fix corrects it by
passing the matrix values correctly.


## Verification
Inspect CI/CD job.

## Documentation
N/A

## Future work
N/A

Closes #1084
