### PR TITLE
Add Numba-backed Python module support

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -2,6 +2,7 @@ pandas
 matplotlib
 numpy
 scipy
+numba
 colorama
 tqdm
 pillow

--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -103,7 +103,7 @@ The script accepts the following options to customize this process.
     * - ``examples``
       - Boolean
       - True
-      - Installs the optional Python dependencies used by Basilisk example scripts, such as ``scipy``.
+      - Installs the optional Python dependencies used by Basilisk example scripts, such as ``scipy`` and ``numba``.
         Disable this flag if you want a leaner clone-based install and do not need the example-only Python packages.
     * - ``mujocoReplay``
       - Boolean

--- a/docs/source/Learn/makingModules.rst
+++ b/docs/source/Learn/makingModules.rst
@@ -34,6 +34,7 @@ The following pages cover the primary tasks required to make a Basilisk module. 
    makingModules/cModules
    makingModules/cppModules
    makingModules/pyModules
+   makingModules/numbaModules
    makingModules/makingModules-3
    makingModules/makingModules-4
    makingModules/makingDraftModule

--- a/docs/source/Learn/makingModules/numbaModules.rst
+++ b/docs/source/Learn/makingModules/numbaModules.rst
@@ -1,0 +1,488 @@
+.. _numbaModules:
+
+Making Numba Modules
+====================
+
+.. sidebar:: Source Code
+
+    The Python code shown below can be downloaded :download:`here </../../docs/source/codeSamples/making-numbaModules.py>`.
+
+``NumbaModel`` is a Basilisk module type that achieves near-C execution speed
+while being written entirely in Python.  It is a good fit for numerically
+intensive inner loops (attitude control laws, filter update steps, trajectory
+integrators) that are too slow as plain Python modules.
+
+Under the hood, ``NumbaModel`` uses `Numba <https://numba.readthedocs.io>`_
+to JIT-compile the user-supplied ``UpdateStateImpl`` static method into a
+``cfunc`` (a C-callable function pointer) that the Basilisk C++ scheduler
+calls directly every tick.  The compilation happens once, at ``Reset`` time.
+
+.. note::
+
+   Because ``UpdateStateImpl`` is compiled by Numba in *nopython* mode, a
+   subset of Python and NumPy is available inside it.  Read the
+   :ref:`numbaModules_constraints` section carefully before writing complex
+   logic.
+
+
+Defining a Numba Module
+-----------------------
+
+Subclass ``NumbaModel`` from ``Basilisk.architecture.numbaModel`` and
+implement ``UpdateStateImpl`` as a ``@staticmethod``.  All message attributes
+and memory fields must be created before ``Reset``; the parameter names of
+``UpdateStateImpl`` tell the framework which of those attributes to wire up.
+
+.. literalinclude:: ../../codeSamples/making-numbaModules.py
+   :language: python
+   :linenos:
+   :lines: 19-
+
+
+Parameter Naming Convention
+----------------------------
+
+Unlike regular Python or C++ modules, ``NumbaModel`` does **not** require you
+to write a ``Reset`` or ``UpdateState`` method.  Instead, the framework
+introspects the parameter names of ``UpdateStateImpl`` at ``Reset`` time and
+automatically wires each one to the correct buffer.
+
+You **may** override ``Reset`` (e.g. to perform additional Python-level
+setup), but you must call ``super().Reset(CurrentSimNanos)`` so that the
+cfunc is compiled and registered::
+
+    def Reset(self, CurrentSimNanos=0):
+        # ... additional setup ...
+        super().Reset(CurrentSimNanos)   # must be called
+
+Do **not** override ``UpdateState``.  The C++ scheduler calls the
+JIT-compiled cfunc registered by ``NumbaModel.Reset`` directly.
+
+The recognised ``UpdateStateImpl`` parameter names are:
+
+.. list-table::
+   :widths: 35 15 50
+   :header-rows: 1
+
+   * - Parameter name pattern
+     - Type inside ``UpdateStateImpl``
+     - What it provides
+   * - ``<name>OutMsgPayload``
+     - Numba Record (struct-like)
+     - Writable payload of ``self.<name>OutMsg``
+   * - ``<name>InMsgPayload``
+     - Numba Record or array of Records
+     - Read-only snapshot of ``self.<name>InMsg``
+   * - ``<name>InMsgIsLinked``
+     - ``bool`` (scalar reader), ``uint8[:]`` (list), or Record (dict)
+     - ``True``/non-zero when the corresponding reader is subscribed
+   * - ``CurrentSimNanos``
+     - ``uint64``
+     - Current simulation time in nanoseconds
+   * - ``moduleID``
+     - ``int64``
+     - This module's unique integer ID
+   * - ``memory``
+     - Numba Record
+     - Persistent state fields (see :ref:`numbaModules_memory`)
+   * - ``bskLogger``
+     - ``BskLoggerProxy``
+     - Logging proxy (see :ref:`numbaModules_logging`)
+   * - ``rng``
+     - xoshiro256++ PRNG
+     - Per-module PRNG seeded from ``self.RNGSeed`` at Reset (see :ref:`numbaModules_rng`)
+
+Any parameter name not matching one of the patterns above raises an
+``AttributeError`` at ``Reset`` time with a descriptive message.
+
+.. note::
+
+    Parameter order inside ``UpdateStateImpl`` does **not** matter; the
+    framework matches by name, not position.
+
+
+Output Messages
+~~~~~~~~~~~~~~~
+
+Declare output messages as ``messaging.<Type>Msg()`` attributes in ``__init__``::
+
+    self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+Use the suffix ``OutMsgPayload`` in ``UpdateStateImpl`` to receive a writable
+view of the payload::
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, ...):
+        dataOutMsgPayload.dataVector[0] = 42.0
+
+The Basilisk header timestamp is written automatically after ``UpdateStateImpl``
+returns.  You do not need to call ``.write()``.
+
+For **multiple** output messages, assign a list or dict to the attribute::
+
+    self.dataOutMsg = [messaging.CModuleTemplateMsg(),
+                       messaging.CModuleTemplateMsg()]
+
+Inside ``UpdateStateImpl``, access them by integer index::
+
+    dataOutMsgPayload[0].dataVector[0] = v
+    dataOutMsgPayload[1].dataVector[0] = v * 2.0
+
+Or by string key when using a dict::
+
+    self.dataOutMsg = {'pos': messaging.CModuleTemplateMsg(),
+                       'neg': messaging.CModuleTemplateMsg()}
+
+    # inside UpdateStateImpl:
+    dataOutMsgPayload['pos'].dataVector[0] =  v
+    dataOutMsgPayload['neg'].dataVector[0] = -v
+
+
+Input Messages (Readers)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Declare readers as ``messaging.<Type>MsgReader()`` attributes::
+
+    self.dataInMsg = messaging.CModuleTemplateMsgReader()
+
+Subscribe before ``InitializeSimulation``::
+
+    mod.dataInMsg.subscribeTo(src.dataOutMsg)
+
+The payload is refreshed from the source every tick by the C++ scheduler.
+Access it in ``UpdateStateImpl`` via the ``InMsgPayload`` parameter.
+
+If a reader **may** be unlinked, declare the corresponding ``IsLinked``
+parameter and guard reads behind it::
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload):
+        if dataInMsgIsLinked:
+            dataOutMsgPayload.dataVector[0] = dataInMsgPayload.dataVector[0]
+
+If ``<name>InMsgPayload`` is declared *without* a corresponding
+``<name>InMsgIsLinked``, ``Reset`` raises ``RuntimeError`` when the reader
+is not subscribed. This is an intentional early failure rather than a silent
+wrong-data scenario.
+
+List and dict attributes work the same way as for output messages.  For a
+**list** reader, ``IsLinked`` is a ``uint8[:]`` array indexed by position
+(``dataInMsgIsLinked[0]``, ``dataInMsgIsLinked[1]``, …).  For a **dict**
+reader, ``IsLinked`` is a Record keyed by the same names as the payload, so
+both can be accessed identically::
+
+    if dataInMsgIsLinked['a']:
+        val = dataInMsgPayload['a'].dataVector[0]
+
+
+.. _numbaModules_memory:
+
+Persistent Memory
+~~~~~~~~~~~~~~~~~
+
+``self.memory`` is a namespace that holds persistent module state across ticks.
+Fields are defined as attributes in ``__init__``::
+
+    self.memory.step   = 0                 # scalar integer (→ int64)
+    self.memory.gain   = 1.5              # scalar float   (→ float64)
+    self.memory.bias   = [0.1, 0.2, 0.3]  # 1-D array (converted to numpy)
+    self.memory.matrix = np.eye(3)         # 2-D array
+
+At ``Reset`` time the fields are packed into a single structured numpy array
+whose pointer is handed to the C++ scheduler.  After ``Reset``, the fields are
+accessible from Python via the same ``self.memory.<name>`` syntax and any
+assignment is forwarded directly to the underlying C buffer - no re-compilation
+is needed.
+
+Rules:
+
+- All fields must be defined **before** ``Reset`` is called (i.e., in
+  ``__init__`` or before ``InitializeSimulation``).
+- New fields cannot be added after ``Reset``.
+- The numpy dtype of each field is inferred from the value assigned in
+  ``__init__``: a plain ``0`` becomes ``int64``, a plain ``0.0`` becomes
+  ``float64``.  Use an explicit numpy type (e.g. ``np.int32(0)``) only when
+  a specific width is required.
+- Inside ``UpdateStateImpl``, ``memory`` behaves like a Numba ``Record``.
+  Array fields are accessed with standard bracket indexing:
+  ``memory.bias[1]``, ``memory.matrix[i, j]``.
+
+
+.. _numbaModules_logging:
+
+Logging with ``bskLogger``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add ``bskLogger`` as a parameter to receive a Numba-compatible logging proxy::
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, bskLogger, memory):
+        bskLogger.bskLog(bskLogging.BSK_INFORMATION, "tick")
+        bskLogger.bskLog1(bskLogging.BSK_WARNING, "step:", memory.step)
+
+The proxy respects the log level set on ``self.bskLogger`` at ``Reset`` time:
+messages below the current threshold are suppressed.  Output goes to stdout via
+``print``; ANSI colour codes match the rest of Basilisk's log output.
+
+Available methods:
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Method
+     - Prints
+   * - ``bskLog(level, msg)``
+     - ``[TAG] msg``
+   * - ``bskLog1(level, msg, v0)``
+     - ``[TAG] msg v0``
+   * - ``bskLog2(level, msg, v0, v1)``
+     - ``[TAG] msg v0 v1``
+   * - ``bskLog3(level, msg, v0, v1, v2)``
+     - ``[TAG] msg v0 v1 v2``
+
+Level constants (``bskLogging.BSK_DEBUG``, ``BSK_INFORMATION``,
+``BSK_WARNING``, ``BSK_ERROR``) work inside ``UpdateStateImpl`` because Numba
+resolves module-level integer attributes at compile time.
+
+``msg`` must be a **string literal** - variables of string type are not
+supported in nopython mode.  Values ``v0``–``v2`` can be any numeric type
+that Numba supports (``int32``, ``float64``, etc.).
+
+.. tip::
+
+   Plain ``print("label:", value)`` also works in ``UpdateStateImpl`` with no
+   additional setup.
+
+
+.. _numbaModules_rng:
+
+Per-module Random Number Generator (``rng``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add ``rng`` as a parameter to receive a per-module xoshiro256++ PRNG that is
+private to this module instance and seeded from ``self.RNGSeed`` at ``Reset``
+time::
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, rng, memory):
+        noise = rng.standard_normal(3)     # independent per-module stream
+        dataOutMsgPayload.dataVector[:3] = memory.signal + noise
+
+The generator state persists across ticks, so each call advances the sequence
+deterministically.  ``self.RNGSeed`` is inherited from ``SysModel`` and
+defaults to ``0x1badcad1``; set it before ``InitializeSimulation()`` for
+reproducible Monte Carlo runs::
+
+    sNav.RNGSeed = 12345
+
+Key properties:
+
+- **Per-module isolation**: each instance owns an independent generator — two
+  modules with the same seed produce the same sequence independently, and two
+  modules with different seeds never interfere.
+- **Re-seeded on Reset**: calling ``Reset`` again seeds a fresh generator from
+  the current ``self.RNGSeed``, resetting the sequence.
+
+Available methods:
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Method
+     - Description
+   * - ``standard_normal(n)``
+     - Return ``n`` independent standard-normal samples as ``float64[n]``
+   * - ``random()``
+     - Uniform ``float64`` in ``[0, 1)``
+   * - ``integers(low, high)``
+     - Uniform ``int64`` in ``[low, high)``
+   * - ``uniform(low, high)``
+     - Uniform ``float64`` in ``[low, high)``
+
+
+.. _numbaModules_constraints:
+
+What is Allowed in ``UpdateStateImpl``
+---------------------------------------
+
+``UpdateStateImpl`` is compiled by Numba in **nopython mode**.  The following
+is a summary of what is and is not supported.
+
+Allowed
+~~~~~~~
+
+- **NumPy array operations** on pre-allocated arrays (element-wise arithmetic,
+  ``[i]`` / ``[i, j]`` indexing, ``array.copy()``, ``np.zeros(n)``,
+  ``np.dot``, reductions, etc.).  See the
+  `Numba NumPy support list <https://numba.readthedocs.io/en/stable/reference/numpysupported.html>`_
+  for the full set.
+- **Explicit numpy scalars** such as ``np.int32(1)``, ``np.float64(3.14)``.
+  Use these when a specific width is required (e.g. to match a memory field
+  declared as ``np.int32``); otherwise plain literals are fine.
+- **Control flow**: ``if``/``elif``/``else``, ``for`` over ``range(n)``,
+  ``while``, ``break``, ``continue``, ``return``.
+- **Math functions**: ``math.sqrt``, ``math.sin``, etc. (import ``math``
+  at module level, use inside the function normally).
+- **Calling other** ``@nb.njit`` **functions** - factor complex logic into
+  helper functions decorated with ``@numba.njit``.
+- **``print(label, value, ...)``** - variadic print to stdout works and is
+  the simplest way to emit debug output.
+- **``bskLogger``** methods as described in :ref:`numbaModules_logging`.
+- **Reading from** ``memory`` **Record fields** and **writing to them**.
+- **Reading from** ``InMsgPayload`` **Record fields** and **writing to**
+  ``OutMsgPayload`` **Record fields**.
+
+Not Allowed
+~~~~~~~~~~~
+
+- **Python objects** of any kind: no lists, dicts, sets, tuples, classes,
+  generators, or iterators.  Use numpy arrays for all collections.
+- **String variables** - string *literals* in ``print`` and ``bskLogger`` calls
+  work, but you cannot assign a string to a variable or pass one as a
+  function argument (other than via the ``bskLog*`` API).
+- **f-strings and %-formatting** - these require Python object creation.
+  Use ``bskLog1``/``bskLog2`` to attach numeric values to log messages.
+- **Exceptions** - ``raise``, ``try``/``except``/``finally`` are not
+  supported.  Use conditional logic and ``bskLogger`` to handle error
+  conditions.
+- **Calling Python functions** that are not themselves ``@nb.njit``-compiled.
+  Standard library functions (``os``, ``sys``, etc.) are unavailable.
+- **Dynamic memory allocation** with arbitrary Python types.  NumPy array
+  creation with a *constant* size (``np.zeros(3)``) is fine; allocation
+  whose size depends on a runtime variable may require care.
+- **Global mutable state** - do not capture mutable Python objects in the
+  closure of ``UpdateStateImpl``.  Use ``memory`` for persistent state.
+- **Messaging API** - do not call ``.write()``, ``.read()``, or
+  ``.subscribeTo()`` inside ``UpdateStateImpl``.  Payload structs are
+  passed as already-refreshed Records; writing back through them is
+  sufficient.
+
+
+Re-use and Re-initialisation
+-----------------------------
+
+**Re-wiring messages mid-simulation** (calling ``subscribeTo`` without a
+``Reset``) is fully supported.  The C++ scheduler refreshes the payload
+pointer dynamically every tick via registered reader slots.
+
+**Calling ``Reset`` a second time** re-compiles the cfunc and re-initialises
+``memory`` from the current buffer state.  The buffer is always the source of
+truth: Python-side writes (``self.memory.gain = 2.0``) and cfunc-internal
+writes (``memory.step += 1`` inside ``UpdateStateImpl``) are treated
+identically; both persist through a subsequent Reset.  The next run always
+continues from whatever value was last written, by any means.
+
+
+.. _numbaModules_rbkn:
+
+``RigidBodyKinematicsNumba``
+----------------------------
+
+:py:mod:`Basilisk.utilities.RigidBodyKinematicsNumba` provides
+``@nb.njit``-compiled versions of every function in
+:py:mod:`Basilisk.utilities.RigidBodyKinematics`, making the full rigid-body
+kinematics library callable from within compiled ``UpdateStateImpl`` kernels.
+
+Import individual functions at module level (outside ``UpdateStateImpl``)::
+
+    from Basilisk.utilities.RigidBodyKinematicsNumba import MRP2C, addMRP, subMRP
+
+    class MyModule(NumbaModel):
+        @staticmethod
+        def UpdateStateImpl(attNavInMsgPayload, attGuidOutMsgPayload, memory):
+            C_BN = MRP2C(attNavInMsgPayload.sigma_BN)
+            sigma_BR = subMRP(attNavInMsgPayload.sigma_BN, memory.sigma_RN)
+            attGuidOutMsgPayload.sigma_BR[:3] = sigma_BR
+
+All kinematics functions (``MRP2C``, ``C2MRP``, ``addMRP``, ``subMRP``,
+``EP2C``, ``C2EP``, ``PRV2C``, and more) are available.  Because they are
+decorated with ``@nb.njit(inline='always')``, calls inside ``UpdateStateImpl``
+compile inline with no per-call overhead.
+
+.. note::
+
+   ``RigidBodyKinematicsNumba`` requires ``scipy`` to be installed for
+   BLAS-backed ``np.linalg`` operations inside Numba nopython mode.
+
+
+.. _numbaModules_stateful:
+
+Continuous-Time States (``StatefulNumbaModel``)
+-----------------------------------------------
+
+``StatefulNumbaModel`` (from ``Basilisk.simulation.StatefulNumbaModel``)
+combines ``NumbaModel`` with ``StatefulSysModel`` to add continuous-time states
+that are integrated by a ``MJScene`` dynamics scene.  Use it when a Numba
+module needs to register differentiable states (position, velocity, etc.) for
+integration alongside MuJoCo dynamics.
+
+Defining a ``StatefulNumbaModel``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subclass ``StatefulNumbaModel``, implement ``registerStates`` to create
+``StateData`` objects, and write the derivatives in ``UpdateStateImpl``::
+
+    from Basilisk.simulation.StatefulNumbaModel import StatefulNumbaModel
+
+    class HarmonicOscillator(StatefulNumbaModel):
+
+        def registerStates(self, registerer):
+            self.posState = registerer.registerState(3, 1, "pos")
+            self.velState = registerer.registerState(3, 1, "vel")
+
+        def Reset(self, CurrentSimNanos=0):
+            self.memory.omega = 2.0
+            super().Reset(CurrentSimNanos)   # compiles the cfunc
+
+        @staticmethod
+        def UpdateStateImpl(posState, posStateDeriv,
+                            velState, velStateDeriv, memory):
+            posStateDeriv[:, 0] = velState[:, 0]
+            velStateDeriv[:, 0] = -memory.omega**2 * posState[:, 0]
+
+``registerStates`` is called by ``MJScene`` before ``Reset()``.  Always call
+``super().Reset(CurrentSimNanos)`` in your ``Reset`` override so that the cfunc
+is compiled after the state objects exist.
+
+Additional ``UpdateStateImpl`` parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All ``NumbaModel`` parameters are supported, plus:
+
+.. list-table::
+   :widths: 35 15 50
+   :header-rows: 1
+
+   * - Parameter name pattern
+     - Type inside ``UpdateStateImpl``
+     - What it provides
+   * - ``<name>State``
+     - ``float64[:, :]`` (Fortran-order)
+     - Read-only current state value; resolved from ``self.<name>State``
+   * - ``<name>StateDeriv``
+     - ``float64[:, :]`` (Fortran-order)
+     - Writable state derivative; resolved from the same ``StateData`` as ``<name>State``
+   * - ``<name>StateDiffusionN``
+     - ``float64[:, :]`` (Fortran-order)
+     - Writable diffusion matrix for the ``N``-th noise source (``N ≥ 0``);
+       requires ``self.<name>State.setNumNoiseSources(N+1)`` in ``registerStates()``
+
+States are registered as *nRow × nCol* matrices with a column-major
+(Fortran-order) backing store, so ``arr[i, j]`` equals matrix element
+``M(i, j)``.  Even 1-D states are exposed as 2-D arrays — a 3×1 column
+vector is accessed as ``posState[i, 0]``.
+
+
+Performance Notes
+-----------------
+
+- Compilation happens once at ``Reset`` time and is cached to disk by Numba
+  (keyed on the bytecode of ``UpdateStateImpl``).  Subsequent runs with the
+  same code load the cached binary instantly.
+- The cfunc is called from C++ with zero Python overhead per tick.  Execution
+  speed is comparable to a hand-written C extension for the same algorithm.
+- Keep ``UpdateStateImpl`` free of Python-level function calls; every call
+  that Numba cannot inline adds compilation complexity and may defeat
+  caching.

--- a/docs/source/Support/bskReleaseNotesSnippets/1348-numba-models.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1348-numba-models.rst
@@ -1,0 +1,5 @@
+- Added ``NumbaModel`` to support Basilisk modules written in Python whose ``UpdateStateImpl`` methods are JIT-compiled with Numba for near-C execution speed.
+- Added zero-copy payload dtype metadata and raw message-pointer accessors to support efficient NumPy and Numba views of Basilisk message data.
+- Added ``StatefulNumbaModel`` to combine Numba-compiled Python modules with ``StatefulSysModel`` continuous-time state registration and integration in MuJoCo ``MJScene`` dynamics.
+- Added ``RigidBodyKinematicsNumba`` as an ``njit``-compatible rigid-body kinematics utility library for use inside compiled Numba kernels.
+- Added the :ref:`numbaModules` user guide together with :ref:`scenarioAttitudePointingNumba`, :ref:`scenarioAttitudeFeedbackNumba`, and :ref:`scenarioBenchmarkNumba` examples to demonstrate the new Numba-based module workflow.

