### PR TITLE
Enable facet drag dynamic effector to link to state effectors

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
@@ -163,7 +163,7 @@ special case of prescribed effector branching explained in :ref:`prescribedMotio
           <th class="rotate"><span class="rotate-inner">Thruster Dynamic Effector</span></th>
           <th class="rotate"><span class="rotate-inner">Thruster State Effector</span></th>
           <th class="rotate"><span class="rotate-inner">Constraint Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Drag Effector</span></th>
+          <th class="rotate"><span class="rotate-inner">Faceted Drag Effector</span></th>
           <th class="rotate"><span class="rotate-inner">External Force Torque</span></th>
           <th class="rotate"><span class="rotate-inner">SRP Effector</span></th>
           <th class="rotate"><span class="rotate-inner">Fuel Tank Effector</span></th>
@@ -185,28 +185,28 @@ special case of prescribed effector branching explained in :ref:`prescribedMotio
             <span class="rotate-inner">Parent Effectors</span>
           </td>
           <td class="label">Spinning Bodies 1DOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
           <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
         </tr>
         <tr>
           <td class="label">Spinning Bodies 2DOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
           <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
         </tr>
         <tr>
           <td class="label">Spinning Bodies NDOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
           <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
         </tr>
         <tr>
           <td class="label">Hinged Rigid Bodies</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
           <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
@@ -227,7 +227,7 @@ special case of prescribed effector branching explained in :ref:`prescribedMotio
         </tr>
         <tr>
           <td class="label">Linear Translating Bodies 1DOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
           <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>

--- a/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
@@ -213,7 +213,7 @@ special case of prescribed effector branching explained in :ref:`prescribedMotio
         </tr>
         <tr>
           <td class="label">Dual Hinged Rigid Bodies</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
           <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>

--- a/docs/source/Support/bskReleaseNotesSnippets/1289-facetdrag-branching.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1289-facetdrag-branching.rst
@@ -1,0 +1,1 @@
+- Enabled :ref:`facetDragDynamicEffector` to be attached to a branching state effector.

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -32,6 +32,10 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
+from Basilisk import __path__
+bskPath = __path__[0]
+
+
 from Basilisk.utilities import SimulationBaseClass, macros, simIncludeThruster
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.architecture.bskLogging import BasiliskError
@@ -60,11 +64,15 @@ from Basilisk.simulation import ( # dynamic effectors
     thrusterDynamicEffector,
     constraintDynamicEffector,
     dragDynamicEffector,
+    facetDragDynamicEffector,
     radiationPressure,
     facetSRPDynamicEffector,
     MtbEffector,
 )
 from Basilisk.architecture import messaging
+from Basilisk.simulation import tabularAtmosphere
+from Basilisk.utilities.readAtmTable import readAtmTable
+from Basilisk.simulation import simpleNav
 
 # uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)
@@ -97,6 +105,7 @@ from Basilisk.architecture import messaging
     ("constraintEffectorOneHub",  True),
     ("constraintEffectorNoHubs",  True),
     # ("dragEffector",                False),
+    ("facetDragDynamicEffector",  True),
     # ("radiationPressure",           False),
     # ("facetSRPDynamicEffector",     False),
     # ("MtbEffector",                 False),
@@ -272,6 +281,28 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
         dynamicEff = setup_extPulseTorque()
     elif dynamicEffector == "thrusterDynamicEffector":
         dynamicEff, thFactory = setup_thrusterDynamicEffector()
