### PR TITLE
Add docstrings to prescribed motion branching example scripts

### DIFF
--- a/examples/scenarioPrescribedMotionWithRotationBranching.py
+++ b/examples/scenarioPrescribedMotionWithRotationBranching.py
@@ -37,6 +37,10 @@ To demonstrate the impact of the prescribed truss motion on the solar panel dyna
 given zero initial deflections. The trusses are profiled to symmetrically rotate 45 degrees from their
 initial configurations using a smoothed bang-coast-bang acceleration profile.
 
+The script is found in the folder ``basilisk/examples`` and executed by using::
+
+    python3 scenarioPrescribedMotionWithRotationBranching.py
+
 The prescribed truss motion, solar panel deflections and their rates, and the hub response to the panel deflections
 is plotted in this scenario.
 

--- a/examples/scenarioPrescribedMotionWithTranslationBranching.py
+++ b/examples/scenarioPrescribedMotionWithTranslationBranching.py
@@ -44,6 +44,10 @@ actuating, the three landing struts are each commanded to deploy away from the p
 axes. Similarly, the struts are given arbitrary reference displacements of 0.2, 0.1, and 0.15 meters relative
 to the platform.
 
+The script is found in the folder ``basilisk/examples`` and executed by using::
+
+    python3 scenarioPrescribedMotionWithTranslationBranching.py
+
 The prescribed platform motion, landing strut displacements and their rates, and the hub response to the lander
 deployment is plotted in this scenario.
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description
This PR adds docstrings to the prescribed motion branching example scripts so that the source code can be accessed from the documentation.