### PR TITLE
Pushing the master documentation with a force push

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -36,7 +36,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build/html
           destination_dir: .
-          keep_files: true
+          force_orphan: true
       - name: Deploy develop branch merges to /develop
         if: success() && github.ref_name == 'develop'
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
With the current setup the BSK documentation history grows unbounded with each push of documentation.  This leads to a lot of visual clutter in SourceTree for example. With the new behavior, the GitHub documentation history thus resets with each force push.  Pushing develop documentation is an amended push that keeps other files there.  This avoids having an ever increasing list of documentation dots confusing the SourceTree history.

## Verification
We will have to push `master` documentation for the new 2.9.1 release to fully test.

## Documentation
None

## Future work
None