### PR TITLE
Expose raw message header and payload pointers

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -71,7 +71,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=container-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
+          # Cache export is best-effort and must not invalidate a published image.
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }},ignore-error=true
 
   publish:
     name: Publish Multi-Arch Manifests

--- a/docs/source/Support/Developer/bskSdkReleaseGuide.rst
+++ b/docs/source/Support/Developer/bskSdkReleaseGuide.rst
@@ -333,7 +333,8 @@ environment:
 
 .. code-block:: bash
 
-   python -m pip wheel --no-deps -v -w /tmp/bsk-dev-wheel "$BSK_ROOT"
+   rm -rf /tmp/bsk-dev-wheel/bsk*.whl # Remove wheels left by previous builds
+   CONAN_ARGS="--clean" python -m pip wheel --no-deps -v -w /tmp/bsk-dev-wheel "$BSK_ROOT"
    python -m pip install --force-reinstall /tmp/bsk-dev-wheel/bsk-*.whl
 
 If the extension needs optional Basilisk components such as OpNav, build
@@ -349,6 +350,7 @@ Build and install the SDK wheel, then run the SDK test suite:
 
 .. code-block:: bash
 
+   rm -rf dist/bsk_sdk-*.whl # Remove wheels left by previous builds
    python -m build --wheel
    python -m pip install --force-reinstall dist/bsk_sdk-*.whl
    python -m pytest tests -v
@@ -365,7 +367,7 @@ verify its runtime imports, and run all example tests:
 .. code-block:: bash
 
    python -m build --wheel --no-isolation examples/custom-atm-extension