--- a/docs/source/codeSamples/making-numbaModules.py
+++ b/docs/source/codeSamples/making-numbaModules.py
@@ -1,0 +1,114 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import numpy as np
+from Basilisk.architecture.numbaModel import NumbaModel
+from Basilisk.architecture import messaging, bskLogging
+from Basilisk.utilities import SimulationBaseClass, macros
+
+
+def run():
+    """
+    Illustration of NumbaModel: two JIT-compiled modules exchanging messages.
+    """
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", macros.sec2nano(1.0)))
+
+    # AccumulatorModel tracks elapsed time in memory; it has no input messages.
+    prod = AccumulatorModel()
+    prod.ModelTag = "accumulator"
+    scSim.AddModelToTask("task", prod)
+
+    # FilterModel reads from AccumulatorModel and scales by a configurable gain.
+    filt = FilterModel()
+    filt.ModelTag = "filter"
+    filt.memory.gain = 2.0                  # override default before Reset
+    filt.dataInMsg.subscribeTo(prod.dataOutMsg)
+    scSim.AddModelToTask("task", filt)
+
+    recorder = filt.dataOutMsg.recorder()
+    scSim.AddModelToTask("task", recorder)
+
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(macros.sec2nano(3.0))  # 4 ticks: t = 0, 1, 2, 3 s
+    scSim.ExecuteSimulation()
+
+    print("ticks recorded by accumulator:", int(prod.memory.ticks))
+    print("filtered dataVector at t=3s:  ", recorder.dataVector[-1])
+
+
+# =============================================================================
+# Module 1: AccumulatorModel
+#
+# Demonstrates: memory namespace, CurrentSimNanos, no readers.
+# =============================================================================
+class AccumulatorModel(NumbaModel):
+    """Outputs the cumulative simulation time (seconds) and a tick counter."""
+
+    def __init__(self):
+        """Declare the output message and persistent accumulator state."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+        # Fields declared here become a C-level structured buffer after Reset.
+        # The dtype is inferred from the value: 0.0 -> float64, 0 -> int64,
+        # np.int32(0) -> int32, np.array(...) -> array field.
+        self.memory.total_s = 0.0
+        self.memory.ticks   = 0
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, CurrentSimNanos, memory):
+        """Accumulate elapsed time and publish the running totals."""
+        # Everything in this method is compiled by Numba in nopython mode.
+        # See the "What is allowed" section in the documentation.
+        memory.total_s += np.float64(CurrentSimNanos) * 1e-9
+        memory.ticks   += 1
+        dataOutMsgPayload.dataVector[0] = memory.total_s
+        dataOutMsgPayload.dataVector[1] = float(memory.ticks)
+
+
+# =============================================================================
+# Module 2: FilterModel
+#
+# Demonstrates: scalar reader with IsLinked guard, bskLogger, memory gain.
+# =============================================================================
+class FilterModel(NumbaModel):
+    """Scales each element of the input dataVector by a configurable gain."""
+
+    def __init__(self):
+        """Set up one reader, one writer, and the configurable gain term."""
+        super().__init__()
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.gain = 1.0               # default; caller may override
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked,
+                        dataOutMsgPayload, bskLogger, memory):
+        """Scale the input vector when linked and warn otherwise."""
+        if not dataInMsgIsLinked:
+            bskLogger.bskLog(bskLogging.BSK_WARNING, "FilterModel: input not linked")
+            return
+        for i in range(3):
+            dataOutMsgPayload.dataVector[i] = dataInMsgPayload.dataVector[i] * memory.gain
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/_default.rst
+++ b/examples/_default.rst
@@ -46,8 +46,10 @@ Attitude Regulation Control
    :maxdepth: 1
 
    Inertial Attitude Pointing <scenarioAttitudeFeedback>
+   Inertial Attitude Pointing with Numba FSW <scenarioAttitudeFeedbackNumba>
    Using Separate Task Group for Control <scenarioAttitudeFeedback2T>
    Basic Attitude Pointing in Deep Space <scenarioAttitudePointing>
+   Basic Attitude Pointing in Deep Space with Numba Control <scenarioAttitudePointingNumba>
    Complex Attitude Pointing in Deep Space <scenarioAttitudeFeedbackNoEarth>
    Sun-Pointing Constraint Violation in Space <scenarioAttitudeConstraintViolation>
    Inertial Pointing with Spice prescribed translational motion <scenarioSpiceSpacecraft>
@@ -454,6 +456,7 @@ Advanced Simulation Options
    Setting Type of Integrator <scenarioIntegrators>
    Using a Variable Time Step Integrator <scenarioVariableTimeStepIntegrators>
    Comparison of different integrators <scenarioIntegratorsComparison>
+   Benchmark Numba Models <scenarioBenchmarkNumba>
    Using a Python BSK Module Inherited from SysModel Class <scenarioAttitudePointingPy>
    Changing the bskLog Verbosity from Python <scenarioBskLog>
 

--- a/examples/scenarioAttitudeFeedbackNumba.py
+++ b/examples/scenarioAttitudeFeedbackNumba.py
@@ -1,0 +1,500 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+r"""
+Overview
+--------
+
+Numba reimplementation of :ref:`scenarioAttitudeFeedback`.
+
+The spacecraft dynamics and effectors stay in C++.  Every other module in the
+pipeline -- navigation sensor, guidance reference, tracking-error computation,
+and feedback controller -- is reimplemented as a :ref:`numbaModules`.
+
+.. code-block:: text
+
+    [spacecraft C++]
+         |  scStateOutMsg
+    [NumbaSimpleNav]          (full Gauss-Markov noise model, optional sun pointing)
+         |  attOutMsg / transOutMsg
+    [NumbaAttTrackingError] <-- [NumbaInertial3D]  attRefOutMsg
+         |  attGuidOutMsg
+    [NumbaMrpFeedback]        (full RW support, controlLawType flag)
+         |  cmdTorqueOutMsg
+    [extForceTorque C++]
+
+The Numba modules are 1-to-1 in capability with the corresponding C/C++ modules:
+
+* **NumbaSimpleNav** matches :ref:`simpleNav`: full 18-state Gauss-Markov error
+  model (position, velocity, attitude, rate, sun-pointing, accumulated-DV),
+  ``crossTrans``/``crossAtt`` coupling flags, optional sun-direction output.
+* **NumbaInertial3D** matches :ref:`inertial3D`: fixed inertial attitude reference.
+* **NumbaAttTrackingError** matches :ref:`attTrackingError`: MRP tracking error,
+  frame-offset correction.
+* **NumbaMrpFeedback** matches :ref:`mrpFeedback`: PD/PID feedback with reaction-wheel
+  angular-momentum augmentation and ``controlLawType`` flag.
+
+The script is found in the folder ``basilisk/examples`` and executed by using::
+
+    python3 scenarioAttitudeFeedbackNumba.py
+
+"""
+
+import os
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.architecture.numbaModel import NumbaModel
+from Basilisk.simulation import extForceTorque, spacecraft
+from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
+                                 simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities.RigidBodyKinematicsNumba import MRP2C, addMRP, subMRP
+
+bskPath = __path__[0]
+fileName = os.path.basename(os.path.splitext(__file__)[0])
+
+
+# =============================================================================
+# Numba modules
+# =============================================================================
+
+class NumbaSimpleNav(NumbaModel):
+    """Navigation sensor with full 18-state Gauss-Markov error model.
+
+    Matches :ref:`simpleNav` in capability:
+
+    * 18 error states: position [0:3], velocity [3:6], attitude [6:9],
+      body-rate [9:12], sun-pointing [12:15], accumulated-DV [15:18].
+    * ``memory.PMatrix`` (18x18 ndarray): process-noise std-deviation matrix.
+    * ``memory.walkBounds`` (18-vector): random-walk bounds per state.
+    * ``memory.crossTrans`` / ``memory.crossAtt`` (int32): coupling flags.
+    * ``self.RNGSeed``: reproducible noise seed (inherited from SysModel,
+      default ``0x1badcad1``).  Set before ``InitializeSimulation()``.
+    * Optional sun-direction output when ``sunStateInMsg`` is subscribed.
+
+    Set all ``memory.*`` attributes *before* ``InitializeSimulation()``.
+    Defaults are zero -> noise-free pass-through.
+    """
+
+    def __init__(self):
+        """Declare navigation I/O and allocate the full Gauss-Markov state."""
+        super().__init__()
+        self.scStateInMsg  = messaging.SCStatesMsgReader()
+        self.sunStateInMsg = messaging.SpicePlanetStateMsgReader()
+        self.attOutMsg     = messaging.NavAttMsg()
+        self.transOutMsg   = messaging.NavTransMsg()
+
+        self.memory.errors     = np.zeros(18)
+        self.memory.PMatrix    = np.zeros((18, 18))
+        self.memory.walkBounds = np.zeros(18)
+        self.memory.crossTrans = np.int32(0)
+        self.memory.crossAtt   = np.int32(0)
+        self.memory.prevTime   = np.uint64(0)
+
+    @staticmethod
+    def UpdateStateImpl(scStateInMsgPayload,
+                        sunStateInMsgPayload, sunStateInMsgIsLinked,
+                        attOutMsgPayload, transOutMsgPayload,
+                        CurrentSimNanos, memory, rng):
+        """Propagate the error-state model and publish noisy nav estimates."""
+        # Time step
+        dt = 0.0 if memory.prevTime == np.uint64(0) else \
+             np.float64(CurrentSimNanos - memory.prevTime) * 1e-9
+
+        # Gauss-Markov: new_e = A * old_e + PMatrix @ randn(18)
+        old_e  = memory.errors.copy()
+        new_e  = old_e.copy()
+        if memory.crossTrans:
+            new_e[:3]  += dt * old_e[3:6]
+        if memory.crossAtt:
+            new_e[6:9] += dt * old_e[9:12]
+        new_e += np.dot(memory.PMatrix, rng.standard_normal(18))
+
+        # Apply walk bounds
+        for k in range(18):
+            if memory.walkBounds[k] > 0.0:
+                if   new_e[k] >  memory.walkBounds[k]: new_e[k] =  memory.walkBounds[k]
+                elif new_e[k] < -memory.walkBounds[k]: new_e[k] = -memory.walkBounds[k]
+
+        memory.errors[:] = new_e
+
+        # Outputs
+        timeTag = np.float64(CurrentSimNanos) * 1e-9
+
+        transOutMsgPayload.r_BN_N[:3]     = scStateInMsgPayload.r_BN_N[:3]          + new_e[:3]
+        transOutMsgPayload.v_BN_N[:3]     = scStateInMsgPayload.v_BN_N[:3]          + new_e[3:6]
+        transOutMsgPayload.vehAccumDV[:3] = scStateInMsgPayload.TotalAccumDVBdy[:3] + new_e[15:18]
+        transOutMsgPayload.timeTag        = timeTag
+
+        attOutMsgPayload.sigma_BN[:3]   = addMRP(scStateInMsgPayload.sigma_BN, new_e[6:9])
+        attOutMsgPayload.omega_BN_B[:3] = scStateInMsgPayload.omega_BN_B[:3] + new_e[9:12]
+        attOutMsgPayload.timeTag        = timeTag
+
+        if sunStateInMsgIsLinked:
+            sc2sun = sunStateInMsgPayload.PositionVector - scStateInMsgPayload.r_BN_N
+            norm   = np.linalg.norm(sc2sun)
+            if norm > 0.0:
+                sc2sun /= norm
+            attOutMsgPayload.vehSunPntBdy[:3] = np.dot(MRP2C(new_e[12:15]),
+                                                        np.dot(MRP2C(scStateInMsgPayload.sigma_BN),
+                                                               sc2sun))
+        else:
+            attOutMsgPayload.vehSunPntBdy[:3] = 0.0
+
+        memory.prevTime = CurrentSimNanos
+
+
+class NumbaInertial3D(NumbaModel):
+    """Guidance: fixed inertial attitude reference with zero rates.
+
+    Matches :ref:`inertial3D`.
+    """
+
+    def __init__(self):
+        """Create the reference output message and fixed inertial attitude."""
+        super().__init__()
+        self.attRefOutMsg     = messaging.AttRefMsg()
+        self.memory.sigma_R0N = np.zeros(3)
+
+    @staticmethod
+    def UpdateStateImpl(attRefOutMsgPayload, memory):
+        """Publish a constant inertial attitude reference with zero rates."""
+        attRefOutMsgPayload.sigma_RN[:3]    = memory.sigma_R0N
+        attRefOutMsgPayload.omega_RN_N[:3]  = 0.0
+        attRefOutMsgPayload.domega_RN_N[:3] = 0.0
+
+
+class NumbaAttTrackingError(NumbaModel):
+    """FSW: MRP attitude tracking error from navigation and reference messages.
+
+    Matches :ref:`attTrackingError` including the frame-offset correction
+    ``memory.sigma_R0R`` (body-fixed offset from reference to control-target
+    frame; default zero).
+    """
+
+    def __init__(self):
+        """Declare the nav/reference readers and tracking-error output."""
+        super().__init__()
+        self.attNavInMsg   = messaging.NavAttMsgReader()
+        self.attRefInMsg   = messaging.AttRefMsgReader()
+        self.attGuidOutMsg = messaging.AttGuidMsg()
+        self.memory.sigma_R0R = np.zeros(3)
+
+    @staticmethod
+    def UpdateStateImpl(attNavInMsgPayload, attRefInMsgPayload,
+                        attGuidOutMsgPayload, memory):
+        """Compute the attitude and rate tracking error in the body frame."""
+        sigma_RN    = addMRP(attRefInMsgPayload.sigma_RN, -memory.sigma_R0R)
+        sigma_BR    = subMRP(attNavInMsgPayload.sigma_BN, sigma_RN)
+        C_BN        = MRP2C(attNavInMsgPayload.sigma_BN)
+        omega_RN_B  = np.dot(C_BN, attRefInMsgPayload.omega_RN_N)
+        domega_RN_B = np.dot(C_BN, attRefInMsgPayload.domega_RN_N)
+
+        attGuidOutMsgPayload.sigma_BR[:3]    = sigma_BR
+        attGuidOutMsgPayload.omega_BR_B[:3]  = attNavInMsgPayload.omega_BN_B[:3] - omega_RN_B
+        attGuidOutMsgPayload.omega_RN_B[:3]  = omega_RN_B
+        attGuidOutMsgPayload.domega_RN_B[:3] = domega_RN_B
+
+
+class NumbaMrpFeedback(NumbaModel):
+    """FSW: MRP PD/PID feedback controller with full reaction-wheel support.
+
+    Matches :ref:`mrpFeedback` including:
+
+    * Reaction-wheel angular-momentum augmentation (``rwParamsInMsg``,
+      ``rwSpeedsInMsg``, optional ``rwAvailInMsg``).
+    * ``memory.controlLawType``: 0 = reference-frame gyroscopic (default),
+      else full-body.
+    * Integral feedback (``memory.Ki > 0``) with ``memory.integralLimit`` bound.
+    * Feed-forward torque via ``memory.knownTorquePntB_B``.
+
+    Memory parameters (set directly before ``InitializeSimulation()``):
+        K                 proportional gain on MRP error
+        P                 rate-error feedback gain [N m s]
+        Ki                integral gain; negative -> disabled
+        integralLimit     wind-up bound [N m]
+        knownTorquePntB_B feed-forward torque [N m, 3-vector]
+        controlLawType    0 = reference-frame gyroscopic; else full-body
+    """
+
+    def __init__(self):
+        """Declare controller I/O and allocate persistent control-law memory."""
+        super().__init__()
+        self.guidInMsg       = messaging.AttGuidMsgReader()
+        self.vehConfigInMsg  = messaging.VehicleConfigMsgReader()
+        self.rwSpeedsInMsg   = messaging.RWSpeedMsgReader()
+        self.rwAvailInMsg    = messaging.RWAvailabilityMsgReader()
+        self.rwParamsInMsg   = messaging.RWArrayConfigMsgReader()  # Python-only (Reset)
+        self.cmdTorqueOutMsg = messaging.CmdTorqueBodyMsg()
+
+        self.memory.K                  = 3.5
+        self.memory.P                  = 30.0
+        self.memory.Ki                 = -1.0
+        self.memory.integralLimit      = 0.0
+        self.memory.int_sigma          = np.zeros(3)
+        self.memory.knownTorquePntB_B  = np.zeros(3)
+        self.memory.priorTime          = np.uint64(0)
+        self.memory.controlLawType     = np.int32(0)
+        self.memory.numRW              = np.int32(0)
+        self.memory.GsMatrix_B         = np.zeros(108)  # up to 36 wheels x 3
+        self.memory.JsList             = np.zeros(36)
+
+    def Reset(self, CurrentSimNanos=0):
+        """Rebuild the cached RW configuration after the compiled reset."""
+        super().Reset(CurrentSimNanos)
+        self.memory.int_sigma[:]  = 0.0
+        self.memory.priorTime     = np.uint64(0)
+        self.memory.numRW         = np.int32(0)
+        if self.rwParamsInMsg.isLinked():
+            cfg = self.rwParamsInMsg()
+            self.memory.numRW      = np.int32(cfg.numRW)
+            self.memory.GsMatrix_B = np.array(cfg.GsMatrix_B, dtype=np.float64)
+            self.memory.JsList     = np.array(cfg.JsList,      dtype=np.float64)
+
+    @staticmethod
+    def UpdateStateImpl(guidInMsgPayload, vehConfigInMsgPayload,
+                        rwSpeedsInMsgPayload, rwSpeedsInMsgIsLinked,
+                        rwAvailInMsgPayload,  rwAvailInMsgIsLinked,
+                        cmdTorqueOutMsgPayload, memory, CurrentSimNanos):
+        """Apply the MRP feedback law and publish the requested body torque."""
+        dt = 0.0 if memory.priorTime == np.uint64(0) else \
+             np.float64(CurrentSimNanos - memory.priorTime) * 1e-9
+        memory.priorTime = CurrentSimNanos
+
+        sigma_BR    = guidInMsgPayload.sigma_BR
+        omega_BR_B  = guidInMsgPayload.omega_BR_B
+        omega_RN_B  = guidInMsgPayload.omega_RN_B
+        domega_RN_B = guidInMsgPayload.domega_RN_B
+        omega_BN_B  = omega_BR_B + omega_RN_B
+
+        I = vehConfigInMsgPayload.ISCPntB_B.reshape(3, 3)
+
+        # Integral term
+        z = np.zeros(3)
+        if memory.Ki > 0.0:
+            memory.int_sigma += memory.K * dt * sigma_BR
+            memory.int_sigma[:] = np.clip(memory.int_sigma,
+                                          -memory.integralLimit, memory.integralLimit)
+            z = memory.int_sigma + np.dot(I, omega_BR_B)
+
+        v3_4 = memory.Ki * z
+
+        # Base torque: K*sigma + P*(omega_BR + Ki*z)
+        Lr = memory.K * sigma_BR + memory.P * (omega_BR_B + v3_4)
+
+        # Angular momentum: h = I*omega_BN + sum_i Js_i*(omega_BN.Gs_i + Omega_i)*Gs_i
+        h = np.dot(I, omega_BN_B)
+        if memory.numRW > 0 and rwSpeedsInMsgIsLinked:
+            for i in range(memory.numRW):
+                if (not rwAvailInMsgIsLinked) or (rwAvailInMsgPayload.wheelAvailability[i] == 0):
+                    Gs_i = memory.GsMatrix_B[i*3 : i*3 + 3]
+                    h   += memory.JsList[i] * (np.dot(omega_BN_B, Gs_i)
+                                               + rwSpeedsInMsgPayload.wheelSpeeds[i]) * Gs_i
+
+        # Gyroscopic + dynamical terms
+        v3_8 = omega_RN_B + v3_4 if memory.controlLawType == np.int32(0) else omega_BN_B
+        Lr  -= np.cross(v3_8, h)
+        Lr  += np.dot(I, np.cross(omega_BN_B, omega_RN_B) - domega_RN_B)
+        Lr  += memory.knownTorquePntB_B
+
+        cmdTorqueOutMsgPayload.torqueRequestBody[:3] = -Lr
+
+
+# =============================================================================
+# Scenario
+# =============================================================================
+
+def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
+    """
+    Args:
+        show_plots (bool): display plots when True
+        useUnmodeledTorque (bool): apply a constant external disturbance torque
+        useIntGain (bool): enable integral feedback in the controller
+        useKnownTorque (bool): feed-forward the known external torque
+    """
+    simTaskName    = "simTask"
+    simProcessName = "simProcess"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    simulationTime     = macros.min2nano(10.)       # [min] -> [ns]
+    simulationTimeStep = macros.sec2nano(.1)        # [s] -> [ns]
+
+    dynProcess = scSim.CreateNewProcess(simProcessName)
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
+
+    # -------------------------------------------------------------------------
+    # Spacecraft dynamics (C++)
+    # -------------------------------------------------------------------------
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    I = [900., 0., 0.,             # [kg m^2]
+         0.,  800., 0.,
+         0.,  0.,  600.]
+    scObject.hub.mHub        = 750.0                    # [kg]
+    scObject.hub.r_BcB_B     = [[0.0], [0.0], [0.0]]   # [m]
+    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scSim.AddModelToTask(simTaskName, scObject)
+
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    earth       = gravFactory.createEarth()
+    earth.isCentralBody = True
+    mu = earth.mu
+    gravFactory.addBodiesTo(scObject)
+
+    extFTObject          = extForceTorque.ExtForceTorque()
+    extFTObject.ModelTag = "externalDisturbance"
+    if useUnmodeledTorque:
+        extFTObject.extTorquePntB_B = [[0.25], [-0.25], [0.1]]   # [N m]
+    scObject.addDynamicEffector(extFTObject)
+    scSim.AddModelToTask(simTaskName, extFTObject)
+
+    # -------------------------------------------------------------------------
+    # Numba navigation (noise-free by default)
+    # -------------------------------------------------------------------------
+    sNav          = NumbaSimpleNav()
+    sNav.ModelTag = "simpleNav"
+    # To enable noise:  sNav.memory.PMatrix = <18x18 std-dev matrix>
+    #                   sNav.memory.walkBounds = <18-vector>
+    scSim.AddModelToTask(simTaskName, sNav)
+
+    # -------------------------------------------------------------------------
+    # Numba FSW
+    # -------------------------------------------------------------------------
+    inertial3DObj          = NumbaInertial3D()
+    inertial3DObj.ModelTag = "inertial3D"
+    scSim.AddModelToTask(simTaskName, inertial3DObj)
+
+    attError          = NumbaAttTrackingError()
+    attError.ModelTag = "attTrackingError"
+    scSim.AddModelToTask(simTaskName, attError)
+
+    mrpCtrl          = NumbaMrpFeedback()
+    mrpCtrl.ModelTag = "mrpFeedback"
+    mrpCtrl.memory.K = 3.5                                        # [N m]
+    mrpCtrl.memory.P = 30.0                                       # [N m s/rad]
+    if useIntGain:
+        mrpCtrl.memory.Ki            = 0.0002                     # [N m/rad]
+        mrpCtrl.memory.integralLimit = 2.0 / mrpCtrl.memory.Ki * 0.1
+    if useKnownTorque:
+        mrpCtrl.memory.knownTorquePntB_B[:] = [0.25, -0.25, 0.1] # [N m]
+    scSim.AddModelToTask(simTaskName, mrpCtrl)
+
+    # -------------------------------------------------------------------------
+    # Logging
+    # -------------------------------------------------------------------------
+    numDataPoints = 50
+    samplingTime  = unitTestSupport.samplingTime(simulationTime, simulationTimeStep,
+                                                  numDataPoints)
+    attGuidLog = attError.attGuidOutMsg.recorder(samplingTime)
+    torqueLog  = mrpCtrl.cmdTorqueOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, attGuidLog)
+    scSim.AddModelToTask(simTaskName, torqueLog)
+
+    # -------------------------------------------------------------------------
+    # Orbital initial conditions
+    # -------------------------------------------------------------------------
+    oe       = orbitalMotion.ClassicElements()
+    oe.a     = 10000e3              # [m]
+    oe.e     = 0.01
+    oe.i     = 33.3 * macros.D2R   # [deg] -> [rad]
+    oe.Omega = 48.2 * macros.D2R   # [deg] -> [rad]
+    oe.omega = 347.8 * macros.D2R  # [deg] -> [rad]
+    oe.f     = 85.3 * macros.D2R   # [deg] -> [rad]
+    r, v     = orbitalMotion.elem2rv(mu, oe)
+    scObject.hub.r_CN_NInit     = r
+    scObject.hub.v_CN_NInit     = v
+    scObject.hub.sigma_BNInit   = [[0.1], [0.2], [-0.3]]          # [MRP]
+    scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]      # [rad/s]
+
+    # -------------------------------------------------------------------------
+    # Message connections
+    # -------------------------------------------------------------------------
+    sNav.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
+    attError.attNavInMsg.subscribeTo(sNav.attOutMsg)
+    attError.attRefInMsg.subscribeTo(inertial3DObj.attRefOutMsg)
+    mrpCtrl.guidInMsg.subscribeTo(attError.attGuidOutMsg)
+    extFTObject.cmdTorqueInMsg.subscribeTo(mrpCtrl.cmdTorqueOutMsg)
+
+    vehicleConfigOut = messaging.VehicleConfigMsgPayload(ISCPntB_B=I)
+    configDataMsg    = messaging.VehicleConfigMsg().write(vehicleConfigOut)
+    mrpCtrl.vehConfigInMsg.subscribeTo(configDataMsg)
+
+    vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
+                                        # , saveFile=fileName
+                                        )
+
+    # -------------------------------------------------------------------------
+    # Run
+    # -------------------------------------------------------------------------
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(simulationTime)
+
+    tic = time.time()
+    scSim.ExecuteSimulation()
+    toc = time.time()
+    print(f"Run scenario in {toc - tic:.3f} s")
+
+    # -------------------------------------------------------------------------
+    # Plots
+    # -------------------------------------------------------------------------
+    dataLr      = torqueLog.torqueRequestBody
+    dataSigmaBR = attGuidLog.sigma_BR
+    timeAxis    = attGuidLog.times()
+
+    plt.close("all")
+    plt.figure(1)
+    for idx in range(3):
+        plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\sigma_' + str(idx) + '$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Attitude Error $\sigma_{B/R}$')
+    figureList = {}
+    pltName = fileName + "1" + str(int(useUnmodeledTorque)) + str(int(useIntGain)) + str(int(useKnownTorque))
+    figureList[pltName] = plt.figure(1)
+
+    plt.figure(2)
+    for idx in range(3):
+        plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label='$L_{r,' + str(idx) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel('Control Torque $L_r$ [Nm]')
+    pltName = fileName + "2" + str(int(useUnmodeledTorque)) + str(int(useIntGain)) + str(int(useKnownTorque))
+    figureList[pltName] = plt.figure(2)
+
+    if show_plots:
+        plt.show()
+    plt.close("all")
+
+    return figureList
+
+
+if __name__ == "__main__":
+    run(
+        True,   # show_plots
+        False,  # useUnmodeledTorque
+        False,  # useIntGain
+        False,  # useKnownTorque
+    )

--- a/examples/scenarioAttitudePointingNumba.py
+++ b/examples/scenarioAttitudePointingNumba.py
@@ -1,0 +1,267 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+r"""
+Overview
+--------
+
+This script showcases how to create a Numba Basilisk module.
+
+Demonstrates how to stabilize the attitude tumble without translational motion.
+This script sets up a 6-DOF spacecraft, but without specifying any orbital motion.  Thus,
+this scenario simulates the spacecraft translating in deep space.  The scenario is a
+version of :ref:`scenarioAttitudePointingPy` where the Python MRP PD control module is
+replaced with an equivalent :ref:`numbaModules`-based implementation.
+
+The script is found in the folder ``basilisk/examples`` and executed by using::
+
+    python3 scenarioAttitudePointingNumba.py
+
+As with :ref:`scenarioAttitudePointingPy`, when the simulation completes 3 plots are
+shown for the MRP attitude history, the rate tracking errors, as well as the control
+torque vector.
+
+The MRP PD control module in this script is a class called ``NumbaMRPPD``.  It subclasses
+``NumbaModel`` and implements the entire control law inside ``UpdateStateImpl``, which is
+JIT-compiled by Numba to native code.  Gains ``K`` and ``P`` are stored in the persistent
+``memory`` namespace and can be configured before ``InitializeSimulation`` is called::
+
+    numMRPPD = NumbaMRPPD()
+    numMRPPD.ModelTag = "numMRP_PD"
+    numMRPPD.memory.K = 3.5     # [N m]
+    numMRPPD.memory.P = 30.0    # [N m s/rad]
+    numMRPPD.guidInMsg.subscribeTo(attError.attGuidOutMsg)
+    scSim.AddModelToTask(simTaskName, numMRPPD)
+
+Illustration of Simulation Results
+-----------------------------------
+
+::
+
+    show_plots = True
+
+Here a small initial tumble is simulated.  The
+resulting attitude and control torque histories are shown below.  The spacecraft quickly
+regains a stable orientation without tumbling past 180 degrees.
+
+.. image:: /_images/Scenarios/scenarioAttitudePointingNumba1.svg
+   :align: center
+
+.. image:: /_images/Scenarios/scenarioAttitudePointingNumba2.svg
+   :align: center
+
+"""
+
+#
+# Basilisk Scenario Script and Integrated Test
+#
+# Purpose:  Integrated test showing how to set up and run a Numba BSK module with C/C++ modules
+# Author:   AVS Lab
+# Creation Date:  2026
+#
+
+import os
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.architecture.numbaModel import NumbaModel
+from Basilisk.fswAlgorithms import attTrackingError
+from Basilisk.fswAlgorithms import inertial3D
+from Basilisk.simulation import extForceTorque
+from Basilisk.simulation import simpleNav
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import vizSupport
+
+bskPath = __path__[0]
+fileName = os.path.basename(os.path.splitext(__file__)[0])
+
+
+def run(show_plots):
+    """
+    The scenarios can be run with the followings setups parameters:
+
+    Args:
+        show_plots (bool): Determines if the script should display plots
+
+    """
+
+    simTaskName = "simTask"
+    simProcessName = "simProcess"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+
+    simulationTime = macros.min2nano(10.)       # [min] -> [ns]
+
+    dynProcess = scSim.CreateNewProcess(simProcessName, 10)
+
+    simulationTimeStep = macros.sec2nano(.1)    # [s] -> [ns]
+    dynProcess.addTask(scSim.CreateNewTask(simTaskName, simulationTimeStep))
+
+    # initialize spacecraft object and set properties
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "bsk-Sat"
+    I = [900., 0., 0.,             # [kg m^2]
+         0., 800., 0.,
+         0., 0., 600.]
+    scObject.hub.mHub = 750.0                   # [kg]
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]   # [MRP]
+    scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]  # [rad/s]
+    scSim.AddModelToTask(simTaskName, scObject)
+
+    extFTObject = extForceTorque.ExtForceTorque()
+    extFTObject.ModelTag = "externalDisturbance"
+    scObject.addDynamicEffector(extFTObject)
+    scSim.AddModelToTask(simTaskName, extFTObject)
+
+    sNavObject = simpleNav.SimpleNav()
+    sNavObject.ModelTag = "SimpleNavigation"
+    scSim.AddModelToTask(simTaskName, sNavObject)
+
+    inertial3DObj = inertial3D.inertial3D()
+    inertial3DObj.ModelTag = "inertial3D"
+    scSim.AddModelToTask(simTaskName, inertial3DObj)
+    inertial3DObj.sigma_R0N = [0., 0., 0.]     # [MRP] inertial reference attitude
+
+    attError = attTrackingError.attTrackingError()
+    attError.ModelTag = "attErrorInertial3D"
+    scSim.AddModelToTask(simTaskName, attError)
+
+    # setup Numba MRP PD control module
+    numMRPPD = NumbaMRPPD()
+    numMRPPD.ModelTag = "numMRP_PD"
+    numMRPPD.memory.K = 3.5     # [N m]
+    numMRPPD.memory.P = 30.0    # [N m s/rad]
+    numMRPPD.guidInMsg.subscribeTo(attError.attGuidOutMsg)
+    scSim.AddModelToTask(simTaskName, numMRPPD)
+
+    numDataPoints = 50
+    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
+    mrpLog = numMRPPD.cmdTorqueOutMsg.recorder(samplingTime)
+    scSim.AddModelToTask(simTaskName, attErrorLog)
+    scSim.AddModelToTask(simTaskName, mrpLog)
+
+    sNavObject.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
+    attError.attNavInMsg.subscribeTo(sNavObject.attOutMsg)
+    attError.attRefInMsg.subscribeTo(inertial3DObj.attRefOutMsg)
+    extFTObject.cmdTorqueInMsg.subscribeTo(numMRPPD.cmdTorqueOutMsg)
+
+    vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
+                                        # , saveFile=fileName
+                                        )
+
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(simulationTime)
+
+    tic = time.time()
+    scSim.ExecuteSimulation()
+    toc = time.time()
+    print("Run scenario in", toc-tic, "s")
+
+    dataLr = mrpLog.torqueRequestBody
+    dataSigmaBR = attErrorLog.sigma_BR
+    dataOmegaBR = attErrorLog.omega_BR_B
+    timeAxis = attErrorLog.times()
+    np.set_printoptions(precision=16)
+
+    plt.close("all")
+    plt.figure(1)
+    for idx in range(3):
+        plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\sigma_' + str(idx) + '$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel(r'Attitude Error $\sigma_{B/R}$')
+    figureList = {}
+    pltName = fileName + "1"
+    figureList[pltName] = plt.figure(1)
+
+    plt.figure(2)
+    for idx in range(3):
+        plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label='$L_{r,' + str(idx) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel('Control Torque $L_r$ [Nm]')
+    pltName = fileName + "2"
+    figureList[pltName] = plt.figure(2)
+
+    plt.figure(3)
+    for idx in range(3):
+        plt.plot(timeAxis * macros.NANO2MIN, dataOmegaBR[:, idx],
+                 color=unitTestSupport.getLineColor(idx, 3),
+                 label=r'$\omega_{BR,' + str(idx) + '}$')
+    plt.legend(loc='lower right')
+    plt.xlabel('Time [min]')
+    plt.ylabel('Rate Tracking Error [rad/s]')
+
+    if show_plots:
+        plt.show()
+
+    plt.close("all")
+
+    return figureList
+
+
+class NumbaMRPPD(NumbaModel):
+    """MRP PD attitude controller implemented as a NumbaModel.
+
+    The control law is::
+
+        L_r = -(K * sigma_BR + P * omega_BR_B)
+
+    Gains ``K`` and ``P`` are stored in the persistent ``memory`` namespace so they
+    are accessible inside the JIT-compiled ``UpdateStateImpl``.
+    """
+
+    def __init__(self):
+        """Declare the guidance I/O and persistent proportional/derivative gains."""
+        super().__init__()
+        self.guidInMsg = messaging.AttGuidMsgReader()
+        self.cmdTorqueOutMsg = messaging.CmdTorqueBodyMsg()
+        # Gains: configure before InitializeSimulation via module.memory.K = ...
+        self.memory.K = 0.0
+        self.memory.P = 0.0
+
+    @staticmethod
+    def UpdateStateImpl(guidInMsgPayload, cmdTorqueOutMsgPayload, memory):
+        """Compute the commanded control torque from attitude and rate error."""
+        for i in range(3):
+            lrCmd = (guidInMsgPayload.sigma_BR[i] * memory.K
+                     + guidInMsgPayload.omega_BR_B[i] * memory.P)
+            cmdTorqueOutMsgPayload.torqueRequestBody[i] = -lrCmd
+
+
+#
+# This statement below ensures that the unit test script can be run as a
+# stand-alone python script
+#
+if __name__ == "__main__":
+    run(
+        True  # show_plots
+    )

--- a/examples/scenarioBenchmarkNumba.py
+++ b/examples/scenarioBenchmarkNumba.py
@@ -1,0 +1,302 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+"""
+Benchmark attitude-control scenarios across C++, Python, and Numba implementations.
+
+This script measures two key timings for each simulation run:
+    init  -- InitializeSimulation (one-time setup; includes Numba cache load)
+    exec  -- ExecuteSimulation    (steady-state runtime cost)
+
+The minimum timing is used as the primary performance metric because it best
+approximates achievable throughput with minimal OS scheduling noise.
+
+Two scenario groups are evaluated:
+    Pointing:
+        Compare a single control module implemented in C++, Python, and Numba.
+
+    Feedback:
+        Compare full FSW + sensor stacks implemented in C++ vs Numba.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Any, Literal
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import scenarioAttitudeFeedback
+import scenarioAttitudeFeedbackNumba
+import scenarioAttitudePointing
+import scenarioAttitudePointingNumba
+import scenarioAttitudePointingPy
+
+from Basilisk.utilities import SimulationBaseClass
+
+sep = "=" * 72
+
+
+@dataclass(frozen=True)
+class TimingStats:
+    """Container for summary statistics of a timing sample."""
+
+    min: float
+    median: float
+    max: float
+    stdev: float
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Stores timing statistics for a single benchmark configuration."""
+
+    label: str
+    init: TimingStats
+    exec: TimingStats
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """
+    Represents a benchmarkable simulation scenario.
+
+    Attributes:
+        label: Human-readable name for reporting.
+        run: Callable that executes the scenario once.
+    """
+
+    label: str
+    run: Callable[[], Any]
+
+
+def computeStats(samples: list[float]) -> TimingStats:
+    """
+    Compute descriptive statistics for a list of timing samples.
+
+    Args:
+        samples: List of timing measurements.
+
+    Returns:
+        TimingStats object containing min, median, max, and stdev.
+
+    Raises:
+        ValueError: If the input list is empty.
+    """
+    if not samples:
+        raise ValueError("Cannot compute statistics of an empty sample list.")
+
+    return TimingStats(
+        min=min(samples),
+        median=statistics.median(samples),
+        max=max(samples),
+        stdev=statistics.stdev(samples) if len(samples) > 1 else 0.0,
+    )
+
+
+@contextlib.contextmanager
+def suppressOutput():
+    """
+    Context manager that suppresses stdout and stderr.
+
+    This prevents scenario print statements from interfering with
+    benchmark timing and output readability.
+    """
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        yield
+
+
+@contextlib.contextmanager
+def patchedSimTimers():
+    """
+    Context manager that patches simulation methods to measure execution time.
+
+    Temporarily replaces:
+        - InitializeSimulation
+        - ExecuteSimulation
+
+    to capture timing information for each run.
+
+    Yields:
+        dict: Mutable dictionary with keys 'init' and 'exec' storing durations.
+
+    Guarantees:
+        Original methods are restored after exiting the context.
+    """
+    timings = {"init": 0.0, "exec": 0.0}
+
+    origInit = SimulationBaseClass.SimBaseClass.InitializeSimulation
+    origExec = SimulationBaseClass.SimBaseClass.ExecuteSimulation
+
+    def timedInit(self):
+        """Wrapped InitializeSimulation that records execution time."""
+        t0 = time.perf_counter()
+        origInit(self)
+        timings["init"] = time.perf_counter() - t0
+
+    def timedExec(self):
+        """Wrapped ExecuteSimulation that records execution time."""
+        t0 = time.perf_counter()
+        origExec(self)
+        timings["exec"] = time.perf_counter() - t0
+
+    SimulationBaseClass.SimBaseClass.InitializeSimulation = timedInit
+    SimulationBaseClass.SimBaseClass.ExecuteSimulation = timedExec
+
+    try:
+        yield timings
+    finally:
+        SimulationBaseClass.SimBaseClass.InitializeSimulation = origInit
+        SimulationBaseClass.SimBaseClass.ExecuteSimulation = origExec
+
+
+def measureScenario(scenario: Scenario, nRuns: int = 10) -> BenchmarkResult:
+    """
+    Benchmark a scenario over multiple runs.
+
+    Args:
+        scenario: Scenario object containing label and run function.
+        nRuns: Number of repetitions.
+
+    Returns:
+        BenchmarkResult containing timing statistics for init and exec.
+    """
+    initTimes: list[float] = []
+    execTimes: list[float] = []
+
+    with patchedSimTimers() as timings:
+        for _ in range(nRuns):
+            with suppressOutput():
+                scenario.run()
+            initTimes.append(timings["init"])
+            execTimes.append(timings["exec"])
+
+    return BenchmarkResult(
+        label=scenario.label,
+        init=computeStats(initTimes),
+        exec=computeStats(execTimes),
+    )
+
+
+def formatSeconds(seconds: float) -> str:
+    """
+    Format a duration using adaptive time units.
+
+    Args:
+        seconds: Duration in seconds.
+
+    Returns:
+        Formatted duration string.
+    """
+    if seconds >= 0.1:
+        return f"{seconds:.3f} s"
+    if seconds >= 1e-3:
+        return f"{seconds * 1e3:.2f} ms"
+    return f"{seconds * 1e6:.1f} us"
+
+
+def printResultsTable(results: list[BenchmarkResult], title: str, labelCol: int = 28) -> None:
+    """
+    Print a single compact benchmark table for one scenario family.
+
+    Args:
+        results: Benchmark results to print.
+        title: Title of the scenario family.
+        labelCol: Width of the label column.
+    """
+    execBaseline = results[0].exec.min
+
+    print(title)
+    print(
+        f"  {'Module':<{labelCol}}  "
+        f"{'exec min':>10}  {'exec med':>10}  {'exec max':>10}  {'exec min rel':>12}  "
+        f"{'init min':>10}  {'init med':>10}  {'init max':>10}"
+    )
+    print(
+        f"  {'-' * labelCol}  "
+        f"{'-' * 10}  {'-' * 10}  {'-' * 10}  {'-' * 12}  "
+        f"{'-' * 10}  {'-' * 10}  {'-' * 10}"
+    )
+
+    for result in results:
+        execRatio = result.exec.min / execBaseline if execBaseline > 0.0 else float("inf")
+        print(
+            f"  {result.label:<{labelCol}}  "
+            f"{formatSeconds(result.exec.min):>10}  "
+            f"{formatSeconds(result.exec.median):>10}  "
+            f"{formatSeconds(result.exec.max):>10}  "
+            f"{execRatio:>11.3f}x  "
+            f"{formatSeconds(result.init.min):>10}  "
+            f"{formatSeconds(result.init.median):>10}  "
+            f"{formatSeconds(result.init.max):>10}  "
+        )
+
+    print()
+
+
+def runGroup(title: str, scenarios: list[Scenario], nRuns: int = 10) -> None:
+    """
+    Execute and report a group of benchmark scenarios.
+
+    Args:
+        title: Title describing the scenario family.
+        scenarios: Scenarios to benchmark.
+        nRuns: Number of runs per scenario.
+    """
+    results = [measureScenario(s, nRuns=nRuns) for s in scenarios]
+    printResultsTable(results, f"{title} ({nRuns} runs)")
+
+def run(case: Literal["pointing", "feedback"] = "feedback", nRuns: int = 10) -> None:
+    """Main scenario entry point"""
+
+    if case == "pointing":
+        runGroup(
+            title="Pointing  - single control module replaced",
+            scenarios=[
+                Scenario("C++   (all C++)", lambda: scenarioAttitudePointing.run(False, False)),
+                Scenario("Python (1 Py module)", lambda: scenarioAttitudePointingPy.run(False)),
+                Scenario("Numba  (1 Nb module)", lambda: scenarioAttitudePointingNumba.run(False)),
+            ],
+            nRuns=nRuns,
+        )
+    elif case == "feedback":
+        runGroup(
+            title="Feedback  - all 4 FSW+sensor modules replaced",
+            scenarios=[
+                Scenario(
+                    "C++   (all C++)",
+                    lambda: scenarioAttitudeFeedback.run(False, False, False, False, False),
+                ),
+                Scenario(
+                    "Numba  (4 Nb modules)",
+                    lambda: scenarioAttitudeFeedbackNumba.run(False, False, False, False),
+                ),
+            ],
+            nRuns=nRuns,
+        )
+
+
+if __name__ == "__main__":
+    """Entry point: run all benchmark scenario groups."""
+    for case in ("pointing", "feedback"):
+        run(case)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ examples = [
   'scipy==1.13.1; python_version < "3.10"',
   'scipy==1.15.3; python_version >= "3.10" and python_version < "3.11"',
   'scipy==1.17.1; python_version >= "3.11"',
+  'numba',
 ]
 
 [tool.cibuildwheel]

--- a/src/architecture/_GeneralModuleFiles/numbaModel.cpp
+++ b/src/architecture/_GeneralModuleFiles/numbaModel.cpp
@@ -1,0 +1,100 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "numbaModel.h"
+
+void NumbaModel::addReaderSlot(uintptr_t payloadPtrAddr, uintptr_t linkedAddr, uintptr_t dummyAddr) {
+    ReaderSlot slot{
+        reinterpret_cast<void**>(payloadPtrAddr),
+        reinterpret_cast<uint8_t*>(linkedAddr),
+        reinterpret_cast<void*>(dummyAddr)
+    };
+    readerSlots_.push_back(slot);
+    readLinked_.push_back(0);
+}
+
+void NumbaModel::addWritePayloadPtr(uintptr_t ptr) {
+    writePayloads_.push_back(reinterpret_cast<void*>(ptr));
+}
+
+void NumbaModel::addWriteHeaderPtr(uintptr_t ptr) {
+    writeHeaders_.push_back(reinterpret_cast<MsgHeader*>(ptr));
+}
+
+void NumbaModel::addUserPointer(uintptr_t ptr) {
+    userPointers_.push_back(reinterpret_cast<void*>(ptr));
+}
+
+uintptr_t NumbaModel::getReadLinkedPtr() const {
+    return reinterpret_cast<uintptr_t>(readLinked_.data());
+}
+
+void NumbaModel::setStateUpdateFunc(uintptr_t funcPtr) {
+    stateUpdateFunc_ = reinterpret_cast<void(*)(void**, uint64_t)>(funcPtr);
+}
+
+void NumbaModel::finalizeAllPtrs() {
+    readCount_ = readerSlots_.size();
+    allPtrs_.clear();
+    allPtrs_.reserve(readerSlots_.size() + writePayloads_.size() + userPointers_.size());
+    // Read section: initialise with dummy pointers; refreshed per tick.
+    for (auto& slot : readerSlots_)
+        allPtrs_.push_back(slot.dummy);
+    // Write section: stable payload pointers set at Reset time.
+    for (auto* p : writePayloads_)
+        allPtrs_.push_back(p);
+    // User section: stable user-data pointers (memory, moduleID, rng, …).
+    for (auto* p : userPointers_)
+        allPtrs_.push_back(p);
+    // Release staging vectors - no longer needed after assembly.
+    writePayloads_.clear();
+    userPointers_.clear();
+}
+
+void NumbaModel::Reset(uint64_t /*CurrentSimNanos*/) {
+    readerSlots_.clear();
+    readLinked_.clear();
+    allPtrs_.clear();
+    writePayloads_.clear();
+    writeHeaders_.clear();
+    userPointers_.clear();
+    readCount_ = 0;
+    stateUpdateFunc_ = nullptr;
+}
+
+void NumbaModel::UpdateState(uint64_t CurrentSimNanos) {
+    if (!stateUpdateFunc_) return;
+
+    // Refresh the read section of allPtrs_ and the linked flags array.
+    // This makes re-wiring (subscribeTo after Reset) transparent to the cfunc.
+    for (size_t i = 0; i < readCount_; i++) {
+        uint8_t linked = *readerSlots_[i].linkedAddr;
+        readLinked_[i] = linked;
+        allPtrs_[i] = linked
+            ? *readerSlots_[i].payloadPtrAddr
+            : readerSlots_[i].dummy;
+    }
+
+    stateUpdateFunc_(allPtrs_.data(), CurrentSimNanos);
+
+    for (MsgHeader* h : writeHeaders_) {
+        h->isWritten   = 1;
+        h->timeWritten = CurrentSimNanos;
+        h->moduleID    = this->moduleID;
+    }
+}

--- a/src/architecture/_GeneralModuleFiles/numbaModel.h
+++ b/src/architecture/_GeneralModuleFiles/numbaModel.h
@@ -1,0 +1,118 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "sys_model.h"
+#include "architecture/messaging/msgHeader.h"
+
+/*! @brief Bookkeeping for one registered ReadFunctor.
+ *
+ * All three addresses remain valid for the lifetime of the corresponding
+ * Python attribute because ``subscribeTo`` updates the functor in place.
+ */
+struct ReaderSlot {
+    void**   payloadPtrAddr;  //!< Address of ``ReadFunctor::payloadPointer``.
+    uint8_t* linkedAddr;      //!< Address of ``ReadFunctor::initialized``.
+    void*    dummy;           //!< Zero-filled fallback payload used when not linked.
+};
+
+/*! @brief Base class for Python-defined Numba modules.
+ *
+ * ``NumbaModel`` lets Python subclasses register message readers, message
+ * writers, and auxiliary buffers, then exposes them to a compiled Numba
+ * callback through a flat pointer array.  The Python layer owns the
+ * ``UpdateStateImpl`` implementation, while this C++ class refreshes the
+ * read pointers, updates message headers, and invokes the compiled callback
+ * every simulation tick.
+ */
+class NumbaModel : virtual public SysModel
+{
+public:
+    /*! Register a reader functor for dynamic payload refresh.
+     *
+     * @param payloadPtrAddr Address of the functor payload pointer storage.
+     * @param linkedAddr Address of the functor linked-flag storage.
+     * @param dummyAddr Address of the fallback payload used when unlinked.
+     */
+    void addReaderSlot(uintptr_t payloadPtrAddr, uintptr_t linkedAddr, uintptr_t dummyAddr);
+
+    /*! Register one writable payload pointer in the flattened pointer table.
+     *
+     * @param ptr Raw payload pointer address.
+     */
+    void addWritePayloadPtr(uintptr_t ptr);
+
+    /*! Register one writable message-header pointer.
+     *
+     * @param ptr Raw message-header pointer address.
+     */
+    void addWriteHeaderPtr(uintptr_t ptr);
+
+    /*! Register one user-owned pointer in the flattened pointer table.
+     *
+     * @param ptr Raw user pointer address.
+     */
+    void addUserPointer(uintptr_t ptr);
+
+    /*! Store the compiled Numba update function pointer.
+     *
+     * @param funcPtr Raw function pointer returned by Numba.
+     */
+    void setStateUpdateFunc(uintptr_t funcPtr);
+
+    /*! Return the raw address of the ``readLinked_`` backing buffer.
+     *
+     * This buffer is typically registered once as a user pointer so the
+     * compiled callback can inspect reader linkage state.
+     */
+    uintptr_t getReadLinkedPtr() const;
+
+    /*! Assemble the flattened pointer table consumed by the compiled callback.
+     *
+     * This must be called from Python ``Reset()`` after ``_nbm_compile()``
+     * finishes registering all reader, writer, and user pointers.
+     */
+    void finalizeAllPtrs();
+
+    /*! Prepare the model for a new simulation run.
+     *
+     * @param CurrentSimNanos Current simulation time in nanoseconds.
+     */
+    void Reset(uint64_t CurrentSimNanos) override;
+
+    /*! Refresh registered pointers and invoke the compiled callback.
+     *
+     * @param CurrentSimNanos Current simulation time in nanoseconds.
+     */
+    void UpdateState(uint64_t CurrentSimNanos) override;
+
+public:
+    BSKLogger bskLogger;  //!< Logger proxy exposed to Python-side Numba modules.
+
+protected:
+    std::vector<ReaderSlot> readerSlots_;    //!< One entry per registered reader functor.
+    std::vector<uint8_t>    readLinked_;     //!< Per-reader linkage flags refreshed each tick.
+    size_t                  readCount_ = 0;  //!< Number of reader entries stored in ``allPtrs_``.
+    std::vector<void*>      writePayloads_;  //!< Staged writable payload pointers awaiting finalization.
+    std::vector<void*>      userPointers_;   //!< Staged user pointers appended after readers and writers.
+    std::vector<void*>      allPtrs_;        //!< Flat pointer table laid out as ``[reads | writes | user]``.
+    std::vector<MsgHeader*> writeHeaders_;   //!< Headers corresponding to registered writable payloads.
+    void (*stateUpdateFunc_)(void**, uint64_t) = nullptr;  //!< Compiled Numba state update callback.
+};

--- a/src/architecture/_GeneralModuleFiles/py_sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/py_sys_model.i
@@ -83,8 +83,8 @@ class SysModelMixin:
         for base in cls.mro()[1:]:
             if base is object:
                 continue
-            # Heuristic: SWIG proxy types have __swig_destroy__ or similar
-            if hasattr(base, "__swig_destroy__"):
+            # Heuristic: SWIG proxy types define __swig_destroy__ directly
+            if "__swig_destroy__" in base.__dict__:
                 cppBases.append(base)
 
         if not cppBases:

--- a/src/architecture/_GeneralModuleFiles/py_sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/py_sys_model.i
@@ -33,6 +33,19 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "std_string.i"
 %include "swig_conly_data.i"
+
+/* Convert std::map<int, const char*> (BSKLogger::logLevelMap) to a Python dict */
+%typemap(out) std::map<int, const char*> {
+    $result = PyDict_New();
+    for (const auto& kv : $1) {
+        PyObject* key = PyLong_FromLong(kv.first);
+        PyObject* val = PyUnicode_FromString(kv.second ? kv.second : "");
+        PyDict_SetItem($result, key, val);
+        Py_DECREF(key);
+        Py_DECREF(val);
+    }
+}
+
 %include "architecture/utilities/bskLogging.h"
 
 /* Director support for the C++ SysModel base */

--- a/src/architecture/_GeneralModuleFiles/sys_model.i
+++ b/src/architecture/_GeneralModuleFiles/sys_model.i
@@ -14,6 +14,19 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_conly_data.i"
 %include "swig_std_array.i"
+
+/* Convert std::map<int, const char*> (BSKLogger::logLevelMap) to a Python dict */
+%typemap(out) std::map<int, const char*> {
+    $result = PyDict_New();
+    for (const auto& kv : $1) {
+        PyObject* key = PyLong_FromLong(kv.first);
+        PyObject* val = PyUnicode_FromString(kv.second ? kv.second : "");
+        PyDict_SetItem($result, key, val);
+        Py_DECREF(key);
+        Py_DECREF(val);
+    }
+}
+
 %include "architecture/utilities/bskLogging.h"
 
 %include "sys_model.h"

--- a/src/architecture/messaging/_UnitTest/test_msgDtype.py
+++ b/src/architecture/messaging/_UnitTest/test_msgDtype.py
@@ -58,6 +58,7 @@ def _writable_view(payload, dtype):
 # ---------------------------------------------------------------------------
 
 def test_epochDtypeLayout():
+    """Check the Epoch payload dtype layout and padding offsets."""
     dt = messaging.EpochMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 32
@@ -70,6 +71,7 @@ def test_epochDtypeLayout():
 
 
 def test_epochDtypeNumpyToPython():
+    """Check numpy writes into Epoch payload memory update Python fields."""
     p   = messaging.EpochMsgPayload()
     arr = _writable_view(p, messaging.EpochMsgPayload.__dtype__)
 
@@ -89,6 +91,7 @@ def test_epochDtypeNumpyToPython():
 
 
 def test_epochDtypePythonToNumpy():
+    """Check Python writes to Epoch fields are visible through the dtype view."""
     p   = messaging.EpochMsgPayload()
     arr = _writable_view(p, messaging.EpochMsgPayload.__dtype__)
 
@@ -105,6 +108,7 @@ def test_epochDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_attStateDtypeLayout():
+    """Check the attitude-state payload dtype layout and vector shapes."""
     dt = messaging.AttStateMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 48
@@ -115,6 +119,7 @@ def test_attStateDtypeLayout():
 
 
 def test_attStateDtypeNumpyToPython():
+    """Check numpy writes into attitude-state memory update Python fields."""
     p   = messaging.AttStateMsgPayload()
     arr = _writable_view(p, messaging.AttStateMsgPayload.__dtype__)
 
@@ -126,6 +131,7 @@ def test_attStateDtypeNumpyToPython():
 
 
 def test_attStateDtypePythonToNumpy():
+    """Check Python attitude-state writes are visible through the dtype view."""
     p   = messaging.AttStateMsgPayload()
     arr = _writable_view(p, messaging.AttStateMsgPayload.__dtype__)
 
@@ -142,6 +148,7 @@ def test_attStateDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_scMassPropsDtypeLayout():
+    """Check spacecraft mass-properties dtype offsets and matrix shape."""
     dt = messaging.SCMassPropsMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 104
@@ -152,6 +159,7 @@ def test_scMassPropsDtypeLayout():
 
 
 def test_scMassPropsDtypeNumpyToPython():
+    """Check numpy writes into mass-properties memory update Python fields."""
     p   = messaging.SCMassPropsMsgPayload()
     arr = _writable_view(p, messaging.SCMassPropsMsgPayload.__dtype__)
 
@@ -166,6 +174,7 @@ def test_scMassPropsDtypeNumpyToPython():
 
 
 def test_scMassPropsDtypePythonToNumpy():
+    """Check Python mass-property writes are visible through the dtype view."""
     p   = messaging.SCMassPropsMsgPayload()
     arr = _writable_view(p, messaging.SCMassPropsMsgPayload.__dtype__)
 
@@ -180,6 +189,7 @@ def test_scMassPropsDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_deviceStatusDtypeLayout():
+    """Check the device-status enum dtype layout."""
     dt = messaging.DeviceStatusMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 4
@@ -188,6 +198,7 @@ def test_deviceStatusDtypeLayout():
 
 
 def test_deviceStatusDtypeNumpyToPython():
+    """Check numpy writes into device-status memory update Python fields."""
     p   = messaging.DeviceStatusMsgPayload()
     arr = _writable_view(p, messaging.DeviceStatusMsgPayload.__dtype__)
 
@@ -196,6 +207,7 @@ def test_deviceStatusDtypeNumpyToPython():
 
 
 def test_deviceStatusDtypePythonToNumpy():
+    """Check Python device-status writes are visible through the dtype view."""
     p   = messaging.DeviceStatusMsgPayload()
     arr = _writable_view(p, messaging.DeviceStatusMsgPayload.__dtype__)
 
@@ -211,6 +223,7 @@ def test_deviceStatusDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_spicePlanetDtypeLayout():
+    """Check the SPICE planet-state dtype offsets and string field type."""
     dt = messaging.SpicePlanetStateMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 272
@@ -220,6 +233,7 @@ def test_spicePlanetDtypeLayout():
 
 
 def test_spicePlanetDtypeNumpyToPython():
+    """Check numpy writes into SPICE planet-state memory update Python fields."""
     p   = messaging.SpicePlanetStateMsgPayload()
     arr = _writable_view(p, messaging.SpicePlanetStateMsgPayload.__dtype__)
 
@@ -234,6 +248,7 @@ def test_spicePlanetDtypeNumpyToPython():
 
 
 def test_spicePlanetDtypePythonToNumpy():
+    """Check Python SPICE planet-state writes are visible through the dtype view."""
     p   = messaging.SpicePlanetStateMsgPayload()
     arr = _writable_view(p, messaging.SpicePlanetStateMsgPayload.__dtype__)
 
@@ -249,6 +264,7 @@ def test_spicePlanetDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_accDataDtypeLayout():
+    """Check the accelerometer-packet nested dtype layout."""
     dt = messaging.AccDataMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 6720
@@ -261,6 +277,7 @@ def test_accDataDtypeLayout():
 
 
 def test_accDataDtypeNumpyToPython():
+    """Check numpy writes into accelerometer-packet memory update Python fields."""
     p   = messaging.AccDataMsgPayload()
     arr = _writable_view(p, messaging.AccDataMsgPayload.__dtype__)
 
@@ -272,6 +289,7 @@ def test_accDataDtypeNumpyToPython():
 
 
 def test_accDataDtypePythonToNumpy():
+    """Check Python accelerometer-packet writes are visible through the dtype view."""
     p   = messaging.AccDataMsgPayload()
     arr = _writable_view(p, messaging.AccDataMsgPayload.__dtype__)
 
@@ -286,6 +304,7 @@ def test_accDataDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_cameraImageDtypeLayout():
+    """Check the camera-image payload dtype layout and pointer field type."""
     dt = messaging.CameraImageMsgPayload.__dtype__
     assert dt is not None
     assert dt.itemsize == 40
@@ -296,6 +315,7 @@ def test_cameraImageDtypeLayout():
 
 
 def test_cameraImageDtypeNumpyToPython():
+    """Check numpy writes into camera-image memory update Python fields."""
     p   = messaging.CameraImageMsgPayload()
     arr = _writable_view(p, messaging.CameraImageMsgPayload.__dtype__)
 
@@ -309,6 +329,7 @@ def test_cameraImageDtypeNumpyToPython():
 
 
 def test_cameraImageDtypePythonToNumpy():
+    """Check Python camera-image writes are visible through the dtype view."""
     p   = messaging.CameraImageMsgPayload()
     arr = _writable_view(p, messaging.CameraImageMsgPayload.__dtype__)
 
@@ -321,4 +342,5 @@ def test_cameraImageDtypePythonToNumpy():
 # ---------------------------------------------------------------------------
 
 def test_jointArrayStateDtypeIsNone():
+    """Check payloads with unsupported vector fields expose no numpy dtype."""
     assert messaging.JointArrayStateMsgPayload.__dtype__ is None

--- a/src/architecture/messaging/_UnitTest/test_msgDtype.py
+++ b/src/architecture/messaging/_UnitTest/test_msgDtype.py
@@ -1,0 +1,324 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+"""
+Tests for PayloadType.__dtype__ - numpy structured dtype mirroring the C struct layout.
+
+Each test:
+  1. Creates a payload object.
+  2. Gets a writable numpy view of the underlying C memory via sim_model.getObjectAddress.
+  3. Writes values through numpy and asserts the Python wrapper sees them (numpy → Python).
+  4. Writes values through the Python wrapper and asserts numpy sees them (Python → numpy).
+
+Coverage:
+  - Primitive scalars with implicit padding   (EpochMsgPayload)
+  - 1-D float arrays                          (AttStateMsgPayload)
+  - 2-D float array                           (SCMassPropsMsgPayload)
+  - Enum field                                (DeviceStatusMsgPayload)
+  - Char array + 2-D array + scalar           (SpicePlanetStateMsgPayload)
+  - Array of nested structs                   (AccDataMsgPayload)
+  - Pointer field → uint64 in dtype           (CameraImageMsgPayload)
+  - Incomplete struct (C++ vectors) → None    (JointArrayStateMsgPayload)
+"""
+
+import ctypes
+
+import numpy as np
+import pytest
+
+from Basilisk.architecture import messaging
+from Basilisk.architecture import sim_model
+
+
+def _writable_view(payload, dtype):
+    """Return a writable 1-element structured numpy array backed by the payload's C memory."""
+    addr = sim_model.getObjectAddress(payload)
+    buf  = (ctypes.c_byte * dtype.itemsize).from_address(addr)
+    return np.ndarray(1, dtype=dtype, buffer=buf)
+
+
+# ---------------------------------------------------------------------------
+# 1. Primitive scalars + implicit padding  (EpochMsgPayload)
+#    struct: int year, month, day, hours, minutes; double seconds;
+#    layout: 5×int32 (20 bytes) + 4-byte pad + float64 = 32 bytes total
+# ---------------------------------------------------------------------------
+
+def test_epochDtypeLayout():
+    dt = messaging.EpochMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 32
+    assert dt.fields['year'][1]    == 0
+    assert dt.fields['month'][1]   == 4
+    assert dt.fields['day'][1]     == 8
+    assert dt.fields['hours'][1]   == 12
+    assert dt.fields['minutes'][1] == 16
+    assert dt.fields['seconds'][1] == 24   # 4-byte padding gap at bytes 20-23
+
+
+def test_epochDtypeNumpyToPython():
+    p   = messaging.EpochMsgPayload()
+    arr = _writable_view(p, messaging.EpochMsgPayload.__dtype__)
+
+    arr[0]['year']    = 2024
+    arr[0]['month']   = 3
+    arr[0]['day']     = 15
+    arr[0]['hours']   = 12
+    arr[0]['minutes'] = 30
+    arr[0]['seconds'] = 45.5
+
+    assert p.year    == 2024
+    assert p.month   == 3
+    assert p.day     == 15
+    assert p.hours   == 12
+    assert p.minutes == 30
+    assert p.seconds == pytest.approx(45.5)
+
+
+def test_epochDtypePythonToNumpy():
+    p   = messaging.EpochMsgPayload()
+    arr = _writable_view(p, messaging.EpochMsgPayload.__dtype__)
+
+    p.year    = 1999
+    p.seconds = 0.125
+
+    assert arr[0]['year']    == 1999
+    assert arr[0]['seconds'] == pytest.approx(0.125)
+
+
+# ---------------------------------------------------------------------------
+# 2. 1-D float arrays  (AttStateMsgPayload)
+#    struct: double state[3], rate[3];  - 48 bytes, no padding
+# ---------------------------------------------------------------------------
+
+def test_attStateDtypeLayout():
+    dt = messaging.AttStateMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 48
+    assert dt.fields['state'][1] == 0
+    assert dt.fields['rate'][1]  == 24
+    assert dt['state'].shape == (3,)
+    assert dt['rate'].shape  == (3,)
+
+
+def test_attStateDtypeNumpyToPython():
+    p   = messaging.AttStateMsgPayload()
+    arr = _writable_view(p, messaging.AttStateMsgPayload.__dtype__)
+
+    arr[0]['state'] = [0.1, 0.2, 0.3]
+    arr[0]['rate']  = [1.0, 2.0, 3.0]
+
+    np.testing.assert_allclose(p.state, [0.1, 0.2, 0.3])
+    np.testing.assert_allclose(p.rate,  [1.0, 2.0, 3.0])
+
+
+def test_attStateDtypePythonToNumpy():
+    p   = messaging.AttStateMsgPayload()
+    arr = _writable_view(p, messaging.AttStateMsgPayload.__dtype__)
+
+    p.state = [9.0, 8.0, 7.0]
+    p.rate  = [-1.0, -2.0, -3.0]
+
+    np.testing.assert_allclose(arr[0]['state'], [9.0, 8.0, 7.0])
+    np.testing.assert_allclose(arr[0]['rate'],  [-1.0, -2.0, -3.0])
+
+
+# ---------------------------------------------------------------------------
+# 3. 2-D float array  (SCMassPropsMsgPayload)
+#    struct: double massSC; double c_B[3]; double ISC_PntB_B[3][3];  - 104 bytes
+# ---------------------------------------------------------------------------
+
+def test_scMassPropsDtypeLayout():
+    dt = messaging.SCMassPropsMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 104
+    assert dt.fields['massSC'][1]     == 0
+    assert dt.fields['c_B'][1]        == 8
+    assert dt.fields['ISC_PntB_B'][1] == 32
+    assert dt['ISC_PntB_B'].shape == (3, 3)
+
+
+def test_scMassPropsDtypeNumpyToPython():
+    p   = messaging.SCMassPropsMsgPayload()
+    arr = _writable_view(p, messaging.SCMassPropsMsgPayload.__dtype__)
+
+    inertia = np.array([[1., 0., 0.], [0., 2., 0.], [0., 0., 3.]])
+    arr[0]['massSC']     = 500.0
+    arr[0]['c_B']        = [0.1, 0.2, 0.3]
+    arr[0]['ISC_PntB_B'] = inertia
+
+    assert p.massSC == pytest.approx(500.0)
+    np.testing.assert_allclose(list(p.c_B), [0.1, 0.2, 0.3])
+    np.testing.assert_allclose(list(p.ISC_PntB_B), inertia.tolist())
+
+
+def test_scMassPropsDtypePythonToNumpy():
+    p   = messaging.SCMassPropsMsgPayload()
+    arr = _writable_view(p, messaging.SCMassPropsMsgPayload.__dtype__)
+
+    p.massSC = 750.0
+
+    assert arr[0]['massSC'] == pytest.approx(750.0)
+
+
+# ---------------------------------------------------------------------------
+# 4. Enum field  (DeviceStatusMsgPayload)
+#    struct: deviceState deviceStatus;  - 4 bytes
+# ---------------------------------------------------------------------------
+
+def test_deviceStatusDtypeLayout():
+    dt = messaging.DeviceStatusMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 4
+    assert dt.fields['deviceStatus'][0] == np.dtype('int32')
+    assert dt.fields['deviceStatus'][1] == 0
+
+
+def test_deviceStatusDtypeNumpyToPython():
+    p   = messaging.DeviceStatusMsgPayload()
+    arr = _writable_view(p, messaging.DeviceStatusMsgPayload.__dtype__)
+
+    arr[0]['deviceStatus'] = 1   # On
+    assert p.deviceStatus == 1
+
+
+def test_deviceStatusDtypePythonToNumpy():
+    p   = messaging.DeviceStatusMsgPayload()
+    arr = _writable_view(p, messaging.DeviceStatusMsgPayload.__dtype__)
+
+    p.deviceStatus = 0           # Off
+    assert arr[0]['deviceStatus'] == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. Char array + 2-D array + scalar  (SpicePlanetStateMsgPayload)
+#    struct: double J2000Current; double PositionVector[3]; double VelocityVector[3];
+#            double J20002Pfix[3][3]; double J20002Pfix_dot[3][3];
+#            int computeOrient; char PlanetName[64];  - 272 bytes
+# ---------------------------------------------------------------------------
+
+def test_spicePlanetDtypeLayout():
+    dt = messaging.SpicePlanetStateMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 272
+    assert dt['PlanetName']            == np.dtype('S64')
+    assert dt.fields['J2000Current'][1]  == 0
+    assert dt.fields['PlanetName'][1]    == 204
+
+
+def test_spicePlanetDtypeNumpyToPython():
+    p   = messaging.SpicePlanetStateMsgPayload()
+    arr = _writable_view(p, messaging.SpicePlanetStateMsgPayload.__dtype__)
+
+    arr[0]['J2000Current']   = 1234.5
+    arr[0]['PositionVector'] = [1e6, 2e6, 3e6]
+    arr[0]['PlanetName']     = b'Earth'
+
+    assert p.J2000Current == pytest.approx(1234.5)
+    np.testing.assert_allclose(list(p.PositionVector), [1e6, 2e6, 3e6])
+    # SWIG exposes char[] as a Python string
+    assert p.PlanetName[:5] == 'Earth'
+
+
+def test_spicePlanetDtypePythonToNumpy():
+    p   = messaging.SpicePlanetStateMsgPayload()
+    arr = _writable_view(p, messaging.SpicePlanetStateMsgPayload.__dtype__)
+
+    p.J2000Current = 9999.0
+    assert arr[0]['J2000Current'] == pytest.approx(9999.0)
+
+
+# ---------------------------------------------------------------------------
+# 6. Array of nested structs  (AccDataMsgPayload)
+#    struct: AccPktDataMsgPayload accPkts[120];
+#    each AccPktDataMsgPayload: uint64 measTime + double gyro_B[3] + double accel_B[3] = 56 bytes
+#    total: 6720 bytes
+# ---------------------------------------------------------------------------
+
+def test_accDataDtypeLayout():
+    dt = messaging.AccDataMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 6720
+    # accPkts field: array of 120 nested structs
+    pkt_dt = dt['accPkts'].base
+    assert pkt_dt.itemsize == 56
+    assert pkt_dt.fields['measTime'][1] == 0
+    assert pkt_dt.fields['gyro_B'][1]   == 8
+    assert pkt_dt.fields['accel_B'][1]  == 32
+
+
+def test_accDataDtypeNumpyToPython():
+    p   = messaging.AccDataMsgPayload()
+    arr = _writable_view(p, messaging.AccDataMsgPayload.__dtype__)
+
+    arr[0]['accPkts'][0]['measTime'] = 999
+    arr[0]['accPkts'][0]['gyro_B']   = [0.1, 0.2, 0.3]
+
+    assert p.accPkts[0].measTime == 999
+    np.testing.assert_allclose(list(p.accPkts[0].gyro_B), [0.1, 0.2, 0.3])
+
+
+def test_accDataDtypePythonToNumpy():
+    p   = messaging.AccDataMsgPayload()
+    arr = _writable_view(p, messaging.AccDataMsgPayload.__dtype__)
+
+    p.accPkts[5].measTime = 42
+    assert arr[0]['accPkts'][5]['measTime'] == 42
+
+
+# ---------------------------------------------------------------------------
+# 7. Struct with pointer field → pointer is uint64 in dtype (CameraImageMsgPayload)
+#    struct: uint64 timeTag; int valid; int64 cameraID; void* imagePointer;
+#            int32 imageBufferLength; int8 imageType;  - 40 bytes
+# ---------------------------------------------------------------------------
+
+def test_cameraImageDtypeLayout():
+    dt = messaging.CameraImageMsgPayload.__dtype__
+    assert dt is not None
+    assert dt.itemsize == 40
+    assert dt['imagePointer']              == np.dtype('uint64')
+    assert dt.fields['timeTag'][1]         == 0
+    assert dt.fields['imagePointer'][1]    == 24
+    assert dt.fields['imageBufferLength'][1] == 32
+
+
+def test_cameraImageDtypeNumpyToPython():
+    p   = messaging.CameraImageMsgPayload()
+    arr = _writable_view(p, messaging.CameraImageMsgPayload.__dtype__)
+
+    arr[0]['timeTag']           = 123456789
+    arr[0]['valid']             = 1
+    arr[0]['imageBufferLength'] = 512
+
+    assert p.timeTag           == 123456789
+    assert p.valid             == 1
+    assert p.imageBufferLength == 512
+
+
+def test_cameraImageDtypePythonToNumpy():
+    p   = messaging.CameraImageMsgPayload()
+    arr = _writable_view(p, messaging.CameraImageMsgPayload.__dtype__)
+
+    p.timeTag = 987654321
+    assert arr[0]['timeTag'] == 987654321
+
+
+# ---------------------------------------------------------------------------
+# 8. Incomplete struct (C++ std::vector fields) → __dtype__ is None
+# ---------------------------------------------------------------------------
+
+def test_jointArrayStateDtypeIsNone():
+    assert messaging.JointArrayStateMsgPayload.__dtype__ is None

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -180,6 +180,16 @@ public:
 
     //! Recorder method description
     Recorder<messageType> recorder(uint64_t timeDiff = 0){return Recorder<messageType>(this, timeDiff);}
