### PR TITLE
Reorder EventHandler args to preserve backwards compatibility

### DIFF
--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -125,11 +125,11 @@ class EventHandlerClass:
         eventName,
         eventRate=int(1e9),
         eventActive=False,
+        conditionList=None,
+        actionList=None,
         conditionFunction=None,
         actionFunction=None,
         conditionTime=None,
-        conditionList=None,
-        actionList=None,
         terminal=False,
         exactRateMatch=True,
     ):


### PR DESCRIPTION
* **Tickets addressed:** bsk-000
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The previous PR moved the old list-of-strings way of specifying conditions and actions to be the last arguments, since specifying functions directly is now preferred. However, this will break code for people who still use the list-based options and rely on order-only EventHandler argument specification 
```
createNewEvent(myEventName, myEventRate, myEventActive, myConditionList, myActionList)
```
instead of using keywords
```
createNewEvent(eventName=myEventName, eventRate=myEventRate, eventActive=myEventActive, conditionList=myConditionList, actionList=myActionList)
```
If we want to preserve compatibility with the first way of adding events, the arguments should be reordered. However, this would require moving the list-of-strings options up in the argument list, despite that being an older way of doing things.

## Verification
Since the tests were updated to use the new function-based event specification, this does not show up in tests.

## Documentation
We can still leave `conditionList` and `actionList` at the end of the docstring, or we could move them to match the order in the function signature.