### PR TITLE
Add workflow to trim beta docs

### DIFF
--- a/.github/workflows/trim-pages-history.yml
+++ b/.github/workflows/trim-pages-history.yml
@@ -1,0 +1,45 @@
+name: Trim GitHub Pages History
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  trim-pages-history:
+    name: Rewrite gh-pages as a single commit
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Rewrite gh-pages history
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive_path="${RUNNER_TEMP}/gh-pages-site.tar"
+          temp_branch="gh-pages-reset"
+
+          tar \
+            --exclude=.git \
+            -cf "${archive_path}" \
+            .
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout --orphan "${temp_branch}"
+
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          tar -xf "${archive_path}"
+
+          git add -A
+          git commit -m "Trim gh-pages history"
+          git branch -M gh-pages
+          git push --force origin gh-pages


### PR DESCRIPTION
* **Review:** By file
* **Merge strategy:** Merge (no squash)

## Description
This branch adds a new GitHub Actions maintenance workflow, `Trim GitHub Pages History`, to manually collapse the `gh-pages` branch history to a single fresh commit while preserving the currently published site contents.

The workflow is intended as a one-time or occasional maintenance tool for cleaning up the long stack of historical documentation deploy commits that accumulate on `gh-pages`, especially from repeated beta documentation publishes. It is exposed through `workflow_dispatch` so it can be run explicitly when needed, without affecting the normal documentation deployment workflows.

## Verification
The workflow logic was validated on GitHub before removing the temporary branch-testing trigger. That test run successfully rewrote `origin/gh-pages` and reduced its history to the current published state as intended.

No automated tests were added or updated, since this change is isolated to GitHub Actions workflow behavior rather than Basilisk runtime code. Validation was performed through a live GitHub Actions run and inspection of the resulting `gh-pages` branch history.

## Documentation
No user-facing Basilisk documentation was changed.

Reviewers should check:
- [.github/workflows/trim-pages-history.yml](/Users/hp/Repos/basilisk/.github/workflows/trim-pages-history.yml)

In particular, verify that the workflow:
- is manual-only through `workflow_dispatch`
- preserves the current `gh-pages` site contents
- rewrites `gh-pages` history down to a single fresh commit

## Future work
This workflow can now remain available as a maintenance utility for future cleanup of `gh-pages` history whenever repeated documentation deploys cause the branch history to grow excessively.