### PR TITLE
fix documentation bugs, misspellings and incorrect variable referencing

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,7 +58,7 @@ University of Colorado `AVS
 Lab <http://hanspeterschaub.info/AVSlab.html>`__ and the `Laboratory for
 Atmospheric and Space Physics <http://lasp.colorado.edu/home/>`__
 (LASP). The resulting framework is targeted for both astrodynamics
-research modeling the orbit and attitue of complex spacecraft systems,
+research modeling the orbit and attitude of complex spacecraft systems,
 as well as sophisticated mission-specific vehicle simulations that
 include hardware-in-the-loop scenarios.
 
@@ -164,9 +164,9 @@ several different (often competing) requirements.
    and Unity visualization are active cross-platform developments.
 
 -  **Validation and Verification:** Each simulation or FSW algorithm
-   module has unit test that can be run automatically using ``pytest``.
-   Integrated scenario test validated coupled behavior between modules.
-   Each dynamics modules has associated momentum, energy and power
+   module has unit tests that can be run automatically using ``pytest``.
+   Integrated scenario tests validate coupled behavior between modules.
+   Each dynamics module has associated momentum, energy and power
    validation tests. This ensures the integrity of the validated modules
    as new simulation capabilities are added.
 
@@ -192,8 +192,8 @@ Related Publications
 - M. Cols Margenet, H. Schaub and S. Piggott, "`Modular Attitude Guidance Development using the Basilisk Software Framework  <https://hanspeterschaub.info/Papers/ColsMargenet2016.pdf>`_," AIAA/AAS Astrodynamics Specialist Conference, Long Beach, California, September 12--15, 2016.
 - J. Alcorn, C. Allard and H. Schaub, "`Fully-Coupled Dynamical Modeling of a Rigid Spacecraft with Imbalanced Reaction Wheels  <https://hanspeterschaub.info/Papers/Alcorn2016a.pdf>`_," AIAA/AAS Astrodynamics Specialist Conference, Long Beach, California, September 12--15, 2016.
 - C. Allard, M. Diaz Ramos and H. Schaub, "`Spacecraft Dynamics Integrating Hinged Solar Panels and Lumped-Mass Fuel Slosh Model  <https://hanspeterschaub.info/Papers/Allard2016a.pdf>`_," AIAA/AAS Astrodynamics Specialist Conference, Long Beach, California, September 12--15, 2016.
-- J. Alcorn, H. Schaub, S. Piggott and D. Kubitschek, "`Simulating Attitude Actuation Options Using the Basilisk Astrodynamics Software Architecture  <https://hanspeterschaub.info/Papers/Alcorn2016b.pdf>`_," 67 :sup:`th` International Astronautical Congress, Guadalajara, Mexico, September 26--30, 2016.
-- S. Piggott, J. Alcorn, M. Cols Margenet, P. Kenneally and H. Schaub,  "`Flight Software Development Through Python  <https://hanspeterschaub.info/Papers/Piggott2016FSWConference.pdf>`_," 2016 Workshop on Spacecraft Flight Software , JPL, California,  Dec. 13--15 2016.
+- J. Alcorn, H. Schaub, S. Piggott and D. Kubitschek, "`Simulating Attitude Actuation Options Using the Basilisk Astrodynamics Software Architecture  <https://hanspeterschaub.info/Papers/Alcorn2016b.pdf>`_," 67\ :sup:`th` International Astronautical Congress, Guadalajara, Mexico, September 26--30, 2016.
+- S. Piggott, J. Alcorn, M. Cols Margenet, P. Kenneally and H. Schaub,  "`Flight Software Development Through Python  <https://hanspeterschaub.info/Papers/Piggott2016FSWConference.pdf>`_," 2016 Workshop on Spacecraft Flight Software, JPL, California,  Dec. 13--15 2016.
 - P. Kenneally and H. Schaub,  "`Modeling Of Solar Radiation Pressure and Self-Shadowing Using Graphics Processing Unit  <https://hanspeterschaub.info/Papers/AAS-17-127.pdf>`_," AAS Guidance, Navigation and Control Conference, Breckenridge, Feb. 2--8, 2017.
 - P. Panicucci, C. Allard and H. Schaub,  "`Spacecraft Dynamics Employing a General Multi-tank and Multi-thruster Mass Depletion Formulation  <https://hanspeterschaub.info/Papers/AAS-17-011.pdf>`_," AAS Guidance, Navigation and Control Conference, Breckenridge, Feb. 2--8, 2017.
 - M. Cols Margenet, H. Schaub, and S. Piggott,   "`Modular Platform for Hardware-in-the-Loop Testing of Autonomous Flight Algorithms  <https://hanspeterschaub.info/Papers/ColsMargenet2017.pdf>`_,"  International Symposium on Space Flight Dynamics, Himegin Hall, Matsuyama-Ehime, Japan, June 3--9, 2017.

