### PR TITLE
Enforce `supportData` line endings are always LF for text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,3 @@
-*.c text eol=lf
-*.cpp text eol=lf
-*.h text eol=lf
-*.hpp text eol=lf
-*.i text eol=lf
-*.py text eol=lf
-*.tex text eol=lf
-
+* text=auto
 supportData/** text eol=lf
 supportData/**/*.bsp -text


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  
* **Merge strategy:** Merge (no squash)  

## Description

This PR updates the git attribute file to enforce that all text files in the support data folder end with lf rather than CRLF.
Without this git attribute, users who check out the repo will have their OS specific line endings applied to the supportData files. This is problematic as we use hashes to generate the registry for the pooch based file downloads. Having different line endings will cause different hash generation. BIN data does not have line endings and should not be forced to have it.

Additionally, this PR simplifies the other git attribute rules. There is no need to enforce lf endings on the source code files
and it is generally preferred to have git handle converting back and forth via auto.

## Verification

N/A

## Documentation

N/A

## Future work

N/A