+
+    //! Return the address of the internal payloadPointer member
+    uintptr_t getPayloadPtrAddress() const {
+        return reinterpret_cast<uintptr_t>(&payloadPointer);
+    }
+
+    //! Return the address of the internal initialized flag
+    uintptr_t getLinkedAddress() const {
+        return reinterpret_cast<uintptr_t>(&initialized);
+    }
 };
 
 /*! Write Functor */
@@ -238,6 +248,12 @@ public:
 
     //! Return the memory size of the payload, be careful about dynamically sized things
     uint64_t getPayloadSize() {return sizeof(messageType);};
+
+    //! Return the raw address of the message payload struct
+    uintptr_t getPayloadAddress() { return reinterpret_cast<uintptr_t>(&payload); }
+
+    //! Return the raw address of the message header struct
+    uintptr_t getHeaderAddress()  { return reinterpret_cast<uintptr_t>(&header);  }
 };
 
 

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -177,6 +177,16 @@ public:
 
     //! Recorder method description
     Recorder<messageType> recorder(uint64_t timeDiff = 0){return Recorder<messageType>(this, timeDiff);}
+
+    //! Return the address of the internal payloadPointer member
+    uintptr_t getPayloadPtrAddress() const {
+        return reinterpret_cast<uintptr_t>(&payloadPointer);
+    }
+
+    //! Return the address of the internal initialized flag
+    uintptr_t getLinkedAddress() const {
+        return reinterpret_cast<uintptr_t>(&initialized);
+    }
 };
 
 /*! Write Functor */
@@ -235,6 +245,12 @@ public:
 
     //! Return the memory size of the payload, be careful about dynamically sized things
     uint64_t getPayloadSize() {return sizeof(messageType);};
+
+    //! Return the raw address of the message payload struct
+    uintptr_t getPayloadAddress() { return reinterpret_cast<uintptr_t>(&payload); }
+
+    //! Return the raw address of the message header struct
+    uintptr_t getHeaderAddress()  { return reinterpret_cast<uintptr_t>(&header);  }
 };
 
 

--- a/src/architecture/messaging/msgAutoSource/generateSWIGModules.py
+++ b/src/architecture/messaging/msgAutoSource/generateSWIGModules.py
@@ -86,6 +86,48 @@ _FLOAT_CTYPES = {
 }
 
 
+# Maps C type strings (from the 'ctype' field in the metadata JSON) to numpy
+# dtype strings.  Pointer fields always map to uint64 (pointer-width on LP64).
+# Enum fields are not in this table - they are inferred from size_bytes instead.
+_C_TYPE_TO_NPY_DTYPE: dict[str, str] = {
+    "bool":  "bool_",  "_Bool": "bool_",
+    "char":  "int8",   "signed char":  "int8",    "unsigned char":  "uint8",
+    "int8_t": "int8",
+    "short": "int16",  "short int": "int16",   "signed short": "int16",
+    "signed short int": "int16",   "int16_t": "int16",
+    "int": "int32",    "signed int": "int32",  "int32_t": "int32",
+    "long": "int64",   "long int": "int64",    "signed long": "int64",
+    "signed long int": "int64",
+    "long long": "int64",    "long long int": "int64",
+    "signed long long": "int64",   "signed long long int": "int64",  "int64_t": "int64",
+    "uint8_t": "uint8",
+    "unsigned short": "uint16",    "unsigned short int": "uint16",   "uint16_t": "uint16",
+    "unsigned": "uint32",  "unsigned int": "uint32",   "uint32_t": "uint32",
+    "unsigned long": "uint64",     "unsigned long int": "uint64",
+    "unsigned long long": "uint64", "unsigned long long int": "uint64", "uint64_t": "uint64",
+    "intptr_t": "int64",   "ptrdiff_t": "int64",  "ssize_t": "int64",
+    "uintptr_t": "uint64", "size_t": "uint64",
+    "float16": "float16",  "half": "float16",
+    "float": "float32",    "float32": "float32",
+    "double": "float64",   "float64": "float64",
+    "long double": "float128",
+}
+
+_ENUM_SIZE_TO_NPY_DTYPE: dict[int, str] = {1: "int8", 2: "int16", 4: "int32", 8: "int64"}
+
+
+def _inferNumpyDtype(field: dict) -> str | None:
+    """Infer the numpy dtype string for *field* from its C-level metadata."""
+    kind = field["kind"]
+    if kind == "primitive":
+        return _C_TYPE_TO_NPY_DTYPE.get(field["ctype"])
+    if kind == "pointer":
+        return "uint64"
+    if kind == "enum":
+        return _ENUM_SIZE_TO_NPY_DTYPE.get(field.get("size_bytes"))
+    return None
+
+
 def _fieldToMacro(field: dict, structName: str, rollback: bool) -> str:
     """
     Convert one JSON field descriptor into the appropriate RECORDER_PROPERTY macro line.
@@ -214,6 +256,53 @@ def _shapeStr(shape: list[int]) -> str:
     return "(" + ", ".join(str(d) for d in shape) + ")"
 
 
+def _fieldToDtypeExpr(field: dict) -> str:
+    """
+    Return a Python expression string for the numpy dtype of *field*.
+    Only called for complete structs (no unknown fields); pointer fields map to uint64.
+    """
+    kind = field["kind"]
+    if kind in ("primitive", "enum", "pointer"):
+        dtype = _inferNumpyDtype(field)
+        if dtype is None:
+            raise ValueError(
+                f"Cannot infer numpy dtype for {kind!r} field {field.get('name')!r} "
+                f"with ctype={field.get('ctype')!r}, size={field.get('size_bytes')}. "
+                f"Add the ctype to _C_TYPE_TO_NPY_DTYPE in generateSWIGModules.py."
+            )
+        return f"np.dtype('{dtype}')"
+    if kind == "array":
+        shape = field["shape"]
+        elem  = field["element"]
+        if elem.get("ctype") == "char":           # char[N] → fixed-length byte string
+            return f"np.dtype('S{shape[0]}')"
+        elemExpr = _fieldToDtypeExpr(elem)
+        shapeStr = ", ".join(str(d) for d in shape)
+        return f"np.dtype(({elemExpr}, ({shapeStr},)))"
+    if kind == "struct":
+        return _buildDtypeExpr(field["fields"], field["size_bytes"])
+    raise ValueError(f"unexpected field kind {kind!r}")
+
+
+def _buildDtypeExpr(fields: list, size_bytes: int) -> str:
+    """
+    Return a Python expression string for np.dtype({...}) using explicit offsets
+    so the result matches the C struct layout exactly, including implicit padding.
+    """
+    names   = ", ".join(repr(f["name"])         for f in fields)
+    formats = ", ".join(_fieldToDtypeExpr(f) for f in fields)
+    offsets = ", ".join(str(f["offset_bytes"])  for f in fields)
+    ind = "        "
+    return (
+        f"np.dtype({{\n"
+        f"{ind}    'names':   [{names}],\n"
+        f"{ind}    'formats': [{formats}],\n"
+        f"{ind}    'offsets': [{offsets}],\n"
+        f"{ind}    'itemsize': {size_bytes},\n"
+        f"{ind}}})"
+    )
+
+
 def _generateShadowInit(meta: dict, payloadType: str) -> str:
     """
     Generate a ``%feature("shadow")`` block that replaces the SWIG-generated