--- a/src/simulation/communication/simpleAntenna/simpleAntenna.rst
+++ b/src/simulation/communication/simpleAntenna/simpleAntenna.rst
@@ -24,31 +24,31 @@ provides information on what this message is used for.
       - Msg Type
       - Description
       - Note
-    * - scInStateMsg
+    * - scStateInMsg
       - :ref:`SCStatesMsgPayload`
       - spacecraft state
-      - Required for space based antennas
-    * - groundInStateMsg
+      - Required for space-based antennas
+    * - groundStateInMsg
       - :ref:`GroundStateMsgPayload`
       - ground state
-      - Required for ground based antennas
-    * - antennaInStateMsg
-      - :ref:`antennaStateMsgPayload`
+      - Required for ground-based antennas
+    * - antennaSetStateInMsg
+      - :ref:`AntennaStateMsgPayload`
       - setting antenna to [off / Rx / Tx / RxTx]
       - optional, default is 'Off'
     * - sunInMsg
       - :ref:`SpicePlanetStateMsgPayload`
       - sun ephemeris data input message
-      - Optional, required for advanced sky noise temperature calculation (see :ref:`detailed-module-description`) (irrelevant for ground based antennas)
+      - Optional, required for advanced sky noise temperature calculation (see :ref:`detailed-module-description`) (irrelevant for ground-based antennas)
     * - planetInMsgs
       - :ref:`SpicePlanetStateMsgPayload`
       - vector of planet ephemeris data input messages
-      - Optional, required for advanced sky noise temperature calculation (see :ref:`detailed-module-description`) (irrelevant for ground based antennas)
+      - Optional, required for advanced sky noise temperature calculation (see :ref:`detailed-module-description`) (irrelevant for ground-based antennas)
     * - sunEclipseInMsg
       - :ref:`EclipseMsgPayload`
-      - sun eclipse state input Message
-      - Optional, required for advanced sky noise temperature calculation (see :ref:`detailed-module-description`) (irrelevant for ground based antennas)
-    * - antennaOutStateMsg
+      - sun eclipse state input message
+      - Optional, required for advanced sky noise temperature calculation (see :ref:`detailed-module-description`) (irrelevant for ground-based antennas)
+    * - antennaOutMsg
       - :ref:`AntennaLogMsgPayload`
       - output msg description
       - Output message containing antenna state information
@@ -125,7 +125,7 @@ The following parameters must be configured by the user:
    * - Use Haslam Map (optional)
      - :code:`useHaslamMap`
      - [bool]
-     - Enable/Disable the use of the Haslam 408 MHz all-sky survey map for sky noise temperature calculation. If false a omnidirectional galactic noise temperature is used. (default: :code:`False`)
+     - Enable/Disable the use of the Haslam 408 MHz all-sky survey map for sky noise temperature calculation. If false, an omnidirectional galactic noise temperature is used. (default: :code:`False`)
      - :code:`True` or :code:`False`
    * - Antenna position vector in body frame (optional)
      - :math:`\mathbf{r}_\mathrm{AB}^\mathrm{B}`
@@ -142,7 +142,7 @@ The following parameters must be configured by the user:
 .. figure:: /../../src/simulation/communication/simpleAntenna/_Documentation/Images/CoordinateFrame.svg
    :width: 25%
    :align: center
-   :alt: Shematic antenna coordinate frame :math:`\mathrm{A}` definition
+   :alt: Schematic antenna coordinate frame :math:`\mathrm{A}` definition
 
    Figure 1: Illustration of the antenna coordinate frame :math:`{A}`
 
@@ -161,7 +161,7 @@ The antenna can be in either state:
    - **Rx** : reception only
    - **RxTx** : transmission and reception
 
-These states can either be set via the :code:`antennaInStateMsg` input message or by setting the state directly with the setter for this property.
+These states can either be set via the :code:`antennaSetStateInMsg` input message or by setting the state directly with the setter for this property.
 
 Radiation Pattern Model
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -170,7 +170,7 @@ Radiation Pattern Model
 .. figure:: /../../src/simulation/communication/simpleAntenna/_Documentation/Images/DocumentationBSKsimpleAntenna.svg
    :width: 60%
    :align: center
