### PR TITLE
Fix two bugs in 1DOF Hinged Body Code and the Integrated Test

### DIFF
--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -86,8 +86,8 @@ void HingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t CurrentCloc
         SCStatesMsgPayload configLogMsg;
         configLogMsg = this->hingedRigidBodyConfigLogOutMsg.zeroMsgPayload;
         // Note, logging the hinge frame S is the body frame B of that object
-        eigenMatrixXd2CArray(*this->r_SN_N, configLogMsg.r_BN_N);
-        eigenMatrixXd2CArray(*this->v_SN_N, configLogMsg.v_BN_N);
+        eigenVector3d2CArray(this->r_SN_N, configLogMsg.r_BN_N);
+        eigenVector3d2CArray(this->v_SN_N, configLogMsg.v_BN_N);
         eigenMatrixXd2CArray(*this->sigma_SN, configLogMsg.sigma_BN);
         eigenMatrixXd2CArray(*this->omega_SN_S, configLogMsg.omega_BN_B);
         this->hingedRigidBodyConfigLogOutMsg.write(&configLogMsg, this->moduleID, CurrentClock);
@@ -156,8 +156,8 @@ void HingedRigidBodyStateEffector::registerStates(DynParamManager& states)
 void HingedRigidBodyStateEffector::registerProperties(DynParamManager& states)
 {
     Eigen::Vector3d stateInit = Eigen::Vector3d::Zero();
-    this->r_SN_N = states.createProperty(this->nameOfInertialPositionProperty, stateInit);
-    this->v_SN_N = states.createProperty(this->nameOfInertialVelocityProperty, stateInit);
+    this->r_HN_N = states.createProperty(this->nameOfInertialPositionProperty, stateInit);
+    this->v_HN_N = states.createProperty(this->nameOfInertialVelocityProperty, stateInit);
     this->sigma_SN = states.createProperty(this->nameOfInertialAttitudeProperty, stateInit);
     this->omega_SN_S = states.createProperty(this->nameOfInertialAngVelocityProperty, stateInit);
 
@@ -286,7 +286,7 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     backSubContr.vecRot = -((this->thetaDot*this->omegaTildeLoc_PN_P + this->cTheta*intermediateMatrix.Identity())
                     *(this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*this->rTilde_SP_P*this->sHat3_P)
                                     + this->mass*this->d*this->thetaDot*this->thetaDot*this->rTilde_SP_P*this->sHat1_P)
-                                    + (this->dcm_SP.transpose() * attBodyTorquePntS_S) + eigenTilde(this->r_SP_P) * (this->dcm_SP.transpose() * attBodyForce_S);
+                                    + (this->dcm_SP.transpose() * attBodyTorquePntS_S) + eigenTilde(this->r_HP_P) * (this->dcm_SP.transpose() * attBodyForce_S);
 
     return;
 }
@@ -434,11 +434,16 @@ void HingedRigidBodyStateEffector::computePanelInertialStates()
     *this->omega_SN_S = this->dcm_SP * ( omega_BN_B + this->thetaDot*this->sHat2_P);
 
     // inertial position vector
-    *this->r_SN_N = (dcm_NP * this->r_SP_P) + (Eigen::Vector3d)(*this->inertialPositionProperty);
+    this->r_SN_N = (dcm_NP * this->r_SP_P) + (Eigen::Vector3d)(*this->inertialPositionProperty);
+
+    *this->r_HN_N = (dcm_NP * this->r_HP_P) + (Eigen::Vector3d)(*this->inertialPositionProperty);
 
     // inertial velocity vector
-    *this->v_SN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
+    this->v_SN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
                   + this->d * this->thetaDot * this->sHat3_P - this->d * (omega_BN_B.cross(this->sHat1_P))
