### PR TITLE
Fix setup.py generation of PY_VERSION_HEX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ class BuildConanExtCommand(Command, SubCommand):
         if sys.version_info >= (3, 13):
             conan_py_limited = "0x030D0000"
         else:
-            conan_py_limited = f"0x03{min_version[1]:>02}0000"
+            conan_py_limited = f"0x03{int(min_version[1:]):>02x}0000"
 
         for ext in self.conan_extensions:
             ext.args += ["--pyLimitedAPI", conan_py_limited]


### PR DESCRIPTION
For more details on the correct format see https://docs.python.org/3/c-api/apiabiversion.html#c.PY_VERSION_HEX

* **Tickets addressed:** Closes #1153
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The format string was rewritten to handle minor versions with two decimal digits. This is by converting the minor version to an int then reformatting as hex.

## Verification
This fix was tested locally

## Documentation
None

## Future work
None