-   :alt: Shematic of SimpleAntenna beam pattern
+   :alt: Schematic of SimpleAntenna beam pattern
 
    Figure 1: Illustration of simpleAntenna 2D Gaussian beam pattern
 
@@ -209,9 +209,9 @@ Where :math:`G_{0}` is the boresight power gain (see :ref:`Figure 1`).
 Setting of the radiation pattern parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To set the radiation-pattern specific parameters, the user can set the directivity :math:`D_\mathrm{dB}` and the beam cross-section shape :math:`k`. From these two parameters, the Half-Power BeamWidths (HPBW) in elevation :math:`\theta_\mathrm{HPBW}` and azimuth :math:`\phi_\mathrm{HPBW}` are calculated\:
+To set the radiation-pattern specific parameters, the user can set the directivity :math:`D_\mathrm{dB}` and the beam cross-section shape :math:`k`. From these two parameters, the half-power beam widths (HPBW) in elevation :math:`\theta_\mathrm{HPBW}` and azimuth :math:`\phi_\mathrm{HPBW}` are calculated\:
 
-The unit less directivity :math:`D` and the boresight power gain :math:`G_{0}` are calculated from :math:`D_\mathrm{dB}` as follows\:
+The unitless directivity :math:`D` and the boresight power gain :math:`G_{0}` are calculated from :math:`D_\mathrm{dB}` as follows\:
 
 .. math::
 
@@ -286,7 +286,7 @@ For space-based antennas\:
 The weights are given by the antenna beam coverage fractions :math:`C_\mathrm{Galaxy}` and :math:`C_\mathrm{Planet}` (see also :ref:`module-overlap-area-computation`). The antenna gain :math:`G(\theta, \phi)` is not considered at this stage (see also :ref:`module-assumptions`).
 
 - For space-based antennas, :math:`T_\mathrm{Ambient}` can be set by the user (optional) if it is not set, a default value of :math:`T_\mathrm{Ambient} = 150.0K` is used.
-- The caculation of :math:`T_\mathrm{Sky}` is described in :ref:`Calculation of T_sky <calculation-of-tsky>`.
+- The calculation of :math:`T_\mathrm{Sky}` is described in :ref:`Calculation of T_sky <calculation-of-tsky>`.
 
 For ground-based antennas\:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -307,7 +307,7 @@ Calculation of :math:`T_\mathrm{sky}`
 
 For space-based antennas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-The sky noise temperature for a spacecraft-mounted antenna is calculated based on the antenna position and orientation with respect to the Earth, Sun and Moon (other celestial bodies are at the moment not incuded). If the setting :code:`useHaslamMap=True` is enabled, the galactic noise temperature is calculated using the Haslam 408 MHz all-sky survey map. if :code:`useHaslamMap=False`, a simple model with a frequency dependent, omnidirectional galactic noise temperature is used.
+The sky noise temperature for a spacecraft-mounted antenna is calculated based on the antenna position and orientation with respect to the Earth, Sun and Moon (other celestial bodies are at the moment not included). If the setting :code:`useHaslamMap=True` is enabled, the galactic noise temperature is calculated using the Haslam 408 MHz all-sky survey map. If :code:`useHaslamMap=False`, a simple model with a frequency-dependent, omnidirectional galactic noise temperature is used.
 
 .. math::
 
@@ -460,7 +460,7 @@ Module Assumptions and Limitations
 
 The following assumptions and limitations apply to the simpleAntenna module:
 
-- The antennas radiation pattern is modelled as a simple 2D Gaussian beam pattern. This has the following implications\:
+- The antenna radiation pattern is modeled as a simple 2D Gaussian beam pattern. This has the following implications\:
   - Sidelobes are neglected, and thus any noise, interference or signal received through sidelobes is not considered.
   - The main-lobe is approximated as a Gaussian function in both elevation and azimuth direction :math:`\rightarrow` The antenna gain is computed as a function of the angle off boresight in both elevation and azimuth direction.
 
@@ -468,7 +468,7 @@ The following assumptions and limitations apply to the simpleAntenna module:
 
 - The antenna can be placed either on a spacecraft or on Earth (ground). It is not (yet) possible to place the antenna on other celestial bodies.
 
-- For ground based antennas, the sky noise temperature is always assumed to be :math:`T_\mathrm{Sky} = 200K`. This is because the ground antenna does not have a pointing direction. It is assumed that the ground based antenna is always precisely pointed at the spacecraft antenna.
+- For ground-based antennas, the sky noise temperature is always assumed to be :math:`T_\mathrm{Sky} = 200K`. This is because the ground antenna does not have a pointing direction. It is assumed that the ground-based antenna is always precisely pointed at the spacecraft antenna.
 
 - Doppler shift between two antennas is not (yet) considered.
 
