### PR TITLE
Upgrade to latest swig 4.1.1

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -29,6 +29,9 @@ runs:
           requirements_dev.txt
           requirements_doc.txt
           requirements.txt
+          .github/workflows/requirements_dev.txt
+          .github/workflows/requirements_doc.txt
+          .github/workflows/requirements.txt
 
     - name: Setup system dependencies
       uses: ./.github/actions/setup

--- a/.github/workflows/requirements_dev.txt
+++ b/.github/workflows/requirements_dev.txt
@@ -4,9 +4,7 @@ conan
 packaging
 setuptools
 setuptools-scm
-# TODO: The SWIG 4.4.X is incompatible with Basilisk. Pin to SWIG 4.3.1 until
-# Basilisk is updated to support SWIG 4.4.X
-swig<=4.3.1,>=4.2.1
+swig
 libclang
 
 pytest

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,11 +10,11 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
-- When building from source on Python 3.13 using SWIG 4.4.0, a build failure may occur
-  if ``pyLimitedAPI`` is set to an ABI lower than Python 3.13 (e.g., ``0x03080000``).
-  SWIG 4.4.0 introduces a new C-API codepath for Python 3.13 that expects newer
-  definition macros which are not present when targeting older ``abi3`` compatibility. As such, when building
-  Basilisk with Python 3.13 or above, we automatically default to using the newer cp313 ABI.
+- SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
+  The development dependency range now excludes SWIG 4.4.0, and SWIG 4.4.1 has been verified to build
+  successfully. If source builds fail with SWIG 4.4.0 or emit ``builtin type swigvarlink has no __module__ attribute``
+  warnings, upgrade to SWIG 4.4.1 or newer.
+
 
 Version 2.10.0 (April 2, 2026)
 ------------------------------

--- a/docs/source/Support/bskReleaseNotesSnippets/1354-swig-pytest-cleanup.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1354-swig-pytest-cleanup.rst
@@ -1,0 +1,2 @@
+- Updated SWIG dependency support to allow compatible latest SWIG releases while excluding SWIG 4.4.0 due to compile regressions observed during testing.  If you are getting lots of ``builtin type swigvarlink has no __module__ attribute`` warnings upgrade to SWIG 4.4.1
+- Cleaned up pytest resource handling so parallel test runs with pytest-xdist and pytest-rerunfailures no longer report unclosed socket warnings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     # Requirements for building Basilisk through conanfile
     "conan>=2.0.5,<=2.23.0",
     "cmake>=3.26,<4.0",
-    "swig>=4.2.1,<=4.3.1",  # Known to work with https://github.com/nightlark/swig-pypi/pull/120
+    "swig>=4.2.1,<5",  # Support Basilisk's established SWIG baseline while allowing the latest 4.4.x releases.
     "libclang>=15.0.6.1,<=18.1.1"  # Required by generatePayloadMetaJson.py (message code generation)
 ]
 
@@ -104,9 +104,4 @@ markers = [
   "slowtest: mark a test as a slow unit test.",
   "scenarioTest: mark a test as a tutorial scenario test.",
   "ciSkip: mark a test that should be skipped on the CI test runs",
-]
-filterwarnings = [
-  "ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning",
-  "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
-  "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     # Requirements for building Basilisk through conanfile
     "conan>=2.0.5,<=2.23.0",
     "cmake>=3.26,<4.0",
-    "swig>=4.2.1,<5",  # Support Basilisk's established SWIG baseline while allowing the latest 4.4.x releases.
+    "swig>=4.2.1,!=4.4.0,<5",  # Support Basilisk's established SWIG baseline while avoiding the known-bad 4.4.0 release.
     "libclang>=15.0.6.1,<=18.1.1"  # Required by generatePayloadMetaJson.py (message code generation)
 ]
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ conan>=2.0.5,<=2.23.0
 packaging>=24,<26
 setuptools>=70.1.0,<=80.9.0
 setuptools-scm>=8.0,<=9.2.2
-swig<=4.3.1,>=4.2.1
+swig>=4.2.1,<5
 libclang>=15.0.6.1,<=18.1.1
 
 pytest>=8.3.5,<=9.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ conan>=2.0.5,<=2.23.0
 packaging>=24,<26
 setuptools>=70.1.0,<=80.9.0
 setuptools-scm>=8.0,<=9.2.2
-swig>=4.2.1,<5
+swig>=4.2.1,!=4.4.0,<5
 libclang>=15.0.6.1,<=18.1.1
 
 pytest>=8.3.5,<=9.0.1

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class BuildConanExtCommand(Command, SubCommand):
 
         # Set limited ABI compatibility by default, targeting the minimum required Python version.
         # See https://docs.python.org/3/c-api/stable.html