-   python -m pip install examples/custom-atm-extension/dist/*.whl
+   python -m pip install --force-reinstall examples/custom-atm-extension/dist/*.whl
    python -c "import Basilisk, numba, custom_atm; from custom_atm import numbaAtmosphere"
    python -m pytest examples -v
 

--- a/docs/source/Support/bskReleaseNotesSnippets/1226-shared-message-base-types.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1226-shared-message-base-types.rst
@@ -1,0 +1,2 @@
+- C++ message and reader wrappers now provide borrowed raw header and payload addresses through ``GetPointers()``; these addresses remain valid only for the documented owner and source lifetimes.
+- Python message and reader wrappers now share common ``MessageBase`` and ``ReadFunctorBase`` types across all generated payload modules, enabling reliable cross-message ``isinstance()`` checks.

--- a/src/architecture/messaging/CMakeLists.txt
+++ b/src/architecture/messaging/CMakeLists.txt
@@ -91,8 +91,11 @@ function(generate_messages searchDir generateCCode)
               OUTPUT_DIR "${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging/")
 
     set_property(TARGET ${TARGET_NAME} APPEND PROPERTY SWIG_DEPENDS
-                 "${CMAKE_CURRENT_SOURCE_DIR}/newMessaging.ih")
-    add_dependencies(${TARGET_NAME} swigtrick)
+                 "${CMAKE_CURRENT_SOURCE_DIR}/newMessaging.ih"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/messaging.h"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/messagingBase.h"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/messagingBase.i")
+    add_dependencies(${TARGET_NAME} messagingBase swigtrick)
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "architecture/messaging/derivedCode")
     set_target_properties(${SWIG_MODULE_${TARGET_NAME}_REAL_NAME}
                           PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging")

--- a/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
+++ b/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
@@ -127,6 +127,7 @@ def test_generated_message_bindings_use_module_local_classes(tmp_path):
     generated = _generate_swig_interface(tmp_path, True)
     new_messaging_template = NEW_MESSAGING_TEMPLATE.read_text(encoding="utf-8")
 
+    assert '%import "architecture/messaging/messagingBase.i"' in generated
     assert "from Basilisk.architecture.messaging.messageType" not in new_messaging_template
     assert "if type(source) == messageType ## _C:" in new_messaging_template
     assert "from Basilisk.architecture.messaging import CustomMsg" not in generated

--- a/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
+++ b/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
@@ -131,6 +131,8 @@ def test_generated_message_bindings_use_module_local_classes(tmp_path):
     assert "from Basilisk.architecture.messaging.messageType" not in new_messaging_template
     assert "if type(source) == messageType ## _C:" in new_messaging_template
     assert "from Basilisk.architecture.messaging import CustomMsg" not in generated
+    assert "%ignore Message::Message(const Message &);" in generated
+    assert "%ignore Message::operator=(const Message &);" in generated
     assert "from Basilisk.architecture.messaging import _msgKeepAlive" in generated
     assert "elif type(source) == CustomMsg:" in generated
     assert "recorder = self._recorder(timeDiff)" in generated

--- a/src/architecture/messaging/_UnitTest/test_recorder_copy_contract.cpp
+++ b/src/architecture/messaging/_UnitTest/test_recorder_copy_contract.cpp
@@ -20,12 +20,100 @@
 #include <gtest/gtest.h>
 
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
 #include "architecture/msgPayloadDefC/CModuleTemplateMsgPayload.h"
 
 class DerivedSysModel : public SysModel {};
+
+namespace {
+
+void
+expectMessagePointersReferenceOwnStorage(Message<CModuleTemplateMsgPayload>& message)
+{
+    messagePointerData* pointers = message.GetPointers();
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(pointers->header), message.getHeaderAddress());
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(pointers->payload), message.getPayloadAddress());
+}
+
+} // namespace
+
+TEST(MessagingPointerContract, PointerDataDefaultsToNull)
+{
+    messagePointerData pointers;
+    MessageBase messageBase;
+    ReadFunctorBase readerBase;
+
+    EXPECT_EQ(pointers.header, nullptr);
+    EXPECT_EQ(pointers.payload, nullptr);
+    EXPECT_EQ(messageBase.GetPointers()->header, nullptr);
+    EXPECT_EQ(messageBase.GetPointers()->payload, nullptr);
+    EXPECT_EQ(readerBase.GetPointers()->header, nullptr);
+    EXPECT_EQ(readerBase.GetPointers()->payload, nullptr);
+}
+
+TEST(MessagingPointerContract, ReadFunctorCopiesAndMovesPointerState)
+{
+    Message<CModuleTemplateMsgPayload> message;
+    messagePointerData* messagePointers = message.GetPointers();
+    ReadFunctor<CModuleTemplateMsgPayload> original = message.addSubscriber();
+
+    ReadFunctor<CModuleTemplateMsgPayload> copied(original);
+    EXPECT_EQ(copied.GetPointers()->header, messagePointers->header);
+    EXPECT_EQ(copied.GetPointers()->payload, messagePointers->payload);
+
+    ReadFunctor<CModuleTemplateMsgPayload> moved(std::move(copied));
+    EXPECT_EQ(moved.GetPointers()->header, messagePointers->header);
+    EXPECT_EQ(moved.GetPointers()->payload, messagePointers->payload);
+    EXPECT_EQ(copied.GetPointers()->header, nullptr);
+    EXPECT_EQ(copied.GetPointers()->payload, nullptr);
+    EXPECT_FALSE(copied.isLinked());
+
+    ReadFunctor<CModuleTemplateMsgPayload> copyAssigned;
+    copyAssigned = original;
+    EXPECT_EQ(copyAssigned.GetPointers()->header, messagePointers->header);
+    EXPECT_EQ(copyAssigned.GetPointers()->payload, messagePointers->payload);
+
+    ReadFunctor<CModuleTemplateMsgPayload> moveAssigned;
+    moveAssigned = std::move(copyAssigned);
+    EXPECT_EQ(moveAssigned.GetPointers()->header, messagePointers->header);
+    EXPECT_EQ(moveAssigned.GetPointers()->payload, messagePointers->payload);
+    EXPECT_EQ(copyAssigned.GetPointers()->header, nullptr);
+    EXPECT_EQ(copyAssigned.GetPointers()->payload, nullptr);
+    EXPECT_FALSE(copyAssigned.isLinked());
+}
+
+TEST(MessagingPointerContract, MessageCopiesAndMovesRebindPointerState)
+{
+    Message<CModuleTemplateMsgPayload> original;
+    Message<CModuleTemplateMsgPayload> copied(original);
+    expectMessagePointersReferenceOwnStorage(copied);
+
+    Message<CModuleTemplateMsgPayload> moved(std::move(copied));
+    expectMessagePointersReferenceOwnStorage(moved);
+    expectMessagePointersReferenceOwnStorage(copied);
+
+    Message<CModuleTemplateMsgPayload> copyAssigned;
+    copyAssigned = original;
+    expectMessagePointersReferenceOwnStorage(copyAssigned);
+
+    Message<CModuleTemplateMsgPayload> moveAssigned;
+    moveAssigned = std::move(copyAssigned);
+    expectMessagePointersReferenceOwnStorage(moveAssigned);
+    expectMessagePointersReferenceOwnStorage(copyAssigned);
+
+    std::vector<Message<CModuleTemplateMsgPayload>> messages;
+    messages.reserve(1);
+    messages.emplace_back();
+    uintptr_t initialHeaderAddress = messages.front().getHeaderAddress();
+    messages.emplace_back();
+
+    EXPECT_NE(messages.front().getHeaderAddress(), initialHeaderAddress);
+    expectMessagePointersReferenceOwnStorage(messages.front());
+}
 
 TEST(RecorderCopyContract, SysModelDerivedTypesAreNotCopyable)
 {

--- a/src/architecture/messaging/_UnitTest/test_unsubscribe.py
+++ b/src/architecture/messaging/_UnitTest/test_unsubscribe.py
@@ -38,6 +38,29 @@ def assertConnectionWithValues(
 
     assert readPayload.dataVector[0] == val
 
+
+def assertRawPointersCleared(
+    outMsg: Union[messaging.CModuleTemplateMsg_C, messaging.CModuleTemplateMsg]
+):
+    """Verify that unsubscribing clears a C++ reader's type-erased pointers."""
+    reader = messaging.CModuleTemplateMsgReader()
+    reader.subscribeTo(outMsg)
+
+    pointers = reader.GetPointers()
+    assert pointers.header is not None
+    assert pointers.payload is not None
+
+    reader.unsubscribe()
+
+    assert not reader.isLinked()
+    assert pointers.header is None
+    assert pointers.payload is None
+
+    currentPointers = reader.GetPointers()
+    assert currentPointers.header is None
+    assert currentPointers.payload is None
+
+
 def test_unsubscribe():
     """
     testing the unsubscribe functions of C and C++ messages
@@ -101,5 +124,16 @@ def test_unsubscribe():
     assert not messaging.CModuleTemplateMsg_C_isLinked(cMod.dataInMsg)
     assert not cppMod.dataInMsg.isLinked()
 
+
+def test_unsubscribe_clears_raw_pointers():
+    """Verify that raw pointers are cleared for both C and C++ message sources."""
+    cMod = cModuleTemplate.cModuleTemplate()
+    cppOutMsg = messaging.CModuleTemplateMsg()
+
+    assertRawPointersCleared(cMod.dataOutMsg)
+    assertRawPointersCleared(cppOutMsg)
+
+
 if __name__ == "__main__":
     test_unsubscribe()
+    test_unsubscribe_clears_raw_pointers()

--- a/src/architecture/messaging/_UnitTest/test_unsubscribe.py
+++ b/src/architecture/messaging/_UnitTest/test_unsubscribe.py
@@ -134,6 +134,22 @@ def test_unsubscribe_clears_raw_pointers():
     assertRawPointersCleared(cppOutMsg)
 
 
+def test_raw_pointer_bookkeeping_is_not_public():
+    """Verify that generated bindings hide raw-pointer bookkeeping members."""
+    message = messaging.CModuleTemplateMsg()
+    reader = messaging.CModuleTemplateMsgReader()
+
+    assert not hasattr(message, "pointers")
+    assert not hasattr(message, "reference")
+    assert not hasattr(reader, "headerVoidPtr")
+    assert not hasattr(reader, "payloadVoidPtr")
+    assert not hasattr(reader, "reference")
+
+    assert callable(message.GetPointers)
+    assert callable(reader.GetPointers)
+
+
 if __name__ == "__main__":
     test_unsubscribe()
     test_unsubscribe_clears_raw_pointers()
+    test_raw_pointer_bookkeeping_is_not_public()

--- a/src/architecture/messaging/_UnitTest/test_unsubscribe.py
+++ b/src/architecture/messaging/_UnitTest/test_unsubscribe.py
@@ -61,6 +61,28 @@ def assertRawPointersCleared(
     assert currentPointers.payload is None
 
 
+def pointerAddresses(pointers: messaging.messagePointerData):
+    """Return the numeric header and payload addresses from a raw pointer view."""
+    return int(pointers.header), int(pointers.payload)
+
+
+def assertRawPointersFollowResubscription(
+    firstOutMsg: Union[messaging.CModuleTemplateMsg_C, messaging.CModuleTemplateMsg],
+    secondOutMsg: Union[messaging.CModuleTemplateMsg_C, messaging.CModuleTemplateMsg],
+):
+    """Verify that a borrowed pointer view follows reader re-subscription."""
+    reader = messaging.CModuleTemplateMsgReader()
+    reader.subscribeTo(firstOutMsg)
+    pointers = reader.GetPointers()
+    firstAddresses = pointerAddresses(pointers)
+
+    reader.subscribeTo(secondOutMsg)
+
+    heldViewAddresses = pointerAddresses(pointers)
+    assert heldViewAddresses != firstAddresses
+    assert heldViewAddresses == pointerAddresses(reader.GetPointers())
+
+
 def test_unsubscribe():
     """
     testing the unsubscribe functions of C and C++ messages
@@ -144,6 +166,9 @@ def test_raw_pointer_bookkeeping_is_not_public():
     assert not hasattr(reader, "headerVoidPtr")
     assert not hasattr(reader, "payloadVoidPtr")
     assert not hasattr(reader, "reference")
+    assert not hasattr(message, "setPointerData")
+    assert not hasattr(reader, "setPointerData")
+    assert not hasattr(reader, "clearPointerData")
 
     assert callable(message.GetPointers)
     assert callable(reader.GetPointers)
@@ -164,8 +189,86 @@ def test_message_base_types_are_shared_across_payload_modules():
     assert isinstance(navReader.GetPointers(), messaging.messagePointerData)
 
 
+def test_raw_pointer_views_follow_resubscription():
+    """Verify that held views track new C and C++ message sources."""
+    firstCModule = cModuleTemplate.cModuleTemplate()
+    secondCModule = cModuleTemplate.cModuleTemplate()
+    firstCppMessage = messaging.CModuleTemplateMsg()
+    secondCppMessage = messaging.CModuleTemplateMsg()
+
+    assertRawPointersFollowResubscription(
+        firstCModule.dataOutMsg, secondCModule.dataOutMsg
+    )
+    assertRawPointersFollowResubscription(firstCppMessage, secondCppMessage)
+
+
+def test_copied_readers_preserve_raw_pointers():
+    """Verify that copied readers retain the subscribed source pointer view."""
+    source = messaging.CModuleTemplateMsg()
+    sourceAddresses = (
+        source.getHeaderAddress(),
+        source.getPayloadAddress(),
+    )
+    reader = source.addSubscriber()
+
+    assert pointerAddresses(reader.GetPointers()) == sourceAddresses
+
+    readers = messaging.CModuleTemplateMsgInMsgsVector()
+    readers.append(reader)
+
+    assert pointerAddresses(readers[0].GetPointers()) == sourceAddresses
+
+
+def test_copied_messages_rebind_raw_pointers():
+    """Verify that copied and relocated messages expose their own storage."""
+    source = messaging.CModuleTemplateMsg()
+    messages = messaging.CModuleTemplateMsgOutMsgsVector()
+    messages.append(source)
+
+    copiedMessage = messages[0]
+    copiedAddresses = (
+        copiedMessage.getHeaderAddress(),
+        copiedMessage.getPayloadAddress(),
+    )
+    assert copiedAddresses != (
+        source.getHeaderAddress(),
+        source.getPayloadAddress(),
+    )
+    assert pointerAddresses(copiedMessage.GetPointers()) == copiedAddresses
+
+    previousHeaderAddress = copiedMessage.getHeaderAddress()
+    del copiedMessage
+    messages.resize(messages.capacity() + 1)
+
+    relocatedMessage = messages[0]
+    relocatedAddresses = (
+        relocatedMessage.getHeaderAddress(),
+        relocatedMessage.getPayloadAddress(),
+    )
+    assert relocatedMessage.getHeaderAddress() != previousHeaderAddress
+    assert pointerAddresses(relocatedMessage.GetPointers()) == relocatedAddresses
+
+
+def test_raw_pointer_base_types_default_to_null():
+    """Verify that standalone pointer and base objects default to null addresses."""
+    pointerData = messaging.messagePointerData()
+    messageBase = messaging.MessageBase()
+    readerBase = messaging.ReadFunctorBase()
+
+    assert pointerData.header is None
+    assert pointerData.payload is None
+    assert messageBase.GetPointers().header is None
+    assert messageBase.GetPointers().payload is None
+    assert readerBase.GetPointers().header is None
+    assert readerBase.GetPointers().payload is None
+
+
 if __name__ == "__main__":
     test_unsubscribe()
     test_unsubscribe_clears_raw_pointers()
     test_raw_pointer_bookkeeping_is_not_public()
     test_message_base_types_are_shared_across_payload_modules()
+    test_raw_pointer_views_follow_resubscription()
+    test_copied_readers_preserve_raw_pointers()
+    test_copied_messages_rebind_raw_pointers()
+    test_raw_pointer_base_types_default_to_null()

--- a/src/architecture/messaging/_UnitTest/test_unsubscribe.py
+++ b/src/architecture/messaging/_UnitTest/test_unsubscribe.py
@@ -149,7 +149,23 @@ def test_raw_pointer_bookkeeping_is_not_public():
     assert callable(reader.GetPointers)
 
 
+def test_message_base_types_are_shared_across_payload_modules():
+    """Verify that generated messages use the central Python base proxy types."""
+    cModuleMessage = messaging.CModuleTemplateMsg()
+    navMessage = messaging.NavAttMsg()
+    cModuleReader = messaging.CModuleTemplateMsgReader()
+    navReader = messaging.NavAttMsgReader()
+
+    assert isinstance(cModuleMessage, messaging.MessageBase)
+    assert isinstance(navMessage, messaging.MessageBase)
+    assert isinstance(cModuleReader, messaging.ReadFunctorBase)
+    assert isinstance(navReader, messaging.ReadFunctorBase)
+    assert isinstance(cModuleMessage.GetPointers(), messaging.messagePointerData)
+    assert isinstance(navReader.GetPointers(), messaging.messagePointerData)
+
+
 if __name__ == "__main__":
     test_unsubscribe()
     test_unsubscribe_clears_raw_pointers()
     test_raw_pointer_bookkeeping_is_not_public()
+    test_message_base_types_are_shared_across_payload_modules()

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -411,6 +411,10 @@ public:
         SourceReplacementGuard replacementGuard(this->replacingSource);
         this->payloadPointer = nullptr;
         this->headerPointer = nullptr;
+        this->payloadVoidPtr = nullptr;
+        this->headerVoidPtr = nullptr;
+        this->reference.payload = nullptr;
+        this->reference.header = nullptr;
         this->initialized = false;
         this->releaseHandle_();   // #676: drop the Python keep-alive reference, if any
     }

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -17,6 +17,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 */
 #ifndef MESSAGING_H
 #define MESSAGING_H
