### PR TITLE
suppress swig warnings about missing `__module__` attribute

### DIFF
--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -4,3 +4,8 @@ markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.
     ciSkip: mark a test that should be skipped on the CI test runs
+
+filterwarnings =
+    ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning
+    ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning
+    ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
The 1000's of missing `__module__` warnings are making other warnings we need to see. 

## Verification
Unit tests pass again without this repeated warning.

## Documentation
None

## Future work
Need to look later into why these warnings are happening.