-        # NOTE: Swig 4.2.1 or higher is required, see https://github.com/swig/swig/pull/2727
+        # NOTE: Swig 4.2.1 or higher is required. Newer 4.4.x releases avoid deprecated wrapper warnings on newer Python.
         min_version = next(self.distribution.python_requires.filter([f"3.{i}" for i in range(2, 100)])).replace(".", "")
         wheel_py_limited = f"cp{min_version}"
         bdist_wheel = self.reinitialize_command("bdist_wheel", py_limited_api=wheel_py_limited)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if(PY_LIMITED_API AND NOT PY_LIMITED_API STREQUAL "")
   # compatibility (basically, we can build a single Python wheel to
   # support all future Python versions).
   # See https://docs.python.org/3/c-api/stable.html
-  # NOTE: Swig 4.2.0 is required, see https://github.com/swig/swig/pull/2727
+  # NOTE: Swig 4.2.0 is required. Swig 4.4.x avoids the deprecated wrapper warnings on newer Python releases.
   add_definitions("-DPy_LIMITED_API=${PY_LIMITED_API}")  # Support for current Python version
 
   # Force libraries to link to the Stable ABI module instead.

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -21,18 +21,11 @@ import os
 import shutil
 import subprocess
 import sys
-import warnings
 from datetime import date
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import pytest
-
-warnings.filterwarnings(
-    "ignore",
-    message="builtin type swigvarlink has no __module__ attribute",
-    category=DeprecationWarning,
-)
 
 SHOW_PLOTS_REMOVAL_DATE = date(2027, 2, 12)
 SHOW_PLOTS_DEPRECATION_MESSAGE = (

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -35,6 +35,39 @@ SHOW_PLOTS_ELEVATED_MESSAGE = (
     "The pytest option '--show_plots' has been deprecated for a year and will be removed shortly."
 )
 
+
+def _patch_rerunfailures_socket_cleanup():
+    """
+    Close pytest-rerunfailures server-side sockets when xdist is active.
+
+    pytest-rerunfailures 16.1 opens localhost sockets to coordinate reruns
+    between xdist workers, but accepted server connections are not closed by
+    the plugin.  This narrow patch preserves the plugin handler while ensuring
+    each accepted connection is closed when the handler exits.
+    """
+    try:
+        import pytest_rerunfailures
+    except ImportError:
+        return
+
+    server_status_db = getattr(pytest_rerunfailures, "ServerStatusDB", None)
+    if server_status_db is None:
+        return
+    if getattr(server_status_db, "_bsk_socket_cleanup_patched", False):
+        return
+
+    original_run_connection = server_status_db.run_connection
+
+    def run_connection_with_socket_close(self, conn):
+        with conn:
+            return original_run_connection(self, conn)
+
+    server_status_db.run_connection = run_connection_with_socket_close
+    server_status_db._bsk_socket_cleanup_patched = True
+
+
+_patch_rerunfailures_socket_cleanup()
+
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 print(path)
@@ -69,6 +102,17 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     message = f"DEPRECATION WARNING: {warning_message}"
     terminalreporter.write_sep("=", "SHOW_PLOTS DEPRECATION", **{terminal_color: True}, bold=True)
     terminalreporter.write_line(message, **{terminal_color: True}, bold=True)
+
+
+def pytest_unconfigure(config):
+    failures_db = getattr(config, "failures_db", None)
+    socket_handle = getattr(failures_db, "sock", None)
+    if socket_handle is None:
+        return
+    try:
+        socket_handle.close()
+    except OSError:
+        pass
 
 
 @pytest.fixture(scope="module")

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -109,4 +109,5 @@ if ('--report' in sys.argv) and ('pytest-html' not in installed_packages):
     quit()
 
 if 'pytest-html' in installed_packages:
-    exec(open(path + "/reportconf.py").read(), globals())
+    with open(path + "/reportconf.py") as reportConfig:
+        exec(reportConfig.read(), globals())

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -4,8 +4,3 @@ markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.
     ciSkip: mark a test that should be skipped on the CI test runs
-
-filterwarnings =
-    ignore:builtin type SwigPyPacked has no __module__ attribute:DeprecationWarning
-    ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning
-    ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning

--- a/src/simulation/environment/spaceWeatherData/spaceWeatherData.i
+++ b/src/simulation/environment/spaceWeatherData/spaceWeatherData.i
@@ -25,26 +25,6 @@
    #include "spaceWeatherData.h"
 %}
 
