### PR TITLE
Update paths to `supportDataTools` instead of `supportData`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       -   id: check-supportdata-registry
           name: Ensure supportData registrySnippet.py is updated
-          entry: python Basilisk/utilities/supportDataTools/checkSync.py
+          entry: python src/utilities/supportDataTools/checkSync.py
           language: python
           files: ^supportData/
           pass_filenames: false

--- a/src/utilities/supportDataTools/checkSync.py
+++ b/src/utilities/supportDataTools/checkSync.py
@@ -26,8 +26,10 @@ import filecmp
 
 
 ROOT = Path(__file__).resolve().parents[3]
-make_script = ROOT.joinpath("src", "utilities", "supportData", "makeRegistry.py")
-registry_path = ROOT.joinpath("src", "utilities", "supportData", "registrySnippet.py")
+make_script = ROOT.joinpath("src", "utilities", "supportDataTools", "makeRegistry.py")
+registry_path = ROOT.joinpath(
+    "src", "utilities", "supportDataTools", "registrySnippet.py"
+)
 
 
 def main():
@@ -51,7 +53,7 @@ def main():
     if not filecmp.cmp(tmp_path, registry_path, shallow=False):
         print("❌ supportData/ changed, but registrySnippet.py is outdated.")
         print(
-            "   Run: python src/utilities/supportData/makeRegistry.py > src/utilities/supportData/registrySnippet.py"
+            "   Run: python src/utilities/supportDataTools/makeRegistry.py > src/utilities/supportDataTools/registrySnippet.py"
         )
         return 1
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)

## Description

A bad rebase resulted in some paths not being updated from `supportData` to `supportDataTools`. This PR fixes that.

## Verification
N/A

## Documentation
N/A

## Future work
N/A