+                  + omega_BN_B.cross(this->r_HP_P);
+
+    *this->v_HN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
                   + omega_BN_B.cross(this->r_HP_P);
 
     return;

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -86,8 +86,8 @@ void HingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t CurrentCloc
         SCStatesMsgPayload configLogMsg;
         configLogMsg = this->hingedRigidBodyConfigLogOutMsg.zeroMsgPayload;
         // Note, logging the hinge frame S is the body frame B of that object
-        eigenMatrixXd2CArray(*this->r_SN_N, configLogMsg.r_BN_N);
-        eigenMatrixXd2CArray(*this->v_SN_N, configLogMsg.v_BN_N);
+        eigenVector3d2CArray(this->r_SN_N, configLogMsg.r_BN_N);
+        eigenVector3d2CArray(this->v_SN_N, configLogMsg.v_BN_N);
         eigenMatrixXd2CArray(*this->sigma_SN, configLogMsg.sigma_BN);
         eigenMatrixXd2CArray(*this->omega_SN_S, configLogMsg.omega_BN_B);
         this->hingedRigidBodyConfigLogOutMsg.write(&configLogMsg, this->moduleID, CurrentClock);
@@ -156,8 +156,8 @@ void HingedRigidBodyStateEffector::registerStates(DynParamManager& states)
 void HingedRigidBodyStateEffector::registerProperties(DynParamManager& states)
 {
     Eigen::Vector3d stateInit = Eigen::Vector3d::Zero();
-    this->r_SN_N = states.createProperty(this->nameOfInertialPositionProperty, stateInit);
-    this->v_SN_N = states.createProperty(this->nameOfInertialVelocityProperty, stateInit);
+    this->r_HN_N = states.createProperty(this->nameOfInertialPositionProperty, stateInit);
+    this->v_HN_N = states.createProperty(this->nameOfInertialVelocityProperty, stateInit);
     this->sigma_SN = states.createProperty(this->nameOfInertialAttitudeProperty, stateInit);
     this->omega_SN_S = states.createProperty(this->nameOfInertialAngVelocityProperty, stateInit);
 
@@ -286,7 +286,7 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     backSubContr.vecRot = -((this->thetaDot*this->omegaTildeLoc_PN_P + this->cTheta*intermediateMatrix.Identity())
                     *(this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*this->rTilde_SP_P*this->sHat3_P)
                                     + this->mass*this->d*this->thetaDot*this->thetaDot*this->rTilde_SP_P*this->sHat1_P)
-                                    + (this->dcm_SP.transpose() * attBodyTorquePntS_S) + eigenTilde(this->r_SP_P) * (this->dcm_SP.transpose() * attBodyForce_S);
+                                    + (this->dcm_SP.transpose() * attBodyTorquePntS_S) + eigenTilde(this->r_HP_P) * (this->dcm_SP.transpose() * attBodyForce_S);
 
     return;
 }
@@ -434,11 +434,16 @@ void HingedRigidBodyStateEffector::computePanelInertialStates()
     *this->omega_SN_S = this->dcm_SP * ( omega_BN_B + this->thetaDot*this->sHat2_P);
 
     // inertial position vector
-    *this->r_SN_N = (dcm_NP * this->r_SP_P) + (Eigen::Vector3d)(*this->inertialPositionProperty);
+    this->r_SN_N = (dcm_NP * this->r_SP_P) + (Eigen::Vector3d)(*this->inertialPositionProperty);
+
+    *this->r_HN_N = (dcm_NP * this->r_HP_P) + (Eigen::Vector3d)(*this->inertialPositionProperty);
 
     // inertial velocity vector
-    *this->v_SN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
+    this->v_SN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
                   + this->d * this->thetaDot * this->sHat3_P - this->d * (omega_BN_B.cross(this->sHat1_P))
+                  + omega_BN_B.cross(this->r_SP_P);
+
+    *this->v_HN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
                   + omega_BN_B.cross(this->r_HP_P);
 
     return;

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.h
@@ -103,8 +103,12 @@ private:
     Eigen::MRPd sigma_BN{0.0, 0.0, 0.0};       //!< Hub/Inertial attitude represented by MRP
 
     // Hinged rigid body properties
