### PR TITLE
Refactor/Update MJSystemCOM EOM Call

### DIFF
--- a/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.cpp
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.cpp
@@ -61,10 +61,6 @@ void MJSystemCoM::UpdateState(uint64_t CurrentSimNanos)
     r_CN_N.setZero();
     v_CN_N.setZero();
 
-    // extract the CoM values
-
-    mj_forward(model, data);
-
     // calculate CoM position
     for (int i = 1; i < model->nbody; i++) {
         const double mi = model->body_mass[i];

--- a/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.rst
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.rst
@@ -31,7 +31,11 @@ This section is to outline the steps needed to setup the ``MJSystemCoM`` module 
 
     from Basilisk.simulation import MJSystemCoM
 
-#. Create an instance of the MJSystemCoM::
+#. Enable extra EOM call when building the Mujoco scene::
+
+    scene.extraEoMCall = True
+
+#. Create an instance of MJSystemCoM::
 
     module = MJSystemCoM.MJSystemCoM()
 

--- a/src/simulation/mujocoDynamics/MJSystemCoM/_UnitTest/test_MJSystemCoM.py
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/_UnitTest/test_MJSystemCoM.py
@@ -213,6 +213,7 @@ def MJSystemCoMTest(show_plots, model, moving, displaced):
 
     # create the Mujoco scene
     scene = mujoco.MJScene.fromFile(xml_path)
+    scene.extraEoMCall = True
     unitTestSim.AddModelToTask(unitTaskName, scene)
 
     # setup module to be tested
@@ -242,16 +243,10 @@ def MJSystemCoMTest(show_plots, model, moving, displaced):
     r_CN_N_module_c = comStatesOutMsgCRec.r_CN_N[-1,:]
     v_CN_N_module_c = comStatesOutMsgCRec.v_CN_N[-1,:]
 
-    print("module pos:", r_CN_N_module)
-    print("module vel:", v_CN_N_module)
-
     # compute the truth data
     r_CN_N_truth0, v_CN_N_truth0 = _expected_com(model, r0, v0)
     r_CN_N_truth = r_CN_N_truth0 + v_CN_N_truth0 * 0.2
     v_CN_N_truth = v_CN_N_truth0
-
-    print("truth pos:", r_CN_N_truth)
-    print("truth vel:", v_CN_N_truth)
 
     # Compare
     acc = 1e-12


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This refactor of the `MJSystemCOM` module removes the `mj_forward` call from within the module and relies on the existing method `MJScene.extraEOMCall`. 

## Verification
The unit tests for the module still pass after the refactor.

## Documentation
The module documentation was updated to reflect the need to enable `MJScene.extraEOMCall`.

## Future work
N/A