-%pythonbegin %{
-import warnings as _warnings
-
-_warnings.filterwarnings(
-    "ignore",
-    message=r"builtin type SwigPyPacked has no __module__ attribute",
-    category=DeprecationWarning,
-)
-_warnings.filterwarnings(
-    "ignore",
-    message=r"builtin type SwigPyObject has no __module__ attribute",
-    category=DeprecationWarning,
-)
-_warnings.filterwarnings(
-    "ignore",
-    message=r"builtin type swigvarlink has no __module__ attribute",
-    category=DeprecationWarning,
-)
-%}
-
 %pythoncode %{
 from Basilisk.architecture.swig_common_model import *
 %}

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_spiceThreadSafety.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_spiceThreadSafety.py
@@ -232,6 +232,59 @@ def _runTestWithTimeout(resultQueue, numWorkers, iterationsPerWorker):
                 False,
             )
         )
+    finally:
+        _closeQueue(resultQueue)
+
+
+def _closeQueue(resultQueue):
+    """
+    Close a multiprocessing queue and wait for its feeder thread.
+
+    Parameters
+    ----------
+    resultQueue : multiprocessing.Queue
+        Queue to close after all expected data has been read or written.
+    """
+    try:
+        resultQueue.close()
+    except (OSError, ValueError):
+        pass
+    try:
+        resultQueue.join_thread()
+    except (AssertionError, OSError, ValueError):
+        pass
+
+
+def _closeProcess(testProcess):
+    """
+    Release multiprocessing process resources after the process exits.
+
+    Parameters
+    ----------
+    testProcess : multiprocessing.Process
+        Process object to close after it has been joined.
+    """
+    try:
+        testProcess.close()
+    except (OSError, ValueError):
+        pass
+
+
+def _terminateProcess(testProcess):
+    """
+    Stop a multiprocessing process and wait for shutdown.
+
+    Parameters
+    ----------
+    testProcess : multiprocessing.Process
+        Process object to terminate.
+    """
+    testProcess.terminate()
+    shutdownTimeout = 1  # [s]
+    testProcess.join(shutdownTimeout)
+    if testProcess.is_alive():
+        os.kill(testProcess.pid, 9)
+        testProcess.join(shutdownTimeout)
 
 
 @pytest.mark.flaky(reruns=3)
@@ -260,34 +313,37 @@ def testSpiceThreadSafety(numWorkers, iterationsPerWorker):
         target=_runTestWithTimeout,
         args=(resultQueue, numWorkers, iterationsPerWorker),
     )
-    testProcess.start()
-
-    timeoutSeconds = 60
-    testProcess.join(timeoutSeconds)
-
-    if testProcess.is_alive():
-        # Hard timeout: kill the worker process and fail the test
-        testProcess.terminate()
-        testProcess.join(1)
-        if testProcess.is_alive():
-            os.kill(testProcess.pid, 9)
-        pytest.fail(f"Thread safety test timed out after {timeoutSeconds} seconds")
-
     try:
-        results, success = resultQueue.get(block=False)
+        testProcess.start()
 
-        if isinstance(results, dict) and "error" in results:
+        timeoutSeconds = 60  # [s]
+        testProcess.join(timeoutSeconds)
+
+        if testProcess.is_alive():
+            # Hard timeout: kill the worker process and fail the test
+            _terminateProcess(testProcess)
             pytest.fail(
-                "Thread safety test failed with error: "
-                f"{results['error']}\n{results.get('traceback')}"
+                f"Thread safety test timed out after {timeoutSeconds} seconds"
             )
 
-        assert success, "Thread safety test reported thread-safety issues"
-        assert results["failedIterations"] == 0, (
-            "Some iterations failed in the thread-safety test"
-        )
-    except queue.Empty:
-        pytest.fail("Thread safety test completed but did not return any results")
+        try:
+            results, success = resultQueue.get(block=False)
+
+            if isinstance(results, dict) and "error" in results:
+                pytest.fail(
+                    "Thread safety test failed with error: "
+                    f"{results['error']}\n{results.get('traceback')}"
+                )
+
+            assert success, "Thread safety test reported thread-safety issues"
+            assert results["failedIterations"] == 0, (
+                "Some iterations failed in the thread-safety test"
+            )
+        except queue.Empty:
+            pytest.fail("Thread safety test completed but did not return any results")
+    finally:
+        _closeQueue(resultQueue)
+        _closeProcess(testProcess)
 
 
 if __name__ == "__main__":
@@ -307,28 +363,29 @@ if __name__ == "__main__":
         target=_runTestWithTimeout,
         args=(resultQueue, numWorkers, iterationsPerWorker),
     )