@@ -340,6 +429,13 @@ def _generateExtendBlock(meta: dict, payloadType: str) -> str:
     lines.append("    def __fields__(cls) -> tuple:")
     lines.append('        """Returns a tuple with all the payload\'s field names (in declaration order)."""')
     lines.append(f"        return {namesTuple}")
+    lines.append("")
+
+    # --- __dtype__ ---
+    if meta.get("complete", True):
+        lines.append(f"    __dtype__ = {_buildDtypeExpr(meta['fields'], meta['size_bytes'])}")
+    else:
+        lines.append("    __dtype__ = None")
     lines.append("")
     lines.append("%}")
     lines.append("}")

--- a/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/msgInterfacePy.i.in
@@ -21,6 +21,10 @@
 %template(DoubleVector) std::vector<double, std::allocator<double>>;
 %template(StringVector) std::vector<std::string, std::allocator<std::string>>;
 
+%typemap(out) uintptr_t {{
+    $result = PyLong_FromUnsignedLongLong((unsigned long long)$1);
+}}
+
 %include "architecture/utilities/macroDefinitions.h"
 %include "fswAlgorithms/fswUtilities/fswDefinitions.h"
 %include "simulation/dynamics/reactionWheels/reactionWheelSupport.h"

--- a/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
+++ b/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
@@ -1227,6 +1227,16 @@ _SUBPROCESS_SCRIPT = textwrap.dedent("""\
 """)
 
 
+def _parse_subprocess_float(stdout):
+    """Return the numeric result line from subprocess stdout."""
+    for line in stdout.splitlines():
+        try:
+            return float(line.strip())
+        except ValueError:
+            continue
+    raise AssertionError(f"No numeric result found in subprocess stdout:\n{stdout}")
+
+
 def test_cacheDiskSurvivesProcessRestart(tmp_path):
     """Disk cache written in process 1 is used correctly by process 2."""
     script = tmp_path / "sub_model.py"
@@ -1238,7 +1248,7 @@ def test_cacheDiskSurvivesProcessRestart(tmp_path):
         capture_output=True, text=True, timeout=120
     )
     assert r1.returncode == 0, f"Process 1 failed:\n{r1.stderr}"
-    assert float(r1.stdout.strip()) == pytest.approx(42.0)
+    assert _parse_subprocess_float(r1.stdout) == pytest.approx(42.0)
 
     # Process 2: should load from disk cache (fast path)
     r2 = subprocess.run(
@@ -1246,7 +1256,7 @@ def test_cacheDiskSurvivesProcessRestart(tmp_path):
         capture_output=True, text=True, timeout=120
     )
     assert r2.returncode == 0, f"Process 2 failed:\n{r2.stderr}"
-    assert float(r2.stdout.splitlines()[0].strip()) == pytest.approx(77.0), (
+    assert _parse_subprocess_float(r2.stdout) == pytest.approx(77.0), (
         "Disk-cached cfunc from process 1 must not contaminate process 2's output"
     )
 
@@ -1305,7 +1315,7 @@ def test_cacheDiskImplBodyChange(tmp_path):
         capture_output=True, text=True, timeout=120
     )
     assert r1.returncode == 0, f"Process 1 failed:\n{r1.stderr}"
-    assert float(r1.stdout.strip()) == pytest.approx(11.0)
+    assert _parse_subprocess_float(r1.stdout) == pytest.approx(11.0)
 
     # Edit the file: impl now outputs 22.0 (mtime advances, co_consts changes)
     script.write_text(_FILE_EDIT_TEMPLATE.format(value="22.0"))
@@ -1316,7 +1326,8 @@ def test_cacheDiskImplBodyChange(tmp_path):
         capture_output=True, text=True, timeout=120
     )
     assert r2.returncode == 0, f"Process 2 failed:\n{r2.stderr}"
