### PR TITLE
change the CI workflow logic of building documentation.

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Build Basilisk
         uses: ./.github/actions/build
@@ -29,8 +29,8 @@ jobs:
           conan-args: --opNav True --allOptPkg --mujoco True --mujocoReplay True
       - name: Build docs
         uses: ./.github/actions/docs
-      - name: Deploy master branch merges to /
-        if: success() && github.ref_name == 'master'
+      - name: Deploy non-develop branch merges to /
+        if: success() && github.ref_name != 'develop'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
It still is triggered if the branch is merged into master or develop. However, it either does the `develop` documentation deployment, other wise it does the `master` documentation deployment. This allow us to manually trigger the documentation build on our v2.9.x patch releases that don't reside in master.

Ensured the workflow can be run from any branch.

## Verification
Tested it on the BSK v2.9.1 release branch and it worked as expected.

## Documentation
None

## Future work
None