-    testProcess.start()
-
-    timeoutSeconds = 60
-    testProcess.join(timeoutSeconds)
-
-    if testProcess.is_alive():
-        testProcess.terminate()
-        testProcess.join(1)
-        if testProcess.is_alive():
-            os.kill(testProcess.pid, 9)
-        print(f"ERROR: Thread safety test timed out after {timeoutSeconds} seconds")
-        sys.exit(2)
-
     try:
-        results, success = resultQueue.get(block=False)
+        testProcess.start()
 
-        if isinstance(results, dict) and "error" in results:
-            print(f"ERROR: Thread safety test failed with error: {results['error']}")
-            print(results.get("traceback"))
+        timeoutSeconds = 60  # [s]
+        testProcess.join(timeoutSeconds)
+
+        if testProcess.is_alive():
+            _terminateProcess(testProcess)
+            print(f"ERROR: Thread safety test timed out after {timeoutSeconds} seconds")
+            sys.exit(2)
+
+        try:
+            results, success = resultQueue.get(block=False)
+
+            if isinstance(results, dict) and "error" in results:
+                print(f"ERROR: Thread safety test failed with error: {results['error']}")
+                print(results.get("traceback"))
+                sys.exit(1)
+
+            sys.exit(0 if success else 1)
+        except queue.Empty:
+            print("ERROR: Thread safety test completed but did not return results")
             sys.exit(1)
-
-        sys.exit(0 if success else 1)
-    except queue.Empty:
-        print("ERROR: Thread safety test completed but did not return results")
-        sys.exit(1)
+    finally:
+        _closeQueue(resultQueue)
+        _closeProcess(testProcess)


### PR DESCRIPTION
* **Tickets addressed:** bsk-1201
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

This PR updates Basilisk test and build infrastructure for cleaner Python 3.14 support.

First, the branch updates SWIG dependency handling so Basilisk supports the latest working SWIG release.  Local development requirements now allow current SWIG versions while explicitly excluding `swig==4.4.0`, which produced compile failures in testing.  SWIG 4.4.1 was verified with a clean Basilisk build and unit test run.  The canary CI requirements continue to use the latest available SWIG so future compatibility issues are detected early.

Second, this PR removes obsolete SWIG runtime warning suppression that was previously hiding Python warnings such as `swigvarlink has no __module__ attribute`.  With SWIG 4.4.1, those warnings no longer appear in the clean build/test path, so the suppression is no longer needed.

Finally, this PR cleans up Python test-suite `ResourceWarning` messages observed when running `pytest -n auto` from `src`.  The warnings were traced to pytest infrastructure rather than Basilisk simulation code.  The SPICE thread-safety test now closes multiprocessing queue and process resources explicitly.  The pytest configuration also closes the optional `reportconf.py` file handle after loading it.

The remaining socket warnings were isolated to the interaction between `pytest-xdist` and `pytest-rerunfailures` 16.1.  Since there is not yet a newer released `pytest-rerunfailures` version that fixes this cleanup path, `src/conftest.py` now performs a narrow local cleanup: it closes the plugin-owned rerun status socket during pytest shutdown and wraps the plugin’s server-side connection handler so accepted sockets are closed when each handler exits.

The commits are organized by infrastructure topic: SWIG version support, removal of obsolete SWIG warning suppression, SPICE multiprocessing cleanup, pytest file-handle cleanup, and pytest-rerunfailures socket cleanup.

## Verification

SWIG 4.4.1 was verified with a clean Basilisk build.  The previous SWIG runtime warnings were not observed in the clean build log, and the unit tests completed successfully.  SWIG 4.4.0 was tested separately and produced compile failures, so that specific version is excluded from the pinned development dependency range.

Validated the ResourceWarning cleanup with warning tracing enabled:

```bash
env PYTHONTRACEMALLOC=25 PYTHONWARNINGS=always::ResourceWarning .venv/bin/pytest -q src/simulation/environment/spiceInterface/_UnitTest/test_spiceThreadSafety.py
```

Also verified the full parallel test suite from src:

pytest -n auto
The full run completed without the previously reported unclosed socket ResourceWarning.

No new tests were added because these changes update build/test infrastructure cleanup behavior rather than Basilisk runtime behavior. Existing build and test coverage was used to confirm the changes.

## Documentation
No user-facing Basilisk documentation was invalidated. This change affects developer/test infrastructure and SWIG dependency compatibility.

Reviewers should check the requirements updates, the removed SWIG warning suppression, src/conftest.py for the local pytest-rerunfailures socket cleanup shim, and src/simulation/environment/spiceInterface/_UnitTest/test_spiceThreadSafety.py for multiprocessing queue/process cleanup behavior.

## Future work
If pytest-rerunfailures releases an upstream fix for closing its xdist coordination sockets, the local cleanup shim in src/conftest.py can be removed after updating the pinned dependency range.