-    assert float(r2.stdout.strip()) == pytest.approx(22.0), (
+    result = _parse_subprocess_float(r2.stdout)
+    assert result == pytest.approx(22.0), (
         f"Edited UpdateStateImpl (22.0) must be used; got {r2.stdout.strip()} — "
         "stale disk cache not invalidated after impl body change"
     )

--- a/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
+++ b/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
@@ -1,0 +1,1322 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+"""
+Unit tests for NumbaModel.
+
+Section  Topic
+-------  ----------------------------------------------------------------------
+1        Basic scalar I/O + memory namespace (smoke test)
+2        Auto-convert scalar / list memory at Reset time
+3        Post-Reset convenience writes via memory namespace
+4        CurrentSimNanos parameter
+5        IsLinked: scalar reader (unlinked, linked, becomes linked mid-sim)
+6        Message chain: producer -> consumer (scalar I/O, memory)
+7        List readers: all linked, partial link (IsLinked array)
+8        List writers
+9        Dict readers: key introspection, data round-trip, unlinked error
+10       Dict writers
+11       2-D memory array
+12       moduleID parameter
+13       Re-wiring: subscribeTo after Reset
+14       Memory persistence across resets
+15       Error cases (incl. empty containers, empty memory)
+16       Dict reader IsLinked keyed access
+17       bskLogger proxy
+"""
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pytest
+
+from Basilisk.architecture import messaging, bskLogging
+from Basilisk.utilities import SimulationBaseClass
+
+try:
+    import Basilisk.architecture.numbaModel as numbaModelModule
+    from Basilisk.architecture.numbaModel import NumbaModel, _NBMODEL_CFUNC_CACHE
+    couldImport = True
+except Exception:
+    numbaModelModule = None
+    NumbaModel = object
+    _NBMODEL_CFUNC_CACHE = {}
+    couldImport = False
+
+pytestmark = pytest.mark.skipif(
+    not couldImport,
+    reason="Compiled Basilisk without numba support or numba not available",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal sim, add a model, initialize and run for N ticks
+# ---------------------------------------------------------------------------
+def _run(model, dt_ns=5, n_ticks=5):
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", dt_ns))
+    scSim.AddModelToTask("task", model)
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(dt_ns * (n_ticks - 1))
+    scSim.ExecuteSimulation()
+    return scSim
+
+
+# ===========================================================================
+# 1. Basic scalar I/O + memory namespace
+# ===========================================================================
+class BasicModel(NumbaModel):
+    """Minimal scalar input/output model with one integer memory field."""
+
+    def __init__(self):
+        """Declare one optional reader, one writer, and the step counter."""
+        super().__init__()
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.step = np.int32(0)
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked,
+                        dataOutMsgPayload, CurrentSimNanos, memory):
+        """Forward the input vector when linked and increment the step count."""
+        vec = np.zeros(3)
+        if dataInMsgIsLinked:
+            vec[:] = dataInMsgPayload.dataVector
+        memory.step += np.int32(1)
+        out = vec.copy()
+        out[0] += memory.step
+        dataOutMsgPayload.dataVector[:] = out
+
+
+def test_basicModel():
+    mod = BasicModel()
+    mod.ModelTag = "basic"
+    _run(mod, dt_ns=5, n_ticks=5)
+
+    out = mod.dataOutMsg.read()
+    assert out.dataVector[0] == pytest.approx(5.0)   # step counts 5 ticks
+    assert mod.memory.step == 5
+
+
+# ===========================================================================
+# 2. Auto-convert scalar / list memory at Reset time
+# ===========================================================================
+class AutoConvertModel(NumbaModel):
+    """Model used to verify scalar and list memory auto-conversion."""
+
+    def __init__(self):
+        """Declare one writer and memory fields with Python-native defaults."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.kp   = 2.0              # plain float → scalar field
+        self.memory.bias = [0.1, 0.2, 0.3]  # list        → 1-D array field
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory):
+        """Write the gain-plus-bias result into the outgoing message."""
+        for i in range(3):
+            dataOutMsgPayload.dataVector[i] = memory.kp + memory.bias[i]
+
+
+def test_autoConvertMemory():
+    mod = AutoConvertModel()
+    _run(mod, dt_ns=5, n_ticks=1)
+
+    assert float(mod.memory.kp)  == pytest.approx(2.0)
+    assert mod.memory.bias.shape == (3,)
+
+    out = mod.dataOutMsg.read()
+    np.testing.assert_allclose(out.dataVector, [2.1, 2.2, 2.3])
+
+
+# ===========================================================================
+# 3. Post-Reset convenience writes via memory namespace
+# ===========================================================================
+def test_postResetConvenienceWrite():
+    mod = BasicModel()
+    _run(mod, dt_ns=5, n_ticks=1)
+
+    # Scalar convenience write propagates to the underlying buffer
+    mod.memory.step = np.int32(99)
+    assert mod.memory.step == 99
+
+    mod.memory.step = np.int32(42)
+    assert mod.memory.step == 42
+
+    # Setting a non-existent field after Reset must raise
+    with pytest.raises(AttributeError, match="does not exist after Reset"):
+        mod.memory.new_field = 1
+
+
+# ===========================================================================
+# 4. CurrentSimNanos parameter
+# ===========================================================================
+class TimeRecorderModel(NumbaModel):
+    """Records the last simulation time and a tick counter in memory."""
+    def __init__(self):
+        """Declare one writer plus timestamp and counter memory fields."""
+        super().__init__()
+        self.dataOutMsg    = messaging.CModuleTemplateMsg()
+        self.memory.last_ns    = np.uint64(0)
+        self.memory.tick_count = np.int32(0)
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, CurrentSimNanos, memory):
+        """Store the current simulation time and publish it as a float."""
+        memory.last_ns     = CurrentSimNanos
+        memory.tick_count += np.int32(1)
+        dataOutMsgPayload.dataVector[0] = float(CurrentSimNanos)
+
+
+def test_currentSimNanos():
+    mod = TimeRecorderModel(); mod.ModelTag = "timer"
+    # ticks at t = 0, 5, 10 ns
+    _run(mod, dt_ns=5, n_ticks=3)
+
+    assert int(mod.memory.last_ns)   == 10   # last tick at 10 ns
+    assert mod.memory.tick_count     == 3
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(10.0)
+
+
+# ===========================================================================
+# 5. IsLinked flag - scalar reader
+# ===========================================================================
+class GuardedReaderModel(NumbaModel):
+    """Forwards payload when linked; writes sentinel −1 when unlinked."""
+    def __init__(self):
+        """Declare one guarded reader, one writer, and a linkage flag."""
+        super().__init__()
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.ever_linked = np.int32(0)
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked,
+                        dataOutMsgPayload, memory):
+        """Copy the input when linked and publish a sentinel otherwise."""
+        if dataInMsgIsLinked:
+            memory.ever_linked = np.int32(1)
+            dataOutMsgPayload.dataVector[:] = dataInMsgPayload.dataVector
+        else:
+            dataOutMsgPayload.dataVector[0] = -1.0
+
+
+def test_islinkedUnlinked():
+    """Unlinked reader → IsLinked is False; cfunc takes the else branch."""
+    mod = GuardedReaderModel(); mod.ModelTag = "unlinked"
+    _run(mod, dt_ns=5, n_ticks=2)
+    assert mod.memory.ever_linked == 0
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(-1.0)
+
+
+def test_islinkedLinked():
+    """Subscribed reader → IsLinked is True; payload is forwarded."""
+    src = messaging.CModuleTemplateMsg()
+    mod = GuardedReaderModel(); mod.ModelTag = "linked"
+    mod.dataInMsg.subscribeTo(src)
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+    scSim.AddModelToTask("task", mod)
+    scSim.InitializeSimulation()
+
+    p = messaging.CModuleTemplateMsgPayload()
+    p.dataVector = [7.0, 8.0, 9.0]
+    src.write(p)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+
+    assert mod.memory.ever_linked == 1
+    np.testing.assert_allclose(mod.dataOutMsg.read().dataVector, [7.0, 8.0, 9.0])
+
+
+def test_islinkedBecomesLinkedMidSim():
+    """Reader starts unlinked; subscribed after first tick - cfunc picks it up."""
+    src = messaging.CModuleTemplateMsg()
+    mod = GuardedReaderModel(); mod.ModelTag = "midlink"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+    scSim.AddModelToTask("task", mod)
+    scSim.InitializeSimulation()
+
+    scSim.ConfigureStopTime(5)       # t=0 - still unlinked
+    scSim.ExecuteSimulation()
+    assert mod.memory.ever_linked == 0
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(-1.0)
+
+    # Subscribe mid-sim (no Reset)
+    mod.dataInMsg.subscribeTo(src)
+    p = messaging.CModuleTemplateMsgPayload()
+    p.dataVector = [2.0, 3.0, 4.0]
+    src.write(p)
+
+    scSim.ConfigureStopTime(10)      # t=5 - now linked
+    scSim.ExecuteSimulation()
+    assert mod.memory.ever_linked == 1
+    np.testing.assert_allclose(mod.dataOutMsg.read().dataVector, [2.0, 3.0, 4.0])
+
+
+# ===========================================================================
+# 6. Message chain: producer → consumer
+# ===========================================================================
+class ProducerModel(NumbaModel):
+    """Source model used to exercise chained message passing."""
+
+    def __init__(self):
+        """Declare one writer and a counter stored in persistent memory."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.count = 0.0
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory):
+        """Increment the counter and publish three scaled copies."""
+        memory.count += 1.0
+        dataOutMsgPayload.dataVector[0] = memory.count
+        dataOutMsgPayload.dataVector[1] = memory.count * 2.0
+        dataOutMsgPayload.dataVector[2] = memory.count * 3.0
+
+
+class ConsumerModel(NumbaModel):
+    """Sink model that scales the producer output by a fixed factor."""
+
+    def __init__(self):
+        """Declare one input reader and one output writer."""
+        super().__init__()
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload):
+        """Copy the input vector into the output after multiplying by ten."""
+        if dataInMsgIsLinked:
+            for i in range(3):
+                dataOutMsgPayload.dataVector[i] = dataInMsgPayload.dataVector[i] * 10.0
+
+
+def test_messageChain():
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+
+    prod = ProducerModel(); prod.ModelTag = "prod"
+    cons = ConsumerModel(); cons.ModelTag = "cons"
+    scSim.AddModelToTask("task", prod)
+    scSim.AddModelToTask("task", cons)
+
+    cons.dataInMsg.subscribeTo(prod.dataOutMsg)
+
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(20)  # t=0,5,10,15,20 → 5 ticks
+    scSim.ExecuteSimulation()
+
+    out = cons.dataOutMsg.read()
+    # prod ran 5 times → count=5; cons scales ×10
+    assert out.dataVector[0] == pytest.approx(50.0)
+    assert out.dataVector[1] == pytest.approx(100.0)
+    assert out.dataVector[2] == pytest.approx(150.0)
+
+
+# ===========================================================================
+# 7. List of messages - readers
+# ===========================================================================
+class MultiInModel(NumbaModel):
+    """Two input readers summed into one output."""
+    def __init__(self):
+        """Declare a two-reader container feeding one output message."""
+        super().__init__()
+        self.dataInMsg  = [messaging.CModuleTemplateMsgReader(),
+                           messaging.CModuleTemplateMsgReader()]
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload):
+        """Sum the first component from each linked reader."""
+        total = 0.0
+        for i in range(2):
+            if dataInMsgIsLinked[i]:
+                total += dataInMsgPayload[i].dataVector[0]
+        dataOutMsgPayload.dataVector[0] = total
+
+
+def test_listReaderBothLinked():
+    """Both readers subscribed → sum of both sources."""
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+
+    src0 = messaging.CModuleTemplateMsg()
+    src1 = messaging.CModuleTemplateMsg()
+    mod  = MultiInModel(); mod.ModelTag = "multi"
+
+    scSim.AddModelToTask("task", mod)
+    mod.dataInMsg[0].subscribeTo(src0)
+    mod.dataInMsg[1].subscribeTo(src1)
+    scSim.InitializeSimulation()
+
+    p0 = messaging.CModuleTemplateMsgPayload(); p0.dataVector = [3.0, 0.0, 0.0]
+    p1 = messaging.CModuleTemplateMsgPayload(); p1.dataVector = [7.0, 0.0, 0.0]
+    src0.write(p0); src1.write(p1)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(10.0)
+
+
+def test_listReaderPartialLink():
+    """reader[0] subscribed, reader[1] unlinked → only reader[0] contributes."""
+    src = messaging.CModuleTemplateMsg()
+    mod = MultiInModel(); mod.ModelTag = "partial"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+    scSim.AddModelToTask("task", mod)
+    mod.dataInMsg[0].subscribeTo(src)
+    # dataInMsg[1] intentionally left unlinked
+
+    scSim.InitializeSimulation()
+
+    p = messaging.CModuleTemplateMsgPayload(); p.dataVector = [4.0, 0.0, 0.0]
+    src.write(p)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+
+    # IsLinked[0]=True (4.0), IsLinked[1]=False (0.0) → sum = 4.0
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(4.0)
+
+
+def test_listReaderNoneLinked():
+    """Both readers unlinked → output stays zero."""
+    mod = MultiInModel(); mod.ModelTag = "nonelinked"
+    _run(mod, dt_ns=5, n_ticks=1)
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(0.0)
+
+
+# ===========================================================================
+# 8. List of messages - writers
+# ===========================================================================
+class MultiOutModel(NumbaModel):
+    """One input reader → two indexed output writers."""
+    def __init__(self):
+        """Declare one reader and two output messages in a list."""
+        super().__init__()
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = [messaging.CModuleTemplateMsg(),
+                           messaging.CModuleTemplateMsg()]
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload):
+        """Write the input value and its doubled copy to the outputs."""
+        v = 0.0
+        if dataInMsgIsLinked:
+            v = dataInMsgPayload.dataVector[0]
+        dataOutMsgPayload[0].dataVector[0] = v
+        dataOutMsgPayload[1].dataVector[0] = v * 2.0
+
+
+def test_listWriter():
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+
+    src = messaging.CModuleTemplateMsg()
+    mod = MultiOutModel(); mod.ModelTag = "multiout"
+    scSim.AddModelToTask("task", mod)
+    mod.dataInMsg.subscribeTo(src)
+    scSim.InitializeSimulation()
+
+    p = messaging.CModuleTemplateMsgPayload(); p.dataVector = [5.0, 0.0, 0.0]
+    src.write(p)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+
+    assert mod.dataOutMsg[0].read().dataVector[0] == pytest.approx(5.0)
+    assert mod.dataOutMsg[1].read().dataVector[0] == pytest.approx(10.0)
+
+
+# ===========================================================================
+# 9. Dict of messages - readers
+# ===========================================================================
+class DictInModel(NumbaModel):
+    """Dictionary-based input reader model used for key-order tests."""
+
+    def __init__(self):
+        """Declare two named readers and one output message."""
+        super().__init__()
+        self.dataInMsg = {
+            'a': messaging.CModuleTemplateMsgReader(),
+            'b': messaging.CModuleTemplateMsgReader(),
+        }
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataOutMsgPayload):
+        """Route the named inputs into separate output vector components."""
+        dataOutMsgPayload.dataVector[0] = dataInMsgPayload['a'].dataVector[0]
+        dataOutMsgPayload.dataVector[1] = dataInMsgPayload['b'].dataVector[0]
+
+
+def test_dictReaderKeys():
+    """Key order is preserved and accessible from Python after Reset."""
+    src_a = messaging.CModuleTemplateMsg()
+    src_b = messaging.CModuleTemplateMsg()
+    mod = DictInModel(); mod.ModelTag = "dictIn"
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc = scSim.CreateNewProcess("p"); proc.addTask(scSim.CreateNewTask("t", 5))
+    scSim.AddModelToTask("t", mod)
+    mod.dataInMsg['a'].subscribeTo(src_a)
+    mod.dataInMsg['b'].subscribeTo(src_b)
+    scSim.InitializeSimulation()
+    assert mod._dataInMsgKeys == ('a', 'b')
+
+
+def test_dictReaderData():
+    """Payload from each dict key is routed to the correct output field."""
+    src_a = messaging.CModuleTemplateMsg()
+    src_b = messaging.CModuleTemplateMsg()
+    mod = DictInModel(); mod.ModelTag = "dictInData"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("p")
+    proc.addTask(scSim.CreateNewTask("t", 5))
+    scSim.AddModelToTask("t", mod)
+    mod.dataInMsg['a'].subscribeTo(src_a)
+    mod.dataInMsg['b'].subscribeTo(src_b)
+    scSim.InitializeSimulation()
+
+    p_a = messaging.CModuleTemplateMsgPayload(); p_a.dataVector = [3.0, 0.0, 0.0]
+    p_b = messaging.CModuleTemplateMsgPayload(); p_b.dataVector = [7.0, 0.0, 0.0]
+    src_a.write(p_a); src_b.write(p_b)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+
+    out = mod.dataOutMsg.read()
+    assert out.dataVector[0] == pytest.approx(3.0)   # from 'a'
+    assert out.dataVector[1] == pytest.approx(7.0)   # from 'b'
+
+
+def test_errorUnlinkedWithoutIslinkedGuard():
+    """Declaring ``InMsgPayload`` without ``InMsgIsLinked`` crashes at reset if a reader is unlinked."""
+    src_a = messaging.CModuleTemplateMsg()
+    mod = DictInModel(); mod.ModelTag = "dictUnguarded"
+    mod.dataInMsg['a'].subscribeTo(src_a)
+    # 'b' intentionally left unlinked - no IsLinked guard in UpdateStateImpl
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("p")
+    proc.addTask(scSim.CreateNewTask("t", 5))
+    scSim.AddModelToTask("t", mod)
+
+    with pytest.raises(RuntimeError):
+        scSim.InitializeSimulation()
+
+
+# ===========================================================================
+# 10. Dict of messages - writers
+# ===========================================================================
+class DictOutModel(NumbaModel):
+    """One input reader → two named output messages."""
+    def __init__(self):
+        """Declare one reader and two named output writers."""
+        super().__init__()
+        self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+        self.dataOutMsg = {
+            'pos': messaging.CModuleTemplateMsg(),
+            'neg': messaging.CModuleTemplateMsg(),
+        }
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload):
+        """Write positive and negative copies of the input value."""
+        v = 0.0
+        if dataInMsgIsLinked:
+            v = dataInMsgPayload.dataVector[0]
+        dataOutMsgPayload['pos'].dataVector[0] =  v
+        dataOutMsgPayload['neg'].dataVector[0] = -v
+
+
+def test_dictWriter():
+    src = messaging.CModuleTemplateMsg()
+    mod = DictOutModel(); mod.ModelTag = "dictOut"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("p")
+    proc.addTask(scSim.CreateNewTask("t", 5))
+    scSim.AddModelToTask("t", mod)
+    mod.dataInMsg.subscribeTo(src)
+    scSim.InitializeSimulation()
+
+    p = messaging.CModuleTemplateMsgPayload(); p.dataVector = [6.0, 0.0, 0.0]
+    src.write(p)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+
+    assert mod.dataOutMsg['pos'].read().dataVector[0] == pytest.approx( 6.0)
+    assert mod.dataOutMsg['neg'].read().dataVector[0] == pytest.approx(-6.0)
+
+
+# ===========================================================================
+# 11. 2-D memory array
+# ===========================================================================
+class MatrixMemoryModel(NumbaModel):
+    """Stores a 3×3 diagonal matrix; outputs the diagonal each tick."""
+    def __init__(self):
+        """Declare one output message and a diagonal matrix memory field."""
+        super().__init__()
+        self.dataOutMsg  = messaging.CModuleTemplateMsg()
+        self.memory.diag = np.diag([1.0, 2.0, 3.0])   # shape (3, 3)
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory):
+        """Copy the matrix diagonal into the output vector."""
+        for i in range(3):
+            dataOutMsgPayload.dataVector[i] = memory.diag[i, i]
+
+
+def test_2dMemoryArrayRead():
+    """Cfunc reads 2-D memory field correctly."""
+    mod = MatrixMemoryModel(); mod.ModelTag = "matmem"
+    _run(mod, dt_ns=5, n_ticks=1)
+    np.testing.assert_allclose(mod.dataOutMsg.read().dataVector, [1.0, 2.0, 3.0])
+
+
+def test_2dMemoryArrayPythonWrite():
+    """Python-side assignment to a 2-D memory field propagates to the C buffer."""
+    mod = MatrixMemoryModel(); mod.ModelTag = "matwrite"
+    _run(mod, dt_ns=5, n_ticks=1)
+
+    mod.memory.diag = np.diag([4.0, 5.0, 6.0])
+    assert mod.memory.diag[0, 0] == pytest.approx(4.0)
+    assert mod.memory.diag[1, 1] == pytest.approx(5.0)
+    assert mod.memory.diag[2, 2] == pytest.approx(6.0)
+
+
+# ===========================================================================
+# 12. moduleID parameter
+# ===========================================================================
+class ModuleIDModel(NumbaModel):
+    """Helper model that captures the module ID seen by the compiled kernel."""
+
+    def __init__(self):
+        """Declare one writer and an integer memory slot for the module ID."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.captured_id = np.int64(0)
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory, moduleID):
+        """Store the provided module identifier in persistent memory."""
+        memory.captured_id = moduleID
+
+
+def test_moduleIdParameter():
+    mod = ModuleIDModel(); mod.ModelTag = "mid"
+    _run(mod, dt_ns=5, n_ticks=1)
+    # Python modules receive negative IDs from the sim framework
+    assert mod.memory.captured_id != 0
+    assert int(mod.memory.captured_id) == mod.moduleID
+
+
+# ===========================================================================
+# 13. Re-wiring: subscribeTo after Reset picks up new payload
+# ===========================================================================
+def test_rewireAfterReset():
+    """Switching sources mid-sim is transparent - no Reset required."""
+    src1 = messaging.CModuleTemplateMsg()
+    src2 = messaging.CModuleTemplateMsg()
+
+    mod = ConsumerModel(); mod.ModelTag = "rewire"
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+    scSim.AddModelToTask("task", mod)
+    mod.dataInMsg.subscribeTo(src1)
+
+    scSim.InitializeSimulation()
+
+    p1 = messaging.CModuleTemplateMsgPayload(); p1.dataVector = [1.0, 0.0, 0.0]
+    src1.write(p1)
+
+    scSim.ConfigureStopTime(5)
+    scSim.ExecuteSimulation()
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(10.0)  # src1 × 10
+
+    # Re-wire to src2 without calling Reset
+    p2 = messaging.CModuleTemplateMsgPayload(); p2.dataVector = [3.0, 0.0, 0.0]
+    src2.write(p2)
+    mod.dataInMsg.subscribeTo(src2)
+
+    scSim.ConfigureStopTime(10)
+    scSim.ExecuteSimulation()
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(30.0)  # src2 × 10
+
+
+# ===========================================================================
+# 14. Multiple resets - memory re-initialized to __init__ values
+# ===========================================================================
+def test_multipleResets():
+    """Reset always continues from the current buffer value; cfunc writes and
+    Python writes are treated identically."""
+    mod = BasicModel(); mod.ModelTag = "multireset"
+    _run(mod, dt_ns=5, n_ticks=3)
+    assert mod.memory.step == 3           # cfunc incremented 3 times
+
+    # Second sim: Reset syncs buffer → __dict__, so step resumes from 3
+    scSim2 = SimulationBaseClass.SimBaseClass()
+    proc   = scSim2.CreateNewProcess("proc")
+    proc.addTask(scSim2.CreateNewTask("task", 5))
+    scSim2.AddModelToTask("task", mod)
+    scSim2.InitializeSimulation()          # Reset fires; memory picks up 3
+    assert mod.memory.step == 3
+
+    scSim2.ConfigureStopTime(10)           # 3 more ticks: t=0,5,10
+    scSim2.ExecuteSimulation()
+    assert mod.memory.step == 6           # 3 + 3
+
+
+def test_memoryWritePersistsThroughReset():
+    """Both Python-side writes and cfunc-internal writes survive a subsequent Reset."""
+    mod = BasicModel(); mod.ModelTag = "memwrite"
+    _run(mod, dt_ns=5, n_ticks=2)
+    assert mod.memory.step == 2           # cfunc wrote 2
+
+    # Python-side override
+    mod.memory.step = np.int32(10)
+    assert mod.memory.step == 10
+
+    # Reset picks up 10 (last write wins, regardless of source)
+    scSim2 = SimulationBaseClass.SimBaseClass()
+    proc   = scSim2.CreateNewProcess("proc")
+    proc.addTask(scSim2.CreateNewTask("task", 5))
+    scSim2.AddModelToTask("task", mod)
+    scSim2.InitializeSimulation()
+    assert mod.memory.step == 10
+
+    scSim2.ConfigureStopTime(5)           # 2 ticks
+    scSim2.ExecuteSimulation()
+    assert mod.memory.step == 12          # 10 + 2
+
+
+# ===========================================================================
+# 15. Error cases
+# ===========================================================================
+def test_errorNotOverridden():
+    class Bad(NumbaModel):
+        """Model that intentionally omits ``UpdateStateImpl``."""
+        pass
+    with pytest.raises(NotImplementedError, match="must override UpdateStateImpl"):
+        Bad().Reset()
+
+
+def test_errorNotStaticmethod():
+    class Bad(NumbaModel):
+        """Model with a non-static compiled entry point."""
+
+        def UpdateStateImpl(self):
+            """Stand-in invalid implementation used for error handling tests."""
+            pass
+    with pytest.raises(TypeError, match="@staticmethod"):
+        Bad().Reset()
+
+
+def test_errorMissingInMsg():
+    class Bad(NumbaModel):
+        """Model whose implementation references a missing input reader."""
+
+        def __init__(self):
+            """Leave out ``dataInMsg`` on purpose for the regression test."""
+            super().__init__()
+            # forgot to add self.dataInMsg
+
+        @staticmethod
+        def UpdateStateImpl(dataInMsgPayload):
+            """Dummy implementation used only to trigger setup validation."""
+            pass
+
+    with pytest.raises(AttributeError, match="dataInMsg"):
+        Bad().Reset()
+
+
+def test_errorIslinkedWithoutPayload():
+    """An IsLinked flag without a matching Payload param leaves the variable
+    undefined in the generated wrapper, which Numba catches as a TypingError."""
+    import numba
+    class Bad(NumbaModel):
+        """Model that declares ``IsLinked`` without the payload parameter."""
+
+        def __init__(self):
+            """Declare one reader and one writer for the malformed signature."""
+            super().__init__()
+            self.dataInMsg  = messaging.CModuleTemplateMsgReader()
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+        @staticmethod
+        def UpdateStateImpl(dataInMsgIsLinked, dataOutMsgPayload):
+            """Intentionally omit the payload parameter to provoke a typing error."""
+            pass   # missing dataInMsgPayload
+
+    with pytest.raises(numba.core.errors.TypingError, match="dataInMsgIsLinked"):
+        Bad().Reset()
+
+
+def test_errorUnrecognisedParam():
+    class Bad(NumbaModel):
+        """Model with an unsupported parameter name in the compiled signature."""
+
+        def __init__(self):
+            """Provide the minimal base initialization for the error case."""
+            super().__init__()
+
+        @staticmethod
+        def UpdateStateImpl(mystery):
+            """Expose an unknown parameter name for validation testing."""
+            pass
+
+    with pytest.raises(AttributeError, match="does not match any known pattern"):
+        Bad().Reset()
+
+
+def test_emptyListReader():
+    """Empty list attribute is allowed; cfunc receives a zero-element array (never iterated)."""
+    class EmptyListInModel(NumbaModel):
+        """Model that exercises an empty list of input readers."""
+
+        def __init__(self):
+            """Declare an empty reader list, one writer, and a counter."""
+            super().__init__()
+            self.dataInMsg  = []
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+            self.memory.count = np.int32(0)
+
+        @staticmethod
+        def UpdateStateImpl(dataInMsgPayload, dataOutMsgPayload, memory):
+            """Increment a counter without ever indexing the empty input list."""
+            memory.count += np.int32(1)
+            dataOutMsgPayload.dataVector[0] = float(memory.count)
+
+    mod = EmptyListInModel(); mod.ModelTag = "emptylist"
+    _run(mod, dt_ns=5, n_ticks=3)
+    assert mod.memory.count == 3
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(3.0)
+
+
+def test_emptyMemory():
+    """No memory fields defined: 'memory' param still compiles as a valid (ignored) Record."""
+    class EmptyMemoryModel(NumbaModel):
+        """Model that requests the memory record without declaring fields."""
+
+        def __init__(self):
+            """Declare only the output message for the empty-memory case."""
+            super().__init__()
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+            # no self.memory.* fields defined
+
+        @staticmethod
+        def UpdateStateImpl(dataOutMsgPayload, memory):
+            """Ignore the empty memory record and publish a constant."""
+            dataOutMsgPayload.dataVector[0] = 42.0
+
+    mod = EmptyMemoryModel(); mod.ModelTag = "emptymem"
+    _run(mod, dt_ns=5, n_ticks=1)
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(42.0)
+
+
+# ===========================================================================
+# 16. bskLogger proxy - bskLog / bskLog1 inside UpdateStateImpl
+# ===========================================================================
+def test_dictIslinkedKeyed():
+    """Dict reader IsLinked is accessible by key name: dataInMsgIsLinked['a']."""
+    class DictIsLinkedModel(NumbaModel):
+        """Dictionary-reader model used to verify keyed ``IsLinked`` access."""
+
+        def __init__(self):
+            """Declare two named readers and one output message."""
+            super().__init__()
+            self.dataInMsg = {
+                'a': messaging.CModuleTemplateMsgReader(),
+                'b': messaging.CModuleTemplateMsgReader(),
+            }
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+        @staticmethod
+        def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload):
+            """Forward only the dictionary entries whose link flags are true."""
+            if dataInMsgIsLinked['a']:
+                dataOutMsgPayload.dataVector[0] = dataInMsgPayload['a'].dataVector[0]
+            if dataInMsgIsLinked['b']:
+                dataOutMsgPayload.dataVector[1] = dataInMsgPayload['b'].dataVector[0]
+
+    src_a = messaging.CModuleTemplateMsg()
+    src_b = messaging.CModuleTemplateMsg()
+    mod = DictIsLinkedModel(); mod.ModelTag = "dictlnk"
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc = scSim.CreateNewProcess("p"); proc.addTask(scSim.CreateNewTask("t", 5))
+    scSim.AddModelToTask("t", mod)
+    mod.dataInMsg['a'].subscribeTo(src_a)   # 'b' left unlinked
+
+    scSim.InitializeSimulation()
+
+    p_a = messaging.CModuleTemplateMsgPayload(); p_a.dataVector = [3.0, 0.0, 0.0]
+    p_b = messaging.CModuleTemplateMsgPayload(); p_b.dataVector = [7.0, 0.0, 0.0]
+    src_a.write(p_a); src_b.write(p_b)
+
+    scSim.ConfigureStopTime(5); scSim.ExecuteSimulation()
+
+    out = mod.dataOutMsg.read()
+    assert out.dataVector[0] == pytest.approx(3.0)   # 'a' linked → forwarded
+    assert out.dataVector[1] == pytest.approx(0.0)   # 'b' unlinked → untouched
+
+    # Now link 'b' mid-sim and verify it becomes accessible
+    mod.dataInMsg['b'].subscribeTo(src_b)
+    scSim.ConfigureStopTime(10); scSim.ExecuteSimulation()
+
+    out2 = mod.dataOutMsg.read()
+    assert out2.dataVector[0] == pytest.approx(3.0)
+    assert out2.dataVector[1] == pytest.approx(7.0)
+
+
+def test_bsklogger():
+    """bskLog / bskLog1 inside UpdateStateImpl should not crash; logic must run."""
+    class LoggingModel(NumbaModel):
+        """Model that exercises the ``bskLogger`` proxy from compiled code."""
+
+        def __init__(self):
+            """Declare one writer and a small integer step counter."""
+            super().__init__()
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+            self.memory.step = np.int32(0)
+
+        @staticmethod
+        def UpdateStateImpl(dataOutMsgPayload, bskLogger, memory):
+            """Log two messages and publish the incremented step count."""
+            memory.step += np.int32(1)
+            bskLogger.bskLog(bskLogging.BSK_INFORMATION, "step update")
+            bskLogger.bskLog1(bskLogging.BSK_WARNING, "step:", memory.step)
+            dataOutMsgPayload.dataVector[0] = float(memory.step)
+
+    mod = LoggingModel(); mod.ModelTag = "logsimple"
+    _run(mod, dt_ns=5, n_ticks=3)
+    assert mod.memory.step == 3
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(3.0)
+
+
+# ===========================================================================
+# 18. Cache correctness — stale-cache stress tests
+#
+# These tests intentionally probe edge cases where the fingerprint-based cache
+# could produce stale or colliding entries.
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Shared model classes used across multiple tests
+# ---------------------------------------------------------------------------
+
+class _ConstWriterModel(NumbaModel):
+    """Writes a configurable constant from memory to CModuleTemplateMsg."""
+    def __init__(self, value: float):
+        """Declare the output message and initialize the stored constant."""
+        super().__init__()
+        self.dataOutMsg   = messaging.CModuleTemplateMsg()
+        self.memory.val = np.float64(value)
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory):
+        """Publish the constant stored in persistent memory."""
+        dataOutMsgPayload.dataVector[0] = memory.val
+
+
+class _DtypeVaryReaderModel(NumbaModel):
+    """Same class but reader type varies per instance (injected via constructor)."""
+    def __init__(self, readerFactory):
+        """Instantiate the injected reader type and a fixed output message."""
+        super().__init__()
+        self.dataInMsg  = readerFactory()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.memory.val = np.float64(99.0)
+
+    @staticmethod
+    def UpdateStateImpl(dataInMsgPayload, dataInMsgIsLinked, dataOutMsgPayload, memory):
+        """Ignore the payload contents and publish the sentinel value."""
+        # Deliberately does NOT access dataInMsgPayload fields (they differ by dtype).
+        # The reader is there solely to force different dtypeHash values.
+        dataOutMsgPayload.dataVector[0] = memory.val
+
+
+class _LoggerCacheModel(NumbaModel):
+    """Model that emits one warning through the compiled logger proxy."""
+
+    def __init__(self):
+        """Declare a writer so the model has a visible execution side effect."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, bskLogger):
+        """Emit a warning and write a sentinel value."""
+        bskLogger.bskLog(bskLogging.BSK_WARNING, "logger cache warning")
+        dataOutMsgPayload.dataVector[0] = 1.0
+
+
+def _runWithLoggerLevel(model, logLevel, dt_ns=5, n_ticks=1):
+    """Run one model while setting the owning simulation logger level."""
+    scSim = SimulationBaseClass.SimBaseClass()
+    scSim.bskLogger.setLogLevel(logLevel)
+    proc = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", dt_ns))
+    scSim.AddModelToTask("task", model)
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(dt_ns * (n_ticks - 1))
+    scSim.ExecuteSimulation()
+    return scSim
+
+
+# ---------------------------------------------------------------------------
+# 18a. Different dtype, same class → no fingerprint collision
+# ---------------------------------------------------------------------------
+
+def test_cacheNoDtypeCollision():
+    """Same class, different reader dtypes → distinct fingerprints, no in-process collision.
+
+    Regression test for the location-based idHash bug: md5(file:qualname) produced
+    the same key for all instances of a class regardless of message-type configuration.
+    """
+    _NBMODEL_CFUNC_CACHE.clear()
+
+    modA = _DtypeVaryReaderModel(messaging.CModuleTemplateMsgReader)
+    modA.ModelTag = "dtypeA"
+    _run(modA, dt_ns=5, n_ticks=1)
+
+    modB = _DtypeVaryReaderModel(messaging.AttGuidMsgReader)
+    modB.ModelTag = "dtypeB"
+    _run(modB, dt_ns=5, n_ticks=1)
+
+    assert len(_NBMODEL_CFUNC_CACHE) >= 2, (
+        "Different reader dtypes must produce distinct fingerprints; "
+        "old location-based idHash would have produced only 1 entry here"
+    )
+    assert modA._cfunc is not modB._cfunc, (
+        "Instances with different dtypes must not share the same cfunc object"
+    )
+    # Both should still produce the correct output
+    assert modA.dataOutMsg.read().dataVector[0] == pytest.approx(99.0)
+    assert modB.dataOutMsg.read().dataVector[0] == pytest.approx(99.0)
+
+
+# ---------------------------------------------------------------------------
+# 18b. Same dtype, same class → single cache entry; cfunc is shared
+# ---------------------------------------------------------------------------
+
+def test_cacheSameDtypeSharesCfunc():
+    """Two instances with identical dtype config share exactly one cfunc."""
+    _NBMODEL_CFUNC_CACHE.clear()
+
+    modA = _ConstWriterModel(1.0); modA.ModelTag = "sharedA"
+    modB = _ConstWriterModel(2.0); modB.ModelTag = "sharedB"
+    _run(modA, dt_ns=5, n_ticks=1)
+
+    cache_before = len(_NBMODEL_CFUNC_CACHE)
+    _run(modB, dt_ns=5, n_ticks=1)
+    cache_after = len(_NBMODEL_CFUNC_CACHE)
+
+    assert cache_after == cache_before, (
+        "Second instance with same dtype must hit in-process cache, not add a new entry"
+    )
+    assert modA._cfunc is modB._cfunc, "Same dtype config must reuse the same cfunc object"
+
+
+# ---------------------------------------------------------------------------
+# 18c. Different logger levels, same class → runtime level respected, cfunc shared
+# ---------------------------------------------------------------------------
+
+def test_cacheLoggerLevelRuntime(monkeypatch, tmp_path, capfd):
+    """Logger level is read at runtime; models with different levels share one cfunc."""
+    _NBMODEL_CFUNC_CACHE.clear()
+    monkeypatch.setattr(numbaModelModule, "getCacheDir", lambda: tmp_path)
+
+    modA = _LoggerCacheModel(); modA.ModelTag = "logCacheA"
+    _runWithLoggerLevel(modA, bskLogging.BSK_ERROR)
+    suppressed = capfd.readouterr()
+    assert "logger cache warning" not in suppressed.out
+
+    modB = _LoggerCacheModel(); modB.ModelTag = "logCacheB"
+    _runWithLoggerLevel(modB, bskLogging.BSK_WARNING)
+    emitted = capfd.readouterr()
+    assert "logger cache warning" in emitted.out
+    assert modA._cfunc is modB._cfunc
+
+
+# ---------------------------------------------------------------------------
+# 18d. Shared cfunc, independent per-instance state (allPtrs_ is per-instance)
+# ---------------------------------------------------------------------------
+
+def test_cacheSharedCfuncIndependentState():
+    """Two instances share one cfunc but each has its own ``allPtrs_`` buffer, so outputs never bleed."""
+    modA = _ConstWriterModel(11.0); modA.ModelTag = "indepA"
+    modB = _ConstWriterModel(22.0); modB.ModelTag = "indepB"
+
+    _run(modA, dt_ns=5, n_ticks=3)
+    _run(modB, dt_ns=5, n_ticks=3)
+
+    assert modA.dataOutMsg.read().dataVector[0] == pytest.approx(11.0)
+    assert modB.dataOutMsg.read().dataVector[0] == pytest.approx(22.0)
+
+
+# ---------------------------------------------------------------------------
+# 18d. In-process cache cleared → disk cache produces correct output
+# ---------------------------------------------------------------------------
+
+def test_cacheDiskReuseAfterInProcessClear():
+    """Clear _NBMODEL_CFUNC_CACHE, re-run same config → disk path gives correct result."""
+    _NBMODEL_CFUNC_CACHE.clear()
+
+    modA = _ConstWriterModel(7.0); modA.ModelTag = "diskA"
+    _run(modA, dt_ns=5, n_ticks=1)
+    assert modA.dataOutMsg.read().dataVector[0] == pytest.approx(7.0)
+
+    # Remember which fp was cached
+    fps_before = set(_NBMODEL_CFUNC_CACHE.keys())
+
+    _NBMODEL_CFUNC_CACHE.clear()
+
+    # Second instance, same class+dtype → must use disk cache
+    modB = _ConstWriterModel(13.0); modB.ModelTag = "diskB"
+    _run(modB, dt_ns=5, n_ticks=1)
+    assert modB.dataOutMsg.read().dataVector[0] == pytest.approx(13.0)
+
+    # fp should be back in the in-process cache (disk hit re-populates it)
+    fps_after = set(_NBMODEL_CFUNC_CACHE.keys())
+    assert fps_before == fps_after, (
+        "Disk cache hit must restore the fingerprint to the in-process cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 18e. Two classes with identical structure + dtypes but different UpdateStateImpl
+#      → implIdentity differs → different fingerprints → independent cfuncs
+# ---------------------------------------------------------------------------
+
+class _ImplIsoClassA(NumbaModel):
+    """Isolation test class whose implementation always writes ``100.0``."""
+
+    def __init__(self):
+        """Declare the output message for the implementation-isolation test."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory):
+        """Publish the class-A sentinel output value."""
+        dataOutMsgPayload.dataVector[0] = 100.0
+
+
+class _ImplIsoClassB(NumbaModel):
+    """Isolation test class whose implementation always writes ``200.0``."""
+
+    def __init__(self):
+        """Declare the output message for the implementation-isolation test."""
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+    @staticmethod
+    def UpdateStateImpl(dataOutMsgPayload, memory):
+        """Publish the class-B sentinel output value."""
+        dataOutMsgPayload.dataVector[0] = 200.0
+
+
+def test_cacheImplIdentityIsolation():
+    """Two classes with same dtype/structure but different UpdateStateImpl must not share cfunc."""
+    _NBMODEL_CFUNC_CACHE.clear()
+
+    modA = _ImplIsoClassA(); modA.ModelTag = "isoA"
+    modB = _ImplIsoClassB(); modB.ModelTag = "isoB"
+    _run(modA, dt_ns=5, n_ticks=1)
+    _run(modB, dt_ns=5, n_ticks=1)
+
+    assert modA.dataOutMsg.read().dataVector[0] == pytest.approx(100.0), (
+        "Class A impl must return 100.0, not bleed into class B's cfunc"
+    )
+    assert modB.dataOutMsg.read().dataVector[0] == pytest.approx(200.0), (
+        "Class B impl must return 200.0, not be overshadowed by class A's cfunc"
+    )
+    assert modA._cfunc is not modB._cfunc, (
+        "Different classes must have different cfuncs even with identical dtype + structure"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 18f. Multiple resets of same model → in-process cache hit on 2nd+ reset
+# ---------------------------------------------------------------------------
+
+def test_cacheMultipleResetsReusesCfunc():
+    """Re-running InitializeSimulation reuses the in-process cfunc (Tier 2 benefit)."""
+    mod = _ConstWriterModel(5.0); mod.ModelTag = "multiReset"
+
+    _NBMODEL_CFUNC_CACHE.clear()
+    _run(mod, dt_ns=5, n_ticks=1)
+    cfunc_first = mod._cfunc
+    cache_size_after_first = len(_NBMODEL_CFUNC_CACHE)
+
+    # Second reset (another InitializeSimulation inside _run)
+    _run(mod, dt_ns=5, n_ticks=1)
+    cfunc_second = mod._cfunc
+
+    assert cfunc_first is cfunc_second, "Second reset must return the same cfunc object"
+    assert len(_NBMODEL_CFUNC_CACHE) == cache_size_after_first, (
+        "No new entry should be added on second reset"
+    )
+    assert mod.dataOutMsg.read().dataVector[0] == pytest.approx(5.0)
+
+# ---------------------------------------------------------------------------
+# 18g. Subprocess: disk cache survives process restart, correct output on reload
+# ---------------------------------------------------------------------------
+
+_SUBPROCESS_SCRIPT = textwrap.dedent("""\
+    import sys, os
+    import numpy as np
+    from Basilisk.architecture.numbaModel import NumbaModel
+    from Basilisk.architecture import messaging
+    from Basilisk.utilities import SimulationBaseClass
+
+    class SubprocModel(NumbaModel):
+        def __init__(self, val):
+            super().__init__()
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+            self.memory.val = np.float64(val)
+
+        @staticmethod
+        def UpdateStateImpl(dataOutMsgPayload, memory):
+            dataOutMsgPayload.dataVector[0] = memory.val
+
+    val = float(sys.argv[1])
+    mod = SubprocModel(val); mod.ModelTag = "sub"
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("proc")
+    proc.addTask(scSim.CreateNewTask("task", 5))
+    scSim.AddModelToTask("task", mod)
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(0)
+    scSim.ExecuteSimulation()
+    print(mod.dataOutMsg.read().dataVector[0])
+""")
+
+
+def test_cacheDiskSurvivesProcessRestart(tmp_path):
+    """Disk cache written in process 1 is used correctly by process 2."""
+    script = tmp_path / "sub_model.py"
+    script.write_text(_SUBPROCESS_SCRIPT)
+
+    # Process 1: cold compile, writes disk cache
+    r1 = subprocess.run(
+        [sys.executable, str(script), "42.0"],
+        capture_output=True, text=True, timeout=120
+    )
+    assert r1.returncode == 0, f"Process 1 failed:\n{r1.stderr}"
+    assert float(r1.stdout.strip()) == pytest.approx(42.0)
+
+    # Process 2: should load from disk cache (fast path)
+    r2 = subprocess.run(
+        [sys.executable, str(script), "77.0"],
+        capture_output=True, text=True, timeout=120
+    )
+    assert r2.returncode == 0, f"Process 2 failed:\n{r2.stderr}"
+    assert float(r2.stdout.splitlines()[0].strip()) == pytest.approx(77.0), (
+        "Disk-cached cfunc from process 1 must not contaminate process 2's output"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 18i. Subprocess: edit UpdateStateImpl body on disk → new process picks it up
+#
+# This is the canonical production staleness scenario:
+#   Process 1 → compiles with impl v1 (11.0), writes disk cache
+#   File edited → impl v2 (22.0), mtime changes
+#   Process 2 → implCodeHash changes → fp changes → new _wrapper file compiled;
+#               Numba detects mtime change → recompiles _impl → output 22.0
+# ---------------------------------------------------------------------------
+
+_FILE_EDIT_TEMPLATE = textwrap.dedent("""\
+    import sys, numpy as np
+    from Basilisk.architecture.numbaModel import NumbaModel
+    from Basilisk.architecture import messaging
+    from Basilisk.utilities import SimulationBaseClass
+
+    class FileEditModel(NumbaModel):
+        def __init__(self):
+            super().__init__()
+            self.dataOutMsg = messaging.CModuleTemplateMsg()
+
+        @staticmethod
+        def UpdateStateImpl(dataOutMsgPayload, memory):
+            dataOutMsgPayload.dataVector[0] = {value}
+
+    mod = FileEditModel(); mod.ModelTag = "fmod"
+    scSim = SimulationBaseClass.SimBaseClass()
+    proc  = scSim.CreateNewProcess("p")
+    proc.addTask(scSim.CreateNewTask("t", 5))
+    scSim.AddModelToTask("t", mod)
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(0)
+    scSim.ExecuteSimulation()
+    print(mod.dataOutMsg.read().dataVector[0])
+""")
+
+
+def test_cacheDiskImplBodyChange(tmp_path):
+    """Edit ``UpdateStateImpl`` on disk between processes and require the new implementation to run.
+
+    This verifies the full production invalidation chain. The implementation
+    body hash changes, the fingerprint changes, a new wrapper file is emitted,
+    and Numba recompiles the implementation after its source timestamp changes.
+    A stale-cache bug would show up as process 2 still returning ``11.0``.
+    """
+    script = tmp_path / "file_edit_model.py"
+
+    # Process 1: impl outputs 11.0 → compile + cache
+    script.write_text(_FILE_EDIT_TEMPLATE.format(value="11.0"))
+    r1 = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True, text=True, timeout=120
+    )
+    assert r1.returncode == 0, f"Process 1 failed:\n{r1.stderr}"
+    assert float(r1.stdout.strip()) == pytest.approx(11.0)
+
+    # Edit the file: impl now outputs 22.0 (mtime advances, co_consts changes)
+    script.write_text(_FILE_EDIT_TEMPLATE.format(value="22.0"))
+
+    # Process 2: must detect the change and output 22.0, not the cached 11.0
+    r2 = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True, text=True, timeout=120
+    )
+    assert r2.returncode == 0, f"Process 2 failed:\n{r2.stderr}"
+    assert float(r2.stdout.strip()) == pytest.approx(22.0), (
+        f"Edited UpdateStateImpl (22.0) must be used; got {r2.stdout.strip()} — "
+        "stale disk cache not invalidated after impl body change"
+    )

--- a/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
+++ b/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
@@ -105,6 +105,7 @@ class BasicModel(NumbaModel):
 
 
 def test_basicModel():
+    """Smoke-test scalar I/O and persistent memory updates."""
     mod = BasicModel()
     mod.ModelTag = "basic"
     _run(mod, dt_ns=5, n_ticks=5)
@@ -135,6 +136,7 @@ class AutoConvertModel(NumbaModel):
 
 
 def test_autoConvertMemory():
+    """Check scalar and list memory fields are converted at reset."""
     mod = AutoConvertModel()
     _run(mod, dt_ns=5, n_ticks=1)
 
@@ -149,6 +151,7 @@ def test_autoConvertMemory():
 # 3. Post-Reset convenience writes via memory namespace
 # ===========================================================================
 def test_postResetConvenienceWrite():
+    """Check post-reset memory writes update existing fields and reject new ones."""
     mod = BasicModel()
     _run(mod, dt_ns=5, n_ticks=1)
 
@@ -185,6 +188,7 @@ class TimeRecorderModel(NumbaModel):
 
 
 def test_currentSimNanos():
+    """Check the compiled model receives the current simulation time."""
     mod = TimeRecorderModel(); mod.ModelTag = "timer"
     # ticks at t = 0, 5, 10 ns
     _run(mod, dt_ns=5, n_ticks=3)
@@ -315,6 +319,7 @@ class ConsumerModel(NumbaModel):
 
 
 def test_messageChain():
+    """Check a NumbaModel output can feed another NumbaModel input."""
     scSim = SimulationBaseClass.SimBaseClass()
     proc  = scSim.CreateNewProcess("proc")
     proc.addTask(scSim.CreateNewTask("task", 5))
@@ -438,6 +443,7 @@ class MultiOutModel(NumbaModel):
 
 
 def test_listWriter():
+    """Check list-based output messages are written by index."""
     scSim = SimulationBaseClass.SimBaseClass()
     proc  = scSim.CreateNewProcess("proc")
     proc.addTask(scSim.CreateNewTask("task", 5))
@@ -561,6 +567,7 @@ class DictOutModel(NumbaModel):
 
 
 def test_dictWriter():
+    """Check dictionary-based output messages are written by key."""
     src = messaging.CModuleTemplateMsg()
     mod = DictOutModel(); mod.ModelTag = "dictOut"
 
@@ -636,6 +643,7 @@ class ModuleIDModel(NumbaModel):
 
 
 def test_moduleIdParameter():
+    """Check the compiled model receives the owning module identifier."""
     mod = ModuleIDModel(); mod.ModelTag = "mid"
     _run(mod, dt_ns=5, n_ticks=1)
     # Python modules receive negative IDs from the sim framework
@@ -727,6 +735,7 @@ def test_memoryWritePersistsThroughReset():
 # 15. Error cases
 # ===========================================================================
 def test_errorNotOverridden():
+    """Check Reset fails when ``UpdateStateImpl`` is not overridden."""
     class Bad(NumbaModel):
         """Model that intentionally omits ``UpdateStateImpl``."""
         pass
@@ -735,6 +744,7 @@ def test_errorNotOverridden():
 
 
 def test_errorNotStaticmethod():
+    """Check Reset fails when ``UpdateStateImpl`` is not static."""
     class Bad(NumbaModel):
         """Model with a non-static compiled entry point."""
 
@@ -746,6 +756,7 @@ def test_errorNotStaticmethod():
 
 
 def test_errorMissingInMsg():
+    """Check Reset fails when a referenced input message is missing."""
     class Bad(NumbaModel):
         """Model whose implementation references a missing input reader."""
 
@@ -786,6 +797,7 @@ def test_errorIslinkedWithoutPayload():
 
 
 def test_errorUnrecognisedParam():
+    """Check Reset fails when the compiled signature has an unknown parameter."""
     class Bad(NumbaModel):
         """Model with an unsupported parameter name in the compiled signature."""
 

--- a/src/architecture/numbaModel/numbaModel.i
+++ b/src/architecture/numbaModel/numbaModel.i
@@ -105,11 +105,18 @@ _bsklogSpec = [
     ('_t3',    nb.types.unicode_type),
 ]
 
+_BSK_LOG_TAGS = (
+    "BSK_DEBUG",
+    "\033[92mBSK_INFORMATION\033[0m",
+    "\033[93mBSK_WARNING\033[0m",
+    "\033[91mBSK_ERROR\033[0m",
+)
+
 @_nbJitclass(_bsklogSpec)
 class BskLoggerProxy:
     """Logging proxy usable inside UpdateStateImpl (nopython mode).
     Calls print(); output goes to stdout.
-    Tags and min-level are read from the module's BSKLogger at Reset time.
+    Tags mirror BSKLogger's static labels; min-level is read from user storage.
     """
     def __init__(self, level, t0, t1, t2, t3):
         self._level = level
@@ -1070,12 +1077,11 @@ class NumbaModel(SysModelMixin, _NumbaModel):
 
         # bskLogger, log level read from userPtr at runtime; tags are compile-time
         if 'bskLogger' in ctx.params:
-            _lmap = self.bskLogger.logLevelMap
             g['BskLoggerProxy'] = BskLoggerProxy
-            g['_bsklog_t0']     = _lmap[0]
-            g['_bsklog_t1']     = _lmap[1]
-            g['_bsklog_t2']     = _lmap[2]
-            g['_bsklog_t3']     = _lmap[3]
+            g['_bsklog_t0']     = _BSK_LOG_TAGS[0]
+            g['_bsklog_t1']     = _BSK_LOG_TAGS[1]
+            g['_bsklog_t2']     = _BSK_LOG_TAGS[2]
+            g['_bsklog_t3']     = _BSK_LOG_TAGS[3]
             preLines.append(
                 f"    bskLogger = BskLoggerProxy("
                 f"nb.carray(allPtrs[_USER_BASE + {ctx.bskLogMinUidx}], 1, np.int32)[0],"

--- a/src/architecture/numbaModel/numbaModel.i
+++ b/src/architecture/numbaModel/numbaModel.i
@@ -1,0 +1,1168 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+%module(directors="1", threads="1", package="Basilisk.architecture") numbaModel
+
+%include "architecture/utilities/bskException.swg"
+%default_bsk_exception();
+
+%{
+#include "architecture/_GeneralModuleFiles/numbaModel.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+/* std::string ↔ Python str, uint64_t, SysModel - same pattern as all BSK sim modules */
+%include "std_string.i"
+%include "stdint.i"
+%import "architecture/_GeneralModuleFiles/py_sys_model.i"
+
+/* uintptr_t: accept any Python int as a raw 64-bit bit-pattern */
+%typemap(in) uintptr_t {
+    unsigned long long tmp = PyLong_AsUnsignedLongLongMask($input);
+    if (PyErr_Occurred()) SWIG_fail;
+    $1 = (uintptr_t)tmp;
+}
+
+/* uintptr_t: return as a full unsigned 64-bit Python int (avoid sign-extension / truncation) */
+%typemap(out) uintptr_t {
+    $result = PyLong_FromUnsignedLongLong((unsigned long long)$1);
+}
+
+/* Expose ReaderSlot struct and NumbaModel class */
+%feature("director") NumbaModel;
+/* UpdateState is implemented in C++ and must NOT go through the Python director.
+   The C++ UpdateState calls the compiled cfunc directly; routing it through SWIG's
+   director mechanism (GIL acquire + Python method lookup) adds ~6 µs per tick. */
+%feature("nodirector") NumbaModel::UpdateState;
+%rename("_NumbaModel") NumbaModel;
+
+/* Suppress SWIG warning for ReaderSlot (internal use only; not wrapped as a Python class) */
+%ignore ReaderSlot;
+
+%include "architecture/_GeneralModuleFiles/numbaModel.h"
+
+%pythoncode %{
+import inspect
+import hashlib
+import importlib.util
+import marshal
+import os
+import pathlib
+import shutil
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from platformdirs import user_cache_dir
+import numpy as np
+import numba as nb
+from numba.experimental import jitclass as _nbJitclass
+
+from Basilisk.architecture import messaging
+from Basilisk.architecture.sysModel import SysModelMixin
+
+_NBMODEL_CFUNC_CACHE: dict = {} # idHash -> cfunc; keeps cfunc alive (prevents GC)
+
+def getCacheDir():
+    """Return platformdirs user cache dir; None if not writable."""
+    d = pathlib.Path(user_cache_dir('basilisk')) / 'numba_model'
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+    except OSError:
+        return None
+
+def clearCacheDir():
+    """Remove all cached numba model functions."""
+    d = getCacheDir()
+    if d is None or not d.exists():
+        return
+    shutil.rmtree(d)
+
+_bsklogSpec = [
+    ('_level', nb.int32),
+    ('_t0',    nb.types.unicode_type),
+    ('_t1',    nb.types.unicode_type),
+    ('_t2',    nb.types.unicode_type),
+    ('_t3',    nb.types.unicode_type),
+]
+
+@_nbJitclass(_bsklogSpec)
+class BskLoggerProxy:
+    """Logging proxy usable inside UpdateStateImpl (nopython mode).
+    Calls print(); output goes to stdout.
+    Tags and min-level are read from the module's BSKLogger at Reset time.
+    """
+    def __init__(self, level, t0, t1, t2, t3):
+        self._level = level
+        self._t0 = t0; self._t1 = t1; self._t2 = t2; self._t3 = t3
+
+    def _tag(self, level):
+        if   level == 0: return self._t0
+        elif level == 1: return self._t1
+        elif level == 2: return self._t2
+        else:            return self._t3
+
+    def bskLog(self, level, msg):
+        if level >= self._level:
+            print(self._tag(level), msg)
+
+    def bskLog1(self, level, msg, v0):
+        if level >= self._level:
+            print(self._tag(level), msg, v0)
+
+    def bskLog2(self, level, msg, v0, v1):
+        if level >= self._level:
+            print(self._tag(level), msg, v0, v1)
+
+    def bskLog3(self, level, msg, v0, v1, v2):
+        if level >= self._level:
+            print(self._tag(level), msg, v0, v1, v2)
+
+
+import math as _math
+
+# ---------------------------------------------------------------------------
+# xoshiro256++ PRNG - state is uint64[4] stored in a NumbaModel userPtr array.
+# The jitclass wraps the array by reference so that state persists between
+# ticks without any Python overhead.
+# ---------------------------------------------------------------------------
+
+@nb.njit(cache=True)
+def _rngRotl64(x, k):
+    return (x << k) | (x >> (np.uint64(64) - k))
+
+
+_rngSpec = [('_s', nb.uint64[:])]
+
+@_nbJitclass(_rngSpec)
+class _RngWrapper:
+    """xoshiro256++ PRNG usable inside nopython kernels.
+
+    Created from a uint64[4] array that lives in the NumbaModel userPtr
+    vector.  Modifications to ``self._s`` are in-place, so state persists
+    across ticks via the underlying C buffer.
+    """
+
+    def __init__(self, state):
+        self._s = state
+
+    def _next(self):
+        s = self._s
+        result = _rngRotl64(s[0] + s[3], np.uint64(23)) + s[0]
+        t = s[1] << np.uint64(17)
+        s[2] ^= s[0]
+        s[3] ^= s[1]
+        s[1] ^= s[2]
+        s[0] ^= s[3]
+        s[2] ^= t
+        s[3] = _rngRotl64(s[3], np.uint64(45))
+        return result
+
+    def random(self):
+        """Uniform float in [0, 1)."""
+        return np.float64(self._next() >> np.uint64(11)) * (1.0 / 9007199254740992.0)
+
+    def standard_normal(self, n):
+        """Return *n* independent standard-normal samples (Box-Muller)."""
+        out = np.empty(n, np.float64)
+        i = 0
+        while i < n:
+            u1 = self.random()
+            u2 = self.random()
+            if u1 < 1e-300:
+                u1 = 1e-300
+            r = _math.sqrt(-2.0 * _math.log(u1))
+            theta = 6.283185307179586 * u2   # 2 * pi
+            out[i] = r * _math.cos(theta)
+            if i + 1 < n:
+                out[i + 1] = r * _math.sin(theta)
+                i += 2
+            else:
+                i += 1
+        return out
+
+    def integers(self, low, high):
+        """Uniform integer in [low, high)."""
+        return np.int64(low) + np.int64(self._next() % np.uint64(high - low))
+
+    def uniform(self, low, high):
+        """Uniform float in [low, high)."""
+        return low + (high - low) * self.random()
+
+
+def _seedXoshiro256pp(seed):
+    """Seed xoshiro256++ state from a 64-bit integer via splitmix64."""
+    state = np.zeros(4, dtype=np.uint64)
+    x = np.uint64(int(seed) & 0xFFFFFFFFFFFFFFFF)
+    with np.errstate(over='ignore'):
+        for i in range(4):
+            x = x + np.uint64(0x9e3779b97f4a7c15)
+            z = x
+            z = (z ^ (z >> np.uint64(30))) * np.uint64(0xbf58476d1ce4e5b9)
+            z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94d049bb133111eb)
+            state[i] = z ^ (z >> np.uint64(31))
+    return state
+
+
+class MemoryNamespace:
+    """Stores user-defined persistent memory for a NumbaModel.
+
+    Before Reset() is called, attributes can be freely set (plain Python
+    values).  After Reset() is called, reads and writes are transparently
+    forwarded to the structured numpy buffer that backs the C++ user-pointer
+    array, so that any change made from Python is immediately visible inside
+    the running cfunc.
+    """
+
+    def __setattr__(self, name, value):
+        d = object.__getattribute__(self, '__dict__')
+        if name.startswith('_nbm_'):
+            d[name] = value
+            return
+        buf = d.get('_nbmBuf')
+        if buf is not None:
+            dt = d['_nbmDtype']
+            if name not in dt.names:
+                raise AttributeError(
+                    f"memory.{name!r} does not exist after Reset(). "
+                    f"All memory fields must be defined before Reset() "
+                    f"(e.g. self.memory.{name} = 0.0 in __init__)."
+                )
+            if dt[name].shape:           # array field
+                buf[0][name][:] = np.asarray(value)
+            else:                         # scalar field
+                buf[0][name] = value
+        else:
+            d[name] = value
+
+    def __getattribute__(self, name):
+        if name.startswith('_') or name in ('__class__', '__dict__'):
+            return object.__getattribute__(self, name)
+        d = object.__getattribute__(self, '__dict__')
+        buf = d.get('_nbmBuf')
+        if buf is not None:
+            dt = d['_nbmDtype']
+            if name in dt.names:
+                return buf[0][name]
+        if name in d:
+            return d[name]
+        return object.__getattribute__(self, name)
+
+
+@dataclass
+class NbmMsgEntry:
+    """One scalar reader or writer registered with the C++ layer."""
+    pName: str
+    dtype: np.dtype
+    idx:   int   # position in the read or write slice of allPtrs
+
+@dataclass
+class NbmMsgListEntry:
+    """One list/dict reader or writer registered with the C++ layer."""
+    pName:  str
+    dtype:  np.dtype
+    n:      int                    # element count (0 for empty containers)
+    base:   int                    # first slot index in the read/write slice of allPtrs
+    bufUidx: int                   # user-pointer index for the payload buffer
+    keys:   Optional[tuple[str, ...]]  # dict keys, or None for plain lists
+    linkedBufUidx: Optional[int] = None  # dict IsLinked buffer, or None
+
+@dataclass
+class NbmMemoryEntry:
+    """Compiled-memory registration."""
+    dtype: np.dtype
+    uidx:  int   # user-pointer index for the memory buffer
+
+
+# ---------------------------------------------------------------------------
+# NbmCtx - mutable compilation context passed through _nbmCompile helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NbmCtx:
+    """Mutable compilation context threaded through all _nbmCompile helper methods.
+
+    Created fresh at the start of every _nbmCompile call and discarded once
+    _nbmBuildCfunc returns.  Every helper receives this object and mutates it
+    in place; no field is written by more than one step (see pipeline below).
+
+    Pipeline
+    --------
+    Step 0  _nbmGetImpl          → populates  params
+    Step 1  _nbmClassifyParam    → populates  readers, writers, listReaders,
+                                              listWriters, memoryCodegen,
+                                              linkedSet;
+                                   increments readIdx, writeIdx, userIdx
+    Step 2  _nbmValidateLinks    → reads      readers, listReaders, linkedSet
+                                   (read-only; raises on unsubscribed msgs)
+    Step 3  _nbmRegisterMetaPtrs → populates  linkedUidx, moduleIdUidx, rngUidx;
+                                   increments userIdx
+    Step 4  _nbmGenerateCode     → reads all of the above;
+                                   populates  g, preLines, postLines
+    Step 5  _nbmBuildCfunc       → reads      g, preLines, postLines, params;
+                                   compiles and registers the cfunc
+
+    allPtrs layout (assembled by C++ finalizeAllPtrs after _nbmCompile):
+        [0 .. readIdx-1]               read-payload slots   (refreshed every tick)
+        [readIdx .. readIdx+writeIdx-1] write-payload slots
+        [readIdx+writeIdx .. ]          user-pointer slots   (arbitrary Python objs)
+
+    _WRITE_BASE = readIdx  and  _USER_BASE = readIdx + writeIdx  are injected into
+    g as integer constants by _nbmGenerateCode so that any preLines strings added
+    by step-1 handlers (before the bases are known) can reference them by name and
+    have them resolved at exec() time.
+    """
+
+    # -- Step 0 ---------------------------------------------------------------
+
+    params: list[str] = field(default_factory=list)
+    # Ordered list of UpdateStateImpl parameter names, taken directly from the
+    # function signature.  Drives the step-1 dispatch loop and is later joined
+    # into the _impl(...) call line by _nbmBuildCfunc.
+
+    # -- Step 1 ---------------------------------------------------------------
+
+    readers: list[NbmMsgEntry] = field(default_factory=list)
+    # One entry per scalar InMsg parameter (e.g. dataInMsgPayload).
+    # Set by _nbmHandleInMsgPayload.  Each entry records the parameter name,
+    # payload dtype, and its slot index in the read slice of allPtrs.
+    # Used by _nbmValidateLinks (link check) and _nbmGenerateCode (binding).
+
+    writers: list[NbmMsgEntry] = field(default_factory=list)
+    # One entry per scalar OutMsg parameter (e.g. dataOutMsgPayload).
+    # Set by _nbmHandleOutMsgPayload.  Each entry records the parameter name,
+    # payload dtype, and its slot index in the write slice of allPtrs.
+    # Used by _nbmGenerateCode to emit the write-payload binding lines.
+
+    listReaders: list[NbmMsgListEntry] = field(default_factory=list)
+    # One entry per list/dict InMsg parameter.
+    # Set by _nbmHandleInMsgPayload.  Each entry records the parameter name,
+    # dtype, element count n, base slot in the read slice, user-pointer index
+    # of the payload buffer, and optional dict keys (None for plain lists).
+    # Used by _nbmValidateLinks and _nbmGenerateCode.
+
+    listWriters: list[NbmMsgListEntry] = field(default_factory=list)
+    # One entry per list/dict OutMsg parameter.
+    # Set by _nbmHandleOutMsgPayload.  Each entry mirrors listReaders but for
+    # write slots.  Used by _nbmGenerateCode to emit both the pre-call binding
+    # and the post-call copy-back lines (via postLines).
+
+    memoryCodegen: Optional[NbmMemoryEntry] = None
+    # Set by _nbmHandleMemory when the user declares a 'memory' parameter.
+    # Holds the structured numpy dtype built from self.memory's fields and the
+    # user-pointer index of the memory buffer.  None if 'memory' is not in params.
+    # Used by _nbmGenerateCode to emit the memory binding line.
+
+    linkedSet: set[str] = field(default_factory=set)
+    # Set of *InMsgIsLinked parameter names declared in UpdateStateImpl.
+    # Populated by _nbmHandleInMsgIsLinked (one add per IsLinked param).
+    # Used in _nbmValidateLinks to skip the always-linked assertion, and in
+    # _nbmGenerateCode to emit the per-slot or per-element IsLinked bindings.
+
+    readIdx: int = 0
+    # Running count of registered reader slots.  Incremented by
+    # _nbmHandleInMsgPayload (by 1 for scalars, by n for list/dict).
+    # Final value equals the number of read-payload slots in allPtrs, and
+    # becomes _WRITE_BASE in the generated code.
+
+    writeIdx: int = 0
+    # Running count of registered writer slots.  Incremented by
+    # _nbmHandleOutMsgPayload (by 1 for scalars, by n for list/dict).
+    # Final value equals the number of write-payload slots in allPtrs, and
+    # contributes to _USER_BASE = readIdx + writeIdx.
+
+    userIdx: int = 0
+    # Running count of registered user pointers.  Incremented by step-1
+    # handlers (payload buffers, stub arrays, memory buffer) and step-3
+    # (_nbmRegisterMetaPtrs: readLinked_ array, moduleID array, rng state).
+    # Each increment corresponds to one addUserPointer() call on the C++ side.
+    # The final value is the length of the user-pointer slice of allPtrs.
+
+    # -- Step 4 ---------------------------------------------------------------
+
+    g: dict[str, Any] = field(default_factory=lambda: {'nb': nb, 'np': np})
+    # Global namespace for exec() / cfunc compilation.  Pre-seeded with 'nb'
+    # and 'np' so generated code can reference numba and numpy by name.
+    # Step-4 injects dtype constants (_rdt_*, _wdt_*, _cdt_*, _WRITE_BASE,
+    # _USER_BASE, _impl, and any handler-specific objects like _RngWrapper).
+
+    preLines: list[str] = field(default_factory=lambda: ["def _wrapper(allPtrs, CurrentSimNanos):"])
+    # Lines of the generated _wrapper function body that execute *before*
+    # calling _impl.  Opened with the def line; step-4 appends one or more
+    # variable-binding lines for each registered parameter.
+
+    postLines: list[str] = field(default_factory=list)
+    # Lines appended after the _impl call.  Used exclusively for list/dict
+    # writer copy-back: after _impl returns, each element of the payload buffer
+    # is written back into the individual allPtrs write slots.
+
+    # -- Step 3 ---------------------------------------------------------------
+
+    linkedUidx: Optional[int] = None
+    # User-pointer index of the readLinked_ uint8 array maintained by the C++
+    # layer (one byte per reader slot, non-zero when the slot is linked).
+    # Set by _nbmRegisterMetaPtrs only when readIdx > 0; stays None if there
+    # are no readers.  Used by _nbmGenerateCode to emit IsLinked bindings that
+    # index into allPtrs[_USER_BASE + linkedUidx].
+
+    moduleIdUidx: Optional[int] = None
+    # User-pointer index of the int64[1] array holding self.moduleID.
+    # Set by _nbmRegisterMetaPtrs when 'moduleID' is in params; stays None
+    # otherwise.  Used by _nbmGenerateCode to emit the moduleID binding line.
+
+    rngUidx: Optional[int] = None
+    # User-pointer index of the uint64[4] xoshiro256++ RNG state array.
+    # Set by _nbmRegisterMetaPtrs when 'rng' is in params; stays None
+    # otherwise.  The array is seeded from self.RNGSeed at Reset time and
+    # mutated in place by _RngWrapper so that state persists across ticks.
+    # Used by _nbmGenerateCode to emit the rng binding line.
+
+    bskLogMinUidx: Optional[int] = None
+    # User-pointer index of a np.int32[1] array holding the BSK logger minimum
+    # level at the time of Reset.  Set by _nbmRegisterMetaPtrs when 'bskLogger'
+    # is in params; stays None otherwise.  Storing it as a runtime userPtr
+    # (rather than a compile-time global) means the log level is read each tick
+    # from the pointer, so different Reset calls with different log levels share
+    # the same compiled cfunc.
+
+
+# ---------------------------------------------------------------------------
+# NumbaModel
+# ---------------------------------------------------------------------------
+
+class NumbaModel(SysModelMixin, _NumbaModel):
+
+    def __init__(self):
+        super().__init__()
+        self.memory = MemoryNamespace()
+
+    # ------------------------------------------------------------------
+    # _nbmCompile - orchestrates cfunc compilation in five steps
+    # ------------------------------------------------------------------
+
+    def _nbmCompile(self, CurrentSimNanos):
+        """Introspect UpdateStateImpl, register pointers, and compile cfunc.
+
+        Called by Reset() after the C++ base has been cleared.
+        Subclasses may override individual _nbmClassifyParam / _nbmHandle*
+        methods to extend which parameter names are recognised.
+        """
+        implFunc, params = self._nbmGetImpl()
+        ctx = NbmCtx(params=params)
+        for pName in params:
+            self._nbmClassifyParam(pName, ctx)
+        self._nbmValidateLinks(ctx)
+        self._nbmRegisterMetaPtrs(ctx)
+        self._nbmGenerateCode(ctx)
+        self._nbmBuildCfunc(implFunc, ctx)
+
+    # ------------------------------------------------------------------
+    # Step 0 - find and validate UpdateStateImpl
+    # ------------------------------------------------------------------
+
+    def _nbmGetImpl(self):
+        """Find UpdateStateImpl in the MRO, validate it, and return (func, params).
+
+        Skips the NumbaModel stub.  Raises NotImplementedError / TypeError for
+        common mistakes (missing override, not a staticmethod, uninspectable).
+        """
+        implDesc = None
+        for klass in type(self).__mro__:
+            if klass is NumbaModel:
+                continue   # skip our own no-op stub
+            if 'UpdateStateImpl' in klass.__dict__:
+                implDesc = klass.__dict__['UpdateStateImpl']
+                break
+
+        if implDesc is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} must override UpdateStateImpl as a @staticmethod."
+            )
+
+        if not isinstance(implDesc, staticmethod):
+            raise TypeError(
+                f"{type(self).__name__}.UpdateStateImpl must be a @staticmethod "
+                f"(it must not have a 'self' parameter)."
+            )
+
+        implFunc = implDesc.__func__
+
+        try:
+            sig = inspect.signature(implFunc)
+        except (ValueError, TypeError) as e:
+            raise TypeError(
+                f"Could not inspect {type(self).__name__}.UpdateStateImpl: {e}"
+            ) from e
+
+        return implFunc, list(sig.parameters.keys())
+
+    # ------------------------------------------------------------------
+    # Step 1 - classify each parameter (dispatch + per-type handlers)
+    # ------------------------------------------------------------------
+
+    def _nbmClassifyParam(self, pName, ctx):
+        """Dispatch a single UpdateStateImpl parameter to its handler.
+
+        Subclasses may override to recognise additional parameter types before
+        falling through to ``super()._nbmClassifyParam(pName, ctx)``.
+        """
+        if pName == 'CurrentSimNanos':
+            return self._nbmHandleCurrentSimNanos(pName, ctx)
+        if pName.endswith('InMsgIsLinked'):
+            return self._nbmHandleInMsgIsLinked(pName, ctx)
+        if pName.endswith('InMsgPayload'):
+            return self._nbmHandleInMsgPayload(pName, ctx)
+        if pName.endswith('OutMsgPayload'):
+            return self._nbmHandleOutMsgPayload(pName, ctx)
+        if pName == 'moduleID':
+            return self._nbmHandleModuleID(pName, ctx)
+        if pName == 'memory':
+            return self._nbmHandleMemory(pName, ctx)
+        if pName == 'bskLogger':
+            return self._nbmHandleBskLogger(pName, ctx)
+        if pName == 'rng':
+            return self._nbmHandleRng(pName, ctx)
+        return self._nbmHandleExtraParam(pName, ctx)
+
+    def _nbmHandleCurrentSimNanos(self, pName, ctx):
+        pass   # always present in the wrapper signature; nothing to register
+
+    def _nbmHandleInMsgIsLinked(self, pName, ctx):
+        ctx.linkedSet.add(pName)
+
+    def _nbmHandleInMsgPayload(self, pName, ctx):
+        attrName = pName[:-len('Payload')]   # "dataInMsgPayload" → "dataInMsg"
+        attr = getattr(self, attrName, None)
+        if attr is None:
+            raise AttributeError(
+                f"UpdateStateImpl parameter {pName!r} implies attribute "
+                f"{attrName!r}, but {type(self).__name__} has no such attribute. "
+                f"Add  self.{attrName} = messaging.<Type>MsgReader()  in __init__."
+            )
+
+        if not isinstance(attr, (list, dict)):
+            # Scalar reader: register via addReaderSlot so the C++ layer
+            # can refresh the payload pointer and linked flag every tick.
+            dt = self._nbmResolveReaderDtype(attrName, attr)
+            dummy = np.zeros(1, dtype=dt)
+            object.__setattr__(self, f'_{attrName}_dummy', dummy)
+            self.addReaderSlot(
+                attr.getPayloadPtrAddress(),
+                attr.getLinkedAddress(),
+                dummy.ctypes.data,
+            )
+            ctx.readers.append(NbmMsgEntry(pName, dt, ctx.readIdx))
+            ctx.readIdx += 1
+        else:
+            # List / dict reader
+            items = list(attr.values()) if isinstance(attr, dict) else list(attr)
+            if len(items) == 0:
+                # Empty container: register nothing; cfunc receives a 0-element
+                # float64 array.  IsLinked is not supported for empty containers.
+                lnkName = pName[:-len('Payload')] + 'IsLinked'
+                if lnkName in ctx.params:
+                    raise ValueError(
+                        f"'{lnkName}' cannot be used with an empty {attrName!r}. "
+                        f"Remove '{lnkName}' from UpdateStateImpl when the "
+                        f"list/dict is empty."
+                    )
+                dt = np.dtype('float64')  # placeholder; no elements accessed
+                _stub = np.zeros(1, dtype=np.uint8)
+                bufUidx = ctx.userIdx
+                self.addUserPointer(_stub.ctypes.data)
+                ctx.userIdx += 1
+                object.__setattr__(self, f'_{attrName}_stub', _stub)
+                if isinstance(attr, dict):
+                    object.__setattr__(self, f'_{attrName}Keys', ())
+                ctx.listReaders.append(NbmMsgListEntry(pName, dt, 0, ctx.readIdx, bufUidx, None))
+                return
+
+            dt = self._nbmResolveReaderDtype(attrName, items[0])
+            for k, item in enumerate(items[1:], 1):
+                dtK = self._nbmResolveReaderDtype(attrName, item)
+                if dtK != dt:
+                    raise TypeError(
+                        f"All messages in {attrName!r} must share the same "
+                        f"payload dtype. Item 0 has dtype {dt}, "
+                        f"item {k} has {dtK}."
+                    )
+            n    = len(items)
+            base = ctx.readIdx
+            # Register each item as a reader slot so C++ can refresh
+            # payload pointers and linked flags dynamically every tick.
+            dummyBuf = np.zeros(n, dtype=dt)
+            for k, item in enumerate(items):
+                elemAddr = dummyBuf.ctypes.data + k * dt.itemsize
+                self.addReaderSlot(
+                    item.getPayloadPtrAddress(),
+                    item.getLinkedAddress(),
+                    elemAddr,
+                )
+            ctx.readIdx += n
+
+            # For dict attrs, build a container dtype so the cfunc can
+            # expose payloads by string key: payload['a'].field
+            linkedBufUidx = None
+            if isinstance(attr, dict):
+                keysOrNone = tuple(attr.keys())
+                containerDt = np.dtype([(k, dt) for k in keysOrNone])
+                payloadBuf  = np.zeros(1, dtype=containerDt)
+                linkedDt    = np.dtype([(k, np.bool_) for k in keysOrNone])
+                linkedBuf   = np.zeros(1, dtype=linkedDt)
+            else:
+                keysOrNone = None
+                payloadBuf  = np.zeros(n, dtype=dt)
+
+            bufUidx = ctx.userIdx
+            self.addUserPointer(payloadBuf.ctypes.data)
+            ctx.userIdx += 1
+            if keysOrNone is not None:
+                linkedBufUidx = ctx.userIdx
+                self.addUserPointer(linkedBuf.ctypes.data)
+                ctx.userIdx += 1
+
+            # Keep alive (prevent GC)
+            object.__setattr__(self, f'_{attrName}_dummy', dummyBuf)
+            object.__setattr__(self, f'_{attrName}_buf',   payloadBuf)
+            if keysOrNone is not None:
+                object.__setattr__(self, f'_{attrName}Keys', keysOrNone)
+                object.__setattr__(self, f'_{attrName}_linkedBuf', linkedBuf)
+
+            ctx.listReaders.append(
+                NbmMsgListEntry(pName, dt, n, base, bufUidx, keysOrNone, linkedBufUidx)
+            )
+
+    def _nbmHandleOutMsgPayload(self, pName, ctx):
+        attrName = pName[:-len('Payload')]   # "dataOutMsgPayload" → "dataOutMsg"
+        attr = getattr(self, attrName, None)
+        if attr is None:
+            raise AttributeError(
+                f"UpdateStateImpl parameter {pName!r} implies attribute "
+                f"{attrName!r}, but {type(self).__name__} has no such attribute. "
+                f"Add  self.{attrName} = messaging.<Type>Msg()  in __init__."
+            )
+
+        if not isinstance(attr, (list, dict)):
+            # Scalar writer
+            dt = self._nbmResolveWriterDtype(attrName, attr)
+            self.addWritePayloadPtr(attr.getPayloadAddress())
+            self.addWriteHeaderPtr(attr.getHeaderAddress())
+            ctx.writers.append(NbmMsgEntry(pName, dt, ctx.writeIdx))
+            ctx.writeIdx += 1
+        else:
+            # List / dict writer
+            items = list(attr.values()) if isinstance(attr, dict) else list(attr)
+            if len(items) == 0:
+                # Empty container: register nothing; cfunc receives a 0-element array.
+                dt = np.dtype('float64')  # placeholder; no elements written
+                _stub = np.zeros(1, dtype=np.uint8)
+                bufUidx = ctx.userIdx
+                self.addUserPointer(_stub.ctypes.data)
+                ctx.userIdx += 1
+                object.__setattr__(self, f'_{attrName}_stub', _stub)
+                if isinstance(attr, dict):
+                    object.__setattr__(self, f'_{attrName}Keys', ())
+                ctx.listWriters.append(NbmMsgListEntry(pName, dt, 0, ctx.writeIdx, bufUidx, None))
+                return
+
+            dt = self._nbmResolveWriterDtype(attrName, items[0])
+            for k, item in enumerate(items[1:], 1):
+                dtK = self._nbmResolveWriterDtype(attrName, item)
+                if dtK != dt:
+                    raise TypeError(
+                        f"All messages in {attrName!r} must share the same "
+                        f"payload dtype. Item 0 has dtype {dt}, "
+                        f"item {k} has {dtK}."
+                    )
+            n    = len(items)
+            base = ctx.writeIdx
+            for item in items:
+                self.addWritePayloadPtr(item.getPayloadAddress())
+                self.addWriteHeaderPtr(item.getHeaderAddress())
+            ctx.writeIdx += n
+
+            if isinstance(attr, dict):
+                keysOrNone = tuple(attr.keys())
+                containerDt = np.dtype([(k, dt) for k in keysOrNone])
+                payloadBuf  = np.zeros(1, dtype=containerDt)
+                object.__setattr__(self, f'_{attrName}Keys', keysOrNone)
+            else:
+                keysOrNone = None
+                payloadBuf  = np.zeros(n, dtype=dt)
+
+            bufUidx = ctx.userIdx
+            self.addUserPointer(payloadBuf.ctypes.data)
+            ctx.userIdx += 1
+
+            object.__setattr__(self, f'_{attrName}_buf', payloadBuf)
+
+            ctx.listWriters.append(NbmMsgListEntry(pName, dt, n, base, bufUidx, keysOrNone))
+
+    def _nbmHandleModuleID(self, pName, ctx):
+        pass
+
+    def _nbmHandleMemory(self, pName, ctx):
+        mem = object.__getattribute__(self, 'memory')
+        # Sync the live buffer back to __dict__ so that cfunc writes and Python
+        # writes are treated identically: the buffer is always the source of truth.
+        memD = object.__getattribute__(mem, '__dict__')
+        if '_nbmBuf' in memD:
+            old_buf = memD['_nbmBuf']
+            old_dt  = memD['_nbmDtype']
+            for fname in old_dt.names:
+                if fname == '_':
+                    continue
+                memD[fname] = np.array(old_buf[0][fname]) if old_dt[fname].shape else old_buf[0][fname].item()
+        raw = {k: v for k, v in vars(mem).items() if not k.startswith('_')}
+        memFields = []
+        memInit   = {}
+        for fname, fval in raw.items():
+            arr = np.asarray(fval)
+            if arr.ndim == 0:
+                memFields.append((fname, arr.dtype))
+                memInit[fname] = (arr.item(), False)
+            else:
+                arr = np.ascontiguousarray(arr)
+                memFields.append((fname, arr.dtype, arr.shape))
+                memInit[fname] = (arr, True)
+        # Empty memory: use a 1-byte placeholder so Numba gets a valid Record.
+        if not memFields:
+            memFields = [('_', np.uint8)]
+        memoryDt  = np.dtype(memFields)
+        memoryBuf = np.zeros(1, dtype=memoryDt)
+        for fname, (fval, isArr) in memInit.items():
+            if isArr:
+                memoryBuf[0][fname][:] = fval
+            else:
+                memoryBuf[0][fname] = fval
+        # Activate the MemoryNamespace redirect (write directly to __dict__ to
+        # avoid MemoryNamespace.__setattr__ interpreting these as user fields)
+        memD['_nbmBuf']   = memoryBuf
+        memD['_nbmDtype'] = memoryDt
+        memoryUidx = ctx.userIdx
+        self.addUserPointer(memoryBuf.ctypes.data)
+        ctx.userIdx += 1
+        object.__setattr__(self, '_memoryBuf', memoryBuf)  # keep alive
+        ctx.memoryCodegen = NbmMemoryEntry(memoryDt, memoryUidx)
+
+    def _nbmHandleBskLogger(self, pName, ctx):
+        pass
+
+    def _nbmHandleRng(self, pName, ctx):
+        pass
+
+    def _nbmHandleExtraParam(self, pName, ctx):
+        """Called when no built-in handler matches pName.
+
+        Raises AttributeError using _nbmValidParamPatterns().
+        Subclasses should override _nbmClassifyParam (to add new handlers)
+        and _nbmValidParamPatterns (to extend the error message), rather
+        than overriding this method directly.
+        """
+        patterns = self._nbmValidParamPatterns()
+        raise AttributeError(
+            f"UpdateStateImpl parameter {pName!r} does not match any known pattern.\n"
+            f"Valid patterns:\n" + "\n".join(f"  {p}" for p in patterns)
+        )
+
+    def _nbmValidParamPatterns(self):
+        """Return a list of human-readable pattern descriptions for error messages.
+
+        Subclasses should override this and prepend their own patterns before
+        calling ``super()._nbmValidParamPatterns()``.
+        """
+        return [
+            "'<name>InMsgPayload'   : ReadFunctor or list/dict of ReadFunctors",
+            "'<name>InMsgIsLinked'  : bool flag(s) for the '<name>InMsg' reader",
+            "'<name>OutMsgPayload'  : Message or list/dict of Messages",
+            "'CurrentSimNanos'      : simulation time (uint64)",
+            "'moduleID'             : this model's unique integer ID (int64)",
+            "'memory'               : persistent state "
+            "(set self.memory.* attributes in __init__)",
+            "'bskLogger'            : logging proxy "
+            "(bskLog/bskLog1/bskLog2/bskLog3)",
+            "'rng'                  : per-module numpy Generator "
+            "(seeded from self.RNGSeed at Reset)",
+        ]
+
+    # ------------------------------------------------------------------
+    # Step 1 helpers - dtype resolution (shared by In/Out handlers)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _nbmResolveReaderDtype(attrName, item):
+        if not hasattr(item, 'subscribeTo'):
+            raise TypeError(
+                f"Attribute {attrName!r} must contain ReadFunctor(s) (InMsg), "
+                f"e.g. messaging.CModuleTemplateMsgReader(), "
+                f"but got {type(item).__name__!r}."
+            )
+        swigType = type(item).__name__
+        if not swigType.endswith('Reader'):
+            raise TypeError(
+                f"Cannot derive payload class from {attrName!r}: SWIG type "
+                f"{swigType!r} does not end with 'Reader'. "
+                f"Ensure {attrName!r} is a SWIG-generated ReadFunctor."
+            )
+        pclsName = swigType[:-len('Reader')] + 'Payload'
+        return NumbaModel._nbmLookupPayloadDtype(attrName, swigType, pclsName)
+
+    @staticmethod
+    def _nbmResolveWriterDtype(attrName, item):
+        if not hasattr(item, 'addSubscriber'):
+            raise TypeError(
+                f"Attribute {attrName!r} must contain Message(s) (OutMsg), "
+                f"e.g. messaging.CModuleTemplateMsg(), "
+                f"but got {type(item).__name__!r}."
+            )
+        swigType = type(item).__name__
+        pclsName = swigType + 'Payload'
+        return NumbaModel._nbmLookupPayloadDtype(attrName, swigType, pclsName)
+
+    @staticmethod
+    def _nbmLookupPayloadDtype(attrName, swigType, pclsName):
+        """Look up messaging.<pclsName> and return its __dtype__, with clear errors."""
+        PayloadClass = getattr(messaging, pclsName, None)
+        if PayloadClass is None:
+            raise AttributeError(
+                f"messaging.{pclsName} does not exist. "
+                f"Derived from SWIG type {swigType!r}; check that the message "
+                f"type is generated and imported correctly."
+            )
+        if PayloadClass.__dtype__ is None:
+            raise TypeError(
+                f"messaging.{pclsName}.__dtype__ is None - this payload contains "
+                f"C++ types (e.g. std::vector) that cannot be represented as a "
+                f"numpy dtype. NumbaModel cannot handle it."
+            )
+        return PayloadClass.__dtype__
+
+    # ------------------------------------------------------------------
+    # Step 2 - validate IsLinked constraints
+    # ------------------------------------------------------------------
+
+    def _nbmValidateLinks(self, ctx):
+        """Assert that non-guarded readers are subscribed."""
+        # Declaring *InMsgPayload without *InMsgIsLinked asserts the reader is
+        # always connected; raise a clear error at Reset time if it is not.
+        for e in ctx.readers:
+            lnk = e.pName[:-len('Payload')] + 'IsLinked'
+            if lnk not in ctx.linkedSet:
+                attrName = e.pName[:-len('Payload')]
+                attr = getattr(self, attrName)
+                if not attr.isLinked():
+                    raise RuntimeError(
+                        f"UpdateStateImpl declares {e.pName!r} without a corresponding "
+                        f"'{lnk}' guard, but self.{attrName} is not subscribed.\n"
+                        f"Either call  self.{attrName}.subscribeTo(...)  before "
+                        f"Reset(), or add '{lnk}' to UpdateStateImpl to handle "
+                        f"the unlinked case gracefully."
+                    )
+
+        for e in ctx.listReaders:
+            if e.n == 0:
+                continue   # empty container, nothing to check
+            lnk = e.pName[:-len('Payload')] + 'IsLinked'
+            if lnk not in ctx.linkedSet:
+                attrName = e.pName[:-len('Payload')]
+                attr = getattr(self, attrName)
+                itemsCheck = list(attr.values()) if isinstance(attr, dict) else list(attr)
+                for k, item in enumerate(itemsCheck):
+                    if not item.isLinked():
+                        keyDesc = (repr(list(attr.keys())[k])
+                                    if isinstance(attr, dict) else str(k))
+                        raise RuntimeError(
+                            f"UpdateStateImpl declares {e.pName!r} without a "
+                            f"corresponding '{lnk}' guard, but "
+                            f"self.{attrName}[{keyDesc}] is not subscribed.\n"
+                            f"Either subscribe it before Reset(), or add '{lnk}' "
+                            f"to UpdateStateImpl to handle the unlinked case."
+                        )
+
+    # ------------------------------------------------------------------
+    # Step 3 - register post-loop C++ user pointers
+    # ------------------------------------------------------------------
+
+    def _nbmRegisterMetaPtrs(self, ctx):
+        """Register the readLinked_ array, moduleID, and rng user pointers.
+
+        Must run after all addReaderSlot() calls (step 1) so that
+        readLinked_.data() is stable.
+        """
+        # readLinked_ array - one uint8 per registered reader slot
+        if ctx.readIdx > 0:
+            ctx.linkedUidx = ctx.userIdx
+            self.addUserPointer(self.getReadLinkedPtr())
+            ctx.userIdx += 1
+
+        # moduleID scalar (int64)
+        if 'moduleID' in ctx.params:
+            moduleIdArr = np.array([self.moduleID], dtype=np.int64)
+            object.__setattr__(self, '_moduleIdArr', moduleIdArr)
+            ctx.moduleIdUidx = ctx.userIdx
+            self.addUserPointer(moduleIdArr.ctypes.data)
+            ctx.userIdx += 1
+
+        # xoshiro256++ RNG state (uint64[4])
+        if 'rng' in ctx.params:
+            rngState = _seedXoshiro256pp(self.RNGSeed)
+            object.__setattr__(self, '_rng_state', rngState)   # keep alive
+            ctx.rngUidx = ctx.userIdx
+            self.addUserPointer(rngState.ctypes.data)
+            ctx.userIdx += 1
+
+        # bskLogger minimum level (int32[1]) — runtime value, not compile-time constant
+        if 'bskLogger' in ctx.params:
+            bskLogMinArr = np.array([np.int32(self.bskLogger.getLogLevel())], dtype=np.int32)
+            object.__setattr__(self, '_bskLogMinArr', bskLogMinArr)  # keep alive
+            ctx.bskLogMinUidx = ctx.userIdx
+            self.addUserPointer(bskLogMinArr.ctypes.data)
+            ctx.userIdx += 1
+
+    # ------------------------------------------------------------------
+    # Step 4 - build the _wrapper source and compile globals
+    # ------------------------------------------------------------------
+
+    def _nbmGenerateCode(self, ctx):
+        """Append variable-binding lines to ctx.preLines / ctx.postLines."""
+        g         = ctx.g
+        preLines = ctx.preLines
+        postLines = ctx.postLines
+
+        # Absolute base offsets into the flat allPtrs array.
+        # _WRITE_BASE and _USER_BASE are stored as integer constants in g so
+        # that code added to preLines by subclass handlers (before this method
+        # runs) can reference them by name and have them resolved at exec() time.
+        g['_WRITE_BASE'] = ctx.readIdx
+        g['_USER_BASE']  = ctx.readIdx + ctx.writeIdx
+
+        # Scalar readers
+        for e in ctx.readers:
+            g[f'_rdt_{e.idx}'] = e.dtype
+            preLines.append(
+                f"    {e.pName} = nb.carray(allPtrs[{e.idx}], 1, _rdt_{e.idx})[0]"
+            )
+            lnk = e.pName[:-len('Payload')] + 'IsLinked'
+            if lnk in ctx.linkedSet:
+                preLines.append(
+                    f"    {lnk} = nb.carray(allPtrs[_USER_BASE + {ctx.linkedUidx}], {ctx.readIdx}, np.uint8)[{e.idx}] != np.uint8(0)"
+                )
+
+        # List / dict readers
+        for e in ctx.listReaders:
+            g[f'_rdt_{e.base}'] = e.dtype
+            if e.n > 0:
+                preLines.append(
+                    f"    _{e.pName}_lnk = nb.carray(allPtrs[_USER_BASE + {ctx.linkedUidx}], {ctx.readIdx}, np.uint8)[{e.base}:{e.base+e.n}]"
+                )
+            if e.keys is None:
+                preLines.append(
+                    f"    _{e.pName}_buf = nb.carray(allPtrs[_USER_BASE + {e.bufUidx}], ({e.n},), _rdt_{e.base})"
+                )
+                if e.n > 0:
+                    preLines.append(f"    for _i_{e.base} in range({e.n}):")
+                    preLines.append(f"        if _{e.pName}_lnk[_i_{e.base}]:")
+                    preLines.append(
+                        f"            _{e.pName}_buf[_i_{e.base}] = "
+                        f"nb.carray(allPtrs[{e.base} + _i_{e.base}], 1, _rdt_{e.base})[0]"
+                    )
+                preLines.append(f"    {e.pName} = _{e.pName}_buf")
+            else:
+                g[f'_cdt_{e.base}'] = np.dtype([(k, e.dtype) for k in e.keys])
+                preLines.append(
+                    f"    _{e.pName}_ctbuf = nb.carray(allPtrs[_USER_BASE + {e.bufUidx}], 1, _cdt_{e.base})"
+                )
+                for k_i, k in enumerate(e.keys):
+                    preLines.append(f"    if _{e.pName}_lnk[{k_i}]:")
+                    preLines.append(
+                        f"        _{e.pName}_ctbuf[0]['{k}'] = "
+                        f"nb.carray(allPtrs[{e.base + k_i}], 1, _rdt_{e.base})[0]"
+                    )
+                preLines.append(f"    {e.pName} = _{e.pName}_ctbuf[0]")
+            lnk = e.pName[:-len('Payload')] + 'IsLinked'
+            if lnk in ctx.linkedSet:
+                if e.keys is not None:
+                    g[f'_lcdt_{e.base}'] = np.dtype([(k, np.bool_) for k in e.keys])
+                    preLines.append(
+                        f"    _lnkbuf_{e.base} = nb.carray("
+                        f"allPtrs[_USER_BASE + {e.linkedBufUidx}], 1, _lcdt_{e.base})"
+                    )
+                    for k_i, k in enumerate(e.keys):
+                        preLines.append(
+                            f"    _lnkbuf_{e.base}[0]['{k}'] = "
+                            f"_{e.pName}_lnk[{k_i}] != np.uint8(0)"
+                        )
+                    preLines.append(f"    {lnk} = _lnkbuf_{e.base}[0]")
+                else:
+                    preLines.append(f"    {lnk} = _{e.pName}_lnk")
+
+        # Scalar writers
+        for e in ctx.writers:
+            g[f'_wdt_{e.idx}'] = e.dtype
+            preLines.append(
+                f"    {e.pName} = nb.carray(allPtrs[_WRITE_BASE + {e.idx}], 1, _wdt_{e.idx})[0]"
+            )
+
+        # List / dict writers - postLines carries copy-back after _impl
+        for e in ctx.listWriters:
+            g[f'_wdt_{e.base}'] = e.dtype
+            if e.keys is not None:
+                g[f'_cdtW{e.base}'] = np.dtype([(k, e.dtype) for k in e.keys])
+                preLines.append(
+                    f"    _{e.pName}_ctbuf = nb.carray(allPtrs[_USER_BASE + {e.bufUidx}], 1, _cdtW{e.base})"
+                )
+                preLines.append(f"    {e.pName} = _{e.pName}_ctbuf[0]")
+                for k_i, k in enumerate(e.keys):
+                    postLines.append(
+                        f"    nb.carray(allPtrs[_WRITE_BASE + {e.base + k_i}], 1, _wdt_{e.base})[0]"
+                        f" = _{e.pName}_ctbuf[0]['{k}']"
+                    )
+            else:
+                preLines.append(
+                    f"    _{e.pName}_buf = nb.carray(allPtrs[_USER_BASE + {e.bufUidx}], ({e.n},), _wdt_{e.base})"
+                )
+                preLines.append(f"    {e.pName} = _{e.pName}_buf")
+                if e.n > 0:
+                    postLines.append(f"    for _j_{e.base} in range({e.n}):")
+                    postLines.append(
+                        f"        nb.carray(allPtrs[_WRITE_BASE + {e.base} + _j_{e.base}], 1, _wdt_{e.base})[0]"
+                        f" = _{e.pName}_buf[_j_{e.base}]"
+                    )
+
+        # Memory
+        if ctx.memoryCodegen is not None:
+            g['_memoryDt'] = ctx.memoryCodegen.dtype
+            preLines.append(
+                f"    memory = nb.carray(allPtrs[_USER_BASE + {ctx.memoryCodegen.uidx}], 1, _memoryDt)[0]"
+            )
+
+        # moduleID
+        if ctx.moduleIdUidx is not None:
+            preLines.append(
+                f"    moduleID = nb.carray(allPtrs[_USER_BASE + {ctx.moduleIdUidx}], 1, np.int64)[0]"
+            )
+
+        # rng - xoshiro256++ state backed by userPtr; instance created per tick
+        if ctx.rngUidx is not None:
+            g['_RngWrapper'] = _RngWrapper
+            preLines.append(
+                f"    rng = _RngWrapper(nb.carray(allPtrs[_USER_BASE + {ctx.rngUidx}], 4, np.uint64))"
+            )
+
+        # bskLogger, log level read from userPtr at runtime; tags are compile-time
+        if 'bskLogger' in ctx.params:
+            _lmap = self.bskLogger.logLevelMap
+            g['BskLoggerProxy'] = BskLoggerProxy
+            g['_bsklog_t0']     = _lmap[0]
+            g['_bsklog_t1']     = _lmap[1]
+            g['_bsklog_t2']     = _lmap[2]
+            g['_bsklog_t3']     = _lmap[3]
+            preLines.append(
+                f"    bskLogger = BskLoggerProxy("
+                f"nb.carray(allPtrs[_USER_BASE + {ctx.bskLogMinUidx}], 1, np.int32)[0],"
+                " _bsklog_t0, _bsklog_t1, _bsklog_t2, _bsklog_t3)"
+            )
+
+    # ------------------------------------------------------------------
+    # Step 5 - compile and register the cfunc
+    # ------------------------------------------------------------------
+
+    def _nbmBuildCfunc(self, implFunc, ctx):
+        ctx.preLines.append(f"    _impl({', '.join(ctx.params)})")
+        _co = implFunc.__code__
+        _implCanCache = (not _co.co_filename.startswith('<')
+                         and os.path.isfile(_co.co_filename))
+        ctx.g['_impl'] = nb.njit(cache=_implCanCache)(implFunc)
+
+        # Content-based fingerprint: (implCodeHash, dtypeHash, rawSrc).
+        # implCodeHash covers identity (co_filename, co_qualname) AND body (co_code,
+        # co_consts) — so moving the file, renaming the class, OR changing the body
+        # all produce a new fp and trigger a fresh compile.
+        rawSrc = "\n".join(ctx.preLines + ctx.postLines)
+
+        implCodeHash = hashlib.sha256(marshal.dumps(implFunc.__code__)).hexdigest()[:16]
+
+        dtypeParts = ([str(e.dtype) for e in ctx.readers + ctx.writers] +
+                      [f"{e.n}:{e.dtype}" for e in ctx.listReaders + ctx.listWriters])
+        if ctx.memoryCodegen:
+            dtypeParts.append(str(ctx.memoryCodegen.dtype))
+        dtypeHash = hashlib.md5('|'.join(dtypeParts).encode()).hexdigest()
+
+        fp = hashlib.sha256(
+            '\n'.join([implCodeHash, dtypeHash, rawSrc]).encode()
+        ).hexdigest()[:16]
+
+        # Path 1: in-process cache hit
+        if fp in _NBMODEL_CFUNC_CACHE:
+            self._cfunc = _NBMODEL_CFUNC_CACHE[fp]
+            self.setStateUpdateFunc(self._cfunc.address)
+            return
+
+        # Path 2+3: disk cache (with fallback to raw compile)
+        cfunc = None
+        cacheDir = getCacheDir()
+        if cacheDir is not None:
+            try:
+                srcPath = cacheDir / f'nbm_{fp}.py'
+                modName = f'_nbm_{fp}'
+
+                if not srcPath.exists():
+                    tmp = srcPath.with_suffix('.tmp')
+                    tmp.write_text(rawSrc, encoding='utf-8')
+                    os.replace(tmp, srcPath)   # atomic on Linux + Windows
+
+                spec = importlib.util.spec_from_file_location(modName, srcPath)
+                mod  = importlib.util.module_from_spec(spec)
+                mod.__dict__.update(ctx.g)
+                spec.loader.exec_module(mod)
+                sys.modules[modName] = mod   # required before cfunc(cache=True)
+
+                cfuncSig = nb.types.void(nb.types.CPointer(nb.types.voidptr), nb.types.uint64)
+                cfunc = nb.cfunc(cfuncSig, cache=True)(mod._wrapper)
+            except Exception:
+                cfunc = None
+
+        if cfunc is None:   # fallback: read-only location or I/O failure
+            exec(rawSrc, ctx.g)
+            cfuncSig = nb.types.void(nb.types.CPointer(nb.types.voidptr), nb.types.uint64)
+            cfunc = nb.cfunc(cfuncSig)(ctx.g['_wrapper'])
+
+        self._cfunc = cfunc
+        _NBMODEL_CFUNC_CACHE[fp] = cfunc
+        self.setStateUpdateFunc(cfunc.address)
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def Reset(self, CurrentSimNanos=0):
+        # C++ Reset clears all pointer vectors
+        super().Reset(CurrentSimNanos)
+        self._nbmCompile(CurrentSimNanos)
+        # Assemble flat allPtrs_ from [reads | writes | user] staging vectors
+        self.finalizeAllPtrs()
+
+    @staticmethod
+    def UpdateStateImpl(*a, **k):
+        """Override with a @staticmethod that numba can compile."""
+        pass
+%}

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.i
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.i
@@ -9,6 +9,7 @@
    #include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 %}
 
+%include "stdint.i"
 %include "std_pair.i"
 %include "std_vector.i"
 %include "std_string.i"

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.cpp
@@ -85,11 +85,11 @@ void MJScene::SelfInit()
 void MJScene::Reset(uint64_t CurrentSimNanos)
 {
     this->timeBefore = CurrentSimNanos * NANO2SEC;
+    this->initializeDynamics();
     this->dynamicsTask.TaskName = "Dynamics:" + this->ModelTag;
     this->dynamicsTask.ResetTaskList(CurrentSimNanos);
     this->dynamicsDiffusionTask.TaskName = "DiffusionDynamics:" + this->ModelTag;
     this->dynamicsDiffusionTask.ResetTaskList(CurrentSimNanos);
-    this->initializeDynamics();
     this->writeOutputStateMessages(CurrentSimNanos);
 }
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.h
@@ -123,7 +123,7 @@ protected:
  * }
  * \endcode
  */
-class StatefulSysModel : public SysModel
+class StatefulSysModel : virtual public SysModel
 {
 public:
     /** Default constructor */

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.h
@@ -23,37 +23,49 @@
 #include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 
-/**A short-lived class passed to StatefulSysModel for them to register
+/** @brief Helper passed to ``StatefulSysModel`` instances while they register
  * their states.
  *
  * This class serves two purposes. First, it adds a prefix to every state
  * name before registering it on the actual DynParamManager. This prevents
- * state name collisions between StatefulSysModel as long as the prefix
- * are unique. Second, it exponses only the registerState method from
- * the DynParamManager. This prevents StatefulSysModel from registering
+ * state-name collisions between ``StatefulSysModel`` instances as long as the
+ * prefixes are unique. Second, it exposes only the ``registerState`` method
+ * from the ``DynParamManager``. This prevents ``StatefulSysModel`` instances
+ * from registering
  * properties or accessing the states of other models, which would allow for
  * information to flow between models without going through the message system.
  * If a model needs to access information from another model, it should do so
- * thorugh a message, not by sharing a state or property.
+ * through a message, not by sharing a state or property.
  */
 class DynParamRegisterer
 {
 public:
-    /** Constructor */
+    /** @brief Construct a state-registering helper.
+     *
+     * @param manager Underlying dynamics-parameter manager.
+     * @param stateNamePrefix Prefix appended to every registered state name.
+     */
     DynParamRegisterer(DynParamManager& manager, std::string stateNamePrefix)
         : manager(manager)
         , stateNamePrefix(stateNamePrefix)
         {}
 
-    /** Creates and returns a new state, which will be managed by the
-     * underlying ``DynParamManager``.
+    /** @brief Create and return a new state managed by the underlying
+     * ``DynParamManager``.
      *
      * The state name should be unique: registering two states with the
-     * same name on this class will cause an error. Different StatefulSysModel
-     * are allowed to use the same state name, however.
+     * same name on this class will cause an error. Different
+     * ``StatefulSysModel`` instances are allowed to use the same state name,
+     * however.
      *
      * This method may optionally be templated to create StateData of
-     * subclasses of StateData.
+     * subclasses of ``StateData``.
+     *
+     * @tparam StateDataType Concrete state-data type to instantiate.
+     * @param nRow Number of rows in the state storage.
+     * @param nCol Number of columns in the state storage.
+     * @param stateName State name local to the registering model.
+     * @return Pointer to the newly registered state object.
      */
     template <typename StateDataType = StateData,
               std::enable_if_t<std::is_base_of_v<StateData, StateDataType>, bool> = true>
@@ -64,7 +76,9 @@ public:
         );
     }
 
-    /** Used when more than one state have dynamics perturbed
+    /** @brief Register a shared stochastic noise source across multiple states.
+     *
+     * Used when more than one state has dynamics perturbed
      * by the same noise process.
      *
      * For example, consider the following SDE:
@@ -93,7 +107,9 @@ public:
      * and the first noise source of the ``StateData`` 'myStateX1' actually
      * correspond to the same noise process.
      *
-     * NOTE: Some stochastic integrators do not support sharing noise sources.
+     * @param in List of state/noise-source-index pairs that share one process.
+     *
+     * @note Some stochastic integrators do not support shared noise sources.
      * In this case, this method should raise ``std::logic_error``.
      */
     inline void registerSharedNoiseSource(std::vector<std::pair<const StateData&, size_t>> in)
@@ -102,16 +118,16 @@ public:
     }
 
 protected:
-    DynParamManager& manager; ///< wrapped manager
-    std::string stateNamePrefix; ///< prefix added to all registered state names
+    DynParamManager& manager;      //!< Wrapped manager that owns the registered states.
+    std::string stateNamePrefix;   //!< Prefix added to all registered state names.
 };
 
-/** A SysModel that has continuous-time states.
+/** @brief ``SysModel`` base class for modules with continuous-time states.
  *
- * StatefulSysModel are added on the dynamics task of an MJScene.
- * On its UpdateState method, a StatefulSysModel should call each state's
- * setDerivative method. This value will be used by the integrator to
- * update the state for the next integrator step.
+ * ``StatefulSysModel`` instances are added to the dynamics task of an
+ * ``MJScene``. On ``UpdateState()``, a ``StatefulSysModel`` should call each
+ * state's ``setDerivative`` method. That derivative is then used by the
+ * integrator to update the state for the next integration step.
  *
  * The sample code below shows how to get the current value of the state
  * and how to set its derivative. In this case, ``x`` would follow an
@@ -126,23 +142,24 @@ protected:
 class StatefulSysModel : virtual public SysModel
 {
 public:
-    /** Default constructor */
+    /** @brief Construct a stateful system model. */
     StatefulSysModel() = default;
 
-    /**Used to register states on the given DynParamRegisterer.
+    /** @brief Register this model's continuous states.
      *
-     * The main purpose of this method is for this class to call
-     * ``registerState`` on the registerer. Note that state names
-     * should not be repeated within the same StatefulSysModel.
+     * The main purpose of this method is to call ``registerState`` on the
+     * supplied registerer. State names must not be repeated within the same
+     * ``StatefulSysModel`` instance.
      *
      * \code{.cpp}
-     * void registerStates(DynParamRegisterer& registerer) override {
-     *     this->posState = registerer.register(3, 1, "pos");
-     *     this->massState = registerer.register(1, 1, "mass");
+     * void registerStates(DynParamRegisterer registerer) override {
+     *     this->posState = registerer.registerState(3, 1, "pos");
+     *     this->massState = registerer.registerState(1, 1, "mass");
      *     // etc.
      * }
      * \endcode
      *
+     * @param registerer Helper used to create namespaced state registrations.
      */
     virtual void registerStates(DynParamRegisterer registerer) = 0;
 };

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py
@@ -1,0 +1,262 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+from Basilisk.utilities import macros
+from Basilisk.utilities import SimulationBaseClass
+
+try:
+    from Basilisk.simulation import mujoco
+    from Basilisk.simulation import StatefulNumbaModel
+    couldImport = True
+except Exception:
+    couldImport = False
+
+import pytest
+import numpy as np
+
+
+@pytest.mark.skipif(not couldImport, reason="Compiled Basilisk without --mujoco or numba not available")
+def test_StatefulNumbaOscillator():
+    """Tests that StatefulNumbaModel works as expected in MJScene.
+
+    We use a simple harmonic oscillator with two 3×1 states (pos, vel) and
+    a scalar memory field (omega).  The UpdateStateImpl is a Numba cfunc.
+
+    posDot = vel
+    velDot = -omega^2 * pos
+
+    With pos(0) = [1, 0, 0] and vel(0) = [0, omega, 0] and omega = 2*pi
+    the analytic solution at tf=0.5 s is:
+
+        pos[0](tf) = cos(omega * tf)
+        pos[1](tf) = sin(omega * tf)
+        pos[2](tf) = 0
+
+        vel[0](tf) = -omega * sin(omega * tf)
+        vel[1](tf) =  omega * cos(omega * tf)
+        vel[2](tf) = 0
+    """
+
+    # Declared inside the test so the import guard works correctly.
+    class OscillatorModel(StatefulNumbaModel.StatefulNumbaModel):
+        """3-D harmonic oscillator integrated by MJScene's RK4 solver."""
+
+        def registerStates(self, registerer):
+            """Register position and velocity states for the oscillator."""
+            self.posState = registerer.registerState(3, 1, "pos")
+            self.velState = registerer.registerState(3, 1, "vel")
+            self.posState.setState([[0], [0], [0]])
+            self.velState.setState([[0], [0], [0]])
+
+        def Reset(self, CurrentSimNanos=0):
+            """Refresh the compiled state and restore the stored frequency."""
+            super().Reset(CurrentSimNanos)
+            # memory fields must be set before Reset, but we can re-set here
+            # because Reset() propagates the updated value into the cfunc buffer.
+            self.memory.omega = self._omega
+
+        @staticmethod
+        def UpdateStateImpl(posState, posStateDeriv, velState, velStateDeriv, memory):
+            """Write the first-order oscillator dynamics into the derivative buffers."""
+            posStateDeriv[:, 0] = velState[:, 0]
+            velStateDeriv[:, 0] = -memory.omega ** 2 * posState[:, 0]
+
+    omega = 2.0 * np.pi   # rad/s
+    dt    = 1e-3           # s - small step for accuracy
+    tf    = 0.5            # s
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("test")
+    dynProcess.addTask(scSim.CreateNewTask("test", macros.sec2nano(dt)))
+
+    scene = mujoco.MJScene("<mujoco/>")
+    scSim.AddModelToTask("test", scene)
+
+    osc = OscillatorModel()
+    osc.ModelTag = "oscillator"
+    osc.memory.omega = omega   # set before Reset is called
+    osc._omega = omega         # stash for Reset()
+
+    scene.AddModelToDynamicsTask(osc)
+
+    scSim.InitializeSimulation()
+
+    # Set initial conditions: pos = [1, 0, 0], vel = [0, omega, 0]
+    osc.posState.setState([[1.0], [0.0], [0.0]])
+    osc.velState.setState([[0.0], [omega], [0.0]])
+
+    scSim.ConfigureStopTime(macros.sec2nano(tf))
+    scSim.ExecuteSimulation()
+
+    pos = osc.posState.getState()
+    vel = osc.velState.getState()
+
+    expectedPos = np.array([[np.cos(omega * tf)],
+                              [np.sin(omega * tf)],
+                              [0.0]])
+    expectedVel = np.array([[-omega * np.sin(omega * tf)],
+                              [ omega * np.cos(omega * tf)],
+                              [0.0]])
+
+    # RK4 with dt=1ms should give ~1e-8 accuracy over 0.5 s
+    np.testing.assert_allclose(pos, expectedPos, atol=1e-6)
+    np.testing.assert_allclose(vel, expectedVel, atol=1e-5)
+
+
+@pytest.mark.skipif(not couldImport, reason="Compiled Basilisk without --mujoco or numba not available")
+def test_StatefulNumbaStateNames():
+    """Tests that state names are prefixed with model tag and ID."""
+
+    class ScalarModel(StatefulNumbaModel.StatefulNumbaModel):
+        """Minimal scalar state model used to verify generated state names."""
+
+        def registerStates(self, registerer):
+            """Register a single scalar state named ``x``."""
+            self.xState = registerer.registerState(1, 1, "x")
+            self.xState.setState([[0]])
+
+        def Reset(self, CurrentSimNanos=0):
+            """Delegate to the base reset to compile and bind state pointers."""
+            super().Reset(CurrentSimNanos)
+
+        @staticmethod
+        def UpdateStateImpl(xState, xStateDeriv):
+            """Set a constant unit derivative for the scalar state."""
+            xStateDeriv[0, 0] = 1.0   # dx/dt = 1
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("test")
+    dynProcess.addTask(scSim.CreateNewTask("test", macros.sec2nano(0.1)))
+
+    scene = mujoco.MJScene("<mujoco/>")
+    scSim.AddModelToTask("test", scene)
+
+    model = ScalarModel()
+    model.ModelTag = "myModel"
+    scene.AddModelToDynamicsTask(model)
+
+    scSim.InitializeSimulation()
+
+    expectedName = f"{model.ModelTag}_{model.moduleID}_x"
+    assert model.xState.getName() == expectedName, (
+        f"State name {model.xState.getName()!r} != {expectedName!r}"
+    )
+
+
+@pytest.mark.skipif(not couldImport, reason="Compiled Basilisk without --mujoco or numba not available")
+def test_StatefulNumbaDiffusion():
+    """Tests that xStateDiffusionN correctly wires to the StateData diffusion buffer.
+
+    We run a scalar Ornstein-Uhlenbeck process:
+        dx = theta*(mu - x)*dt + sigma*dW
+
+    once using StatefulNumbaModel (diffusion written via xStateDiffusion0 in
+    UpdateStateImpl) and once using StatefulSysModel (diffusion written via
+    setDiffusion in Python UpdateState).  With the same integrator seed both
+    simulations must produce bit-identical final states.
+    """
+    from Basilisk.simulation import svIntegrators
+    from Basilisk.simulation import StatefulSysModel
+
+    theta = 0.5
+    mu    = 0.0
+    sigma = 0.1
+    x0    = 1.0
+    dt    = 0.1
+    tf    = 1.0
+    seed  = 42
+
+    def _make_sim():
+        scSim = SimulationBaseClass.SimBaseClass()
+        scSim.CreateNewProcess("test").addTask(
+            scSim.CreateNewTask("test", macros.sec2nano(dt))
+        )
+        scene = mujoco.MJScene("<mujoco/>")
+        scSim.AddModelToTask("test", scene)
+        intg = svIntegrators.svStochasticIntegratorMayurama(scene)
+        intg.setRNGSeed(seed)
+        scene.setIntegrator(intg)
+        # intg must be returned: scene stores only a raw C++ pointer, so Python
+        # would GC the integrator before the simulation runs without this.
+        return scSim, scene, intg
+
+    # ---- Numba model: diffusion written via xStateDiffusion0 in cfunc ----
+    class OuNumba(StatefulNumbaModel.StatefulNumbaModel):
+        """Stateful Numba implementation of the scalar OU process."""
+
+        def registerStates(self, registerer):
+            """Register the scalar stochastic state and one noise source."""
+            self.xState = registerer.registerState(1, 1, "x")
+            self.xState.setNumNoiseSources(1)
+
+        @staticmethod
+        def UpdateStateImpl(xState, xStateDeriv, xStateDiffusion0, memory):
+            """Write the OU drift and diffusion terms into the state buffers."""
+            xStateDeriv[0, 0]      = memory.theta * (memory.mu - xState[0, 0])
+            xStateDiffusion0[0, 0] = memory.sigma
+
+    scSimA, sceneA, intgA = _make_sim()
+    modelA = OuNumba()
+    modelA.ModelTag     = "ou_numba"
+    modelA.memory.theta = theta
+    modelA.memory.mu    = mu
+    modelA.memory.sigma = sigma
+    sceneA.AddModelToDynamicsTask(modelA)
+    sceneA.AddModelToDiffusionDynamicsTask(modelA)
+    scSimA.InitializeSimulation()
+    modelA.xState.setState([[x0]])
+    scSimA.ConfigureStopTime(macros.sec2nano(tf))
+    scSimA.ExecuteSimulation()
+    xNumba = np.array(modelA.xState.getState())[0, 0]
+
+    # ---- Reference: plain StatefulSysModel using setDiffusion in Python ----
+    class OuStateful(StatefulSysModel.StatefulSysModel):
+        """Reference Python StatefulSysModel implementation of the OU process."""
+
+        def registerStates(self, registerer):
+            """Register the scalar stochastic state and one noise source."""
+            self.xState = registerer.registerState(1, 1, "x")
+            self.xState.setNumNoiseSources(1)
+
+        def UpdateState(self, CurrentSimNanos):
+            """Update the OU drift and diffusion using the Python API."""
+            x = np.array(self.xState.getState())[0, 0]
+            self.xState.setDerivative([[theta * (mu - x)]])
+            self.xState.setDiffusion([[sigma]], index=0)
+
+    scSimB, sceneB, intgB = _make_sim()
+    modelB = OuStateful()
+    modelB.ModelTag = "ou_stateful"
+    sceneB.AddModelToDynamicsTask(modelB)
+    sceneB.AddModelToDiffusionDynamicsTask(modelB)
+    scSimB.InitializeSimulation()
+    modelB.xState.setState([[x0]])
+    scSimB.ConfigureStopTime(macros.sec2nano(tf))
+    scSimB.ExecuteSimulation()
+    xStateful = np.array(modelB.xState.getState())[0, 0]
+
+    np.testing.assert_allclose(xNumba, xStateful, atol=1e-14, rtol=0)
+
+
+if __name__ == "__main__":
+    test_StatefulNumbaDiffusion()
+    if True:
+        test_StatefulNumbaOscillator()
+        test_StatefulNumbaStateNames()
+        test_StatefulNumbaDiffusion()
+    else:
+        pytest.main([__file__])

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/pyStatefulNumbaModel.i
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/pyStatefulNumbaModel.i
@@ -1,0 +1,197 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+%module(directors="1", threads="1", package="Basilisk.simulation") StatefulNumbaModel
+
+%include "architecture/utilities/bskException.swg"
+%default_bsk_exception();
+
+%{
+#include "statefulNumbaModel.h"
+%}
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "std_string.i"
+%include "stdint.i"
+
+/* Import parent SWIG modules so SWIG knows about base class types */
+%import "architecture/numbaModel/numbaModel.i"
+%import "simulation/mujocoDynamics/_GeneralModuleFiles/StatefulSysModel.i"
+
+/* uintptr_t: accept any Python int as a raw 64-bit bit-pattern */
+%typemap(in) uintptr_t {
+    unsigned long long tmp = PyLong_AsUnsignedLongLongMask($input);
+    if (PyErr_Occurred()) SWIG_fail;
+    $1 = (uintptr_t)tmp;
+}
+
+/* uintptr_t: return as a full unsigned 64-bit Python int (avoid sign-extension / truncation) */
+%typemap(out) uintptr_t {
+    $result = PyLong_FromUnsignedLongLong((unsigned long long)$1);
+}
+
+/* Free helper functions to access StateData's public Eigen data pointers.
+ * stateData.h is transitively included via statefulNumbaModel.h → StatefulSysModel.h
+ * → dynParamManager.h → stateData.h, so StateData is already visible. */
+%inline %{
+    uintptr_t getStateDataPtr(StateData* sd) {
+        return reinterpret_cast<uintptr_t>(sd->state.data());
+    }
+    uintptr_t getDerivDataPtr(StateData* sd) {
+        return reinterpret_cast<uintptr_t>(sd->stateDeriv.data());
+    }
+    uintptr_t getDiffusionDataPtr(StateData* sd, size_t index) {
+        return reinterpret_cast<uintptr_t>(sd->stateDiffusion.at(index).data());
+    }
+%}
+
+/* Director: allow Python to override registerStates.
+   UpdateState must NOT go through the director - C++ calls the cfunc directly. */
+%feature("director") StatefulNumbaModel;
+%feature("nodirector") StatefulNumbaModel::UpdateState;
+%rename("_StatefulNumbaModel") StatefulNumbaModel;
+
+%include "statefulNumbaModel.h"
+
+%pythoncode %{
+import numpy as np
+import numba as nb
+from Basilisk.architecture.numbaModel import NumbaModel
+from Basilisk.architecture.sysModel import SysModelMixin
+
+class StatefulNumbaModel(NumbaModel, _StatefulNumbaModel):
+    """A SysModel with JIT-compiled UpdateStateImpl and continuous-time states.
+
+    Combines NumbaModel (Numba cfunc compilation) with StatefulSysModel
+    (continuous-time states integrated by MJScene's RK4 solver).
+
+    Usage
+    -----
+    class MyModel(StatefulNumbaModel):
+        def registerStates(self, registerer):
+            self.posState = registerer.registerState(3, 1, "pos")
+            self.velState = registerer.registerState(3, 1, "vel")
+
+        def Reset(self, CurrentSimNanos=0):
+            super().Reset(CurrentSimNanos)
+            self.memory.omega = 2.0
+
+        @staticmethod
+        def UpdateStateImpl(posState, posStateDeriv, velState, velStateDeriv, memory):
+            posStateDeriv[:, 0] = velState[:, 0]
+            velStateDeriv[:, 0] = -memory.omega**2 * posState[:, 0]
+
+    Parameter naming in UpdateStateImpl
+    ------------------------------------
+    All NumbaModel parameters are supported, plus:
+
+    '<name>State'
+        Read-only current state value.  Resolved from self.<name>State
+        (a StateData*).  Type: float64[nRow, nCol] Fortran-order 2-D array.
+
+    '<name>StateDeriv'
+        Writable state derivative.  Resolved from self.<name>State
+        (same StateData* as '<name>State').
+        Type: float64[nRow, nCol] Fortran-order 2-D array.
+
+    '<name>StateDiffusionN'
+        Writable diffusion matrix for the N-th noise source (N >= 0).
+        Resolved from self.<name>State (same StateData*).
+        Type: float64[nRow, nCol] Fortran-order 2-D array.
+        Requires self.<name>State.setNumNoiseSources(N+1) in registerStates().
+
+    States are registered in registerStates(), which is called by MJScene
+    before Reset().  The Eigen MatrixXd backing store is column-major
+    (Fortran order), so arr[i, j] = M(i, j).  Even 1-D states are exposed
+    as 2-D arrays (e.g. a 3x1 column vector: posState[i, 0]).
+    """
+
+    def _nbmHandleExtraParam(self, pName, ctx):
+        # 'StateDeriv' and 'StateDiffusionN' are checked before 'State' so that
+        # the longer suffixes win over the plain 'State' match.
+        if pName.endswith('StateDeriv'):
+            attrName = pName[:-len('Deriv')]   # "posStateDeriv" → "posState"
+            stateObj = getattr(self, attrName, None)
+            if stateObj is None:
+                raise AttributeError(
+                    f"UpdateStateImpl parameter {pName!r} implies attribute "
+                    f"{attrName!r}, but {type(self).__name__} has no such attribute.\n"
+                    f"Ensure self.{attrName} was assigned in registerStates() "
+                    f"before Reset()."
+                )
+            ptr = getDerivDataPtr(stateObj)
+        elif 'StateDiffusion' in pName and pName.rsplit('StateDiffusion', 1)[-1].isdigit():
+            parts = pName.rsplit('StateDiffusion', 1)
+            attrName = parts[0] + 'State'      # "posStateDiffusion0" → "posState"
+            diffIdx = int(parts[1])
+            stateObj = getattr(self, attrName, None)
+            if stateObj is None:
+                raise AttributeError(
+                    f"UpdateStateImpl parameter {pName!r} implies attribute "
+                    f"{attrName!r}, but {type(self).__name__} has no such attribute.\n"
+                    f"Ensure self.{attrName} was assigned in registerStates() "
+                    f"before Reset()."
+                )
+            if diffIdx >= stateObj.getNumNoiseSources():
+                raise IndexError(
+                    f"UpdateStateImpl parameter {pName!r}: diffusion index {diffIdx} is "
+                    f"out of range. self.{attrName} has {stateObj.getNumNoiseSources()} "
+                    f"noise source(s). Call self.{attrName}.setNumNoiseSources(...) "
+                    f"in registerStates()."
+                )
+            ptr = getDiffusionDataPtr(stateObj, diffIdx)
+        elif pName.endswith('State'):
+            attrName = pName                   # "posState" → "posState"
+            stateObj = getattr(self, attrName, None)
+            if stateObj is None:
+                raise AttributeError(
+                    f"UpdateStateImpl parameter {pName!r} implies attribute "
+                    f"{attrName!r}, but {type(self).__name__} has no such attribute.\n"
+                    f"Ensure self.{attrName} was assigned in registerStates() "
+                    f"before Reset()."
+                )
+            ptr = getStateDataPtr(stateObj)
+        else:
+            super()._nbmHandleExtraParam(pName, ctx)
+            return
+        nRow = stateObj.getRowSize()
+        nCol = stateObj.getColumnSize()
+        self.addUserPointer(ptr)
+        ctx.preLines.append(
+            f"    {pName} = nb.farray(allPtrs[_USER_BASE + {ctx.userIdx}], ({nRow}, {nCol}), np.float64)"
+        )
+        ctx.userIdx += 1
+
+    def _nbmValidParamPatterns(self):
+        return [
+            "'<name>State'              : read-only state value "
+            "(float64[nRow, nCol] Fortran-order)",
+            "'<name>StateDeriv'         : writable derivative "
+            "(float64[nRow, nCol] Fortran-order)",
+            "'<name>StateDiffusionN'    : writable diffusion matrix for noise source N "
+            "(float64[nRow, nCol] Fortran-order; N >= 0; requires "
+            "setNumNoiseSources(N+1) in registerStates())",
+        ] + super()._nbmValidParamPatterns()
+
+    def registerStates(self, registerer):
+        """Override to register continuous-time states on the given registerer."""
+        pass
+%}

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/statefulNumbaModel.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/statefulNumbaModel.cpp
@@ -1,0 +1,29 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "statefulNumbaModel.h"
+
+void StatefulNumbaModel::Reset(uint64_t CurrentSimNanos)
+{
+    NumbaModel::Reset(CurrentSimNanos);
+}
+
+void StatefulNumbaModel::UpdateState(uint64_t CurrentSimNanos)
+{
+    NumbaModel::UpdateState(CurrentSimNanos);
+}

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/statefulNumbaModel.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/statefulNumbaModel.h
@@ -1,0 +1,52 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+#include "architecture/_GeneralModuleFiles/numbaModel.h"
+#include "StatefulSysModel.h"
+
+/** @brief SysModel that combines ``NumbaModel`` with ``StatefulSysModel``.
+ *
+ * This class combines ``NumbaModel`` (JIT-compiled ``UpdateStateImpl``) with
+ * StatefulSysModel (continuous-time states integrated by MJScene's solver).
+ *
+ * Users subclass this in Python by inheriting from StatefulNumbaModel and:
+ *   1. Overriding registerStates() to register state variables.
+ *   2. Providing a static UpdateStateImpl() method (compiled to a Numba cfunc).
+ *
+ * State and derivative arrays are accessible in ``UpdateStateImpl`` via
+ * parameters named ``nameState`` and ``nameStateDeriv``, resolved from
+ * attributes such as ``self.posState``.
+ *
+ * All NumbaModel features (messages, memory, rng, bskLogger) are also available.
+ */
+class StatefulNumbaModel : public NumbaModel, public StatefulSysModel
+{
+public:
+    /** Default constructor */
+    StatefulNumbaModel() = default;
+
+    /** Delegates to NumbaModel::Reset (C++ clear + triggers Python _nbm_compile) */
+    void Reset(uint64_t CurrentSimNanos) override;
+
+    /** Delegates to NumbaModel::UpdateState (calls the compiled cfunc) */
+    void UpdateState(uint64_t CurrentSimNanos) override;
+
+    /** Must be overridden by user subclasses to register their state variables. */
+    virtual void registerStates(DynParamRegisterer registerer) override = 0;
+};

--- a/src/tests/test_bskPrinciples.py
+++ b/src/tests/test_bskPrinciples.py
@@ -55,6 +55,9 @@ files = fnmatch.filter(os.listdir(path + '/../../docs/source/codeSamples'), "*.p
 @pytest.mark.scenarioTest
 def test_scenarioBskPrinciples(show_plots, bskScript):
 
+    if bskScript == "making-numbaModules.py":
+        pytest.importorskip("numba")
+
     bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/tests/test_bskPrinciples.py
+++ b/src/tests/test_bskPrinciples.py
@@ -54,6 +54,7 @@ files = fnmatch.filter(os.listdir(path + '/../../docs/source/codeSamples'), "*.p
 @pytest.mark.parametrize("bskScript", files)
 @pytest.mark.scenarioTest
 def test_scenarioBskPrinciples(show_plots, bskScript):
+    """Run each documentation code sample included in the BSK principles set."""
 
     if bskScript == "making-numbaModules.py":
         pytest.importorskip("numba")

--- a/src/tests/test_scenarioAttitudeFeedbackNumba.py
+++ b/src/tests/test_scenarioAttitudeFeedbackNumba.py
@@ -1,0 +1,67 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import unitTestSupport
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path     = os.path.dirname(os.path.abspath(filename))
+
+sys.path.append(path + '/../../examples')
+try:
+    import scenarioAttitudeFeedbackNumba
+    couldImport = True
+except Exception:
+    couldImport = False
+
+
+pytestmark = pytest.mark.skipif(
+    not couldImport,
+    reason="numba not available",
+)
+
+
+@pytest.mark.parametrize("useUnmodeledTorque, useIntGain, useKnownTorque", [
+    (False, False, False),
+    (True,  False, False),
+    (True,  True,  False),
+    (True,  False, True),
+])
+@pytest.mark.scenarioTest
+def test_scenarioAttitudeFeedbackNumba(show_plots,
+                                       useUnmodeledTorque,
+                                       useIntGain,
+                                       useKnownTorque):
+    """Parametrised test matching the variants in scenarioAttitudeFeedback."""
+    testFailCount = 0
+    testMessages  = []
+
+    try:
+        figureList = scenarioAttitudeFeedbackNumba.run(
+            show_plots, useUnmodeledTorque, useIntGain, useKnownTorque)
+        for pltName, plt in list(figureList.items()):
+            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+    except OSError:
+        testFailCount += 1
+        testMessages.append("scenarioAttitudeFeedbackNumba test failed.")
+
+    assert testFailCount < 1, testMessages

--- a/src/tests/test_scenarioAttitudePointingNumba.py
+++ b/src/tests/test_scenarioAttitudePointingNumba.py
@@ -1,0 +1,73 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2025, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+
+#
+# Basilisk Scenario Script and Integrated Test
+#
+# Purpose:  Integrated test of a script that uses a Numba BSK module
+# Author:   AVS Lab
+# Creation Date:  2025
+#
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import unitTestSupport
+
+# Get current file path
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+sys.path.append(path + '/../../examples')
+try:
+    import scenarioAttitudePointingNumba
+    couldImport = True
+except Exception:
+    couldImport = False
+
+
+# uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
+# @pytest.mark.skipif(conditionstring)
+# uncomment this line if this test has an expected failure, adjust message as needed
+# @pytest.mark.xfail(True)
+
+pytestmark = pytest.mark.skipif(
+    not couldImport,
+    reason="numba not available",
+)
+
+@pytest.mark.scenarioTest
+def test_bskAttitudePointingNumba(show_plots):
+    """This function is called by the py.test environment."""
+
+    testFailCount = 0
+    testMessages = []
+
+    try:
+        figureList = scenarioAttitudePointingNumba.run(show_plots)
+        for pltName, plt in list(figureList.items()):
+            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+
+    except OSError as err:
+        testFailCount += 1
+        testMessages.append("scenarioAttitudePointingNumba test failed.")
+
+    assert testFailCount < 1, testMessages

--- a/src/tests/test_scenarioBenchmarkNumba.py
+++ b/src/tests/test_scenarioBenchmarkNumba.py
@@ -1,0 +1,46 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+import inspect
+import os
+import sys
+
+import pytest
+
+# Get current file path
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+sys.path.append(path + '/../../examples')
+try:
+    import scenarioBenchmarkNumba
+    couldImport = True
+except Exception:
+    couldImport = False
+
+
+pytestmark = pytest.mark.skipif(
+    not couldImport,
+    reason="numba not available",
+)
+
+@pytest.mark.scenarioTest
+@pytest.mark.parametrize("case", ["pointing", "feedback"])
+def test_scenarioBenchmarkNumba(case):
+    """This function is called by the py.test environment."""
+
+    scenarioBenchmarkNumba.run(case, nRuns = 1)

--- a/src/utilities/RigidBodyKinematics.py
+++ b/src/utilities/RigidBodyKinematics.py
@@ -664,7 +664,7 @@ def BinvEP(q):
 
     		w = 2 [B(Q)]^(-1) dQ/dt
     """
-    B = np.zeros([3, 4])
+    B = np.zeros((3, 4))
     B[0, 0] = -q[1]
     B[0, 1] = q[0]
     B[0, 2] = q[3]
@@ -697,7 +697,7 @@ def BinvEuler121(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = c2
     B[0, 1] = 0
     B[0, 2] = 1
@@ -727,7 +727,7 @@ def BinvEuler123(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = c2 * c3
     B[0, 1] = s3
     B[0, 2] = 0
@@ -757,7 +757,7 @@ def BinvEuler131(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = c2
     B[0, 1] = 0
     B[0, 2] = 1
@@ -787,7 +787,7 @@ def BinvEuler132(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = c2 * c3
     B[0, 1] = -s3
     B[0, 2] = 0
@@ -817,7 +817,7 @@ def BinvEuler212(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = s2 * s3
     B[0, 1] = c3
     B[0, 2] = 0
@@ -847,7 +847,7 @@ def BinvEuler213(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = c2 * s3
     B[0, 1] = c3
     B[0, 2] = 0
@@ -877,7 +877,7 @@ def BinvEuler231(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = s2
     B[0, 1] = 0
     B[0, 2] = 1
@@ -907,7 +907,7 @@ def BinvEuler232(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = s2 * c3
     B[0, 1] = -s3
     B[0, 2] = 0
@@ -937,7 +937,7 @@ def BinvEuler312(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = -c2 * s3
     B[0, 1] = c3
     B[0, 2] = 0
@@ -967,7 +967,7 @@ def BinvEuler313(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = s2 * s3
     B[0, 1] = c3
     B[0, 2] = 0
@@ -997,7 +997,7 @@ def BinvEuler321(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = -s2
     B[0, 1] = 0
     B[0, 2] = 1
@@ -1027,7 +1027,7 @@ def BinvEuler323(q):
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = -s2 * c3
     B[0, 1] = s3
     B[0, 2] = 0
@@ -1052,7 +1052,7 @@ def BinvGibbs(q):
     		w = 2 [B(Q)]^(-1) dQ/dt
     """
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = 1
     B[0, 1] = q[2]
     B[0, 2] = -q[1]
@@ -1079,7 +1079,7 @@ def BinvMRP(q):
     """
 
     s2 = np.dot(q, q)
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = 1 - s2 + 2 * q[0] * q[0]
     B[0, 1] = 2 * (q[0] * q[1] + q[2])
     B[0, 2] = 2 * (q[0] * q[2] - q[1])
@@ -1109,7 +1109,7 @@ def BinvPRV(q):
     c1 = (1 - math.cos(p)) / p / p
     c2 = (p - math.sin(p)) / p / p / p
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = 1 - c2 * (q[1] * q[1] + q[2] * q[2])
     B[0, 1] = c1 * q[2] + c2 * q[0] * q[1]
     B[0, 2] = -c1 * q[1] + c2 * q[0] * q[2]
@@ -1134,7 +1134,7 @@ def BmatEP(q):
     		dQ/dt = 1/2 [B(Q)] w
     """
 
-    B = np.zeros([4, 3])
+    B = np.zeros((4, 3))
     B[0, 0] = -q[1]
     B[0, 1] = -q[2]
     B[0, 2] = -q[3]
@@ -1166,7 +1166,7 @@ def BmatEuler121(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = 0
     B[0, 1] = s3
@@ -1197,7 +1197,7 @@ def BmatEuler123(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = c3
     B[0, 1] = -s3
@@ -1228,7 +1228,7 @@ def BmatEuler131(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = 0
     B[0, 1] = -c3
@@ -1259,7 +1259,7 @@ def BmatEuler132(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = c3
     B[0, 1] = 0
@@ -1290,7 +1290,7 @@ def BmatEuler212(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = s3
     B[0, 1] = 0
@@ -1321,7 +1321,7 @@ def BmatEuler213(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = s3
     B[0, 1] = c3
@@ -1352,7 +1352,7 @@ def BmatEuler231(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = 0
     B[0, 1] = c3
@@ -1383,7 +1383,7 @@ def BmatEuler232(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = c3
     B[0, 1] = 0
@@ -1414,7 +1414,7 @@ def BmatEuler312(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = -s3
     B[0, 1] = 0
@@ -1445,7 +1445,7 @@ def BmatEuler313(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = s3
     B[0, 1] = c3
@@ -1476,7 +1476,7 @@ def BmatEuler321(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = 0
     B[0, 1] = s3
@@ -1507,7 +1507,7 @@ def BmatEuler323(q):
     c2 = math.cos(q[1])
     s3 = math.sin(q[2])
     c3 = math.cos(q[2])
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
 
     B[0, 0] = -c3
     B[0, 1] = s3
@@ -1534,7 +1534,7 @@ def BmatGibbs(q):
     		dQ/dt = 1/2 [B(Q)] w
     """
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = 1 + q[0] * q[0]
     B[0, 1] = q[0] * q[1] - q[2]
     B[0, 2] = q[0] * q[2] + q[1]
@@ -1559,7 +1559,7 @@ def BmatMRP(q):
     		dQ/dt = 1/4 [B(Q)] w
     """
 
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     s2 = np.dot(q, q)
     B[0, 0] = 1 - s2 + 2 * q[0] * q[0]
     B[0, 1] = 2 * (q[0] * q[1] - q[2])
@@ -1585,7 +1585,7 @@ def BdotmatMRP(q, dq):
     	(d^2Q)/(dt^2) = 1/4 ( [B(Q)] dw + [Bdot(Q,dQ)] w )
     """
 
-    Bdot = np.zeros([3, 3])
+    Bdot = np.zeros((3, 3))
     s = -2 * np.dot(q, dq)
     Bdot[0, 0] = s + 4 * (q[0] * dq[0])
     Bdot[0, 1] = 2 * (-dq[2] + q[0] * dq[1] + dq[0] * q[1])
@@ -1613,7 +1613,7 @@ def BmatPRV(q):
 
     p = np.linalg.norm(q)
     c = 1 / p / p * (1 - p / 2 / math.tan(p / 2))
-    B = np.zeros([3, 3])
+    B = np.zeros((3, 3))
     B[0, 0] = 1 - c * (q[1] * q[1] + q[2] * q[2])
     B[0, 1] = -q[2] / 2 + c * (q[0] * q[1])
     B[0, 2] = q[1] / 2 + c * (q[0] * q[2])
@@ -1847,7 +1847,7 @@ def dMRP2Omega(q, dq):
         W = 4 [B(Q)]^(-1) dQ
     """
 
-    return 4 * np.matmul(BinvMRP(q), dq)
+    return 4 * np.dot(BinvMRP(q), dq)
 
 
 def ddMRP(q, dq, w, dw):
@@ -1925,7 +1925,7 @@ def gibbs2C(q):
     q3 = q[2]
     qm = np.linalg.norm(q)
     d1 = qm * qm
-    C = np.zeros([3, 3])
+    C = np.zeros((3, 3))
     C[0, 0] = 1 + 2 * q1 * q1 - d1
     C[0, 1] = 2 * (q1 * q2 + q3)
     C[0, 2] = 2 * (q1 * q3 - q2)
@@ -2359,10 +2359,10 @@ def PRV2C(q):
         Direction cosine (rotation) matrix.
     """
 
-    q = np.asarray(q, dtype=float).reshape(3)
+    q = np.asarray(q, dtype=np.float64).reshape(3)
     angle = np.linalg.norm(q)
 
-    if np.isclose(angle, 0.0):
+    if angle < 1e-8:
         # No rotation -> identity matrix
         return np.eye(3)
 
@@ -2895,7 +2895,7 @@ def EP2C(q):
     q1 = q[1]
     q2 = q[2]
     q3 = q[3]
-    C = np.zeros([3, 3])
+    C = np.zeros((3, 3))
     C[0, 0] = q0 * q0 + q1 * q1 - q2 * q2 - q3 * q3
     C[0, 1] = 2 * (q1 * q2 + q0 * q3)
     C[0, 2] = 2 * (q1 * q3 - q0 * q2)

--- a/src/utilities/RigidBodyKinematicsNumba.py
+++ b/src/utilities/RigidBodyKinematicsNumba.py
@@ -1,0 +1,80 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+"""
+RigidBodyKinematicsNumba.py, a Numba nopython version of RigidBodyKinematics.py
+
+Applies ``nb.njit(cache=True, inline='always')`` to every function so they
+can be called from other compiled Numba kernels (e.g. NumbaModel
+``UpdateStateImpl``).
+
+Design
+------
+``RigidBodyKinematics.py`` is loaded into a **private, isolated module object**
+via ``importlib`` - it is never registered under the original name in
+``sys.modules``.  Functions defined in that private copy have ``__globals__``
+pointing to its own ``__dict__``.  Only that private copy is patched with
+jitted versions; the public ``RigidBodyKinematics`` module is never imported
+or modified here, so it retains full plain-Python behaviour (accepts lists,
+returns plain numpy objects, raises normal Python errors).
+
+Requires scipy (for BLAS-backed ``np.dot`` / ``np.linalg.norm`` inside
+Numba nopython).  A clear ``ImportError`` is raised at import time if missing.
+"""
+
+try:
+    import scipy  # noqa: F401  – verifies BLAS is available for Numba linalg
+except ImportError as _e:
+    raise ImportError(
+        "RigidBodyKinematicsNumba requires scipy for np.dot / "
+        "np.linalg.norm inside Numba nopython kernels."
+    ) from _e
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import numba as nb
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from Basilisk.utilities.RigidBodyKinematics import *
+
+# Load RigidBodyKinematics into a fresh, private module (zero side effects).
+# The module is registered in sys.modules so Numba's environment serialiser can
+# import it by name when loading cached compilations.
+import sys as _sys
+_MODULE_NAME = "RigidBodyKinematicsNumba._source"
+_spec = importlib.util.spec_from_file_location(
+    _MODULE_NAME,
+    Path(__file__).parent / "RigidBodyKinematics.py",
+)
+_src = importlib.util.module_from_spec(_spec)
+_sys.modules[_MODULE_NAME] = _src   # register BEFORE exec so the name is stable
+_spec.loader.exec_module(_src)      # populates _src.__dict__; public RBK untouched
+
+# Apply nb.njit to every function and patch the private copy so that
+# inter-function calls (e.g. C2MRP -> C2EP) resolve to jitted versions.
+# cache=False: these functions live in a dynamically-loaded private module.
+# When inlined into a NumbaModel, the caller's compiled form is cached by
+# numbaModel's own cache; standalone calls recompile per process (fast).
+_deco = nb.njit(cache=False, inline='always')
+
+for _name, _func in inspect.getmembers(_src, inspect.isfunction):
+    _jitted = _deco(_func)
+    setattr(_src, _name, _jitted)   # patch isolated copy so cross-calls work
+    globals()[_name] = _jitted      # re-export from this module

--- a/src/utilities/tests/test_RigidBodyKinematicsNumba.py
+++ b/src/utilities/tests/test_RigidBodyKinematicsNumba.py
@@ -1,0 +1,396 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Tests for RigidBodyKinematicsNumba (RBKN).
+
+Two orthogonal concerns are checked:
+
+  1. Side-effect isolation - importing RBKN must not alter RigidBodyKinematics
+     (RBK).  All RBK functions must remain plain Python callables that accept
+     the same inputs and return the same outputs as before RBKN was imported.
+
+  2. Numerical correctness - every RBKN function must return results that
+     match the RBK reference to floating-point tolerance.  The test matrix
+     covers:
+       - direct functions (no internal calls)
+       - functions that call other functions (cross-call chains)
+       - edge cases (zero rotation, shadow-set switches, 180° rotations)
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+from Basilisk.utilities import RigidBodyKinematics as RBK
+
+try:
+    # Import RBKN *after* RBK to exercise the side-effect isolation guarantee.
+    from Basilisk.utilities import RigidBodyKinematicsNumba as RBKN
+    couldImport = True
+except Exception:
+    RBKN = None
+    couldImport = False
+
+pytestmark = pytest.mark.skipif(
+    not couldImport,
+    reason="Compiled Basilisk without numba support or numba not available",
+)
+
+ATOL = 1e-12
+
+# ---------------------------------------------------------------------------
+# Fixtures - shared attitude parameters
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mrp():
+    return np.array([0.1, 0.2, 0.3])
+
+@pytest.fixture
+def mrp2():
+    return np.array([0.05, 0.1, 0.15])
+
+@pytest.fixture
+def ep():
+    q = np.array([0.9, 0.1, 0.2, 0.3])
+    return q / np.linalg.norm(q)
+
+@pytest.fixture
+def ep2():
+    q = np.array([0.8, 0.2, 0.3, 0.1])
+    return q / np.linalg.norm(q)
+
+@pytest.fixture
+def gibbs():
+    return np.array([0.1, 0.2, 0.15])
+
+@pytest.fixture
+def prv():
+    return np.array([0.3, 0.5, 0.2])
+
+@pytest.fixture
+def euler():
+    return np.array([0.1, 0.2, 0.3])
+
+@pytest.fixture
+def euler2():
+    return np.array([0.05, 0.1, 0.15])
+
+@pytest.fixture
+def dcm(mrp):
+    return RBK.MRP2C(mrp)
+
+@pytest.fixture
+def omega():
+    return np.array([0.01, 0.02, 0.03])
+
+# ---------------------------------------------------------------------------
+# 1. Side-effect isolation
+# ---------------------------------------------------------------------------
+
+class TestSideEffectIsolation:
+    """Importing RBKN must not change the behaviour of RBK in any way."""
+
+    def testRbkFunctionsRemainPlainPython(self):
+        """All RBK functions must still be plain Python callables."""
+        for name, obj in inspect.getmembers(RBK, inspect.isfunction):
+            assert type(obj).__name__ == 'function', (
+                f"RBK.{name} was replaced by a {type(obj).__name__} "
+                f"(expected plain Python function)"
+            )
+
+    def testRbkMrp2cOutputType(self, mrp):
+        """RBK ``MRP2C`` must still return a 3x3 NumPy array."""
+        C = RBK.MRP2C(mrp)
+        assert isinstance(C, np.ndarray)
+        assert C.shape == (3, 3)
+
+    def testRbkC2epOutputType(self, dcm):
+        """RBK ``C2EP`` must still return a length-4 NumPy array."""
+        ep = RBK.C2EP(dcm)
+        assert isinstance(ep, np.ndarray)
+        assert ep.shape == (4,)
+
+    def testRbkAddmrpOutputType(self, mrp, mrp2):
+        """RBK ``addMRP`` must still return a length-3 NumPy array."""
+        result = RBK.addMRP(mrp, mrp2)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (3,)
+
+    def testRbkSubmrpUnchanged(self, mrp, mrp2):
+        """Verify the original RBK.subMRP test still passes after RBKN import."""
+        mrp_1 = np.array([1.5, 0.5, 0.5])
+        mrp_2 = np.array([-0.5, 0.25, 0.15])
+        ans = [-0.005376344086021518, 0.04301075268817203, -0.4408602150537635]
+        np.testing.assert_allclose(
+            RBK.subMRP(mrp_1, mrp_2), ans, atol=1e-10
+        )
+        mrp_2_shadow = RBK.MRPswitch(mrp_2, 0.0)
+        np.testing.assert_allclose(
+            RBK.subMRP(mrp_1, mrp_2_shadow), ans, atol=1e-10
+        )
+
+    def testRbkResultMatchesPreImportReference(self, mrp):
+        """RBK.MRP2C must return the same matrix regardless of RBKN being imported."""
+        expected = np.array([
+            [ 0.19975377,  0.91720529, -0.34472145],
+            [-0.67097568,  0.38442598,  0.63404124],
+            [ 0.71406587,  0.10464758,  0.69221299],
+        ])
+        np.testing.assert_allclose(RBK.MRP2C(mrp), expected, atol=1e-7)
+
+# ---------------------------------------------------------------------------
+# 2. Numerical correctness - RBKN results must match RBK
+# ---------------------------------------------------------------------------
+
+class TestNumericalCorrectness:
+    """Numerical comparisons between RBKN kernels and the RBK reference."""
+
+    # --- Direct functions (no internal calls) ---
+
+    def test_MRP2C(self, mrp):
+        """Validate ``MRP2C`` against the reference implementation."""
+        np.testing.assert_allclose(RBKN.MRP2C(mrp), RBK.MRP2C(mrp), atol=ATOL)
+
+    def test_EP2C(self, ep):
+        """Validate ``EP2C`` against the reference implementation."""
+        np.testing.assert_allclose(RBKN.EP2C(ep), RBK.EP2C(ep), atol=ATOL)
+
+    def test_PRV2C(self, prv):
+        """Validate ``PRV2C`` against the reference implementation."""
+        np.testing.assert_allclose(RBKN.PRV2C(prv), RBK.PRV2C(prv), atol=ATOL)
+
+    def test_PRV2C_zero_angle(self):
+        """Edge case: zero PRV must return identity."""
+        np.testing.assert_allclose(RBKN.PRV2C(np.zeros(3)), np.eye(3), atol=1e-10)
+
+    def test_MRPswitch(self, mrp):
+        """Validate ``MRPswitch`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.MRPswitch(mrp, 1.0), RBK.MRPswitch(mrp, 1.0), atol=ATOL
+        )
+
+    def test_Picheck(self):
+        """Validate ``Picheck`` over representative wrapped-angle cases."""
+        for angle in [-4.0, -np.pi, 0.0, np.pi, 4.0]:
+            assert RBKN.Picheck(angle) == pytest.approx(RBK.Picheck(angle))
+
+    def testV3tilde(self, mrp):
+        """Validate ``v3Tilde`` against the reference implementation."""
+        np.testing.assert_allclose(RBKN.v3Tilde(mrp), RBK.v3Tilde(mrp), atol=ATOL)
+
+    def test_Mi(self):
+        """Validate ``Mi`` for each principal rotation axis."""
+        for axis in [1, 2, 3]:
+            np.testing.assert_allclose(
+                RBKN.Mi(0.3, axis), RBK.Mi(0.3, axis), atol=ATOL
+            )
+
+    # --- Cross-call chains ---
+
+    def test_C2MRP_calls_C2EP_EP2MRP(self, dcm):
+        """C2MRP -> C2EP -> EP2MRP: two-level cross-call."""
+        np.testing.assert_allclose(RBKN.C2MRP(dcm), RBK.C2MRP(dcm), atol=ATOL)
+
+    def test_C2EP(self, dcm):
+        """Validate ``C2EP`` against the reference implementation."""
+        np.testing.assert_allclose(RBKN.C2EP(dcm), RBK.C2EP(dcm), atol=ATOL)
+
+    def testAddmrpCallsMrpswitch(self, mrp, mrp2):
+        """addMRP internally calls MRPswitch for shadow-set check."""
+        np.testing.assert_allclose(
+            RBKN.addMRP(mrp, mrp2), RBK.addMRP(mrp, mrp2), atol=ATOL
+        )
+
+    def testSubmrpCallsAddmrpMrpswitch(self, mrp, mrp2):
+        """subMRP -> addMRP -> MRPswitch: three-level cross-call chain."""
+        np.testing.assert_allclose(
+            RBKN.subMRP(mrp, mrp2), RBK.subMRP(mrp, mrp2), atol=ATOL
+        )
+
+    def testSubmrpShadowSet(self):
+        """subMRP with a near-180° difference triggers shadow-set switch."""
+        s1 = np.array([1.5, 0.5, 0.5])
+        s2 = np.array([-0.5, 0.25, 0.15])
+        np.testing.assert_allclose(
+            RBKN.subMRP(s1, s2), RBK.subMRP(s1, s2), atol=ATOL
+        )
+
+    def testSubmrp180deg(self):
+        """Exact 180° case must yield zero MRP."""
+        s1 = np.array([0.0, 0.0, 1.0])
+        s2 = np.array([0.0, 0.0, -1.0])
+        np.testing.assert_allclose(
+            RBKN.subMRP(s1, s2), np.zeros(3), atol=1e-10
+        )
+
+    def test_EP2MRP_calls_MRPswitch(self, ep):
+        """EP2MRP calls MRPswitch to choose the shorter MRP set."""
+        np.testing.assert_allclose(
+            RBKN.EP2MRP(ep), RBK.EP2MRP(ep), atol=ATOL
+        )
+
+    def testAddepCallsEp2cC2ep(self, ep, ep2):
+        """addEP -> EP2C -> C2EP: DCM-mediated composition."""
+        np.testing.assert_allclose(
+            RBKN.addEP(ep, ep2), RBK.addEP(ep, ep2), atol=ATOL
+        )
+
+    def testDmrp2omegaCallsBinvmrp(self, mrp, omega):
+        """dMRP2Omega uses np.dot(BinvMRP(q), dq) (was np.matmul)."""
+        np.testing.assert_allclose(
+            RBKN.dMRP2Omega(mrp, omega), RBK.dMRP2Omega(mrp, omega), atol=ATOL
+        )
+
+    def testAddeuler123CallsMi(self, euler, euler2):
+        """addEuler123 builds DCMs via Mi() internally."""
+        np.testing.assert_allclose(
+            RBKN.addEuler123(euler, euler2), RBK.addEuler123(euler, euler2),
+            atol=ATOL,
+        )
+
+    def testAddeuler321CallsMi(self, euler, euler2):
+        """Validate ``addEuler321`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.addEuler321(euler, euler2), RBK.addEuler321(euler, euler2),
+            atol=ATOL,
+        )
+
+    def testGibbs2c(self, gibbs):
+        """Validate ``gibbs2C`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.gibbs2C(gibbs), RBK.gibbs2C(gibbs), atol=ATOL
+        )
+
+    def testGibbs2mrp(self, gibbs):
+        """Validate ``gibbs2MRP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.gibbs2MRP(gibbs), RBK.gibbs2MRP(gibbs), atol=ATOL
+        )
+
+    def test_MRP2EP_round_trip(self, mrp):
+        """MRP -> EP -> MRP round-trip must recover original."""
+        ep = RBKN.MRP2EP(mrp)
+        recovered = RBKN.EP2MRP(ep)
+        np.testing.assert_allclose(recovered, mrp, atol=ATOL)
+
+    def test_PRV2EP_round_trip(self, prv):
+        """PRV -> EP -> PRV round-trip."""
+        ep = RBKN.PRV2EP(prv)
+        recovered = RBKN.EP2PRV(ep)
+        np.testing.assert_allclose(recovered, prv, atol=ATOL)
+
+    def test_BmatMRP(self, mrp):
+        """Validate ``BmatMRP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.BmatMRP(mrp), RBK.BmatMRP(mrp), atol=ATOL
+        )
+
+    def test_BinvMRP(self, mrp):
+        """Validate ``BinvMRP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.BinvMRP(mrp), RBK.BinvMRP(mrp), atol=ATOL
+        )
+
+    def test_BinvEP(self, ep):
+        """Validate ``BinvEP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.BinvEP(ep), RBK.BinvEP(ep), atol=ATOL
+        )
+
+    def test_BmatEP(self, ep):
+        """Validate ``BmatEP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.BmatEP(ep), RBK.BmatEP(ep), atol=ATOL
+        )
+
+    def testDep(self, ep, omega):
+        """Validate ``dEP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.dEP(ep, omega), RBK.dEP(ep, omega), atol=ATOL
+        )
+
+    def testDmrp(self, mrp, omega):
+        """Validate ``dMRP`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.dMRP(mrp, omega), RBK.dMRP(mrp, omega), atol=ATOL
+        )
+
+    def testDdmrp(self, mrp, omega):
+        """Validate ``ddMRP`` against the reference implementation."""
+        domega = np.array([0.001, -0.002, 0.003])
+        np.testing.assert_allclose(
+            RBKN.ddMRP(mrp, omega, omega, domega),
+            RBK.ddMRP(mrp, omega, omega, domega),
+            atol=ATOL,
+        )
+
+    def test_C2PRV(self, dcm):
+        """Validate ``C2PRV`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.C2PRV(dcm), RBK.C2PRV(dcm), atol=ATOL
+        )
+
+    def test_C2Gibbs(self, dcm):
+        """Validate ``C2Gibbs`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.C2Gibbs(dcm), RBK.C2Gibbs(dcm), atol=ATOL
+        )
+
+    def test_MRP2Gibbs(self, mrp):
+        """Validate ``MRP2Gibbs`` against the reference implementation."""
+        np.testing.assert_allclose(
+            RBKN.MRP2Gibbs(mrp), RBK.MRP2Gibbs(mrp), atol=ATOL
+        )
+
+    # --- Euler-angle families (spot-check each sequence) ---
+
+    @pytest.mark.parametrize("seq", [
+        "121", "123", "131", "132",
+        "212", "213", "231", "232",
+        "312", "313", "321", "323",
+    ])
+    def test_C2Euler(self, dcm, seq):
+        """Validate ``C2Euler*`` for each supported Euler sequence."""
+        fn_rbk  = getattr(RBK,  f"C2Euler{seq}")
+        fn_rbkn = getattr(RBKN, f"C2Euler{seq}")
+        np.testing.assert_allclose(fn_rbkn(dcm), fn_rbk(dcm), atol=ATOL)
+
+    @pytest.mark.parametrize("seq", [
+        "121", "123", "131", "132",
+        "212", "213", "231", "232",
+        "312", "313", "321", "323",
+    ])
+    def testAddeuler(self, euler, euler2, seq):
+        """Validate ``addEuler*`` for each supported Euler sequence."""
+        fn_rbk  = getattr(RBK,  f"addEuler{seq}")
+        fn_rbkn = getattr(RBKN, f"addEuler{seq}")
+        np.testing.assert_allclose(
+            fn_rbkn(euler, euler2), fn_rbk(euler, euler2), atol=ATOL
+        )
+
+    @pytest.mark.parametrize("seq", [
+        "121", "123", "131", "132",
+        "212", "213", "231", "232",
+        "312", "313", "321", "323",
+    ])
+    def test_BinvEuler(self, euler, seq):
+        """Validate ``BinvEuler*`` for each supported Euler sequence."""
+        fn_rbk  = getattr(RBK,  f"BinvEuler{seq}")
+        fn_rbkn = getattr(RBKN, f"BinvEuler{seq}")
+        np.testing.assert_allclose(fn_rbkn(euler), fn_rbk(euler), atol=ATOL)


### PR DESCRIPTION
* **Tickets addressed:** Closes #1348
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR adds a Numba-based module workflow to Basilisk so numerically intensive Python modules can run through Numba `cfunc` dispatch at near-C speed while still fitting into the normal Basilisk scheduling and messaging model.

The main additions are:
- `NumbaModel`, including zero-copy message/payload access, persistent memory support, logging and RNG support, and cache-aware compilation of `UpdateStateImpl`
- `StatefulNumbaModel`, which combines `NumbaModel` with `StatefulSysModel` for continuous-time states integrated through MuJoCo `MJScene`
- `RigidBodyKinematicsNumba`, an `njit`-compatible companion to the existing rigid-body kinematics utilities
- user documentation, code samples, benchmark coverage, and new Numba example scenarios

The commits are organized by feature area so the core infrastructure, utilities, examples, and follow-up fixes can be reviewed incrementally.

## Verification
Changes were validated with a combination of new and updated unit/scenario tests plus targeted local checks.

Validation included:
- `src/architecture/numbaModel/_UnitTest/test_numbaModel.py`
- `src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py`
- `src/utilities/tests/test_RigidBodyKinematicsNumba.py`
- scenario tests for the new Numba examples

Tests were also updated to skip cleanly when Numba is unavailable so builds without Numba support fail less noisily.

## Documentation
This PR adds and updates documentation for the new workflow and examples.:
- `docs/source/Learn/makingModules/numbaModules.rst`
- `docs/source/codeSamples/making-numbaModules.py`
- the generated docs pages for `NumbaModel`, `StatefulNumbaModel`, and `RigidBodyKinematicsNumba`
- the new example pages for `scenarioAttitudePointingNumba`, `scenarioAttitudeFeedbackNumba`, `scenarioBenchmarkNumba`, and `benchmarkScenarios`
- the release notes snippet in `docs/source/Support/bskReleaseNotesSnippets/1348-numba-models.rst`

## Future work
Fallback so numba models can run without numba (fallback to default python).