+#include <memory>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include <vector>
 #include <deque>
@@ -27,6 +28,48 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #include <utility>
 #include "architecture/messaging/payloadEqualityTraits.h"
 
+
+struct messagePointerData{
+  void *header;
+  void *payload;
+};
+
+
+class MessageBase{
+    public:
+        messagePointerData pointers;
+        messagePointerData *reference;
+
+        messagePointerData *GetPointers(void)
+        {
+            this->reference =  (messagePointerData*)malloc(sizeof(messagePointerData));
+            this->reference->payload = pointers.payload;
+            this->reference->header = pointers.header;
+
+            return this->reference;
+        }
+};
+
+class ReadFunctorBase{
+    public :
+        void *headerVoidPtr; //! TODO: kludge to fix PITL, do we want to keep this member?
+        void *payloadVoidPtr;
+        messagePointerData *reference;
+
+        //! constructor
+        ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL), reference(NULL) {};
+
+        messagePointerData *GetPointers(void)
+        {
+            this->reference =  (messagePointerData*)malloc(sizeof(messagePointerData));
+            this->reference->header = this->headerVoidPtr;
+            this->reference->payload = this->payloadVoidPtr;
+            return this->reference;
+        }
+
+};
+
+
 /*! forward-declare sim message for use by read functor */
 template<typename messageType>
 class Message;
