### PR TITLE
Added Space Weather Data loader module

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/space-weather-data-module.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/space-weather-data-module.rst
@@ -1,0 +1,1 @@
+- Added a new :ref:`spaceWeatherData` C++ module that loads CelesTrak space-weather CSV data and publishes the 23-message weather set required by :ref:`msisAtmosphere`.

--- a/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
+++ b/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
@@ -1,0 +1,848 @@
+#
+# ISC License
+#
+# Copyright (c) 2026, PIC4SeR & AVS Lab, Politecnico di Torino & Argotec S.R.L., University of Colorado Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+import tempfile
+from pathlib import Path
+import pytest
+
+from Basilisk.architecture import bskLogging
+from Basilisk.simulation import spaceWeatherData
+from Basilisk.utilities import SimulationBaseClass, macros, unitTestSupport
+from Basilisk.architecture.bskLogging import BasiliskError
+
+
+_CELESTRAK_CSV = "\n".join([
+    "DATE,BSRN,ND,KP1,KP2,KP3,KP4,KP5,KP6,KP7,KP8,KP_SUM,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,CP,C9,ISN,F10.7_OBS,F10.7_ADJ,F10.7_DATA_TYPE,F10.7_OBS_CENTER81,F10.7_OBS_LAST81,F10.7_ADJ_CENTER81,F10.7_ADJ_LAST81",
+    "2026-02-28,2626,4,20,27,13,13,20,17,20,23,153,7,12,5,5,7,6,7,9,7,0.4,2,58,140.7,138.1,OBS,141.7,144.2,139.2,139.9",
+    "2026-03-01,2626,5,27,27,23,20,13,7,17,13,147,12,12,9,7,5,3,6,5,7,0.4,2,80,147.0,144.4,OBS,141.1,143.9,138.6,139.7",
+    "2026-03-02,2626,6,13,7,10,3,17,10,7,13,80,5,3,4,2,6,4,3,5,4,0.1,0,81,147.6,145.0,OBS,140.3,143.9,138.0,139.7",
+    "2026-03-03,2626,7,7,27,20,23,20,33,33,50,213,3,12,7,9,7,18,18,48,15,0.9,4,83,143.5,141.1,OBS,139.5,144.0,137.2,139.8",
+    "2026-03-04,2626,8,23,30,17,20,7,7,13,10,127,9,15,6,7,3,3,5,4,6,0.3,1,68,141.2,138.8,OBS,138.5,144.3,136.3,140.1",
+])
+
+
+def test_space_weather_data_celestrak_example_columns():
+    """Validate parsing against the provided CelesTrak-style rows.
+
+    **Test Description**
+
+    This test uses the provided CelesTrak CSV rows and validates output values
+    against the supplied ground-truth weather channel values.
+
+    **Description of Variables Being Tested**
+
+    The test checks all 23 outputs in ``swDataOutMsgs`` against known values for
+    the epoch ``2026-03-04 21:48:00``.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(1.0)))  # [s]
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(_CELESTRAK_CSV)
+
+        module.loadSpaceWeatherFile(str(file_path))
+
+        timeInitString = "2026 March 04 21:48:00.000000"
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+        module.epochInMsg.subscribeTo(epochMsg)
+
+        sim.AddModelToTask(unit_task_name, module)
+
+        logs = []
+        for msg_index in range(23):
+            recorder = module.swDataOutMsgs[msg_index].recorder()
+            logs.append(recorder)
+            sim.AddModelToTask(unit_task_name, recorder)
+
+        sim.InitializeSimulation()
+        sim.ConfigureStopTime(macros.sec2nano(1.0))  # [s]
+        sim.ExecuteSimulation()
+
+        expected = [6.0, 4.0, 5.0, 3.0, 3.0, 7.0, 6.0, 15.0, 9.0,
+                    48.0, 18.0, 18.0, 7.0, 9.0, 7.0, 12.0,
+                    3.0, 5.0, 3.0, 4.0, 6.0, 138.5, 143.5]
+
+        for msg_index in range(23):
+            assert abs(logs[msg_index].dataValue[0] - expected[msg_index]) < 1e-12
+
+
+def test_space_weather_data_stops_at_first_invalid_row():
+    """Validate reading stops at the first invalid row (e.g., PRM monthly line).
+
+    **Test Description**
+
+    This test appends invalid PRM-style rows with missing AP fields after valid
+    daily rows and verifies that the valid section is still used correctly.
+
+    **Description of Variables Being Tested**
+
+    The test checks the 23 weather outputs against the same ground-truth values
+    as the valid CelesTrak example set.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(1.0)))  # [s]
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    csv_text = "\n".join([
+        "DATE,BSRN,ND,KP1,KP2,KP3,KP4,KP5,KP6,KP7,KP8,KP_SUM,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,CP,C9,ISN,F10.7_OBS,F10.7_ADJ,F10.7_DATA_TYPE,F10.7_OBS_CENTER81,F10.7_OBS_LAST81,F10.7_ADJ_CENTER81,F10.7_ADJ_LAST81",
+        "2026-02-28,2626,4,20,27,13,13,20,17,20,23,153,7,12,5,5,7,6,7,9,7,0.4,2,58,140.7,138.1,OBS,141.7,144.2,139.2,139.9",
+        "2026-03-01,2626,5,27,27,23,20,13,7,17,13,147,12,12,9,7,5,3,6,5,7,0.4,2,80,147.0,144.4,OBS,141.1,143.9,138.6,139.7",
+        "2026-03-02,2626,6,13,7,10,3,17,10,7,13,80,5,3,4,2,6,4,3,5,4,0.1,0,81,147.6,145.0,OBS,140.3,143.9,138.0,139.7",
+        "2026-03-03,2626,7,7,27,20,23,20,33,33,50,213,3,12,7,9,7,18,18,48,15,0.9,4,83,143.5,141.1,OBS,139.5,144.0,137.2,139.8",
+        "2026-03-04,2626,8,23,30,17,20,7,7,13,10,127,9,15,6,7,3,3,5,4,6,0.3,1,68,141.2,138.8,OBS,138.5,144.3,136.3,140.1",
+        "2038-11-01,2797,16,,,,,,,,,,,,,,,,,,,,,64,95.7,94.3,PRM,96.0,95.4,94.7,96.1",
+        "2038-12-01,2798,19,,,,,,,,,,,,,,,,,,,,,62,95.9,93.3,PRM,96.2,95.9,93.8,95.1",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(csv_text)
+
+        module.loadSpaceWeatherFile(str(file_path))
+
+        timeInitString = "2026 March 04 21:48:00.000000"
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+        module.epochInMsg.subscribeTo(epochMsg)
+
+        sim.AddModelToTask(unit_task_name, module)
+
+        logs = []
+        for msg_index in range(23):
+            recorder = module.swDataOutMsgs[msg_index].recorder()
+            logs.append(recorder)
+            sim.AddModelToTask(unit_task_name, recorder)
+
+        sim.InitializeSimulation()
+        sim.ConfigureStopTime(macros.sec2nano(1.0))  # [s]
+        sim.ExecuteSimulation()
+
+        expected = [6.0, 4.0, 5.0, 3.0, 3.0, 7.0, 6.0, 15.0, 9.0,
+                    48.0, 18.0, 18.0, 7.0, 9.0, 7.0, 12.0,
+                    3.0, 5.0, 3.0, 4.0, 6.0, 138.5, 143.5]
+
+        for msg_index in range(23):
+            assert abs(logs[msg_index].dataValue[0] - expected[msg_index]) < 1e-12
+
+
+def test_space_weather_data_missing_required_column():
+    """Validate missing required CSV columns lead to zero-state output publication.
+
+    **Test Description**
+
+    This test removes ``F10.7_OBS_CENTER81`` from the CSV header and checks that
+    the module cannot build a valid weather table and thus publishes zeros.
+
+    **Description of Variables Being Tested**
+
+    The test checks all 23 weather outputs and verifies every value is zero.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    csv_text = "\n".join([
+        "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS",
+        "2025-01-04,401,402,403,404,405,406,407,408,450,73",
+        "2025-01-05,301,302,303,304,305,306,307,308,350,72",
+        "2025-01-06,201,202,203,204,205,206,207,208,250,71",
+        "2025-01-07,101,102,103,104,105,106,107,108,150,70",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(csv_text)
+
+        with pytest.raises(BasiliskError, match="Space-weather file missing required column"):
+            module.loadSpaceWeatherFile(str(file_path))
+
+
+def test_space_weather_data_duplicate_date_rows():
+    """Validate duplicate DATE rows are rejected and zero-state output is published.
+
+    **Test Description**
+
+    This test provides duplicate ``DATE`` rows in the weather table. The module
+    should reject the file and publish zero outputs.
+
+    **Description of Variables Being Tested**
+
+    The test checks all 23 weather outputs and verifies every value is zero.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    csv_text = "\n".join([
+        "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
+        "2025-01-04,401,402,403,404,405,406,407,408,450,73,83",
+        "2025-01-04,301,302,303,304,305,306,307,308,350,72,82",
+        "2025-01-06,201,202,203,204,205,206,207,208,250,71,81",
+        "2025-01-07,101,102,103,104,105,106,107,108,150,70,80",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(csv_text)
+
+        with pytest.raises(BasiliskError, match="Duplicate DATE row found in space-weather table"):
+            module.loadSpaceWeatherFile(str(file_path))
+
+
+def test_space_weather_data_unsorted_rows():
+    """Validate unsorted DATE rows are rejected and zero-state output is published.
+
+    **Test Description**
+
+    This test provides weather rows out of chronological order. The loader should
+    reject the table and the module should publish zero outputs.
+
+    **Description of Variables Being Tested**
+
+    The test checks all 23 weather outputs and verifies every value is zero.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    csv_text = "\n".join([
+        "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
+        "2025-01-05,301,302,303,304,305,306,307,308,350,72,82",
+        "2025-01-04,401,402,403,404,405,406,407,408,450,73,83",
+        "2025-01-06,201,202,203,204,205,206,207,208,250,71,81",
+        "2025-01-07,101,102,103,104,105,106,107,108,150,70,80",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(csv_text)
+
+        with pytest.raises(BasiliskError, match="Space-weather DATE rows must be sorted in ascending order"):
+            module.loadSpaceWeatherFile(str(file_path))
+
+
+def test_reset_error_when_epoch_before_table():
+    """Validate that Reset emits BSK_ERROR when the epoch date is not in the table.
+
+    **Test Description**
+
+    The simulation epoch is set to 2026-02-27, one day before the first row of
+    the loaded table (2026-02-28).  The ``Reset`` probe calls ``computeSwState``
+    at initialisation time; the four-day look-back window cannot be assembled and
+    a ``BSK_ERROR`` is emitted, which Basilisk converts to a ``BasiliskError``.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``InitializeSimulation`` with the message
+    ``"simulation start date is not covered"``.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(1.0)))  # [s]
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(_CELESTRAK_CSV)
+        module.loadSpaceWeatherFile(str(file_path))
+
+        # epoch one day before the table start — D0 = 2026-02-27, not in table
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2026 February 27 00:00:00.000000")
+        module.epochInMsg.subscribeTo(epochMsg)
+        sim.AddModelToTask(unit_task_name, module)
+
+        with pytest.raises(BasiliskError, match="simulation start date is not covered"):
+            sim.InitializeSimulation()
+
+
+def test_stale_output_retained_on_missing_day():
+    """Validate that outputs are not overwritten when a required day is missing.
+
+    **Test Description**
+
+    The simulation runs two stages with the same module instance.  In stage 1
+    (t = 1 s, epoch 2026-03-04) the look-up succeeds and known values are
+    written.  In stage 2 (t = 25 h + 1 s) D0 advances to 2026-03-05 which is
+    absent from the table; the module must log ``BSK_WARNING`` and return without
+    writing, leaving the outputs at the stage-1 values.
+
+    **Description of Variables Being Tested**
+
+    - ``swDataOutMsgs[0]``  (``ap_24_0``, AP_AVG):        6.0 after both stages.
+    - ``swDataOutMsgs[21]`` (``f107_1944_0``, F10.7c81): 138.5 after both stages.
+    """
+    # Suppress the expected BSK_WARNING, not testing them at the moment.
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_ERROR)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(1.0)))  # [s]
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(_CELESTRAK_CSV)
+        module.loadSpaceWeatherFile(str(file_path))
+
+        # epoch on the last day in the table; after 24 h D0 = 2026-03-05 (absent)
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2026 March 04 00:00:00.000000")
+        module.epochInMsg.subscribeTo(epochMsg)
+        sim.AddModelToTask(unit_task_name, module)
+
+        recorder_avg   = module.swDataOutMsgs[0].recorder()
+        recorder_f107c = module.swDataOutMsgs[21].recorder()
+        sim.AddModelToTask(unit_task_name, recorder_avg)
+        sim.AddModelToTask(unit_task_name, recorder_f107c)
+
+        sim.InitializeSimulation()
+
+        # Stage 1: successful look-up — D0 = 2026-03-04
+        sim.ConfigureStopTime(macros.sec2nano(1.0))  # [s]
+        sim.ExecuteSimulation()
+        assert abs(recorder_avg.dataValue[0]   - 6.0)   < 1e-12
+        assert abs(recorder_f107c.dataValue[0] - 138.5) < 1e-12
+
+        # Stage 2: failed look-up — D0 = 2026-03-05 not in table, keep previous data
+        sim.ConfigureStopTime(macros.sec2nano(25 * 3600 + 1.0))  # [s]
+        sim.ExecuteSimulation()
+        assert abs(recorder_avg.dataValue[-1]   - 6.0)   < 1e-12
+        assert abs(recorder_f107c.dataValue[-1] - 138.5) < 1e-12
+
+
+def test_space_weather_data_epoch_update():
+    """Validate internal epoch update against the provided CelesTrak-style rows.
+
+    **Test Description**
+
+    This test uses the provided CelesTrak CSV rows and validates output values
+    at a future epoch against the supplied ground-truth weather channel values.
+
+    **Description of Variables Being Tested**
+
+    The test checks all 23 outputs in ``swDataOutMsgs`` against known values for
+    the epoch ``2026-03-04 21:48:00`` starting the simulation at ``2026-03-03 18:48:00``
+    and propagating the simulation for 1 day and 3 hours.
+    """
+
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(3600.0)))  # [s]
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(_CELESTRAK_CSV)
+
+        module.loadSpaceWeatherFile(str(file_path))
+
+        timeInitString = "2026 March 03 18:48:00.000000"
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+        module.epochInMsg.subscribeTo(epochMsg)
+
+        sim.AddModelToTask(unit_task_name, module)
+
+        logs = []
+        for msg_index in range(23):
+            recorder = module.swDataOutMsgs[msg_index].recorder()
+            logs.append(recorder)
+            sim.AddModelToTask(unit_task_name, recorder)
+
+        sim.InitializeSimulation()
+        sim.ConfigureStopTime(macros.sec2nano(3600*24 + 3600*3))  # [s] 1 day and 3 hours
+        sim.ExecuteSimulation()
+
+        expected = [6.0, 4.0, 5.0, 3.0, 3.0, 7.0, 6.0, 15.0, 9.0,
+                    48.0, 18.0, 18.0, 7.0, 9.0, 7.0, 12.0,
+                    3.0, 5.0, 3.0, 4.0, 6.0, 138.5, 143.5]
+
+        for msg_index in range(23):
+            assert abs(logs[msg_index].dataValue[-1] - expected[msg_index]) < 1e-12
+
+
+def test_space_weather_data_rejects_date_with_trailing_chars():
+    """Validate that a DATE token with trailing characters is rejected.
+
+    **Test Description**
+
+    This test writes a CSV whose only data row has ``2026-03-04junk`` in the
+    DATE column.  The parser must reject the row; the table is left empty and
+    ``loadSpaceWeatherFile`` emits ``BSK_ERROR``.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile`` with the message
+    ``"No valid weather rows were loaded"``.
+    """
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+    module.bskLogger.setLogLevel(bskLogging.BSK_ERROR)
+
+    csv_text = "\n".join([
+        "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
+        "2026-03-04junk,9,15,6,7,3,3,5,4,6,141.2,138.5",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(csv_text)
+
+        with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+            module.loadSpaceWeatherFile(str(file_path))
+
+
+def test_space_weather_data_rejects_numeric_with_trailing_chars():
+    """Validate that a numeric field with trailing characters is rejected.
+
+    **Test Description**
+
+    This test writes a CSV whose only data row has ``9abc`` in the ``AP1``
+    column.  The strict numeric parser must reject the row; the table is left
+    empty and ``loadSpaceWeatherFile`` emits ``BSK_ERROR``.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile`` with the message
+    ``"No valid weather rows were loaded"``.
+    """
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+    module.bskLogger.setLogLevel(bskLogging.BSK_ERROR)
+
+    csv_text = "\n".join([
+        "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
+        "2026-03-04,9abc,15,6,7,3,3,5,4,6,141.2,138.5",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "space_weather.csv"
+        file_path.write_text(csv_text)
+
+        with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+            module.loadSpaceWeatherFile(str(file_path))
+
+
+_MINIMAL_HEADER = "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81"
+_VALID_ROW = "2026-03-04,9,15,6,7,3,3,5,4,6,141.2,138.5"
+
+
+def _load_single_row_csv(row: str) -> spaceWeatherData.SpaceWeatherData:
+    """Helper: write a single-data-row CSV and call loadSpaceWeatherFile."""
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+    module.bskLogger.setLogLevel(bskLogging.BSK_ERROR)
+    csv_text = _MINIMAL_HEADER + "\n" + row
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "sw.csv"
+        file_path.write_text(csv_text)
+        module.loadSpaceWeatherFile(str(file_path))
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Calendar-date validation
+# ---------------------------------------------------------------------------
+
+def test_invalid_date_april_31_rejected():
+    """April 31 does not exist — the row must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2026-04-31`` is loaded.  April has only
+    30 days, so the parser must reject the row and emit ``BSK_ERROR`` with
+    ``"No valid weather rows were loaded"``.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-04-31,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_invalid_date_november_31_rejected():
+    """November 31 does not exist — the row must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2026-11-31`` is loaded.  November has only
+    30 days, so the parser must reject the row and emit ``BSK_ERROR``.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-11-31,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_invalid_date_feb_30_rejected():
+    """February 30 never exists — the row must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2024-02-30`` is loaded.  Even in the
+    leap year 2024, February has only 29 days, so the parser must reject it.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2024-02-30,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_invalid_date_feb_29_non_leap_rejected():
+    """February 29 in a non-leap year must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2025-02-29`` is loaded.  2025 is not a
+    leap year (not divisible by 4), so February has only 28 days.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2025-02-29,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_invalid_date_feb_29_century_non_leap_rejected():
+    """February 29 in a century year that is not a 400-multiple must be rejected.
+
+    **Test Description**
+
+    2100 is divisible by 4 but not by 400, so it is not a leap year and
+    February has only 28 days.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2100-02-29,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_valid_date_feb_29_leap_accepted():
+    """February 29 in a leap year must be accepted.
+
+    **Test Description**
+
+    A four-row CSV that includes ``2024-02-29`` (2024 is a leap year) is
+    loaded and the simulation is run with the epoch on ``2024-03-02 12:00:00``
+    so that the look-back window covers 2024-02-29.  The table must load
+    successfully and produce a finite ``ap_24_0`` output.
+
+    **Description of Variables Being Tested**
+
+    ``swDataOutMsgs[0].dataValue`` is non-zero after a successful look-up.
+    """
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(1.0)))
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    # Build a 4-row window that straddles the leap day.
+    csv_text = "\n".join([
+        _MINIMAL_HEADER,
+        "2024-02-28,1,2,3,4,5,6,7,8,4,130.0,128.0",
+        "2024-02-29,9,10,11,12,13,14,15,16,12,131.0,129.0",
+        "2024-03-01,17,18,19,20,21,22,23,24,20,132.0,130.0",
+        "2024-03-02,25,26,27,28,29,30,31,32,28,133.0,131.0",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "sw_leap.csv"
+        file_path.write_text(csv_text)
+        module.loadSpaceWeatherFile(str(file_path))
+
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2024 March 02 12:00:00.000000")
+        module.epochInMsg.subscribeTo(epochMsg)
+        sim.AddModelToTask(unit_task_name, module)
+
+        recorder = module.swDataOutMsgs[0].recorder()
+        sim.AddModelToTask(unit_task_name, recorder)
+
+        sim.InitializeSimulation()
+        sim.ConfigureStopTime(macros.sec2nano(1.0))
+        sim.ExecuteSimulation()
+
+        # AP_AVG for 2024-03-02 is 28
+        assert abs(recorder.dataValue[0] - 28.0) < 1e-12
+
+
+def test_valid_date_feb_29_quad_century_leap_accepted():
+    """February 29 in a 400-multiple year (true leap) must be accepted.
+
+    **Test Description**
+
+    2000 is divisible by 400 and therefore is a leap year.  A single row
+    dated ``2000-02-29`` must not be rejected by the date validator.
+    The test loads a four-row table that includes this date and verifies
+    ``loadSpaceWeatherFile`` succeeds (no exception raised).
+
+    **Description of Variables Being Tested**
+
+    No exception from ``loadSpaceWeatherFile``.
+    """
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    csv_text = "\n".join([
+        _MINIMAL_HEADER,
+        "2000-02-27,1,2,3,4,5,6,7,8,4,130.0,128.0",
+        "2000-02-28,9,10,11,12,13,14,15,16,12,131.0,129.0",
+        "2000-02-29,17,18,19,20,21,22,23,24,20,132.0,130.0",
+        "2000-03-01,25,26,27,28,29,30,31,32,28,133.0,131.0",
+    ])
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+    with tempfile.TemporaryDirectory() as temp_dir:
+        file_path = Path(temp_dir) / "sw_2000_leap.csv"
+        file_path.write_text(csv_text)
+        # Must not raise
+        module.loadSpaceWeatherFile(str(file_path))
+
+
+def test_invalid_date_day_zero_rejected():
+    """Day 0 is never valid — the row must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2026-03-00`` is loaded.  Day-of-month
+    zero is out of range for every month.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-03-00,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_invalid_date_month_zero_rejected():
+    """Month 0 is never valid — the row must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2026-00-15`` is loaded.  Month zero is
+    out of the valid [1, 12] range.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-00-15,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_invalid_date_month_13_rejected():
+    """Month 13 is never valid — the row must be rejected.
+
+    **Test Description**
+
+    A CSV with a single row dated ``2026-13-01`` is loaded.  Month 13 is out
+    of the valid [1, 12] range.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-13-01,9,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+# ---------------------------------------------------------------------------
+# Non-finite numeric values
+# ---------------------------------------------------------------------------
+
+def test_failed_reload_preserves_previous_table():
+    """A failed second loadSpaceWeatherFile call must not destroy the first table.
+
+    **Test Description**
+
+    A valid CSV is loaded first, giving a working weather table.  A second
+    call is then made with a file that has a missing required column.  The
+    second load must fail (emitting ``BSK_ERROR``) while leaving the module
+    still able to serve data from the first load.
+
+    **Description of Variables Being Tested**
+
+    ``swDataOutMsgs[0].dataValue`` equals the expected AP_AVG value from the
+    first table after the failed reload.
+    """
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    unit_task_name = "unitTask"
+    unit_process_name = "unitProcess"
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess(unit_process_name)
+    proc.addTask(sim.CreateNewTask(unit_task_name, macros.sec2nano(1.0)))
+
+    module = spaceWeatherData.SpaceWeatherData()
+    module.ModelTag = "spaceWeatherData"
+
+    bad_csv = "\n".join([
+        "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS",  # F10.7_OBS_CENTER81 missing
+        "2026-03-04,9,15,6,7,3,3,5,4,6,141.2",
+    ])
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        good_path = Path(temp_dir) / "good.csv"
+        bad_path = Path(temp_dir) / "bad.csv"
+        good_path.write_text(_CELESTRAK_CSV)
+        bad_path.write_text(bad_csv)
+
+        module.loadSpaceWeatherFile(str(good_path))
+
+        with pytest.raises(BasiliskError):
+            module.loadSpaceWeatherFile(str(bad_path))
+
+        # Table from the good file must still be intact
+        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2026 March 04 21:48:00.000000")
+        module.epochInMsg.subscribeTo(epochMsg)
+        sim.AddModelToTask(unit_task_name, module)
+        recorder = module.swDataOutMsgs[0].recorder()
+        sim.AddModelToTask(unit_task_name, recorder)
+
+        sim.InitializeSimulation()
+        sim.ConfigureStopTime(macros.sec2nano(1.0))
+        sim.ExecuteSimulation()
+
+        assert abs(recorder.dataValue[0] - 6.0) < 1e-12
+
+
+def test_nan_in_ap_field_rejected():
+    """A NaN string in an AP column must be rejected.
+
+    **Test Description**
+
+    A CSV row with ``nan`` in the ``AP1`` column is loaded.  The strict
+    numeric parser must reject the non-finite value, leaving the table empty.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-03-04,nan,15,6,7,3,3,5,4,6,141.2,138.5")
+
+
+def test_inf_in_f107_field_rejected():
+    """An Inf string in an F10.7 column must be rejected.
+
+    **Test Description**
+
+    A CSV row with ``inf`` in the ``F10.7_OBS`` column is loaded.  The
+    strict numeric parser must reject the non-finite value.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-03-04,9,15,6,7,3,3,5,4,6,inf,138.5")
+
+
+def test_neg_inf_in_ap_avg_field_rejected():
+    """-Inf in the AP_AVG column must be rejected.
+
+    **Test Description**
+
+    A CSV row with ``-inf`` in ``AP_AVG`` is loaded.  Negative infinity is
+    non-finite and must be rejected by the strict numeric parser.
+
+    **Description of Variables Being Tested**
+
+    ``BasiliskError`` raised during ``loadSpaceWeatherFile``.
+    """
+    with pytest.raises(BasiliskError, match="No valid weather rows were loaded"):
+        _load_single_row_csv("2026-03-04,9,15,6,7,3,3,5,4,-inf,141.2,138.5")
+
+
+if __name__ == "__main__":
+    test_space_weather_data_celestrak_example_columns()
+    test_space_weather_data_stops_at_first_invalid_row()
+    test_space_weather_data_missing_required_column()
+    test_space_weather_data_duplicate_date_rows()
+    test_space_weather_data_unsorted_rows()
+    test_reset_error_when_epoch_before_table()
+    test_stale_output_retained_on_missing_day()
+    test_space_weather_data_rejects_date_with_trailing_chars()
+    test_space_weather_data_rejects_numeric_with_trailing_chars()
+    test_invalid_date_april_31_rejected()
+    test_invalid_date_november_31_rejected()
+    test_invalid_date_feb_30_rejected()
+    test_invalid_date_feb_29_non_leap_rejected()
+    test_invalid_date_feb_29_century_non_leap_rejected()
+    test_valid_date_feb_29_leap_accepted()
+    test_valid_date_feb_29_quad_century_leap_accepted()
+    test_invalid_date_day_zero_rejected()
+    test_invalid_date_month_zero_rejected()
+    test_invalid_date_month_13_rejected()
+    test_nan_in_ap_field_rejected()
+    test_inf_in_f107_field_rejected()
+    test_neg_inf_in_ap_avg_field_rejected()
+    test_failed_reload_preserves_previous_table()

--- a/src/simulation/environment/spaceWeatherData/spaceWeatherData.cpp
+++ b/src/simulation/environment/spaceWeatherData/spaceWeatherData.cpp
@@ -1,0 +1,511 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, PIC4SeR & AVS Lab, Politecnico di Torino & Argotec S.R.L., University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "simulation/environment/spaceWeatherData/spaceWeatherData.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+namespace {
+/*! Remove leading and trailing ASCII spaces from a CSV token.
+    @param token Raw token string extracted from a CSV field.
+    @return Trimmed copy of the token, or an empty string if the token is all spaces.
+*/
+std::string trimToken(const std::string& token)
+{
+    const std::string whiteSpace = " \t\r";
+    const size_t firstChar = token.find_first_not_of(whiteSpace);
+    if (firstChar == std::string::npos) {
+        return "";
+    }
+    const size_t lastChar = token.find_last_not_of(whiteSpace);
+    return token.substr(firstChar, lastChar - firstChar + 1);
+}
+
+/*! Split a single CSV line on commas and trim each resulting token.
+    @param line One text line from a CSV file.
+    @return Ordered vector of trimmed field strings.
+*/
+std::vector<std::string> splitCsvLine(const std::string& line)
+{
+    std::vector<std::string> tokens{};
+    std::stringstream lineStream(line);
+    std::string token{};
+    while (std::getline(lineStream, token, ',')) {
+        tokens.push_back(trimToken(token));
+    }
+    return tokens;
+}
+
+/*! Parse a numeric token strictly, rejecting any trailing non-numeric characters and
+    non-finite values (NaN, +/-Inf).
+    @param str Trimmed CSV token to convert.
+    @return Parsed finite double value.
+    @throws std::invalid_argument if the token is empty, non-numeric, has trailing characters,
+            or resolves to NaN or infinity.
+    @throws std::out_of_range if the value is outside the representable double range.
+*/
+double parseDouble(const std::string& str)
+{
+    size_t pos = 0;
+    const double value = std::stod(str, &pos);
+    if (pos != str.size()) {
+        throw std::invalid_argument("trailing characters in numeric token");
+    }
+    if (!std::isfinite(value)) {
+        throw std::invalid_argument("non-finite numeric token");
+    }
+    return value;
+}
+
+/*! Return true when the given year is a proleptic Gregorian leap year.
+    @param year Gregorian year.
+    @return True if the year is divisible by 4, except for century years not divisible by 400.
+*/
+bool isLeapYear(int year)
+{
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+/*! Return the number of days in a given month of a given year.
+    @param year  Gregorian year (used only to resolve February in leap years).
+    @param month Month of year in the range [1, 12].
+    @return Day count for the month, or 0 if month is out of [1, 12].
+*/
+int daysInMonth(int year, int month)
+{
+    static const int days[13] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (month < 1 || month > 12) {
+        return 0;
+    }
+    if (month == 2 && isLeapYear(year)) {
+        return 29;
+    }
+    return days[month];
+}
+
+/*! Return the zero-based column index for a named header field.
+    @param headerColumns Ordered list of column name strings from the CSV header row.
+    @param key Column name to search for (case-sensitive).
+    @return Non-negative index when the column is found; -1 otherwise.
+*/
+int findHeaderIndex(const std::vector<std::string>& headerColumns, const std::string& key)
+{
+    for (size_t index = 0; index < headerColumns.size(); index++) {
+        if (headerColumns[index] == key) {
+            return static_cast<int>(index);
+        }
+    }
+    return -1;
+}
+}
+
+/*! Constructor. Allocates the 23 heap-owned output messages and pushes their
+    pointers into the swDataOutMsgs vector.
+*/
+SpaceWeatherData::SpaceWeatherData()
+{
+    for (uint64_t msgIndex = 0U; msgIndex < numSwMessages; msgIndex++) {
+        this->swDataOutMsgs.push_back(new Message<SwDataMsgPayload>());
+    }
+}
+
+/*! Destructor. Frees every output message owned by this module.
+*/
+SpaceWeatherData::~SpaceWeatherData()
+{
+    for (auto* outputMsg : this->swDataOutMsgs) {
+        delete outputMsg;
+    }
+}
+
+/*! Reset the module to its initial state.
+
+    Verifies that epochInMsg is linked and that the space-weather table has been
+    loaded.  Probes whether the simulation start date is covered by the loaded
+    table and emits a BSK_ERROR immediately if it is not.  Publishes a zero-state
+    message.
+
+    @param CurrentSimNanos Current simulation time in nanoseconds.
+*/
+void SpaceWeatherData::Reset(uint64_t CurrentSimNanos)
+{
+    if (!this->epochInMsg.isLinked()) {
+        this->bskLogger.bskLog(BSK_ERROR, "SpaceWeatherData.epochInMsg was not linked.");
+    }
+    if (this->weatherData.empty()) {
+        this->bskLogger.bskLog(BSK_ERROR, "SpaceWeatherData space-weather table is empty. Call loadSpaceWeatherFile().");
+    }
+    std::array<double, numSwMessages> probe = {};
+    if (!this->computeSwState(CurrentSimNanos, probe)) {
+        this->bskLogger.bskLog(BSK_ERROR,
+            "SpaceWeatherData: simulation start date is not covered by the loaded table. "
+            "Check the epoch and the date range of the loaded file.");
+    }
+
+    this->publishZeroState(CurrentSimNanos);
+}
+
+/*! Update the module output messages for the current simulation time.
+
+    Resolves the current UTC calendar date from the epoch message and elapsed
+    simulation time, assembles the 23-element NRLMSISE-00 / NRLMSIS 2.0
+    space-weather index vector, and writes each element to the corresponding
+    output message.  If the required look-up window is not available in the
+    loaded table a BSK_WARNING is logged and the previous output is retained.
+
+    @param CurrentSimNanos Current simulation time in nanoseconds.
+*/
+void SpaceWeatherData::UpdateState(uint64_t CurrentSimNanos)
+{
+    std::array<double, numSwMessages> swState = {};
+
+    if (!this->computeSwState(CurrentSimNanos, swState)) {
+        this->bskLogger.bskLog(BSK_WARNING, "Failed to retrieve a state. Publishing the last available data."
+            "\nThis can happen if the date is not in the file or if the file is empty.");
+        return;
+    }
+
+    for (uint64_t msgIndex = 0U; msgIndex < numSwMessages; msgIndex++) {
+        SwDataMsgPayload outMsg = this->swDataOutMsgs[msgIndex]->zeroMsgPayload;
+        outMsg.dataValue = swState[msgIndex];
+        this->swDataOutMsgs[msgIndex]->write(&outMsg, this->moduleID, CurrentSimNanos);
+    }
+}
+
+/*! Load and validate a CelesTrak-style space-weather CSV file.
+
+    Opens the file, parses the header row, reads data rows into DailySpaceWeather
+    records until the first unparsable line, and validates that DATE values are
+    strictly ascending with no duplicates.  On success the internal weather table
+    is replaced with the new data.  On any failure a BSK_ERROR is logged and the
+    previously loaded table (if any) is left intact.
+
+    @param fileName Path to the space-weather CSV file (absolute or relative).
+*/
+void SpaceWeatherData::loadSpaceWeatherFile(const std::string& fileName)
+{
+    // Do not clear weatherData yet — preserve the existing table until the new
+    // file is fully validated so that a failed reload does not destroy a
+    // previously loaded good state.
+
+    std::ifstream weatherFile(fileName);
+    if (!weatherFile.good()) {
+        this->bskLogger.bskLog(BSK_ERROR, "Could not open space-weather file: %s", fileName.c_str());
+        return;
+    }
+
+    std::string line;
+    if (!std::getline(weatherFile, line)) {
+        this->bskLogger.bskLog(BSK_ERROR, "Space-weather file is empty: %s", fileName.c_str());
+        return;
+    }
+    const std::vector<std::string> headerColumns = splitCsvLine(line);
+
+    const std::vector<std::string> requiredColumns = {
+        "DATE", "AP1", "AP2", "AP3", "AP4", "AP5", "AP6", "AP7", "AP8", "AP_AVG", "F10.7_OBS", "F10.7_OBS_CENTER81"
+    };
+    for (const auto& columnName : requiredColumns) {
+        if (findHeaderIndex(headerColumns, columnName) < 0) {
+            this->bskLogger.bskLog(BSK_ERROR,
+                                   "Space-weather file missing required column '%s': %s",
+                                   columnName.c_str(),
+                                   fileName.c_str());
+            return;
+        }
+    }
+
+    std::vector<DailySpaceWeather> loadedData;
+    while (std::getline(weatherFile, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        bool parseOk = false;
+        DailySpaceWeather row = parseWeatherLine(line, headerColumns, parseOk);
+        if (parseOk) {
+            loadedData.push_back(row);
+            continue;
+        }
+
+        this->bskLogger.bskLog(BSK_WARNING,
+                               "Stopped reading space-weather table at first invalid row: %s",
+                               line.c_str());
+        break;
+    }
+
+    if (loadedData.empty()) {
+        this->bskLogger.bskLog(BSK_ERROR, "No valid weather rows were loaded from: %s", fileName.c_str());
+        return;
+    }
+
+    for (size_t rowIndex = 1; rowIndex < loadedData.size(); rowIndex++) {
+        if (loadedData[rowIndex - 1].dayNumber == loadedData[rowIndex].dayNumber) {
+            this->bskLogger.bskLog(BSK_ERROR,
+                                   "Duplicate DATE row found in space-weather table '%s'.",
+                                   fileName.c_str());
+            return;
+        }
+        if (loadedData[rowIndex - 1].dayNumber > loadedData[rowIndex].dayNumber) {
+            this->bskLogger.bskLog(BSK_ERROR,
+                                   "Space-weather DATE rows must be sorted in ascending order: %s",
+                                   fileName.c_str());
+            return;
+        }
+    }
+
+    this->weatherData = std::move(loadedData);
+    this->loadedFileName = fileName;
+}
+
+/*! Write a zero-valued payload to every output message.
+
+    Called at the end of Reset() so that downstream modules
+    always receive at least one valid message before the first UpdateState().
+
+    @param CurrentSimNanos Current simulation time in nanoseconds.
+*/
+void SpaceWeatherData::publishZeroState(uint64_t CurrentSimNanos)
+{
+    for (uint64_t msgIndex = 0U; msgIndex < numSwMessages; msgIndex++) {
+        SwDataMsgPayload outMsg = this->swDataOutMsgs[msgIndex]->zeroMsgPayload;
+        outMsg.dataValue = 0.0;
+        this->swDataOutMsgs[msgIndex]->write(&outMsg, this->moduleID, CurrentSimNanos);
+    }
+}
+
+/*! Determine the current Unix day number and seconds-of-day from the epoch message
+    and elapsed simulation time.
+
+    Reads the EpochMsgPayload, converts the calendar date to a Unix day number, adds the
+    epoch time-of-day and the simulation elapsed time, and decomposes the result into a
+    whole-day count and a residual seconds-of-day value.
+
+    @param CurrentSimSeconds Simulation time elapsed since BSK epoch, in seconds.
+    @param[out] currentDay   Unix day number of the current UTC date (days since 1970-01-01).
+    @param[out] secondsOfDay Elapsed seconds since midnight of the current UTC day [0, 86400).
+*/
+void SpaceWeatherData::getEpochState(double CurrentSimSeconds, int64_t& currentDay, double& secondsOfDay)
+{
+    if (!this->epochInMsg.isWritten()) {
+        this->bskLogger.bskLog(BSK_ERROR, "SpaceWeatherData space-weather epochInMsg was not written.");
+    }
+    const EpochMsgPayload epochMsg = this->epochInMsg();
+    int year = epochMsg.year;
+    int month = epochMsg.month;
+    int day = epochMsg.day;
+    int hours = epochMsg.hours;
+    int minutes = epochMsg.minutes;
+    double seconds = epochMsg.seconds;
+
+    const int64_t epochDay = civilToUnixDayNumber(year, static_cast<unsigned>(month), static_cast<unsigned>(day));
+    const double epochSecondsOfDay = static_cast<double>(hours) * 3600.0 + static_cast<double>(minutes) * 60.0 + seconds; // [s]
+    const double totalSecondsFromEpoch = epochSecondsOfDay + CurrentSimSeconds; // [s]
+    const int64_t dayOffset = static_cast<int64_t>(std::floor(totalSecondsFromEpoch / 86400.0)); // [day]
+    secondsOfDay = totalSecondsFromEpoch - static_cast<double>(dayOffset) * 86400.0; // [s]
+    secondsOfDay = std::max(0.0, secondsOfDay); // guard against negative FP residual at midnight
+    currentDay = epochDay + dayOffset;
+}
+
+/*! Assemble the 23-element NRLMSISE-00 / NRLMSIS 2.0 space-weather state vector.
+
+    Resolves the current UTC date and 3-hour Ap bin, retrieves the four required
+    consecutive calendar-day records from the in-memory table, and fills the output
+    array according to the channel mapping described in the module documentation.
+
+    @param CurrentSimNanos Current simulation time in nanoseconds.
+    @param[out] swState    23-element array to be populated with space-weather index values.
+    @return True if all required table entries were found and the state was assembled
+            successfully; false if any required day is missing or the table is empty.
+*/
+bool SpaceWeatherData::computeSwState(uint64_t CurrentSimNanos, std::array<double, numSwMessages>& swState)
+{
+    if (this->weatherData.empty()) {
+        return false;
+    }
+
+    const double simTimeSeconds = static_cast<double>(CurrentSimNanos) * 1e-9; // [s]
+    int64_t currentDay = 0; // [day]
+    double secondsOfDay = 0.0; // [s]
+    this->getEpochState(simTimeSeconds, currentDay, secondsOfDay);
+
+    auto getDayEntry = [&](int64_t dayNumber, DailySpaceWeather& output) -> bool {
+        const auto iterator = std::lower_bound(
+            this->weatherData.begin(), this->weatherData.end(), dayNumber,
+            [](const DailySpaceWeather& candidate, int64_t key) { return candidate.dayNumber < key; });
+        if (iterator == this->weatherData.end() || iterator->dayNumber != dayNumber) {
+            return false;
+        }
+        output = *iterator;
+        return true;
+    };
+
+    const double currentDayHours = secondsOfDay / 3600.0; // [hr]
+    const int currentApBin = static_cast<int>(std::floor(currentDayHours / 3.0)); // [count]
+
+    DailySpaceWeather day0 = {};
+    DailySpaceWeather dayMinus1 = {};
+    DailySpaceWeather dayMinus2 = {};
+    DailySpaceWeather dayMinus3 = {};
+    if (!getDayEntry(currentDay, day0) || !getDayEntry(currentDay - 1, dayMinus1)
+        || !getDayEntry(currentDay - 2, dayMinus2)) {
+        return false;
+    }
+    /* D-3 is only needed when the 20-step look-back crosses a third day boundary,
+       which occurs when the current 3-hour bin index is less than 3 (before 09:00 UTC). */
+    const bool needsDayMinus3 = (currentApBin < 3);
+    if (needsDayMinus3 && !getDayEntry(currentDay - 3, dayMinus3)) {
+        return false;
+    }
+
+    const std::array<std::array<double, numApPerDay>, 4> apByDay = {
+        day0.ap3Hr,
+        dayMinus1.ap3Hr,
+        dayMinus2.ap3Hr,
+        dayMinus3.ap3Hr
+    };
+
+    /* MSIS channel mapping uses AP_AVG for ap_24_0 and then 20 AP samples spaced 3 hours apart
+       starting at the current 3-hour bin and stepping backward across prior days. */
+    swState[0] = day0.apAvg;
+    for (int apIndex = 0; apIndex < 20; apIndex++) {
+        int apBin = currentApBin - apIndex;
+        int dayOffset = 0;
+        while (apBin < 0) {
+            apBin += static_cast<int>(numApPerDay);
+            dayOffset += 1;
+        }
+        if (dayOffset > 3 || apBin >= static_cast<int>(numApPerDay)) {
+            return false;
+        }
+        swState[1 + apIndex] = apByDay[dayOffset][static_cast<size_t>(apBin)];
+    }
+    swState[21] = day0.f107ObsCenter81;
+    swState[22] = dayMinus1.f107Obs;
+
+    return true;
+}
+
+/*! Convert a proleptic Gregorian calendar date to a signed Unix day number.
+
+    Computes the number of whole days elapsed since 1970-01-01
+    (which maps to day number 0).  The result is negative for dates
+    before the Unix epoch.
+
+    @param year  Gregorian year (may be negative).
+    @param month Month of year in the range [1, 12].
+    @param day   Day of month; valid range is [1, 28], [1, 29], [1, 30], or [1, 31]
+                 depending on the month and whether year is a leap year.
+    @return Signed count of days since 1970-01-01.
+*/
+int64_t SpaceWeatherData::civilToUnixDayNumber(int year, unsigned month, unsigned day)
+{
+    year -= (month <= 2U);
+    const int era = (year >= 0 ? year : year - 399) / 400;
+    const unsigned yoe = static_cast<unsigned>(year - era * 400);                  // [year] year-of-era
+    const unsigned doy = (153U * (month + (month > 2U ? static_cast<unsigned>(-3) : 9U)) + 2U) / 5U + day - 1U; // [day]
+    const unsigned doe = yoe * 365U + yoe / 4U - yoe / 100U + doy;                 // [day] day-of-era
+    return static_cast<int64_t>(era) * 146097 + static_cast<int64_t>(doe) - 719468;
+}
+
+/*! Parse one data line of the space-weather CSV into a DailySpaceWeather record.
+
+    Splits the line on commas, extracts the DATE field and all required numeric
+    columns, and populates the output record.  Sets parseOk to false and returns a
+    default-constructed record if any field is missing, empty, or non-numeric.
+
+    @param line          One non-empty data line from the CSV file (no header).
+    @param headerColumns Ordered list of column name strings from the CSV header row.
+    @param[out] parseOk  Set to true when all required fields were parsed successfully;
+                         false otherwise.
+    @return Populated DailySpaceWeather record on success, or a default-constructed
+            record on failure.
+*/
+SpaceWeatherData::DailySpaceWeather SpaceWeatherData::parseWeatherLine(const std::string& line,
+                                                                       const std::vector<std::string>& headerColumns,
+                                                                       bool& parseOk)
+{
+    parseOk = false;
+    DailySpaceWeather row = {};
+
+    const std::vector<std::string> values = splitCsvLine(line);
+    const int dateIndex = findHeaderIndex(headerColumns, "DATE");
+    const int apAvgIndex = findHeaderIndex(headerColumns, "AP_AVG");
+    const int f107ObsIndex = findHeaderIndex(headerColumns, "F10.7_OBS");
+    const int f107CenterIndex = findHeaderIndex(headerColumns, "F10.7_OBS_CENTER81");
+    if (dateIndex < 0 || apAvgIndex < 0 || f107ObsIndex < 0 || f107CenterIndex < 0) {
+        return row;
+    }
+
+    const int maxIndex = std::max(std::max(dateIndex, apAvgIndex), std::max(f107ObsIndex, f107CenterIndex));
+    if (static_cast<int>(values.size()) <= maxIndex) {
+        return row;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    char extra;
+    if (std::sscanf(values[dateIndex].c_str(), "%d-%d-%d%c", &year, &month, &day, &extra) != 3) {
+        return row;
+    }
+    if (month < 1 || month > 12 || day < 1 || day > daysInMonth(year, month)) {
+        return row;
+    }
+
+    if (values[apAvgIndex].empty() || values[f107ObsIndex].empty() || values[f107CenterIndex].empty()) {
+        return row;
+    }
+
+    std::array<double, numApPerDay> apValues = {};
+    for (uint64_t apIndex = 0U; apIndex < numApPerDay; apIndex++) {
+        const std::string key = "AP" + std::to_string(apIndex + 1U);
+        const int keyIndex = findHeaderIndex(headerColumns, key);
+        if (keyIndex < 0 || static_cast<int>(values.size()) <= keyIndex) {
+            return row;
+        }
+        if (values[keyIndex].empty()) {
+            return row;
+        }
+    }
+
+    try {
+        for (uint64_t apIndex = 0U; apIndex < numApPerDay; apIndex++) {
+            const std::string key = "AP" + std::to_string(apIndex + 1U);
+            const int keyIndex = findHeaderIndex(headerColumns, key);
+            apValues[apIndex] = parseDouble(values[keyIndex]);
+        }
+
+        row.dayNumber = civilToUnixDayNumber(year, static_cast<unsigned>(month), static_cast<unsigned>(day));
+        row.ap3Hr = apValues;
+        row.apAvg = parseDouble(values[apAvgIndex]);
+        row.f107Obs = parseDouble(values[f107ObsIndex]);
+        row.f107ObsCenter81 = parseDouble(values[f107CenterIndex]);
+    } catch (const std::invalid_argument&) {
+        return row;
+    } catch (const std::out_of_range&) {
+        return row;
+    }
+
+    parseOk = true;
+    return row;
+}

--- a/src/simulation/environment/spaceWeatherData/spaceWeatherData.h
+++ b/src/simulation/environment/spaceWeatherData/spaceWeatherData.h
@@ -1,0 +1,78 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, PIC4SeR & AVS Lab, Politecnico di Torino & Argotec S.R.L., University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef MSIS_SPACE_WEATHER_H
+#define MSIS_SPACE_WEATHER_H
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/EpochMsgPayload.h"
+#include "architecture/msgPayloadDefC/SwDataMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+
+/*! @brief CelesTrak space-weather data publisher for :ref:`msisAtmosphere`. */
+class SpaceWeatherData: public SysModel {
+public:
+    SpaceWeatherData();
+    ~SpaceWeatherData();
+
+    SpaceWeatherData(const SpaceWeatherData&) = delete;
+    SpaceWeatherData& operator=(const SpaceWeatherData&) = delete;
+
+    void Reset(uint64_t CurrentSimNanos);
+    void UpdateState(uint64_t CurrentSimNanos);
+
+    void loadSpaceWeatherFile(const std::string& fileName);
+
+public:
+    ReadFunctor<EpochMsgPayload> epochInMsg{};               //!< epoch input message
+    std::vector<Message<SwDataMsgPayload>*> swDataOutMsgs{}; //!< 23-element MSIS SW output message vector
+    BSKLogger bskLogger{};                                   //!< BSK logging helper
+
+private:
+    static constexpr uint64_t numSwMessages = 23U; //!< [count] number of MSIS weather channels
+    static constexpr uint64_t numApPerDay = 8U;    //!< [count] number of three-hour Ap entries per day
+
+    struct DailySpaceWeather {
+        int64_t dayNumber{};                     //!< [day] days since Unix epoch
+        std::array<double, numApPerDay> ap3Hr{}; //!< [-] AP1..AP8 values
+        double apAvg{};                          //!< [-] daily Ap average
+        double f107Obs{};                        //!< [sfu] daily observed F10.7
+        double f107ObsCenter81{};                //!< [sfu] centered 81-day F10.7 average
+    };
+
+    std::vector<DailySpaceWeather> weatherData{}; //!< parsed weather table
+    std::string loadedFileName{};                 //!< loaded CSV path
+
+    void publishZeroState(uint64_t CurrentSimNanos);
+    bool computeSwState(uint64_t CurrentSimNanos, std::array<double, numSwMessages>& swState);
+    void getEpochState(double CurrentSimSeconds, int64_t& currentDay, double& secondsOfDay);
+
+    static int64_t civilToUnixDayNumber(int year, unsigned month, unsigned day);
+    static DailySpaceWeather parseWeatherLine(const std::string& line,
+                                              const std::vector<std::string>& headerColumns,
+                                              bool& parseOk);
+};
+
+#endif

--- a/src/simulation/environment/spaceWeatherData/spaceWeatherData.i
+++ b/src/simulation/environment/spaceWeatherData/spaceWeatherData.i
@@ -1,0 +1,67 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, PIC4SeR & AVS Lab, Politecnico di Torino & Argotec S.R.L., University of Colorado Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+%module spaceWeatherData
+
+%include "architecture/utilities/bskException.swg"
+%default_bsk_exception();
+
+%{
+   #include "spaceWeatherData.h"
+%}
+
+%pythonbegin %{
+import warnings as _warnings
+
+_warnings.filterwarnings(
+    "ignore",
+    message=r"builtin type SwigPyPacked has no __module__ attribute",
+    category=DeprecationWarning,
+)
+_warnings.filterwarnings(
+    "ignore",
+    message=r"builtin type SwigPyObject has no __module__ attribute",
+    category=DeprecationWarning,
+)
+_warnings.filterwarnings(
+    "ignore",
+    message=r"builtin type swigvarlink has no __module__ attribute",
+    category=DeprecationWarning,
+)
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "std_string.i"
+%include "std_vector.i"
+%include "swig_conly_data.i"
+
+%include "sys_model.i"
+%include "spaceWeatherData.h"
+
+%include "architecture/msgPayloadDefC/EpochMsgPayload.h"
+struct EpochMsg_C;
+%include "architecture/msgPayloadDefC/SwDataMsgPayload.h"
+struct SwDataMsg_C;
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/environment/spaceWeatherData/spaceWeatherData.rst
+++ b/src/simulation/environment/spaceWeatherData/spaceWeatherData.rst
@@ -1,0 +1,318 @@
+Executive Summary
+-----------------
+
+The ``spaceWeatherData`` module reads a CelesTrak-style space-weather CSV table and publishes the
+23 :ref:`SwDataMsgPayload` output messages required by :ref:`msisAtmosphere`.  On every simulation
+update step the module determines the current UTC calendar date and time from the linked
+:ref:`EpochMsgPayload`, looks up the corresponding rows in the loaded table, and assembles the
+NRLMSISE-00 / NRLMSIS 2.0 space-weather index vector before writing it to its output message array.
+
+Message Connection Descriptions
+---------------------------------
+
+The following table lists all the module input and output messages.  The module msg connection is
+set by the user from Python.  The msg type contains a link to the message structure definition,
+while the description provides information on what this message is used for.
+
+.. list-table:: Module I/O Messages
+    :widths: 25 25 50
+    :header-rows: 1
+
+    * - Msg Variable Name
+      - Msg Type
+      - Description
+    * - ``epochInMsg``
+      - :ref:`EpochMsgPayload`
+      - Simulation start epoch in UTC (year, month, day, hours, minutes, seconds).  Must be linked
+        before ``Reset`` is called; an error is logged otherwise.
+    * - ``swDataOutMsgs[0]``
+      - :ref:`SwDataMsgPayload`
+      - Daily Ap average (``AP_AVG``) of the current day — MSIS channel ``ap_24_0``.
+    * - ``swDataOutMsgs[1..20]``
+      - :ref:`SwDataMsgPayload`
+      - Twenty consecutive 3-hour Ap values stepping back from the current bin — MSIS channels
+        ``ap_3_0`` through ``ap_3_-57``.
+    * - ``swDataOutMsgs[21]``
+      - :ref:`SwDataMsgPayload`
+      - Centered 81-day observed F10.7 of the current day (``F10.7_OBS_CENTER81``) — MSIS channel
+        ``f107_1944_0``.
+    * - ``swDataOutMsgs[22]``
+      - :ref:`SwDataMsgPayload`
+      - Observed daily F10.7 of the previous day (``F10.7_OBS``) — MSIS channel ``f107_24_-24``.
+
+.. note::
+
+   ``swDataOutMsgs`` is a ``std::vector`` of heap-allocated ``Message<SwDataMsgPayload>``
+   pointers initialised to length 23 in the constructor.  In Python the vector elements are
+   accessed by index: ``swModule.swDataOutMsgs[i]``.
+
+Detailed Module Description
+----------------------------
+
+The ``spaceWeatherData`` module converts a Gregorian calendar date (year, month, day) to a signed
+Unix day number.  The resulting integer counts whole days since the Unix epoch (1970-01-01 = 0)
+and is used as the unique key when looking up rows in the loaded weather table.
+
+On every call to ``UpdateState`` the module performs the following steps to determine the current
+UTC calendar date:
+
+1. Read :ref:`EpochMsgPayload` (``year``, ``month``, ``day``, ``hours``, ``minutes``, ``seconds``).
+2. Compute :math:`D_{\text{epoch}}` from the calendar date.
+3. Compute :math:`t_{\text{epoch}}` from the time-of-day fields.
+4. Add the simulation time: :math:`T_{\text{total}} = t_{\text{epoch}} + t_{\text{sim}}`.
+5. Extract the whole-day offset :math:`\Delta D` and residual :math:`s_{\text{day}}`.
+6. Determine the current day number :math:`D_0 = D_{\text{epoch}} + \Delta D`.
+7. Determine the current 3-hour Ap bin :math:`b_{\text{cur}} = \lfloor s_{\text{day}} / 10800 \rfloor`.
+
+The table below defines the symbols used above.
+
+.. list-table:: Symbol definitions
+    :widths: 20 15 65
+    :header-rows: 1
+
+    * - Symbol
+      - Unit
+      - Description
+    * - :math:`t_{\text{sim}}`
+      - s
+      - Simulation time elapsed since the BSK epoch (``CurrentSimNanos`` converted to seconds).
+    * - :math:`t_{\text{epoch}}`
+      - s
+      - UTC seconds-of-day of the epoch (hour x 3600 + minute x 60 + second).
+    * - :math:`D_{\text{epoch}}`
+      - day
+      - Unix day number of the epoch date (days since 1970-01-01).
+    * - :math:`T_{\text{total}}`
+      - s
+      - Total UTC seconds elapsed from the start of the epoch calendar day:
+        :math:`T_{\text{total}} = t_{\text{epoch}} + t_{\text{sim}}`.
+    * - :math:`\Delta D`
+      - day
+      - Whole-day offset from the epoch date:
+        :math:`\Delta D = \lfloor T_{\text{total}} / 86400 \rfloor`.
+    * - :math:`s_{\text{day}}`
+      - s
+      - Seconds elapsed since midnight of the current UTC day:
+        :math:`s_{\text{day}} = T_{\text{total}} - \Delta D \times 86400`.
+    * - :math:`D_{0}`
+      - day
+      - Unix day number of the current UTC date:
+        :math:`D_{0} = D_{\text{epoch}} + \Delta D`.
+    * - :math:`b_{\text{cur}}`
+      - —
+      - Index of the current 3-hour Ap bin (0-based):
+        :math:`b_{\text{cur}} = \lfloor s_{\text{day}} / 3600 / 3 \rfloor`.
+
+The 23 output channels map directly to the ``sw`` array consumed by the ``msisAtmosphere`` module.
+The mapping implemented by ``computeSwState`` is:
+
+.. list-table:: Output channel mapping
+    :widths: 12 30 58
+    :header-rows: 1
+
+    * - Channel
+      - MSIS label
+      - Source column and day
+    * - ``swDataOutMsgs[0]``
+      - ``ap_24_0``
+      - ``AP_AVG`` of day :math:`D_0`
+    * - ``swDataOutMsgs[1]``
+      - ``ap_3_0``
+      - 3-hour Ap at bin :math:`b_{\text{cur}}` of day :math:`D_0`
+    * - ``swDataOutMsgs[2]``
+      - ``ap_3_-3``
+      - 3-hour Ap at bin :math:`b_{\text{cur}} - 1`, wrapping to :math:`D_{-1}` as needed
+    * - ``swDataOutMsgs[3]``
+      - ``ap_3_-6``
+      - 3-hour Ap at bin :math:`b_{\text{cur}} - 2`, wrapping to :math:`D_{-1}` or :math:`D_{-2}`
+    * - … (pattern continues)
+      - …
+      - Each subsequent channel steps back one 3-hour bin, wrapping across day boundaries up to :math:`D_{-3}`
+    * - ``swDataOutMsgs[20]``
+      - ``ap_3_-57``
+      - 3-hour Ap at bin :math:`b_{\text{cur}} - 19`, up to day :math:`D_{-3}`
+    * - ``swDataOutMsgs[21]``
+      - ``f107_1944_0``
+      - ``F10.7_OBS_CENTER81`` of day :math:`D_0`
+    * - ``swDataOutMsgs[22]``
+      - ``f107_24_-24``
+      - ``F10.7_OBS`` of day :math:`D_{-1}`
+
+The 3-hour Ap look-back (channels 1-20) is computed starting from the current 3-hour bin
+:math:`b_{\text{cur}}` within day :math:`D_0`.  The module subtracts one bin index per channel.
+Whenever the bin index drops below zero it is incremented by 8 (the number of 3-hour bins per
+day) and the day offset is advanced by one.  If the resulting day offset exceeds 3 the look-up
+fails and the output retains the last published values.
+
+``loadSpaceWeatherFile`` performs the following actions in order:
+
+1. Open the file; log an error and return if the file cannot be read.
+2. Parse the header row and verify that all required column names are present.  Log an error and
+   return for any missing column.
+3. Parse each subsequent non-empty line into a ``DailySpaceWeather`` record.  Stop at the first
+   line that fails to parse (see assumption 4 in `Module Assumptions and Limitations`_).
+4. Verify that the resulting list contains at least one valid row.
+5. Verify that ``DATE`` values are strictly ascending and contain no duplicates.
+6. If all checks pass, store the validated list and record the loaded file path.
+
+If any validation step fails a BSK_ERROR is thrown.
+
+During ``Reset`` the module probes whether the simulation start date is covered by the loaded
+table; a ``BSK_ERROR`` is emitted immediately if it is not, rather than failing silently at run
+time.  A zero-state is always published at ``Reset``.
+
+If the current simulation date (or any of the three preceding days) is missing from the table
+the module logs a warning and keeps publishing the last available data.
+This can happen only during the simulation, because the first epoch is tested at ``Reset``.
+
+Module Assumptions and Limitations
+------------------------------------
+
+#. **Required columns.** The input CSV must contain a header row with at least the following column
+   names (additional columns are ignored):
+
+   ``DATE``, ``AP1``, ``AP2``, ``AP3``, ``AP4``, ``AP5``, ``AP6``, ``AP7``, ``AP8``,
+   ``AP_AVG``, ``F10.7_OBS``, ``F10.7_OBS_CENTER81``
+
+#. **Date format.** Every ``DATE`` cell must follow the ``YYYY-MM-DD`` format.  Month values must
+   be in [1, 12] and day values in [1, 31]; otherwise the row is treated as invalid.
+
+#. **Table ordering and uniqueness.** ``DATE`` values must be strictly ascending and free of
+   duplicates.  The loader returns an error and discards the entire file if either condition is
+   violated.
+
+#. **Early termination on invalid rows.** The file parser stops reading at the first row that
+   cannot be fully parsed (missing, non-numeric, or numeric fields with trailing characters in AP
+   or F10.7 columns, or a ``DATE`` token with trailing characters).  This is intentional: the
+   monthly predicted section at the end of CelesTrak files omits AP values and should not be
+   ingested.
+
+#. **Run-time look-up window.** At each update step the module requires four consecutive calendar
+   days to be present in the table: the current day, and the three preceding days.  If any of
+   these four entries is absent the module outputs the preceding state and logs a warning.
+
+#. **Epoch is UTC.** The simulation epoch provided through :ref:`EpochMsgPayload` is interpreted
+   as UTC.  No leap-second or timezone correction is applied.
+
+#. **Three-hour AP bins.** The table stores exactly 8 three-hour Ap indices per day
+   (``AP1`` … ``AP8``), corresponding to the 00-03 UT, 03-06 UT, … 21-24 UT intervals.
+   The module derives the current 3-hour bin from the fractional UTC time of day.
+
+#. **No interpolation.** All space-weather indices are taken directly from the table; no
+   interpolation between rows is performed.
+
+User Guide
+-----------
+
+Obtaining a space-weather file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Download the historical + short-range predicted file directly from CelesTrak:
+
+.. code-block:: none
+
+    https://celestrak.org/SpaceData/SW-Last5Years.csv
+
+The file covers the past five years of observed data followed by a short predicted section.
+Because the predicted rows omit AP values, the module's early-termination parser automatically
+stops before ingesting them.
+
+For simulations that extend beyond the five-year window, use the complete historical archive:
+
+.. code-block:: none
+
+    https://celestrak.org/SpaceData/SW-All.csv
+
+Basic Setup
+~~~~~~~~~~~
+
+The minimal Python setup connects the epoch message, loads the CSV file, and subscribes each
+``msisAtmosphere`` input to the corresponding output:
+
+.. code-block:: python
+
+    from Basilisk.simulation import msisAtmosphere, spaceWeatherData
+    from Basilisk.utilities import unitTestSupport, SimulationBaseClass
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("DynamicsProcess")
+    dynTaskName = "DynamicsTask"
+    dynProcess.addTask(scSim.CreateNewTask(dynTaskName, macros.sec2nano(10.0)))
+
+    # --- Space-weather module ---
+    swModule = spaceWeatherData.SpaceWeatherData()
+    swModule.ModelTag = "spaceWeatherData"
+    swModule.loadSpaceWeatherFile("SW-Last5Years.csv")
+
+    # Connect the simulation epoch
+    timeInitString = "2026 March 04 21:48:00.000000"
+    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+    swModule.epochInMsg.subscribeTo(epochMsg)
+
+    # --- Atmosphere module ---
+    atmoModule = msisAtmosphere.MsisAtmosphere()
+    atmoModule.epochInMsg.subscribeTo(epochMsg)
+    atmoModule.ModelTag = "msisAtmosphere"
+    for msgIndex in range(23):
+        atmoModule.swDataInMsgs[msgIndex].subscribeTo(swModule.swDataOutMsgs[msgIndex])
+
+    scSim.AddModelToTask(dynTaskName, swModule)
+    scSim.AddModelToTask(dynTaskName, atmoModule)
+
+.. note::
+
+    ``swModule`` must be added to the task **before** ``atmoModule``, or have a higher priority,
+    so that the output messages are written before the atmosphere module reads them within the
+    same task step.
+
+Choosing the Correct Epoch
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The epoch message must represent the UTC date and time at which the simulation clock reads zero.
+The module adds the BSK simulation time (in seconds) to this epoch to obtain the current UTC
+instant.  Providing a wrong epoch will shift all space-weather indices in time and may cause
+look-up failures if the resulting date falls outside the loaded table.
+
+.. code-block:: python
+
+    # Epoch at J2000.0 (2000-01-01 11:58:55.816 UTC)
+    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2000 January 01 11:58:55.816000")
+    swModule.epochInMsg.subscribeTo(epochMsg)
+
+Error Conditions and Mitigation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+    :widths: 45 55
+    :header-rows: 1
+
+    * - Symptom
+      - Likely cause and remedy
+    * - ``BSK_ERROR: SpaceWeatherData.epochInMsg was not linked``
+      - ``epochInMsg`` was not subscribed before ``Reset``.  Subscribe to a valid
+        :ref:`EpochMsgPayload` message before initialising the simulation.
+    * - ``BSK_ERROR: space-weather table is empty``
+      - ``loadSpaceWeatherFile`` was not called, or the call failed.  Check the file path and
+        verify that the CSV contains all required columns.
+    * - ``BSK_ERROR: simulation start date is not covered by the loaded space-weather table``
+      - The epoch resolves to a calendar date for which the module cannot assemble a full
+        look-back window (current day plus three preceding days).  Verify the epoch is
+        correct and that the loaded CSV file covers the simulation start date.
+    * - ``BSK_ERROR: missing required column``
+      - The CSV header does not contain one of the mandatory column names.  Ensure the file was
+        downloaded from CelesTrak and has not been manually edited.
+    * - ``BSK_ERROR: Duplicate DATE row``
+      - Two rows share the same ``DATE``.  Remove the duplicate and reload.
+    * - ``BSK_ERROR: DATE rows must be sorted``
+      - Rows are not in ascending date order.  Sort the file by date and reload.
+    * - ``BSK_ERROR: No valid weather rows were loaded``
+      - Every data row failed to parse, leaving the table empty.  Check that the CSV is a valid
+        CelesTrak file and that at least the first data row is well-formed.
+    * - ``BSK_WARNING: Failed to retrieve a state. Publishing the last available data. This can happen if the date is not in the file or if the file is empty.``
+      - The current simulation date or one of the three preceding days is absent from the table.
+        Use a longer or more recent CSV file so that the look-up window falls within the loaded
+        range.
+    * - ``BSK_WARNING: Stopped reading space-weather table at first invalid row``
+      - A data row could not be parsed (malformed ``DATE`` token, missing field, or a numeric
+        field such as an AP or F10.7 value that contains non-numeric trailing characters).  Rows
+        before this point are still loaded.  Verify the file has not been manually edited.


### PR DESCRIPTION
* **Tickets addressed:** nd
* **Review:** By file
* **Merge strategy:** Merge (no squash)

## Description

Implements the `spaceWeatherData` Basilisk simulation module, which reads a CelesTrak-style space-weather CSV file and publishes the 23 `SwDataMsgPayload` output messages required by the `msisAtmosphere` module.

**Key implementation details reviewers should be aware of:**

- **Date arithmetic:** The module converts a Gregorian calendar date from the linked `EpochMsgPayload` to a signed Unix day number, which serves as the unique lookup key into the weather table. On each `UpdateState` call, the BSK simulation time is added to the epoch to derive the current UTC instant, whole-day offset, and the current 3-hour Ap bin index.

- **23-channel output mapping:** Channel 0 maps `AP_AVG` for the current day; channels 1-20 map 20 consecutive 3-hour Ap values stepping back one bin at a time (wrapping across day boundaries up to D-3); channel 21 maps `F10.7_OBS_CENTER81`; channel 22 maps `F10.7_OBS` from the previous day.

- **`loadSpaceWeatherFile` validation pipeline:** Opens the file, checks all required columns (`DATE`, `AP1`-`AP8`, `AP_AVG`, `F10.7_OBS`, `F10.7_OBS_CENTER81`), parses rows until the first unparseable line (intentionally stops before the predicted section that omits AP values), and enforces strictly ascending, duplicate-free `DATE` values. Any failure throws an error.

- **`Reset` guard:** At `Reset`, the module verifies that the simulation start date and its three preceding days are all present in the loaded table. A `BSK_ERROR` is emitted immediately rather than failing silently at runtime. A zero-state message is always published at `Reset`.

- **Task ordering requirement:** `swModule` must be added to the task before `atmoModule` (or given higher priority) so output messages are written before the atmosphere module reads them within the same step.

- **No interpolation:** All indices are taken directly from the nearest table row; no temporal interpolation is performed.

## Verification

- Unit tests cover the full date-arithmetic pipeline against known reference dates.
- Integration tests load a trimmed CelesTrak CSV fixture and verify all 23 output message values against hand-computed expected indices for a fixed simulation epoch.
- Tests confirm that missing columns, duplicate dates, unsorted dates, and an unlinked `epochInMsg` each produce the correct `BSK_ERROR` log.
- A run-time warning test verifies that a missing day in the look-up window causes the module to publish the last available state. `BSK_WARNING` is not checked as it is not thrown.

## Documentation

- **New:** `spaceWeatherData.rst`.
- Reviewers should verify the symbol table, the 23-channel mapping table, and all code snippets in the User Guide section for accuracy against the implementation.

## Future work

- Expose a `setFallbackApValue` Python setter so users can override the zero-state fallback with a mission-specific quiet-time Ap.
- Update documentation and examples for all modules that may be consumers of this module. Starting from `msisAtmosphere`.