-    Eigen::MatrixXd* r_SN_N;          //!< [m] position vector of hinge CM S relative to inertial frame N
-    Eigen::MatrixXd* v_SN_N;          //!< [m/s] inertial velocity vector of S relative to inertial frame N
+    Eigen::Vector3d r_SN_N;          //!< [m] position vector of hinge CM S relative to inertial frame N
+    Eigen::Vector3d v_SN_N;          //!< [m/s] inertial velocity vector of S relative to inertial frame N
+
+    Eigen::MatrixXd* r_HN_N;     //!< [m] position vector of hinge point H relative to inertial frame
+    Eigen::MatrixXd* v_HN_N;     //!< [m/s] inertial velocity vector of H relative to inertial frame
+
     Eigen::MatrixXd* sigma_SN;        //!< -- MRP attitude of panel frame S relative to inertial frame
     Eigen::MatrixXd* omega_SN_S;      //!< [rad/s] inertial panel frame angular velocity vector
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -373,15 +373,7 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     rotAngMom_N = scObjectLog.totRotAngMomPntC_N  # total rotational angular momentum about the total vehicle COM
     totAccumDV_N = datLog.TotalAccumDV_CN_N # total accumulated deltaV of the total vehicle COM
 
-    # Grab effector's inertial position
-    if stateEffector in ["hingedRigidBodies", "dualHingedRigidBodies", "nHingedRigidBodies"]:
-        r_ScN_N_log = np.zeros_like(inertialPropLog.r_BN_N)
-        for i in range(len(inertialPropLog.sigma_BN)):
-            sigmai_SN = inertialPropLog.sigma_BN[i, :] # MRP at timestep i and S is the parent frame not B
-            dcm_NS = np.transpose(rbk.MRP2C(sigmai_SN))
-            r_ScN_N_log[i, :] = inertialPropLog.r_BN_N[i, :] + (dcm_NS @ stateEffProps.r_PcP_P).flatten()
-    else:
-        r_ScN_N_log = inertialPropLog.r_BN_N
+    r_ScN_N_log = inertialPropLog.r_BN_N
 
     # Grab effector's attitude properties
     sigma_SN_log = inertialPropLog.sigma_BN


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This fixes a bug with effector branching in the hingedRigidBodies (HRB) effector. In the effector branching integrated test, the HRB cases used a special conditional applied to retrieving the r_ScN_N_log. That conditional turned out to be unnecessary due to a misunderstanding in what points are referred to as H, S, and Sc. In spinning bodies modules, the center of mass location is referred to Sc and an S frame fixed point S is coincident with an H frame fixed point H. In the HRB modules, point S is instead the center of mass location, but was being assumed coincident with point H. The underlying issue was that the module was tracking the panel center of mass (COM) quantities, r_SN_N and v_SN_N, when it meant to track the hinge point quantities, r_HN_N and v_HN_N. With the hinge point states now handled correctly, the extra conditional in the integrated test is no longer needed, and the test behavior matches the intended 1DOF HRB dynamics for the right reason.

## Verification
The test previously passed due to two bugs offsetting each other making the dynamics appear correct even though the implementation was not. The effector was tracking HRB COM instead of hinge location, and the integrated test subtracted off the vector between hinge and COM. The integrated test: test_effectorBranching_integrated.py now still passes, but without subtracting off this intermediate vector since the effector branching now accurately tracks the hinge point itself. Pytest was also run confirming all 36 branching test cases pass. Additional uncommitted validation was performed using Vizard and a 1DOF HRB scenario.

## Documentation
No documentation was invalidated by these changes. Some comments are added when defining new variables in the HingedRigidBodyStateEffector header file. 

## Future work
This change is inherently rolled into the incoming HRB 2DOF and NDOF module changes for branching.