@@ -36,7 +79,7 @@ class Recorder;
 
 /*! Read functors have read-only access to messages*/
 template<typename messageType>
-class ReadFunctor{
+class ReadFunctor : public ReadFunctorBase{
 private:
     messageType* payloadPointer;    //!< -- pointer to the incoming msg data
     MsgHeader *headerPointer;      //!< -- pointer to the incoming msg header
@@ -131,7 +174,12 @@ public:
     ReadFunctor() : initialized(false) {};
 
     //! constructor
-    ReadFunctor(messageType* payloadPtr, MsgHeader *headerPtr) : payloadPointer(payloadPtr), headerPointer(headerPtr), initialized(true){};
+    ReadFunctor(messageType* payloadPtr, MsgHeader *headerPtr) :
+                  payloadPointer(payloadPtr), headerPointer(headerPtr), initialized(true)
+    {
+        this->headerVoidPtr = headerPtr;
+        this->payloadVoidPtr = payloadPtr;
+    };
 
     //! destructor -- REQUIRED for the #676 keep-alive: a ReadFunctor is usually a C++ member
     //! of a module, so SWIG %extend destructors never run for it; only this real C++
@@ -327,10 +375,12 @@ public:
         MsgHeader* pt = this->headerPointer;
         this->payloadPointer = (messageType *) (++pt);
 
-
         // set flag that this input message is connected to another message
         this->initialized = true;           // set input message as linked
         this->headerPointer->isLinked = 1;  // set source output message as linked
+
+        this->payloadVoidPtr = this->payloadPointer;
+        this->headerVoidPtr = this->headerPointer;
     };
     //! Subscribe to the message located at the sourceAddr in memory
     void subscribeToAddr(uint64_t sourceAddr)
@@ -417,7 +467,7 @@ template<typename messageType>
 class WriteFunctor{
 private:
     messageType* payloadPointer;    //!< pointer to the message payload
-    MsgHeader* headerPointer;       //!< pointer to the message header
+    MsgHeader* headerPointer;      //!< pointer to the message header
 public:
     //! write functor constructor
     WriteFunctor(){};
@@ -440,12 +490,13 @@ class Recorder;
  * base class template for bsk messages
  */
 template<typename messageType>
-class Message{
+class Message : public MessageBase{
 private:
     messageType payload = {};   //!< struct defining message payload, zero'd on creation
     MsgHeader header = {};      //!< struct defining the message header, zero'd on creation
     ReadFunctor<messageType> read = ReadFunctor<messageType>(&payload, &header);  //!< read functor instance
 public:
+    Message();
     //! write functor to this message
     WriteFunctor<messageType> write = WriteFunctor<messageType>(&payload, &header);
     //! -- request read rights. returns reference to class ``read`` variable
@@ -476,6 +527,12 @@ public:
     uintptr_t getHeaderAddress()  { return reinterpret_cast<uintptr_t>(&header);  }
 };
 
+template<typename messageType>
+Message<messageType>::Message()
+{
+    this->pointers.payload = &payload;
+    this->pointers.header = &header;
+}
 
 template<typename messageType>
 ReadFunctor<messageType> Message<messageType>::addSubscriber(){
@@ -516,12 +573,11 @@ public:
     Recorder(void* message, uint64_t timeDiff = 0){
         this->timeInterval = timeDiff;
 
-        MsgHeader* msgPt = (MsgHeader *) message;
-        MsgHeader *pt = msgPt;
-        messageType* payloadPointer;
-        payloadPointer = (messageType *) (++pt);
+        auto* headerPtr  = static_cast<MsgHeader*>(message);
+        auto* payloadPtr = reinterpret_cast<messageType*>(headerPtr + 1);
 
-        this->readMessage = ReadFunctor<messageType>(payloadPointer, msgPt);
+        this->readMessage = ReadFunctor<messageType>(payloadPtr, headerPtr);
+
         this->ModelTag = "Rec:";
         Message<messageType> tempMsg;
         std::string msgName = typeid(tempMsg).name();

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -40,10 +40,16 @@ struct messagePointerData{
 class MessageBase{
     protected:
         messagePointerData pointers;   //!< stores the message's header/payload pointers
-        messagePointerData reference;  //!< copy returned by GetPointers to avoid dangling
+        messagePointerData reference;  //!< cached storage for the borrowed pointer view
 
     public:
-        //! Returns pointer to struct containing type-erased message header and payload pointers
+        /*!
+         * Return a borrowed view of the type-erased message header and payload pointers.
+         *
+         * The returned ``messagePointerData`` structure is owned by this object and remains
+         * valid only while the associated ``Message`` exists. Its header and payload addresses
+         * are non-owning and remain valid only for the lifetime of that message.
+         */
         messagePointerData *GetPointers(void)
         {
             reference.payload =  pointers.payload;
@@ -57,13 +63,20 @@ class ReadFunctorBase{
     protected:
         void *headerVoidPtr;  //!< type-erased header pointer for external interface access
         void *payloadVoidPtr; //!< type-erased payload pointer for external interface access
-        messagePointerData reference; //!< copy returned by GetPointers
+        messagePointerData reference; //!< cached storage for the borrowed pointer view
 
     public:
         //! constructor
         ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL) {}
 
-        //! Returns pointer to struct containing type-erased header and payload pointers
+        /*!
+         * Return a borrowed view of the type-erased source header and payload pointers.
+         *
+         * The returned ``messagePointerData`` structure is owned by this object and remains
+         * valid only while the associated ``ReadFunctor`` exists. Its non-null header and
+         * payload addresses are non-owning and remain valid only while the reader is subscribed
+         * and the source message exists.
+         */
         messagePointerData *GetPointers(void)
         {
             reference.header  = headerVoidPtr;

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -39,9 +39,9 @@ class Recorder;
 template<typename messageType>
 class ReadFunctor : public ReadFunctorBase{
 private:
-    messageType* payloadPointer;    //!< -- pointer to the incoming msg data
-    MsgHeader *headerPointer;      //!< -- pointer to the incoming msg header
-    bool initialized;               //!< -- flag indicating if the input message is connect to another message
+    messageType* payloadPointer = nullptr; //!< -- pointer to the incoming msg data
+    MsgHeader *headerPointer = nullptr;    //!< -- pointer to the incoming msg header
+    bool initialized = false;              //!< -- flag indicating if the input message is connected to another message
 
     // --- issue #676 keep-alive bridge -------------------------------------------------------
     // When a Python-created stand-alone message is subscribed to, the SWIG layer installs an
@@ -129,20 +129,24 @@ public:
 
 
     //! constructor
-    ReadFunctor() : initialized(false) {};
+    ReadFunctor() = default;
 
     //! constructor
     ReadFunctor(messageType* payloadPtr, MsgHeader *headerPtr) :
                   payloadPointer(payloadPtr), headerPointer(headerPtr), initialized(true)
     {
-        this->headerVoidPtr = headerPtr;
-        this->payloadVoidPtr = payloadPtr;
+        this->setPointerData(headerPtr, payloadPtr);
     };
 
     //! destructor -- REQUIRED for the #676 keep-alive: a ReadFunctor is usually a C++ member
     //! of a module, so SWIG %extend destructors never run for it; only this real C++
     //! destructor does, and it must drop the Python reference held via releaseSource.
     ~ReadFunctor() {
+        SourceReplacementGuard replacementGuard(this->replacingSource);
+        this->payloadPointer = nullptr;
+        this->headerPointer = nullptr;
+        this->clearPointerData();
+        this->initialized = false;
         this->releaseHandle_();
     }
 
@@ -153,6 +157,7 @@ public:
           initialized(other.initialized),
           bskLogger(other.bskLogger),
           zeroMsgPayload(other.zeroMsgPayload) {
+        this->setPointerData(other.headerPointer, other.payloadPointer);
         this->adoptHandleFrom_(other);
     }
 
@@ -165,6 +170,7 @@ public:
         if (sameSource) {
             this->payloadPointer = other.payloadPointer;
             this->headerPointer = other.headerPointer;
+            this->setPointerData(other.headerPointer, other.payloadPointer);
             this->initialized = other.initialized;
             this->bskLogger = other.bskLogger;
             this->zeroMsgPayload = other.zeroMsgPayload;
@@ -187,6 +193,7 @@ public:
                                         true);
         this->payloadPointer = nullptr;
         this->headerPointer = nullptr;
+        this->clearPointerData();
         this->initialized = false;
         this->releaseHandle_();
 
@@ -194,6 +201,7 @@ public:
         this->zeroMsgPayload = std::move(incomingZeroPayload);
         this->payloadPointer = incomingPayload;
         this->headerPointer = incomingHeader;
+        this->setPointerData(incomingHeader, incomingPayload);
         this->initialized = incomingInitialized;
         this->sourceHandle = incomingHandle;
         this->acquireSource = incomingAcquire;
@@ -212,6 +220,11 @@ public:
           releaseSource(other.releaseSource),
           bskLogger(std::move(other.bskLogger)),
           zeroMsgPayload(std::move(other.zeroMsgPayload)) {
+        this->setPointerData(this->headerPointer, this->payloadPointer);
+        other.payloadPointer = nullptr;
+        other.headerPointer = nullptr;
+        other.clearPointerData();
+        other.initialized = false;
         other.sourceHandle = nullptr;   // moved-from reader no longer owns the reference
         other.acquireSource = nullptr;
         other.releaseSource = nullptr;
@@ -230,6 +243,10 @@ public:
         void* incomingHandle = other.sourceHandle;
         void (*incomingAcquire)(void*) = other.acquireSource;
         void (*incomingRelease)(void*) = other.releaseSource;
+        other.payloadPointer = nullptr;
+        other.headerPointer = nullptr;
+        other.clearPointerData();
+        other.initialized = false;
         other.sourceHandle = nullptr;
         other.acquireSource = nullptr;
         other.releaseSource = nullptr;
@@ -241,6 +258,7 @@ public:
                                         false);
         this->payloadPointer = nullptr;
         this->headerPointer = nullptr;
+        this->clearPointerData();
         this->initialized = false;
         this->releaseHandle_();
 
@@ -248,6 +266,7 @@ public:
         this->zeroMsgPayload = std::move(incomingZeroPayload);
         this->payloadPointer = incomingPayload;
         this->headerPointer = incomingHeader;
+        this->setPointerData(incomingHeader, incomingPayload);
         this->initialized = incomingInitialized;
         this->sourceHandle = incomingHandle;
         this->acquireSource = incomingAcquire;
@@ -337,8 +356,7 @@ public:
         this->initialized = true;           // set input message as linked
         this->headerPointer->isLinked = 1;  // set source output message as linked
 
-        this->payloadVoidPtr = this->payloadPointer;
-        this->headerVoidPtr = this->headerPointer;
+        this->setPointerData(this->headerPointer, this->payloadPointer);
     };
     //! Subscribe to the message located at the sourceAddr in memory
     void subscribeToAddr(uint64_t sourceAddr)
@@ -367,10 +385,7 @@ public:
         SourceReplacementGuard replacementGuard(this->replacingSource);
         this->payloadPointer = nullptr;
         this->headerPointer = nullptr;
-        this->payloadVoidPtr = nullptr;
-        this->headerVoidPtr = nullptr;
-        this->reference.payload = nullptr;
-        this->reference.header = nullptr;
+        this->clearPointerData();
         this->initialized = false;
         this->releaseHandle_();   // #676: drop the Python keep-alive reference, if any
     }
@@ -459,6 +474,14 @@ private:
     ReadFunctor<messageType> read = ReadFunctor<messageType>(&payload, &header);  //!< read functor instance
 public:
     Message();
+    //! copy constructor
+    Message(const Message& other);
+    //! copy assignment operator
+    Message& operator=(const Message& other);
+    //! move constructor
+    Message(Message&& other);
+    //! move assignment operator
+    Message& operator=(Message&& other);
     //! write functor to this message
     WriteFunctor<messageType> write = WriteFunctor<messageType>(&payload, &header);
     //! -- request read rights. returns reference to class ``read`` variable
@@ -492,8 +515,43 @@ public:
 template<typename messageType>
 Message<messageType>::Message()
 {
-    this->pointers.payload = &payload;
-    this->pointers.header = &header;
+    this->setPointerData(&header, &payload);
+}
+
+template<typename messageType>
+Message<messageType>::Message(const Message& other) : Message()
+{
+    *this = other;
+}
+
+template<typename messageType>
+Message<messageType>& Message<messageType>::operator=(const Message& other)
+{
+    if (this != &other) {
+        this->payload = other.payload;
+        this->header = other.header;
+        this->zeroMsgPayload = other.zeroMsgPayload;
+        this->setPointerData(&this->header, &this->payload);
+    }
+    return *this;
+}
+
+template<typename messageType>
+Message<messageType>::Message(Message&& other) : Message()
+{
+    *this = std::move(other);
+}
+
+template<typename messageType>
+Message<messageType>& Message<messageType>::operator=(Message&& other)
+{
+    if (this != &other) {
+        this->payload = std::move(other.payload);
+        this->header = std::move(other.header);
+        this->zeroMsgPayload = std::move(other.zeroMsgPayload);
+        this->setPointerData(&this->header, &this->payload);
+    }
+    return *this;
 }
 
 template<typename messageType>

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -38,15 +38,13 @@ struct messagePointerData{
 class MessageBase{
     public:
         messagePointerData pointers;
-        messagePointerData *reference;
+        messagePointerData reference;
 
         messagePointerData *GetPointers(void)
         {
-            this->reference =  (messagePointerData*)malloc(sizeof(messagePointerData));
-            this->reference->payload = pointers.payload;
-            this->reference->header = pointers.header;
-
-            return this->reference;
+            reference.payload =  pointers.payload;
+            reference.header = pointers.header;
+            return &reference;
         }
 };
 
@@ -54,17 +52,16 @@ class ReadFunctorBase{
     public :
         void *headerVoidPtr; //! TODO: kludge to fix PITL, do we want to keep this member?
         void *payloadVoidPtr;
-        messagePointerData *reference;
+        messagePointerData reference;
 
         //! constructor
-        ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL), reference(NULL) {};
+        ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL) {}
 
         messagePointerData *GetPointers(void)
         {
-            this->reference =  (messagePointerData*)malloc(sizeof(messagePointerData));
-            this->reference->header = this->headerVoidPtr;
-            this->reference->payload = this->payloadVoidPtr;
-            return this->reference;
+            reference.header  = headerVoidPtr;
+            reference.payload = payloadVoidPtr;
+            return &reference;
         }
 
 };

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -38,10 +38,11 @@ struct messagePointerData{
 
 /*! A base class for Message that enables type-erased pointer access */
 class MessageBase{
-    public:
-        messagePointerData pointers;    //!< stores the message's header/payload pointers
-        messagePointerData reference;   //!< copy returned by GetPointers to avoid dangling
+    protected:
+        messagePointerData pointers;   //!< stores the message's header/payload pointers
+        messagePointerData reference;  //!< copy returned by GetPointers to avoid dangling
 
+    public:
         //! Returns pointer to struct containing type-erased message header and payload pointers
         messagePointerData *GetPointers(void)
         {
@@ -53,11 +54,12 @@ class MessageBase{
 
 /*! A base class for ReadFunctor that enables type-erased pointer access */
 class ReadFunctorBase{
-    public :
+    protected:
         void *headerVoidPtr;  //!< type-erased header pointer for external interface access
         void *payloadVoidPtr; //!< type-erased payload pointer for external interface access
         messagePointerData reference; //!< copy returned by GetPointers
 
+    public:
         //! constructor
         ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL) {}
 

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -29,17 +29,20 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #include "architecture/messaging/payloadEqualityTraits.h"
 
 
+/*! Holds type-erased pointers to a message's header and payload */
 struct messagePointerData{
-  void *header;
-  void *payload;
+  void *header;   //!< pointer to the message header
+  void *payload;  //!< pointer to the message payload
 };
 
 
+/*! A base class for Message that enables type-erased pointer access */
 class MessageBase{
     public:
-        messagePointerData pointers;
-        messagePointerData reference;
+        messagePointerData pointers;    //!< stores the message's header/payload pointers
+        messagePointerData reference;   //!< copy returned by GetPointers to avoid dangling
 
+        //! Returns pointer to struct containing type-erased message header and payload pointers
         messagePointerData *GetPointers(void)
         {
             reference.payload =  pointers.payload;
@@ -48,15 +51,17 @@ class MessageBase{
         }
 };
 
+/*! A base class for ReadFunctor that enables type-erased pointer access */
 class ReadFunctorBase{
     public :
-        void *headerVoidPtr; //! TODO: kludge to fix PITL, do we want to keep this member?
-        void *payloadVoidPtr;
-        messagePointerData reference;
+        void *headerVoidPtr;  //!< type-erased header pointer for external interface access
+        void *payloadVoidPtr; //!< type-erased payload pointer for external interface access
+        messagePointerData reference; //!< copy returned by GetPointers
 
         //! constructor
         ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL) {}
 
+        //! Returns pointer to struct containing type-erased header and payload pointers
         messagePointerData *GetPointers(void)
         {
             reference.header  = headerVoidPtr;
@@ -570,6 +575,8 @@ public:
     Recorder(void* message, uint64_t timeDiff = 0){
         this->timeInterval = timeDiff;
 
+        // C messages store header followed immediately by payload in memory.
+        // Advance past header to get payload pointer.
         auto* headerPtr  = static_cast<MsgHeader*>(message);
         auto* payloadPtr = reinterpret_cast<messageType*>(headerPtr + 1);
 

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -17,75 +17,16 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 */
 #ifndef MESSAGING_H
 #define MESSAGING_H
-#include <memory>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include <vector>
 #include <deque>
 #include "architecture/messaging/msgHeader.h"
+#include "architecture/messaging/messagingBase.h"
 #include "architecture/utilities/bskLogging.h"
 #include <typeinfo>
 #include <stdlib.h>
 #include <utility>
 #include "architecture/messaging/payloadEqualityTraits.h"
-
-
-/*! Holds type-erased pointers to a message's header and payload */
-struct messagePointerData{
-  void *header;   //!< pointer to the message header
-  void *payload;  //!< pointer to the message payload
-};
-
-
-/*! A base class for Message that enables type-erased pointer access */
-class MessageBase{
-    protected:
-        messagePointerData pointers;   //!< stores the message's header/payload pointers
-        messagePointerData reference;  //!< cached storage for the borrowed pointer view
-
-    public:
-        /*!
-         * Return a borrowed view of the type-erased message header and payload pointers.
-         *
-         * The returned ``messagePointerData`` structure is owned by this object and remains
-         * valid only while the associated ``Message`` exists. Its header and payload addresses
-         * are non-owning and remain valid only for the lifetime of that message.
-         */
-        messagePointerData *GetPointers(void)
-        {
-            reference.payload =  pointers.payload;
-            reference.header = pointers.header;
-            return &reference;
-        }
-};
-
-/*! A base class for ReadFunctor that enables type-erased pointer access */
-class ReadFunctorBase{
-    protected:
-        void *headerVoidPtr;  //!< type-erased header pointer for external interface access
-        void *payloadVoidPtr; //!< type-erased payload pointer for external interface access
-        messagePointerData reference; //!< cached storage for the borrowed pointer view
-
-    public:
-        //! constructor
-        ReadFunctorBase() : headerVoidPtr(NULL), payloadVoidPtr(NULL) {}
-
-        /*!
-         * Return a borrowed view of the type-erased source header and payload pointers.
-         *
-         * The returned ``messagePointerData`` structure is owned by this object and remains
-         * valid only while the associated ``ReadFunctor`` exists. Its non-null header and
-         * payload addresses are non-owning and remain valid only while the reader is subscribed
-         * and the source message exists.
-         */
-        messagePointerData *GetPointers(void)
-        {
-            reference.header  = headerVoidPtr;
-            reference.payload = payloadVoidPtr;
-            return &reference;
-        }
-
-};
-
 
 /*! forward-declare sim message for use by read functor */
 template<typename messageType>

--- a/src/architecture/messaging/messagingBase.h
+++ b/src/architecture/messaging/messagingBase.h
@@ -22,16 +22,25 @@
 /*! Holds type-erased pointers to a message's header and payload. */
 struct messagePointerData
 {
-    void* header;  //!< pointer to the message header
-    void* payload; //!< pointer to the message payload
+    void* header = nullptr;  //!< pointer to the message header
+    void* payload = nullptr; //!< pointer to the message payload
 };
 
 /*! A base class for Message that enables type-erased pointer access. */
 class MessageBase
 {
   protected:
-    messagePointerData pointers;  //!< stores the message's header/payload pointers
-    messagePointerData reference; //!< cached storage for the borrowed pointer view
+    messagePointerData pointers = {};  //!< stores the message's header/payload pointers
+    messagePointerData reference = {}; //!< cached storage for the borrowed pointer view
+
+    //! Update the stored pointers and any previously returned borrowed view.
+    void setPointerData(void* headerPointer, void* payloadPointer)
+    {
+        pointers.header = headerPointer;
+        pointers.payload = payloadPointer;
+        reference.header = headerPointer;
+        reference.payload = payloadPointer;
+    }
 
   public:
     /*!
@@ -53,17 +62,25 @@ class MessageBase
 class ReadFunctorBase
 {
   protected:
-    void* headerVoidPtr;          //!< type-erased header pointer for external interface access
-    void* payloadVoidPtr;         //!< type-erased payload pointer for external interface access
-    messagePointerData reference; //!< cached storage for the borrowed pointer view
+    void* headerVoidPtr = nullptr;     //!< type-erased header pointer for external interface access
+    void* payloadVoidPtr = nullptr;    //!< type-erased payload pointer for external interface access
+    messagePointerData reference = {}; //!< cached storage for the borrowed pointer view
+
+    //! Update the stored pointers and any previously returned borrowed view.
+    void setPointerData(void* headerPointer, void* payloadPointer)
+    {
+        headerVoidPtr = headerPointer;
+        payloadVoidPtr = payloadPointer;
+        reference.header = headerPointer;
+        reference.payload = payloadPointer;
+    }
+
+    //! Clear the stored pointers and any previously returned borrowed view.
+    void clearPointerData() { this->setPointerData(nullptr, nullptr); }
 
   public:
     //! constructor
-    ReadFunctorBase()
-      : headerVoidPtr(nullptr)
-      , payloadVoidPtr(nullptr)
-    {
-    }
+    ReadFunctorBase() = default;
 
     /*!
      * Return a borrowed view of the type-erased source header and payload pointers.

--- a/src/architecture/messaging/messagingBase.h
+++ b/src/architecture/messaging/messagingBase.h
@@ -1,0 +1,84 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef MESSAGING_BASE_H
+#define MESSAGING_BASE_H
+
+/*! Holds type-erased pointers to a message's header and payload. */
+struct messagePointerData
+{
+    void* header;  //!< pointer to the message header
+    void* payload; //!< pointer to the message payload
+};
+
+/*! A base class for Message that enables type-erased pointer access. */
+class MessageBase
+{
+  protected:
+    messagePointerData pointers;  //!< stores the message's header/payload pointers
+    messagePointerData reference; //!< cached storage for the borrowed pointer view
+
+  public:
+    /*!
+     * Return a borrowed view of the type-erased message header and payload pointers.
+     *
+     * The returned ``messagePointerData`` structure is owned by this object and remains
+     * valid only while the associated ``Message`` exists. Its header and payload addresses
+     * are non-owning and remain valid only for the lifetime of that message.
+     */
+    messagePointerData* GetPointers(void)
+    {
+        reference.payload = pointers.payload;
+        reference.header = pointers.header;
+        return &reference;
+    }
+};
+
+/*! A base class for ReadFunctor that enables type-erased pointer access. */
+class ReadFunctorBase
+{
+  protected:
+    void* headerVoidPtr;          //!< type-erased header pointer for external interface access
+    void* payloadVoidPtr;         //!< type-erased payload pointer for external interface access
+    messagePointerData reference; //!< cached storage for the borrowed pointer view
+
+  public:
+    //! constructor
+    ReadFunctorBase()
+      : headerVoidPtr(nullptr)
+      , payloadVoidPtr(nullptr)
+    {
+    }
+
+    /*!
+     * Return a borrowed view of the type-erased source header and payload pointers.
+     *
+     * The returned ``messagePointerData`` structure is owned by this object and remains
+     * valid only while the associated ``ReadFunctor`` exists. Its non-null header and
+     * payload addresses are non-owning and remain valid only while the reader is subscribed
+     * and the source message exists.
+     */
+    messagePointerData* GetPointers(void)
+    {
+        reference.header = headerVoidPtr;
+        reference.payload = payloadVoidPtr;
+        return &reference;
+    }
+};
+
+#endif

--- a/src/architecture/messaging/messagingBase.i
+++ b/src/architecture/messaging/messagingBase.i
@@ -1,0 +1,25 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+%module(threads="1", package="Basilisk.architecture") messagingBase
+
+%{
+#include "architecture/messaging/messagingBase.h"
+%}
+
+%include "architecture/messaging/messagingBase.h"

--- a/src/architecture/messaging/msgAutoSource/generatePackageInit.py
+++ b/src/architecture/messaging/msgAutoSource/generatePackageInit.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
                 className = os.path.splitext(filePre)[0]
                 msgName = className.split('Payload')[0]
                 mainImportFid.write('from Basilisk.architecture.messaging.' + className + ' import *\n')
+    mainImportFid.write('from Basilisk.architecture.messagingBase import *\n')
     mainImportFid.close()
     setOldPath = moduleOutputPath.split('messaging')[0] + '/cMsgCInterfacePy'
 

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -45,6 +45,10 @@ STRUCTASLIST(CSSArraySensorMsgPayload)
 %ignore ReadFunctor::operator=(const ReadFunctor &);
 %ignore ReadFunctor::operator=(ReadFunctor &&);
 %ignore ReadFunctor::setSource;
+%ignore Message::Message(const Message &);
+%ignore Message::Message(Message &&);
+%ignore Message::operator=(const Message &);
+%ignore Message::operator=(Message &&);
 
 %pythonappend Recorder::Recorder %{{
     from Basilisk.architecture.messaging import _msgKeepAlive

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -14,6 +14,7 @@
     #include <string>
 %}}
 %include "messaging/newMessaging.ih"
+%import "architecture/messaging/messagingBase.i"
 
 %include "std_vector.i"
 %include "std_string.i"


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

This patch integrates the raw-message-pointer API requested by Ten One Aerospace with the current implementation of `messaging.h`.

It adds type-erased access to the header and payload addresses of C++ `Message` and `ReadFunctor` objects through `GetPointers()`. The implementation also:

- uses object-owned cached storage for the returned pointer view, avoiding allocation and leaks;
- documents that the returned structure and addresses are borrowed and lifetime-bound;
- clears both typed and type-erased reader pointers during `unsubscribe()`;
- keeps pointer bookkeeping protected from generated Python bindings; and
- wraps `MessageBase`, `ReadFunctorBase`, and `messagePointerData` once in a central SWIG module so generated message types share common Python base classes and support reliable cross-message `isinstance()` checks.

## Verification

- Full Basilisk project build completed successfully.
- Focused messaging regression tests passed: `11 passed`.
- Verified shared Python base-class identity across C, standard C++, and MuJoCo payload modules.
- Pre-commit checks passed.

## Documentation

- Added Doxygen lifetime documentation for `GetPointers()`.
- Added a release-note snippet describing the shared Python message base types.

## Future work

- Coordinate the corresponding BSK-SDK synchronization update so `architecture/messaging/messagingBase.i` is included in the SDK SWIG support files for out-of-tree custom-message builds.