### PR TITLE
Build docs from bumped version commit

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -49,6 +49,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
       - name: Build Basilisk
         uses: ./.github/actions/build
         with:


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description

The docs build step in the merge workflow was checking out the workflow’s triggering commit. Since the version bump adds a new commit to develop, we need to ensure the docs are built from the bumped commit instead.

By explicitly checking out ref: develop with fetch-depth: 0, the build step always pulls the latest state of the develop branch which includes the new bumped version commit.

## Verification

This change can only be verified when the Merge workflow runs, which requires merging this PR into develop.

## Documentation
N/A

## Future work
N/A
