### PR TITLE
Compile swig message wrappers with lower optimization

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/messaging-wrapper-build-optimization.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/messaging-wrapper-build-optimization.rst
@@ -1,0 +1,1 @@
+- Reduced clean build time by compiling generated messaging SWIG wrapper modules with lower optimization while preserving normal optimization settings for Basilisk source modules.

--- a/src/architecture/messaging/CMakeLists.txt
+++ b/src/architecture/messaging/CMakeLists.txt
@@ -1,5 +1,19 @@
 cmake_policy(SET CMP0078 NEW)
 
+function(set_messaging_swig_compile_options targetName)
+  if(MSVC)
+    target_compile_options(${targetName} PRIVATE
+      $<$<CONFIG:Release>:/Od>
+      $<$<CONFIG:RelWithDebInfo>:/Od>
+      $<$<CONFIG:MinSizeRel>:/Od>)
+  else()
+    target_compile_options(${targetName} PRIVATE
+      $<$<CONFIG:Release>:-O0>
+      $<$<CONFIG:RelWithDebInfo>:-O0>
+      $<$<CONFIG:MinSizeRel>:-O0>)
+  endif()
+endfunction()
+
 function(generate_messages searchDir generateCCode)
   file(
     GLOB_RECURSE message_files
@@ -85,6 +99,7 @@ function(generate_messages searchDir generateCCode)
     set_target_properties(
       ${SWIG_MODULE_${TARGET_NAME}_REAL_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE
                                                          "${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging")
+    set_messaging_swig_compile_options(${SWIG_MODULE_${TARGET_NAME}_REAL_NAME})
     target_link_libraries(${SWIG_MODULE_${TARGET_NAME}_REAL_NAME} PUBLIC architectureLib)
   endforeach()
 endfunction(generate_messages)


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR improves clean build time by reducing optimization only for the generated messaging SWIG wrapper targets. These generated wrapper translation units are expensive for the compiler to optimize and are not expected to be runtime-critical compared with Basilisk simulation and FSW source modules.

The change is intentionally target-local: normal Basilisk source modules continue to use the existing project optimization settings, while the generated messaging wrapper modules use lower optimization for release-style builds.

In local testing, a clean build improved from approximately 3:51 to 2:33.

## Verification
Validated with a full rebuild and the messaging unit test suite:

```text
.venv/bin/cmake -S src -B dist3
.venv/bin/cmake --build dist3 -j 8
.venv/bin/pytest -q src/architecture/messaging/_UnitTest
```

The messaging unit tests passed:

```text
72 passed in 40.24s
```

No automated tests were added because this is a build-system optimization that should preserve generated messaging behavior rather than introduce new runtime functionality.

## Documentation
Added a release-note snippet describing the build-time improvement:

```text
docs/source/Support/bskReleaseNotesSnippets/messaging-wrapper-build-optimization.rst
```

No user-facing documentation was otherwise invalidated.

## Future work
If additional build-time reductions are desired, follow-up work could profile other generated wrapper targets or evaluate compiler/cache settings. The previous batching approach for messaging SWIG modules was tested separately and increased clean build time, so this PR keeps the safer per-target structure.