+    elif dynamicEffector == "facetDragDynamicEffector":
+        dynamicEff = setup_facetDragDynamicEffector(stateEffProps)
+
+        tabAtmo = tabularAtmosphere.TabularAtmosphere()
+        tabAtmo.ModelTag = "tabularAtmosphere"
+
+        tabAtmo.addSpacecraftToModel(scObject.scStateOutMsg)
+
+        r_eq = 6378136.6
+        dataFileName = bskPath + '/supportData/AtmosphereData/EarthGRAMNominal.txt'
+        altList, rhoList, tempList = readAtmTable(dataFileName, 'EarthGRAM')
+
+        # assign constants & ref. data to module
+        tabAtmo.planetRadius = r_eq
+        tabAtmo.altList = tabularAtmosphere.DoubleVector(altList)
+        tabAtmo.rhoList = tabularAtmosphere.DoubleVector(rhoList)
+        tabAtmo.tempList = tabularAtmosphere.DoubleVector(tempList)
+
+        dynamicEff.atmoDensInMsg.subscribeTo(tabAtmo.envOutMsgs[0])
+
+        unitTestSim.AddModelToTask(unitTaskName, tabAtmo)
+
     elif dynamicEffector == "constraintEffectorOneHub":
         dynamicEff, scObjectx = setup_constraintEffectorOneHub(scObject, stateEffProps)
         unitTestSim.AddModelToTask("unitTask", scObjectx)
@@ -532,6 +563,34 @@ def setup_thrusterDynamicEffector():
     thruster.cmdsInMsg.subscribeTo(thrMsg)
 
     return(thruster, thFactory)
+
+def setup_facetDragDynamicEffector(stateEffProps):
+    facetDrag = facetDragDynamicEffector.FacetDragDynamicEffector()
+    facetDrag.ModelTag = "facetDragDynamicEffector"
+
+    facetDrag.setPropName_inertialPosition(stateEffProps.nameOfInertialPositionProperty)
+    facetDrag.setPropName_inertialVelocity(stateEffProps.nameOfInertialVelocityProperty)
+    facetDrag.setPropName_inertialAttitude(stateEffProps.nameOfInertialAttitudeProperty)
+
+    panelArea = 10
+    panelOffset = 0.3  # Distance from hub COM
+    panelCd = 5
+
+    panel_normals = [
+        np.array([0, 0,  1]),
+        np.array([0, 0, -1])
+    ]
+
+    # Centered on panel
+    panel_locations = [
+        np.array([0.0, 0.0, panelOffset]),
+        np.array([0.0, 0.0, panelOffset])
+    ]
+
+    for i in range(2):
+        facetDrag.addFacet(panelArea, panelCd, panel_normals[i], panel_locations[i])
+
+    return(facetDrag)
 
 def setup_constraintEffector(scObject1):
     scObject2 = spacecraft.Spacecraft()
@@ -800,6 +859,9 @@ def setup_hingedRigidBodyStateEffector():
     stateEffProps.r_PB_B = hingedBody.r_HB_B
     stateEffProps.r_PcP_P = hingedBody.d * s1_hat
     stateEffProps.inertialPropLogName = "hingedRigidBodyConfigLogOutMsg"
+    stateEffProps.nameOfInertialPositionProperty = hingedBody.ModelTag + "InertialPosition1"
+    stateEffProps.nameOfInertialVelocityProperty = hingedBody.ModelTag + "InertialVelocity1"
+    stateEffProps.nameOfInertialAttitudeProperty = hingedBody.ModelTag + "InertialAttitude1"
 
     return(hingedBody, stateEffProps)
 
@@ -867,4 +929,4 @@ class stateEffectorProperties:
     r_PcP_P = [[0.0], [0.0], [0.0]] # individual COM for linkage that dynEff will be attached to
 
 if __name__ == "__main__":
