### PR TITLE
Increase workflow timeout to 2 hours

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: pre-commit
     strategy:
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
 
   build-windows:
     runs-on: windows-2025
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: pre-commit
     strategy:
       fail-fast: false
@@ -74,7 +74,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs: pre-commit
     strategy:
       fail-fast: false


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)

## Description

Some workflows are timing out before they finish running, this increases the timeout to 2 hours to avoid this. We may not merge this PR as I suspect the real issue people are having is just tests hanging.

## Verification

N/A

## Documentation

N/A

## Future work

N/A
