### PR TITLE
Add fuel tank leak parameter

### DIFF
--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -68,6 +68,8 @@ Version |release|
 - ``ConfigureStopTime`` now supports specifying the stop condition as ``<=`` (default, prior behavior) or ``>=`` (new).
   The new option is useful when the user wants to ensure that the simulation runs for at least the specified time,
   instead of at most the specified time.
+- Add the ``fuelLeakRate`` parameter to the :ref:`FuelTank` module to simulate fuel leaks that cause a loss of fuel mass
+  without imparting momentum.
 
 
 Version 2.8.0 (August 30, 2025)

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -106,6 +106,7 @@ void FuelTank::updateEffectorMassProps(double integTime) {
 
     // Mass depletion (call thrusters attached to this tank to get their mDot, and contributions)
     this->fuelConsumption = 0.0;
+    this->fuelConsumption += this->fuelLeakRate;
     for (auto &dynEffector: this->thrDynEffectors) {
         dynEffector->computeStateContribution(integTime);
         this->fuelConsumption += dynEffector->stateDerivContribution(0);

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -270,6 +270,7 @@ public:
     bool updateOnly = true;                             //!< -- Sets whether to use update only mass depletion
     Message<FuelTankMsgPayload> fuelTankOutMsg{};       //!< -- fuel tank output message name
     FuelTankMsgPayload fuelTankMassPropMsg{};           //!< instance of messaging system message struct
+    double fuelLeakRate{};                              //!< [kg/s] rate of fuel leaking from tank; does not produce force
 
 private:
     StateData *omegaState{};                            //!< -- state data for omega_BN of the hub

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -426,6 +426,8 @@ void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spic
     }
 }
 
+const int MAXLEN = 256;
+
 /*! This method loads a requested SPICE kernel into the system memory.  It is
  its own method because we have to load several SPICE kernels in for our
  application.  Note that they are stored in the SPICE library and are not
@@ -438,6 +440,33 @@ int SpiceInterface::loadSpiceKernel(char *kernelName, const char *dataPath)
 {
     char *fileName = new char[this->charBufferSize];
     SpiceChar *name = new SpiceChar[this->charBufferSize];
+
+    // Check if the kernel is already loaded
+    SpiceChar fileCompare [MAXLEN];
+    SpiceChar filtyp [MAXLEN];
+    SpiceChar srcfil [MAXLEN];
+    SpiceInt handle;
+    SpiceBoolean found = SPICEFALSE;
+    SpiceInt total_kernels;
+    ktotal_c( "ALL", &total_kernels );
+
+    for (SpiceInt i = 0; i < total_kernels; i++ )
+    {
+        // Get the i-th loaded kernel information
+        kdata_c(i, "ALL", MAXLEN, MAXLEN, MAXLEN, fileCompare, filtyp, srcfil, &handle, &found);
+
+        if (found){
+            // Check if kernelName is at the end of the file string
+            size_t fileLen = strlen(fileCompare);
+            size_t kernelLen = strlen(kernelName);
+            if (fileLen >= kernelLen &&
+                strcmp(fileCompare + fileLen - kernelLen, kernelName) == 0)
+            {
+                // The kernel_to_check has already been successfully loaded
+                return 0;
+            }
+        }
+    }
 
     //! - The required calls come from the SPICE documentation.
     //! - The most critical call is furnsh_c


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Adds the `fuelLeakRate` parameter to fuel tanks to simulate a loss of fuel without imparting momentum on the spacecraft.

## Verification
Added unit test for new feature.

## Documentation
Documented in .h file and release notes.

## Future work
None.