-    effectorBranchingIntegratedTest(True, "hingedRigidBodies", True, "extForceTorque", True)
+    effectorBranchingIntegratedTest(True, "hingedRigidBodies", True, "facetDragDynamicEffector", True)

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -61,6 +61,7 @@ from Basilisk.simulation import ( # dynamic effectors
     thrusterDynamicEffector,
     constraintDynamicEffector,
     dragDynamicEffector,
+    facetDragDynamicEffector,
     radiationPressure,
     facetSRPDynamicEffector,
     MtbEffector,
@@ -101,6 +102,7 @@ FINE_TIMESTEP = 0.0005  # [s]
     ("constraintEffectorOneHub",  True),
     ("constraintEffectorNoHubs",  True),
     # ("dragEffector",                False),
+    ("facetDragDynamicEffector",  True),
     # ("radiationPressure",           False),
     # ("facetSRPDynamicEffector",     False),
     # ("MtbEffector",                 False),
@@ -417,6 +419,8 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
         dynamicEff = setup_extPulseTorque()
     elif dynamicEffector == "thrusterDynamicEffector":
         dynamicEff, thFactory = setup_thrusterDynamicEffector()
+    elif dynamicEffector == "facetDragDynamicEffector":
+        dynamicEff = setup_facetDragDynamicEffector()
     elif dynamicEffector == "constraintEffectorOneHub":
         dynamicEff, scObjectx = setup_constraintEffectorOneHub(scObject, stateEffProps)
         unitTestSim.AddModelToTask("unitTask", scObjectx)
@@ -689,6 +693,27 @@ def setup_thrusterDynamicEffector():
     thruster.cmdsInMsg.subscribeTo(thrMsg)
 
     return(thruster, thFactory)
+
+def setup_facetDragDynamicEffector():
+    facetDrag = facetDragDynamicEffector.FacetDragDynamicEffector()
+    facetDrag.ModelTag = "facetDragDynamicEffector"
+
+    # facet geometry is expressed in the parent frame, not the hub body frame
+    panelArea = 10.0  # [m^2]
+    panelCd = 5.0  # [-]
+    r_FP_P = np.array([0.0, 0.0, 0.3])  # [m] both faces share the panel centroid
+    for panelNormal_P in [np.array([0.0, 0.0, 1.0]), np.array([0.0, 0.0, -1.0])]:
+        facetDrag.addFacet(panelArea, panelCd, panelNormal_P, r_FP_P)
+
+    # the orbit shared by every case here sits above any atmosphere table, so feed the effector a
+    # fixed density rather than an atmosphere model or the drag load is zero
+    atmoMsgData = messaging.AtmoPropsMsgPayload()
+    atmoMsgData.neutralDensity = 4.2e-10  # [kg/m^3] nominal 200 km density
+    atmoMsg = messaging.AtmoPropsMsg()
+    atmoMsg.write(atmoMsgData)
+    facetDrag.atmoDensInMsg.subscribeTo(atmoMsg)
+
+    return(facetDrag)
 
 def setup_constraintEffector(scObject1):
     scObject2 = spacecraft.Spacecraft()

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -238,6 +238,11 @@ def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dy
     where again :math:`j` is the segment that the dynamic effector is attached to among all
     :math:`i` segments. The sim 'truth' :math:`{}^{\mathcal{N}}\!\Delta v_{accum,C}` is logged from
     the spacecraft module.
+
+    For the :ref:`facetDragDynamicEffector` cases, the force and torque are also recomputed from
+    the parent segment's inertial attitude and velocity properties. The parent segment frames are
+    intentionally offset from the hub frame, so this comparison detects use of the hub kinematics
+    or an incorrect parent-to-inertial frame transformation.
     """
 
     coarseResidual = effectorBranchingIntegratedTest(show_plots, stateEffector, isParent,
@@ -420,7 +425,7 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     elif dynamicEffector == "thrusterDynamicEffector":
         dynamicEff, thFactory = setup_thrusterDynamicEffector()
     elif dynamicEffector == "facetDragDynamicEffector":
-        dynamicEff = setup_facetDragDynamicEffector()
+        dynamicEff, facetProps = setup_facetDragDynamicEffector()
     elif dynamicEffector == "constraintEffectorOneHub":
         dynamicEff, scObjectx = setup_constraintEffectorOneHub(scObject, stateEffProps)
         unitTestSim.AddModelToTask("unitTask", scObjectx)
@@ -517,6 +522,34 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     stopTime = 1
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
+
+    if dynamicEffector == "facetDragDynamicEffector":
+        sigma_PN = np.array(scObject.dynManager.getPropertyReference(
+            dynamicEff.getPropName_inertialAttitude())).flatten()
+        v_PN_N = np.array(scObject.dynManager.getPropertyReference(
+            dynamicEff.getPropName_inertialVelocity())).flatten()
+        expectedForce_P, expectedTorque_P = facetDragLoad_P(facetProps, sigma_PN, v_PN_N)
+
+        sigma_BN = np.array(scObject.dynManager.getStateObject(
+            scObject.hub.nameOfHubSigma).getState()).flatten()
+        v_BN_N = np.array(scObject.dynManager.getStateObject(
+            scObject.hub.nameOfHubVelocity).getState()).flatten()
+        hubForce_B, _ = facetDragLoad_P(facetProps, sigma_BN, v_BN_N)
+
+        # RKF45 takes its last stage at the step midpoint, so re-evaluate against the reads above
+        dynamicEff.computeForceTorque(0.0, 0.0)  # [s]
+        force_accuracy = 1e-12  # [N]
+        torque_accuracy = 1e-12  # [N*m]
+        assert not np.allclose(expectedForce_P, hubForce_B, rtol=0.0, atol=force_accuracy), (
+            "FAILED: this parent is not offset enough from the hub to tell their kinematics apart")
+        np.testing.assert_allclose(
+            np.array(dynamicEff.forceExternal_B).flatten(), expectedForce_P,
+            rtol=0.0, atol=force_accuracy,
+            err_msg="FAILED: branched facet drag force was not built from the parent kinematics")
+        np.testing.assert_allclose(
+            np.array(dynamicEff.torqueExternalPntB_B).flatten(), expectedTorque_P,
+            rtol=0.0, atol=torque_accuracy,
+            err_msg="FAILED: branched facet drag moment was not taken about the parent frame origin")
 
     # Continue to check state effector EOMs using pure force & torque
     if dynamicEffector != "extForceTorque":
@@ -698,22 +731,27 @@ def setup_facetDragDynamicEffector():
     facetDrag = facetDragDynamicEffector.FacetDragDynamicEffector()
     facetDrag.ModelTag = "facetDragDynamicEffector"
 
+    facetProps = facetDragProperties()
+    facetProps.area = 10.0  # [m^2]
+    facetProps.dragCoeff = 5.0  # [-]
+    facetProps.density = 4.2e-10  # [kg/m^3] nominal 200 km density
+    facetProps.r_FP_P = np.array([0.0, 0.0, 0.3])  # [m] both faces share the panel centroid
+    facetProps.normals_P = [np.array([0.0, 0.0, 1.0]), np.array([0.0, 0.0, -1.0])]
+
     # facet geometry is expressed in the parent frame, not the hub body frame
-    panelArea = 10.0  # [m^2]
-    panelCd = 5.0  # [-]
-    r_FP_P = np.array([0.0, 0.0, 0.3])  # [m] both faces share the panel centroid
-    for panelNormal_P in [np.array([0.0, 0.0, 1.0]), np.array([0.0, 0.0, -1.0])]:
-        facetDrag.addFacet(panelArea, panelCd, panelNormal_P, r_FP_P)
+    for normal_P in facetProps.normals_P:
+        facetDrag.addFacet(facetProps.area, facetProps.dragCoeff, normal_P, facetProps.r_FP_P)
 
     # the orbit shared by every case here sits above any atmosphere table, so feed the effector a
     # fixed density rather than an atmosphere model or the drag load is zero
     atmoMsgData = messaging.AtmoPropsMsgPayload()
-    atmoMsgData.neutralDensity = 4.2e-10  # [kg/m^3] nominal 200 km density
+    atmoMsgData.neutralDensity = facetProps.density
     atmoMsg = messaging.AtmoPropsMsg()
     atmoMsg.write(atmoMsgData)
     facetDrag.atmoDensInMsg.subscribeTo(atmoMsg)
 
-    return(facetDrag)
+    return(facetDrag, facetProps)
+
 
 def setup_constraintEffector(scObject1):
     scObject2 = spacecraft.Spacecraft()
@@ -728,6 +766,26 @@ def setup_constraintEffector(scObject1):
     scObject2.gravField.gravBodies = scObject1.gravField.gravBodies
 
     return scObject2
+
+
+def facetDragLoad_P(facetProps, sigma_PN, v_PN_N):
+    """Reference facet drag force and moment about the parent frame origin."""
+    dcm_PN = rbk.MRP2C(sigma_PN)
+    v_PN_P = dcm_PN @ v_PN_N
+    speed = np.linalg.norm(v_PN_P)
+    vHat_P = v_PN_P / speed
+
+    force_P = np.zeros(3)
+    torque_P = np.zeros(3)
+    for normal_P in facetProps.normals_P:
+        projectedArea = facetProps.area * normal_P.dot(vHat_P)
+        if projectedArea > 0.0:
+            facetForce_P = (-0.5 * facetProps.density * facetProps.dragCoeff * projectedArea
+                            * speed**2 * vHat_P)
+            force_P += facetForce_P
+            torque_P += np.cross(facetProps.r_FP_P, facetForce_P)
+
+    return(force_P, torque_P)
 
 
 def weldParentSegmentToHub(stateEffector, stateEff):
@@ -1129,6 +1187,14 @@ class stateEffectorProperties:
     # to be used in checking equations of motion
     inertialPropLogName = "" # name of inertial property output log message
     r_PcP_P = [[0.0], [0.0], [0.0]] # individual COM for linkage that dynEff will be attached to
+
+class facetDragProperties:
+    # facet geometry and flow conditions, all expressed in the parent frame
+    area = 0.0 # individual facet area
+    dragCoeff = 0.0 # individual facet drag coefficient
+    density = 0.0 # atmospheric density held fixed for the test
+    r_FP_P = [0.0, 0.0, 0.0] # facet centroid relative to the parent frame origin
+    normals_P = [] # outward facet normals
 
 if __name__ == "__main__":
     effectorBranchingIntegratedTest(True, "hingedRigidBodies", True, "extForceTorque", True)

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -31,7 +31,24 @@ FacetDragDynamicEffector::FacetDragDynamicEffector()
     this->atmoInData = {};  // Initialize atmosphere data to zero
     this->windInData = {};  // Initialize wind data to zero
 	this->numFacets = 0;
-	return;
+
+   // Initialize state pointers
+   this->hubSigma = nullptr;
+   this->hubVelocity = nullptr;
+
+   // Initialize property pointers
+   this->inertialPositionProperty = nullptr;
+   this->inertialVelocityProperty = nullptr;
+   this->inertialAttitudeProperty = nullptr;
+
+   // Set default state names for hub attachment
+   this->stateNameOfSigma = "hubSigma";
+   this->stateNameOfVelocity = "hubVelocity";
+
+   /* This effector can be attached onto a state effector */
+   isAttachableToStateEffector = true;
+
+   return;
 }
 
 /*! The destructor.*/
@@ -106,13 +123,76 @@ void FacetDragDynamicEffector::linkInStates(DynParamManager& states){
 	this->hubVelocity = states.getStateObject(this->stateNameOfVelocity);
 }
 
+/*! This method is used to link the dragEffector to the state effectors attitude, position and velocity,
+which are required for calculating drag forces and torques.
+@param properties The parameter manager to collect from
+*/
+void FacetDragDynamicEffector::linkInProperties(DynParamManager& properties)
+{
+
+   // updateDragDir only requires these two to do calculations (Keep linking position in case you want to add altitude-dependent drag coefficients or other position-based effects later)
+   this->inertialAttitudeProperty = properties.getPropertyReference(this->propName_inertialAttitude);
+   this->inertialVelocityProperty = properties.getPropertyReference(this->propName_inertialVelocity);
+}
+
+/*! This method is used to set the inertialPosition property when facet drag is attached to a state effector rather than the hub
+ */
+void FacetDragDynamicEffector::setPropName_inertialPosition(std::string value) {
+   if (!value.empty()) {
+       this->propName_inertialPosition = value;
+   } else {
+       bskLogger.bskLog(BSK_ERROR, "FacetDragDynamicEffector: propName_inertialPosition variable must be a non-empty string");
+   }
+}
+
+/*! This method is used to set the inertialVelocity property when facet drag is attached to a state effector rather than the hub
+ */
+void FacetDragDynamicEffector::setPropName_inertialVelocity(std::string value) {
+   if (!value.empty()) {
+       this->propName_inertialVelocity = value;
+   } else {
+       bskLogger.bskLog(BSK_ERROR, "FacetDragDynamicEffector: propName_inertialVelocity variable must be a non-empty string");
+   }
+}
+
+/*! This method is used to set the inertialAttitude property when facet drag is attached to a state effector rather than the hub
+ */
+void FacetDragDynamicEffector::setPropName_inertialAttitude(std::string value) {
+   if (!value.empty()) {
+       this->propName_inertialAttitude = value;
+   } else {
+       bskLogger.bskLog(BSK_ERROR, "FacetDragDynamicEffector: propName_inertialAttitude variable must be a non-empty string");
+   }
+}
+
+/*! This method is used to set the inertialAngVelocity property when facet drag is attached to a state effector rather than the hub
+ */
+void FacetDragDynamicEffector::setPropName_inertialAngVelocity(std::string value) {
+   if (!value.empty()) {
+       this->propName_inertialAngVelocity = value;
+   } else {
+       bskLogger.bskLog(BSK_ERROR, "FacetDragDynamicEffector: propName_inertialAngVelocity variable must be a non-empty string");
+   }
+}
+
 /*! This method updates the internal drag direction based on the spacecraft velocity vector.
  * It accounts for wind velocity if the wind message is linked.
 */
 void FacetDragDynamicEffector::updateDragDir(){
-    Eigen::MRPd sigmaBN;
-    sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
-    Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
+   Eigen::MRPd sigmaBN;
+   Eigen::Vector3d velocity;
+   // Determine which parent to use based on what's been linked
+   if (this->inertialAttitudeProperty != nullptr && this->inertialVelocityProperty != nullptr) {
+       // Attached to state effector: use properties
+       sigmaBN = (Eigen::Vector3d)(*this->inertialAttitudeProperty);
+       velocity = (*this->inertialVelocityProperty);
+   } else {
+       // Attached to hub: use states
+       sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
+       velocity = this->hubVelocity->getState();
+   }
+
+   Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
     Eigen::Vector3d v_BN_N = this->hubVelocity->getState();
 
@@ -131,7 +211,7 @@ void FacetDragDynamicEffector::updateDragDir(){
         this->v_hat_B.setZero();
     }
 
-    return;
+   return;
 }
 
 /*! This method WILL implement a more complex flat-plate aerodynamics model with attitude

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -31,7 +31,10 @@ FacetDragDynamicEffector::FacetDragDynamicEffector()
     this->atmoInData = {};  // Initialize atmosphere data to zero
     this->windInData = {};  // Initialize wind data to zero
 	this->numFacets = 0;
-	return;
+
+    this->isAttachableToStateEffector = true;
+
+    return;
 }
 
 /*! The destructor.*/
@@ -106,14 +109,29 @@ void FacetDragDynamicEffector::linkInStates(DynParamManager& states){
 	this->hubVelocity = states.getStateObject(this->stateNameOfVelocity);
 }
 
+/*! This method is used to link the dragEffector to its parent state effector's properties
+ @param properties The parameter manager to collect from
+ */
+void FacetDragDynamicEffector::linkInProperties(DynParamManager& properties){
+    this->inertialAttitudeProperty = properties.getPropertyReference(this->propName_inertialAttitude);
+    this->inertialVelocityProperty = properties.getPropertyReference(this->propName_inertialVelocity);
+}
+
 /*! This method updates the internal drag direction based on the spacecraft velocity vector.
  * It accounts for wind velocity if the wind message is linked.
 */
 void FacetDragDynamicEffector::updateDragDir(){
-    Eigen::MRPd sigmaBN(this->hubSigma->getState().data());
-    Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
+    Eigen::MRPd sigmaBN;
+    Eigen::Vector3d v_BN_N;
+    if (!this->stateNameOfSigma.empty()) {
+        sigmaBN = Eigen::MRPd(this->hubSigma->getState().data());
+        v_BN_N = this->hubVelocity->getState();
+    } else {
+        sigmaBN = Eigen::MRPd(this->inertialAttitudeProperty->data());
+        v_BN_N = *this->inertialVelocityProperty;
+    }
 
-    Eigen::Vector3d v_BN_N = this->hubVelocity->getState();
+    Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
     if (this->windVelInMsg.isLinked()) {
         Eigen::Map<Eigen::Vector3d> v_air_N(this->windInData.v_air_N);

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -55,6 +55,7 @@ public:
     FacetDragDynamicEffector();
     ~FacetDragDynamicEffector();
     void linkInStates(DynParamManager& states);
+    void linkInProperties(DynParamManager& properties); // To allow dynamic effector to attach to state effectors
     void computeForceTorque(double integTime, double timeStep);
     void Reset(uint64_t CurrentSimNanos);               //!< class method
     void UpdateState(uint64_t CurrentSimNanos);
@@ -77,11 +78,36 @@ public:
     Eigen::Vector3d v_hat_B;                        //!< -- Drag force direction in the body frame
     BSKLogger bskLogger;                            //!< -- BSK Logging
 
+    // State names (for hub attachment)
+    std::string stateNameOfSigma;
+    std::string stateNameOfVelocity;
+
+    // Property names (for state effector attachment)
+    std::string propName_inertialPosition;
+    std::string propName_inertialVelocity;
+    std::string propName_inertialAttitude;
+    std::string propName_inertialAngVelocity;
+
+    void setPropName_inertialPosition(std::string value) override;
+    void setPropName_inertialVelocity(std::string value) override;
+    void setPropName_inertialAttitude(std::string value) override;
+    void setPropName_inertialAngVelocity(std::string value) override;
+
+    std::string getPropName_inertialPosition() const { return this->propName_inertialPosition; }
+    std::string getPropName_inertialVelocity() const { return this->propName_inertialVelocity; }
+    std::string getPropName_inertialAttitude() const { return this->propName_inertialAttitude; }
+    std::string getPropName_inertialAngVelocity() const { return this->propName_inertialAngVelocity; }
+
 private:
     AtmoPropsMsgPayload atmoInData;
     WindMsgPayload windInData;
     SpacecraftGeometryData scGeometry;              //!< -- Struct to hold spacecraft facet data
 
+    // Property pointers (for state effector attachment)
+    Eigen::MatrixXd *inertialPositionProperty;      //!< [m] position relative to inertial frame
+    Eigen::MatrixXd *inertialVelocityProperty;      //!< [m/s] velocity relative to inertial frame
+    Eigen::MatrixXd *inertialAttitudeProperty;      //!< attitude relative to inertial frame
+    Eigen::MatrixXd *inertialAngVelocity;      //!< attitude relative to inertial frame
 };
 
 #endif

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.h
@@ -55,6 +55,7 @@ public:
     FacetDragDynamicEffector();
     ~FacetDragDynamicEffector();
     void linkInStates(DynParamManager& states);
+    void linkInProperties(DynParamManager& properties) override;
     void computeForceTorque(double integTime, double timeStep);
     void Reset(uint64_t CurrentSimNanos);               //!< class method
     void UpdateState(uint64_t CurrentSimNanos);
@@ -71,8 +72,8 @@ public:
     uint64_t numFacets;                             //!< number of facets
     ReadFunctor<AtmoPropsMsgPayload> atmoDensInMsg; //!< atmospheric density input message
     ReadFunctor<WindMsgPayload> windVelInMsg;       //!< wind velocity input message
-    StateData *hubSigma;                            //!< -- Hub/Inertial attitude represented by MRP
-    StateData *hubVelocity;                         //!< m/s Hub inertial velocity vector
+    StateData *hubSigma = nullptr;                  //!< -- Hub/Inertial attitude represented by MRP
+    StateData *hubVelocity = nullptr;               //!< m/s Hub inertial velocity vector
     Eigen::Vector3d v_B;                            //!< m/s spacecraft velocity expressed in body frame B (relative to air if windVelInMsg is linked, else relative to inertial frame N)
     Eigen::Vector3d v_hat_B;                        //!< -- Drag force direction in the body frame
     BSKLogger bskLogger;                            //!< -- BSK Logging
@@ -82,6 +83,8 @@ private:
     WindMsgPayload windInData;
     SpacecraftGeometryData scGeometry;              //!< -- Struct to hold spacecraft facet data
 
+    Eigen::MatrixXd *inertialVelocityProperty = nullptr;  //!< m/s parent frame origin inertial velocity
+    Eigen::MatrixXd *inertialAttitudeProperty = nullptr;  //!< -- parent frame attitude relative to the inertial frame
 };
 
 #endif

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.rst
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.rst
@@ -35,6 +35,22 @@ Example setup:
 
     scObject.addDynamicEffector(drag)
 
+Attaching to a State Effector
+-----------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a drag surface can
+be carried by an appendage instead of the hub. Attach it to the parent state effector rather than
+to the spacecraft:
+
+.. code-block:: python
+
+    stateEff.addDynamicEffector(drag, segment)
+
+The parent's inertial attitude and velocity then replace the hub's in the drag calculation, so a
+panel that rotates or translates relative to the hub sees its own relative wind. Every facet normal
+and facet location passed to ``addFacet()`` is expressed in the parent segment's frame in that
+configuration, not in the hub body frame, and the resulting force and torque are returned about the
+parent frame origin.
+
 Input Message Timing
 ---------------------
 Both ``atmoDensInMsg`` and ``windVelInMsg`` are refreshed only during ``UpdateState()``.


### PR DESCRIPTION
* **Tickets addressed:** #1289
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

The faceted drag effector could only attach to the hub, so a panel on an appendage saw the hub's attitude and velocity rather than its own. This adds the dynamic effector half of the branching in `bskPrinciples-11`. `linkInProperties()` collects the parent's inertial attitude and velocity, and `updateDragDir()` selects between those and the hub states on whether the hub state names were assigned, the same discriminator `ThrusterDynamicEffector` uses.

Four commits, one concern each: effector source, integrated test, documentation, release note.

## Verification

`test_effectorBranching_integrated.py` gains a `facetDragDynamicEffector` parametrization covering the branching-capable state effectors. Density comes from a stand-alone message, because the orbit shared by that file sits at 3613 km, above the atmosphere table, so there was no drag load to test.

## Documentation

`facetDragDynamicEffector.rst` gains an "Attaching to a State Effector" section. The paragraph on which frame facet geometry is expressed in is the one worth checking.

The compatibility table in `bskPrinciples-11.rst` now names its drag column for the faceted effector and marks it supported. Cannonball `dragDynamicEffector` is not planned for branching, since its force is attitude-independent.

Release note snippet added.

## Future work

The aerobraking scenario this was built for.