@@ -532,7 +532,7 @@ The following parameters are optional:
 
 .. note::
 
-   Calling :code:`antenna.setUseHaslamMap(True)`` enables the use of the Haslam 408 MHz all-sky survey map for sky noise temperature calculation, and calles the function :code:`configureBrightnessFile(<filepath>)` internally.
+   Calling :code:`antenna.setUseHaslamMap(True)` enables the use of the Haslam 408 MHz all-sky survey map for sky noise temperature calculation, and calls the function :code:`configureBrightnessFile(<filepath>)` internally.
    If the user wants to use a custom brightness temperature map file, they must call :code:`antenna.configureBrightnessFile(<custom filePath>)` after calling :code:`antenna.setUseHaslamMap(True)`.
 
 Setting the Antenna Position and Orientation (Space-Based Only)

--- a/src/simulation/environment/groundLocation/groundLocation.rst
+++ b/src/simulation/environment/groundLocation/groundLocation.rst
@@ -6,11 +6,11 @@ Reading in the planet's ephemeris state the position of :math:`L` relative to th
 the inertial frame are evaluated at output as a message.
 
 Further, one or more spacecraft states can be added to this module to compute the spacecraft position
-relative to the ground location :math:`L`.  The associated output access output message contains the relative
-position vector in terms the spherical coordinates range, azimuth and elevation angle, as well as in terms of
+relative to the ground location :math:`L`.  The associated output access message contains the relative
+position vector in terms of the spherical coordinates range, azimuth and elevation angle, as well as in terms of
 South-East-Zenith (SEZ) coordinates.  Finally, the velocity of the spacecraft as seen by the :math:`L` location
 is provided in terms of range, azimuth, elevation, south east and zenith rates.  Finally, this access message
-has a integer variable indicating if the spacecraft is above a minimum elevation angle of the :math:`L` SEC frame.
+has an integer variable indicating if the spacecraft is above a minimum elevation angle of the :math:`L` SEZ frame.
 
 
 
@@ -23,7 +23,7 @@ a conical field of view around the normal vector from the body's surface at the 
 Message Connection Descriptions
 -------------------------------
 The following table lists all the module input and output messages.  The module msg variable name is set by the
-user from python.  The msg type contains a link to the message structure definition, while the description
+user from Python.  The msg type contains a link to the message structure definition, while the description
 provides information on what this message is used for.
 
 .. list-table:: Module I/O Messages
@@ -63,13 +63,13 @@ The ``groundLocation`` module handles the following behavior:
 Determining States
 ~~~~~~~~~~~~~~~~~~
 The position of the spacecraft in the SEZ frame, relative to the ground station, is parameterized
-by the cartesian coordinates:
+by the Cartesian coordinates:
 
 .. math:: \mathbf{r}_{B/L} = x\hat{S} + y\hat{E} + z\hat{Z}
     :label: eq:SEZ_coords:1
 
-The cartesian coordinates are converted to spherical coordinates, centered at the ground station position,
-which give the range (:math:`\rho`), azimuth(:math:`Az`), and elevation(:math:`El`).
+The Cartesian coordinates are converted to spherical coordinates, centered at the ground station position,
+which give the range (:math:`\rho`), azimuth (:math:`Az`), and elevation (:math:`El`).
 
 .. math:: \rho = \sqrt{x^2 + y^2 + z^2}
     :label: eq:rho:2
@@ -102,13 +102,13 @@ User Guide
 ----------
 
 To use this module, instantiate the class and provide it with a body-fixed location (in either lat/long/altitude,
-via the specifyLocation method, or in
+via the ``specifyLocation()`` method, or in
 planet-centered planet-fixed coordinates directly via the ``r_LP_P_Init`` attribute) and a planet position/attitude
 message (i.e., an instance of :ref:`SpicePlanetStateMsgPayload`);
 to compute access, at least one :ref:`SCStatesMsgPayload` message must be added to the module using the ``addSpacecraftToModel()`` method.
 The first spacecraft is 0, the second is 1, and so on.
 
-A new instance of groundLocation, alongside necessary user-supplied parameters, can be created by calling:
+A new instance of ``groundLocation``, alongside necessary user-supplied parameters, can be created by calling:
 
 .. code-block:: python
 
@@ -123,7 +123,7 @@ A new instance of groundLocation, alongside necessary user-supplied parameters, 
 The ``planetRadius`` variable is optional and defaults to Earth's radius.  Instead of specifying the ground location
 through the ``specifyLocation()`` method, you can also set the module variable ``r_LP_P_Init`` using the
 ``specifyLocationPCPF()`` method. Avoid setting the module variable ``r_LP_P_Init`` directly, as there are computations
-that occur within the ``specifyLocation()`` and ``specifylocationPCPF()`` methods that are important for access message
+that occur within the ``specifyLocation()`` and ``specifyLocationPCPF()`` methods that are important for access message
 states.
 
 The ``maximumRange`` variable is optional and defaults to -1.  This means by default no maximum range is considered.  Set it to a positive value to have ``hasAccess`` output message variable depend on range.

--- a/src/simulation/environment/spacecraftLocation/spacecraftLocation.rst
+++ b/src/simulation/environment/spacecraftLocation/spacecraftLocation.rst
@@ -77,7 +77,7 @@ The line of sight vector is defined through the point `B` and the direction :mat
 .. math::
     {\bf l} =  {\bf r}_{B/P} + \kappa * {\bf r}_{S/B}
 
-The process of intersecting a line with an ellipsoid is simplified by using an affine project to render the ellipsoid a sphere.  This affine mapping preserves a line to remain a line.  The math of this is as follow.  The planet is assumed to have rotational symmetry about the 3:sup`rd` axis about which it is spinning.  Thus, to map the ellipsoid into a sphere the planet relative 3:sup`rd` coordinates must scaled by the ratio of the equatorial radius to the polar radius.  The following math assumes this affine mapping has been performed in the above planet-relative position coordinates.
+The process of intersecting a line with an ellipsoid is simplified by using an affine project to render the ellipsoid a sphere.  This affine mapping preserves a line to remain a line.  The math of this is as follows.  The planet is assumed to have rotational symmetry about the 3\ :sup:`rd` axis about which it is spinning.  Thus, to map the ellipsoid into a sphere the planet relative 3\ :sup:`rd` coordinates must be scaled by the ratio of the equatorial radius to the polar radius.  The following math assumes this affine mapping has been performed in the above planet-relative position coordinates.
 
 To determine the minimum distance of the line :math:`\bf l` to the planet origin, consider the cost function :math:`J`:
 
@@ -135,18 +135,18 @@ A new instance of ``spacecraftLocation``, alongside necessary user-supplied para
     location.ModelTag = "scLocation"
     location.rEquator = orbitalMotion.REQ_EARTH * 1000.
     location.rPolar = orbitalMotion.RP_EARTH * 1000.  # optional, include to account for oblateness
-    location.maximumRange = 100e3 # optinal, sets maximum range for visibility in meters
+    location.maximumRange = 100e3 # optional, sets maximum range for visibility in meters
     scSim.AddModelToTask(simTaskName, location)
 
 The variable ``maximumRange`` is optional and set to -1 by default.  If it is set to a positive value, then the ``hasAccess`` variable is only set to 1 if the relative spacecraft distance is less than this maximum range.
 
-A optional planet emphemeris is connected via the``planetInMsg`` input message:
+An optional planet ephemeris is connected via the ``planetInMsg`` input message:
 
 .. code-block:: python
 
     location.planetInMsg.subscribeTo(planetMsg)
 
-It this message is not connected, then zero planet position and attitude orientation are set.
+If this message is not connected, then zero planet position and attitude orientation are set.
 
 
 To set a primary spacecraft body fixed sensor or communication axis :math:`\hat{\bf a}` and half-cone angle :math:`\theta`, use::


### PR DESCRIPTION
## Summary
This PR applies documentation corrections and cleanup across selected Basilisk docs pages.

## Changes
- Fixed ordinal superscript rendering issues:
  - `3rd` axis rendering in `spacecraftLocation` docs
  - `67th` rendering in docs index publication list
- Corrected obvious spelling/grammar issues in:
  - `docs/source/index.rst`
  - `src/simulation/environment/spacecraftLocation/spacecraftLocation.rst`
  - `src/simulation/environment/groundLocation/groundLocation.rst`
  - `src/simulation/communication/simpleAntenna/simpleAntenna.rst`
- Fixed `simpleAntenna` documentation message names/references to match API names (e.g., `scStateInMsg`, `groundStateInMsg`, `antennaSetStateInMsg`, `antennaOutMsg`).
- Fixed minor inline-code/rendering issues in `simpleAntenna` docs note text.

## Validation
- Rebuilt docs:
  - `PATH="/Users/dahu1128/Repositories/basilisk/.venv/bin:$PATH" make -C docs html`
- Build completed successfully.

## Notes
- Documentation-only changes with no runtime behavior changes.
