### PR TITLE
Remove build-macos gate from docs build job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -117,7 +117,6 @@ jobs:
         run: ctest -C Release
 
   docs:
-    needs: build-macos
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  
* **Merge strategy:** Merge (no squash) 

## Description

We gated building the docs on the successful completion of all macOS builds. Once those passed, we would kick off a separate build for the docs job. It’s better to know if the docs job fails early, so this PR updates the docs job to execute in parallel with the other jobs.

The original intention was to forward a build artifact from the macOS builds to the docs job, avoiding the need for the docs job to perform its own build. However, this would still require waiting for all macOS builds to complete before the docs job could start. It’s preferable to detect docs build issues as early as possible.

## Verification
N/A

## Documentation
N/A

## Future work
N/A
