### PR TITLE
Allow some satellites to be None in enableUnityVisualization args

### DIFF
--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -952,11 +952,20 @@ def createCameraConfigMsg(
 
 
 def ensure_correct_len_list(input, length, depth=1):
+    # Allow lists of all None to pass through as long as they are the correct length
+    if (
+        isinstance(input, list)
+        and all([i is None for i in input])
+        and len(input) == length
+    ):
+        return input
+
     current_depth = 0
     level = input
     while isinstance(level, list):
         current_depth += 1
-        level = level[0]
+        # Skip over Nones when checking shapes at a given level
+        level = next((item for item in level if item is not None), None)
 
     for _ in range(current_depth, depth):
         input = [input]


### PR DESCRIPTION
* **Tickets addressed:** bsk-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Allows for things like `thrEffectorList` and `thrColors` in `enableUnityVisualization` to be a mixed list of `None` and the appropriate object. This behavior was somewhat supported before the `vizSupport` refactor, but it was not well defined.

## Verification
Tests still pass.

## Documentation
N/A

## Future work
N/A