### PR TITLE
1141 adding nanoavionics cubesat reaction wheels rw0 4rw0

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -26,6 +26,7 @@ Basilisk Release Notes
 
 Version |release|
 -----------------
+- Added custom reaction wheel: "NanoAvionics RW0" to ``src/utilities/simIncludeRW.py``
 - Added TLE handling utilities in :ref:`tleHandling` to parse TLE files and convert to orbital elements
 - Removed deprecated use of astro constants from ``src/utilities/astroFunction.py``.
   Users should be astrodynamics constants from ``Basilisk.architecture.astroConstants``.

--- a/src/utilities/simIncludeRW.py
+++ b/src/utilities/simIncludeRW.py
@@ -568,6 +568,41 @@ class rwFactory(object):
 
         return
 
+    def NanoAvionics_RW0(self, RW):
+        """
+        NanoAvionics RW0
+
+        RW Information Source:
+        https://nanoavionics.com/cubesat-components/cubesat-reaction-wheels-control-system-satbus-4rw/?utm_source=chatgpt.com
+
+        Not complete; fields not listed are estimates.
+
+        :param RW: reaction wheel configuration message
+        :return:
+        """
+        # maximum allowable wheel speed
+        RW.Omega_max = 6500.0*macros.RPM
+        # maximum RW torque [Nm]
+        RW.u_max = 3.2e-3
+        # minimum RW torque [Nm]
+        RW.u_min = 0.04923e-3 # Derived as "u_max * Omega_min (100 RPM) / Omega_max (6500 RPM)"
+        # static friction torque [Nm]
+        RW.fCoulomb = 0.00005 # Guestimate
+        # RW rotor mass [kg]
+        # Note: the rotor mass here is set equal to the RW mass of the above spec sheet.
+        # static RW imbalance [kg*m]
+        # dynamic RW imbalance [kg*m^2]
+
+        if self.maxMomentum > 0.0:
+            print("WARNING: NanoAvionics_RW0 has a fixed maxMomentum value. Custom value being replaced.")
+        self.maxMomentum = 20.0e-3     # Nms
+
+        RW.mass = 0.127 # Based on disk diameter of 43cm, NOTE: complete reaction wheel weight (incl housing) is 0.137kg
+        RW.U_s = 1E-7 # Guestimate
+        RW.U_d = 1E-8 # Guestimate
+
+        return
+
     def custom(self, RW):
         """
         Creates an empty reaction wheel configuration message.  This assumes the user provided the


### PR DESCRIPTION
* **Tickets addressed:** bsk-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Nano Avionics reaction wheel RW0 was implemented in BSK (NanoAvionics_RW0)
The reaction wheel mass (127g) was calculated by estimating a homogenous spinning disk with a diameter of 43cm.
The Reaction wheel total mass (inkl. housing) is 137g, the RW outer diameter (inkl. housing) is 43.5cm.

## Verification
Visual inspection. No new functionality, therefore no test necessary

## Documentation
No documentation was invalidated

## Future work
N/A, NanoAvionics has currently only one reaction wheel in their assortment, therefore no other RW to be implemented for that producer.
