### PR TITLE
Publish nightly wheels to a self hosted index

### DIFF
--- a/.github/scripts/generate_nightly_index.py
+++ b/.github/scripts/generate_nightly_index.py
@@ -1,0 +1,66 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import argparse
+from pathlib import Path
+
+
+def _package_index(wheels: list[Path]) -> str:
+    links = "\n".join(f'  <a href="{w.name}">{w.name}</a><br/>' for w in wheels)
+    return (
+        "<!DOCTYPE html>\n"
+        "<html><head><title>Links for bsk</title></head><body>\n"
+        "<h1>Links for bsk</h1>\n"
+        f"{links}\n"
+        "</body></html>\n"
+    )
+
+
+def _root_index() -> str:
+    return (
+        "<!DOCTYPE html>\n"
+        "<html><head><title>Simple Index</title></head><body>\n"
+        "<h1>Simple Index</h1>\n"
+        '  <a href="bsk/">bsk</a><br/>\n'
+        "</body></html>\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wheels-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    wheels = sorted(args.wheels_dir.glob("*.whl"))
+    if not wheels:
+        raise SystemExit(f"No wheels found in {args.wheels_dir}")
+
+    pkg_dir = args.output_dir / "bsk"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    (pkg_dir / "index.html").write_text(_package_index(wheels))
+    (args.output_dir / "index.html").write_text(_root_index())
+
+    for whl in wheels:
+        (pkg_dir / whl.name).write_bytes(whl.read_bytes())
+
+    print(f"Index generated with {len(wheels)} wheel(s) in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -1,0 +1,100 @@
+name: Nightly Wheels
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Every day at 6:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build-wheels:
+    name: Build Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - ubuntu-22.04-arm
+          - windows-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.4
+        env:
+          CONAN_ARGS: "--opNav True --mujoco True --mujocoReplay True"
+          CIBW_TEST_SKIP: "*"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  publish-index:
+    name: Publish Nightly Index
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+          sparse-checkout: .github/scripts
+
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-wheels-*
+          merge-multiple: true
+          path: wheels
+
+      - name: Generate simple index
+        run: python .github/scripts/generate_nightly_index.py --wheels-dir wheels --output-dir nightly
+
+      - name: Deploy nightly index to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./nightly
+          destination_dir: nightly
+          keep_files: false
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+          path: gh-pages-site
+
+      - name: Trim gh-pages history
+        shell: bash
+        working-directory: gh-pages-site
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          archive_path="${RUNNER_TEMP}/gh-pages-site.tar"
+          tar --exclude=.git -cf "${archive_path}" .
+
+          git checkout --orphan gh-pages-reset
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          tar -xf "${archive_path}"
+
+          git add -A
+          git commit -m "Trim gh-pages history"
+          git branch -M gh-pages
+          git push --force origin gh-pages

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -1,0 +1,95 @@
+name: Nightly Wheels
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Every day at 6:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build-wheels:
+    name: Build Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - ubuntu-22.04-arm
+          - windows-latest
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.4
+        env:
+          CONAN_ARGS: "--opNav True --mujoco True --mujocoReplay True"
+          CIBW_TEST_SKIP: "*"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  publish-index:
+    name: Publish Nightly Index
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v5
+        with:
+          ref: develop
+          sparse-checkout: .github/scripts
+
+      - name: Download all wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-wheels-*
+          merge-multiple: true
+          path: wheels
+
+      - name: Generate simple index
+        run: python .github/scripts/generate_nightly_index.py --wheels-dir wheels --output-dir nightly
+
+      - name: Deploy nightly index to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./nightly
+          destination_dir: nightly
+          keep_files: false
+
+      - name: Trim gh-pages history
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin gh-pages
+          git checkout gh-pages
+
+          archive_path="${RUNNER_TEMP}/gh-pages-site.tar"
+          tar --exclude=.git -cf "${archive_path}" .
+
+          git checkout --orphan gh-pages-reset
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          tar -xf "${archive_path}"
+
+          git add -A
+          git commit -m "Trim gh-pages history"
+          git branch -M gh-pages
+          git push --force origin gh-pages

--- a/docs/source/Install.rst
+++ b/docs/source/Install.rst
@@ -66,6 +66,48 @@ versions.
    This requires a C++ compiler toolchain and standard build tools
    to be installed on your system.
 
+Nightly Builds
+--------------
+
+Nightly pre-release wheels are built automatically from the ``develop`` branch and
+published to the Basilisk nightly index for all supported platforms. These
+builds are replaced each night and reflect the latest state of active development.
+They are intended for testing and early access to new features, but may be
+unstable and are not recommended for production use.
+
+To install the latest nightly build, use the Basilisk nightly index as the primary
+source, allow pip to fall back to PyPI for dependencies, and pass ``--pre`` since
+nightly wheels are pre-release versions:
+
+.. code-block:: bash
+
+   pip install \
+     --index-url https://avslab.github.io/basilisk/nightly/ \
+     --extra-index-url https://pypi.org/simple/ \
+     --pre \
+     bsk
+
+Because nightly wheels are built from the ``develop`` branch and carry the same
+version string until ``bskVersion.txt`` changes, pip may report
+``Requirement already satisfied`` even when a newer build is available. To
+force an overwrite of whatever is currently installed, add
+``--upgrade --force-reinstall --no-cache-dir``:
+
+.. code-block:: bash
+
+   pip install \
+     --index-url https://avslab.github.io/basilisk/nightly/ \
+     --extra-index-url https://pypi.org/simple/ \
+     --pre \
+     --upgrade --force-reinstall --no-cache-dir \
+     bsk
+
+.. warning::
+
+   Nightly builds are development snapshots and are not suitable for production use.
+   For stable releases, install from `PyPI <https://pypi.org/project/bsk/>`_ as described above.
+
+
 Basilisk Support Data
 ---------------------
 

--- a/docs/source/Install.rst
+++ b/docs/source/Install.rst
@@ -66,6 +66,33 @@ versions.
    This requires a C++ compiler toolchain and standard build tools
    to be installed on your system.
 
+Nightly Builds
+--------------
+
+Nightly pre-release wheels are built automatically from the ``develop`` branch and
+published to the Basilisk nightly index for all supported platforms. These
+builds are replaced each night and reflect the latest state of active development.
+They are intended for testing and early access to new features, but may be
+unstable and are not recommended for production use.
+
+To install the latest nightly build, use the Basilisk nightly index as the primary
+source, allow pip to fall back to PyPI for dependencies, and pass ``--pre`` since
+nightly wheels are pre-release versions:
+
+.. code-block:: bash
+
+   pip install \
+     --index-url https://avslab.github.io/basilisk/nightly/ \
+     --extra-index-url https://pypi.org/simple/ \
+     --pre \
+     bsk
+
+.. warning::
+
+   Nightly builds are development snapshots and are not suitable for production use.
+   For stable releases, install from `PyPI <https://pypi.org/project/bsk/>`_ as described above.
+
+
 Basilisk Support Data
 ---------------------
 

--- a/docs/source/Support/Developer/releaseGuide.rst
+++ b/docs/source/Support/Developer/releaseGuide.rst
@@ -30,6 +30,9 @@ To prepare ``develop`` for the next beta cycle:
 #. Update ``docs/source/Support/bskReleaseNotes.rst``
    and ``docs/source/Support/bskKnownIssues.rst`` files to next beta cycle
 #. Make PR and push to ``develop``
+#. Manually run the ``Nightly Wheels`` workflow using the ``workflow_dispatch``
+   trigger after merging the beta branch so the nightly package index is
+   republished on GitHub Pages.
 
 
 The following documentation provides detailed instructions for some of these steps.

--- a/docs/source/Support/bskReleaseNotesSnippets/1360-nightly-wheels-gh-pages-trim.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1360-nightly-wheels-gh-pages-trim.rst
@@ -1,0 +1,2 @@
+- Fixed the ``Nightly Wheels`` GitHub Actions workflow so gh-pages history trimming uses a full ``gh-pages`` checkout and no longer fails after sparse ``develop`` checkout.
+- Added release-guide instructions to manually run ``Nightly Wheels`` via ``workflow_dispatch`` after merging the next beta branch to republish the nightly package index.


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description

It would be useful to be able to download a wheel that reflects the recent state of the development branch for testing purposes. This PR adds a new workflow that publishes wheels from a nightly build to an index that we host ourselves.  This index is incredibly simple and only contains the wheels for the latest nightly build.

## Verification

Generated the index page locally using prebuilt wheels.

## Documentation

Added new documentation with instructions for downloading the wheels from the registry.

