### PR TITLE
Reduce Number of Runners used for Pull Request CI 

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
 
   build-windows:
     runs-on: windows-2025
-    timeout-minutes: 90
+    timeout-minutes: 105
     needs: pre-commit
     strategy:
       fail-fast: false


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
CI is taking forever to run on PRs. In an effort to reduce the amount of CI that runs, we are thinning out the types of macOS
runs performed. Now we just do Python 3.8 and 3.13 on macOS.

## Verification
CI

## Documentation
N/A

## Future work
We will probably make further tweaks to CI in the future to try and speed things up more.
