### PR TITLE
Harden Basilisk string and logging security

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,14 @@ Apply these rules to all **new or modified code** in this repository.
    - For legacy non-conforming files: keep style consistent for minor edits; use major refactors to move code toward guideline compliance.
    - Follow the checkout recommendation in `docs/source/Support/Developer/bskModuleCheckoutList.rst`
 
-5. **PR metadata requirements**
+5. **String and logging security review**
+   - For new or modified C/C++ code, check for unsafe writes to fixed-size C buffers, including `strcpy`, `strcat`, `sprintf`, unbounded `%s` scans, and `strncpy` uses that can silently truncate or omit null termination.
+   - Prefer bounded formatting/copying APIs such as `snprintf` with `sizeof(destination)` when writing to fixed-size buffers.
+   - If a user- or module-supplied string is too long for a fixed-size Basilisk payload field, emit `BSK_ERROR` so execution stops immediately rather than silently truncating.
+   - For `bskLog()` and other printf-style logging calls, ensure the format string is a string literal. Dynamic text must be passed through a literal format such as `"%s"`.
+   - When a PR fixes one instance of a buffer-write or format-string issue, search nearby BSK modules and related payload paths for the same pattern and flag or fix matching issues.
+
+6. **PR metadata requirements**
    - For normal PRs, include one release-note snippet in:
      `docs/source/Support/bskReleaseNotesSnippets/`.
    - Ensure snippet content follows:
@@ -31,19 +38,19 @@ Apply these rules to all **new or modified code** in this repository.
    - Do not edit `docs/source/Support/bskReleaseNotes.rst` directly for normal PRs.
    - If there is a BSK fix, make sure it is mentioned in the `docs/source/Support/bskKnownIssues.rst` file.
 
-6. **SysModel documentation requirement**
+7. **SysModel documentation requirement**
    - Every new SysModel must include a corresponding `.rst` documentation file.
    - Pattern new module docs after:
      `src/moduleTemplates/cModuleTemplate/cModuleTemplate.rst` or
      `src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.rst`.
 
-7. **Basilisk Module Creation**
+8. **Basilisk Module Creation**
     - Ensure new Basilisk modules have a unit test
     - Unit test method needs to have documentation strings
     - Ensure the copyright statement is in new files using the current year
 
 
-8. **Basilisk Example Files**
+9. **Basilisk Example Files**
    - If an example scenario is included in the `examples` folder, ensure this example has a unit test in `src/tests` that imports and runs this example file.
    - If the example file includes the `enableUnityVisualization()` method, ensure the `saveFile` argument is included but commented out.
    - Ensure new Python example scripts are linked in `examples/_default.rst`.

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import json
 import shutil
+import shlex
 import subprocess
 import sys
 from datetime import datetime
@@ -126,10 +127,13 @@ class BasiliskConan(ConanFile):
         # managePipEnvironment (i.e. conanfile.py-based build).
 
         # ensure latest pip is installed
-        cmakeCmdString = f'{sys.executable} -m pip install --upgrade pip'
+        cmakeCmd = [sys.executable, "-m", "pip", "install", "--upgrade", "pip"]
         print(statusColor + "Updating pip:" + endColor)
-        print(cmakeCmdString)
-        os.system(cmakeCmdString)
+        print(shlex.join(cmakeCmd))
+        try:
+            subprocess.check_call(cmakeCmd)
+        except subprocess.CalledProcessError:
+            print(warningColor + "Was not able to upgrade pip; continuing with the existing pip installation." + endColor)
 
         # TODO: Remove this: requirements and optional requirements are
         # installed automatically by add_basilisk_to_sys_path(). Only build
@@ -530,18 +534,17 @@ if __name__ == "__main__":
             raise RuntimeError("Failed to install MuJoCo replay! See error above.")
 
     # setup conan install command arguments
-    conanInstallList = list()
-    conanInstallList.append(f'{sys.executable} -m conans.conan install . --build=missing')
-    conanInstallList.append(' -s build_type=' + str(args.buildType))
+    conanInstallArgs = [sys.executable, "-m", "conans.conan", "install", ".", "--build=missing"]
+    conanInstallArgs.extend(["-s", "build_type=" + str(args.buildType)])
     conanBuildOptionsList = list()  # setup list of conan build arguments
-    conanBuildOptionsList.append(' -s compiler.cppstd=17')
+    conanBuildOptionsList.extend(["-s", "compiler.cppstd=17"])
     if os.name != "nt":
-        conanBuildOptionsList.append(" -s compiler.cstd=gnu17")
+        conanBuildOptionsList.extend(["-s", "compiler.cstd=gnu17"])
     if args.generator:
-        conanBuildOptionsList.append(' -o "&:generator=' + str(args.generator) + '"')
+        conanBuildOptionsList.extend(["-o", "&:generator=" + str(args.generator)])
     for opt, value in bskModuleOptionsBool.items():
-        conanBuildOptionsList.append(' -o "&:' + opt + '=' + str(vars(args)[opt]) + '"')
-    conanInstallList.append(''.join(conanBuildOptionsList))  # argument get used in both install and build
+        conanBuildOptionsList.extend(["-o", "&:" + opt + "=" + str(vars(args)[opt])])
+    conanInstallArgs.extend(conanBuildOptionsList)  # arguments get used in both install and build
 
     # Most of these options go to both conan install and build commands
     for opt, value in bskModuleOptionsString.items():
@@ -549,28 +552,27 @@ if __name__ == "__main__":
             if opt == "pathToExternalModules":
                 externalPath = os.path.abspath(str(vars(args)[opt]).rstrip(os.path.sep))
                 if os.path.exists(externalPath):
-                    conanInstallList.append(' -o "&:' + opt + '=' + externalPath + '"')
-                    conanBuildOptionsList.append(' -o "&:' + opt + '=' + externalPath + '"')
+                    conanInstallArgs.extend(["-o", "&:" + opt + "=" + externalPath])
+                    conanBuildOptionsList.extend(["-o", "&:" + opt + "=" + externalPath])
                 else:
                     print(f"{failColor}Error: path {str(vars(args)[opt])} does not exist{endColor}")
                     sys.exit(1)
             else:
                 if opt != "autoKey":
-                    conanInstallList.append(' -o "&:' + opt + '=' + str(vars(args)[opt]) + '"')
-                    conanBuildOptionsList.append(' -o "&:' + opt + '=' + str(vars(args)[opt]) + '"')
+                    conanInstallArgs.extend(["-o", "&:" + opt + "=" + str(vars(args)[opt])])
+                    conanBuildOptionsList.extend(["-o", "&:" + opt + "=" + str(vars(args)[opt])])
 
     # only used for conan install arguments, not build
     for opt, value in bskModuleOptionsFlag.items():
         if vars(args)[opt]:
-            conanInstallList.append(' -o "&:' + opt + '=True"')
-    conanInstallString = ''.join(conanInstallList)
+            conanInstallArgs.extend(["-o", "&:" + opt + "=True"])
 
     print(statusColor + "Running conan install:" + endColor)
-    print(conanInstallString)
-    completedProcess = subprocess.run(conanInstallString, shell=True, check=True)
+    print(shlex.join(conanInstallArgs))
+    completedProcess = subprocess.run(conanInstallArgs, check=True)
 
     # run conan build
-    buildCmdString = f'{sys.executable} -m conans.conan build . ' + ''.join(conanBuildOptionsList)
+    buildCmd = [sys.executable, "-m", "conans.conan", "build", "."] + conanBuildOptionsList
     print(statusColor + "Running conan build:" + endColor)
-    print(buildCmdString)
-    completedProcess = subprocess.run(buildCmdString, shell=True, check=True)
+    print(shlex.join(buildCmd))
+    completedProcess = subprocess.run(buildCmd, check=True)

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,10 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
+- BSK-2026-001, BSK-2026-002, BSK-2026-003, and related fixed-buffer string handling and format-string
+  logging issues are fixed in the current version.
+- Additional build-helper command execution, temporary file cleanup, remote example download, and image buffer
+  validation hardening is included in the current version.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   The development dependency range now excludes SWIG 4.4.0, and SWIG 4.4.1 has been verified to build
   successfully. If source builds fail with SWIG 4.4.0 or emit ``builtin type swigvarlink has no __module__ attribute``

--- a/docs/source/Support/bskReleaseNotesSnippets/BSK-2026-001-vizInterface-buffer.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/BSK-2026-001-vizInterface-buffer.rst
@@ -1,0 +1,1 @@
+- Fixed a potential stack buffer overflow in :ref:`vizInterface` by rejecting default celestial body names that exceed the fixed SPICE payload name storage.

--- a/docs/source/Support/bskReleaseNotesSnippets/BSK-2026-002-mappingInstrument-buffer.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/BSK-2026-002-mappingInstrument-buffer.rst
@@ -1,0 +1,1 @@
+- Fixed a potential heap buffer overflow in :ref:`mappingInstrument` by rejecting mapping point names that exceed the fixed data node name storage.

--- a/docs/source/Support/bskReleaseNotesSnippets/BSK-2026-003-dentonFluxModel-format.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/BSK-2026-003-dentonFluxModel-format.rst
@@ -1,0 +1,1 @@
+- Fixed a potential format string vulnerability in :ref:`dentonFluxModel` when reporting missing Denton data files.

--- a/docs/source/Support/bskReleaseNotesSnippets/security-string-hardening.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/security-string-hardening.rst
@@ -1,1 +1,2 @@
 - Hardened Basilisk module string handling and logging against fixed-buffer overflow and format-string misuse.
+- Hardened build and helper utilities against shell command injection, unsafe temporary file cleanup, unbounded downloads, and malformed image buffer lengths.

--- a/docs/source/Support/bskReleaseNotesSnippets/security-string-hardening.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/security-string-hardening.rst
@@ -1,0 +1,1 @@
+- Hardened Basilisk module string handling and logging against fixed-buffer overflow and format-string misuse.

--- a/run_all_test.py
+++ b/run_all_test.py
@@ -1,4 +1,4 @@
-from os import system
+import subprocess
 
-system('cd dist3 && ctest -C Release')
-system('cd src && pytest -n auto')
+subprocess.run(["ctest", "-C", "Release"], cwd="dist3", check=True)
+subprocess.run(["pytest", "-n", "auto"], cwd="src", check=True)

--- a/src/architecture/utilities/bskLogging.cpp
+++ b/src/architecture/utilities/bskLogging.cpp
@@ -147,7 +147,7 @@ EXTERN void _setLogLevel(BSKLogger* bskLogger, logLevel_t logLevel)
 */
 EXTERN void _bskLog(BSKLogger* bskLogger, logLevel_t logLevel, const char* info)
 {
-    bskLogger->bskLog(logLevel, info);
+    bskLogger->bskLog(logLevel, "%s", info);
 }
 
 /// \endcond

--- a/src/architecture/utilities/bskLogging.rst
+++ b/src/architecture/utilities/bskLogging.rst
@@ -113,5 +113,5 @@ If you want to print variables to the logging string, this must be done before c
 .. code-block:: c
 
    char info[MAX_LOGGING_LENGTH];
-   sprintf(info, "Variable is too large (%d). Setting to max value.", variable);
+   snprintf(info, sizeof(info), "Variable is too large (%d). Setting to max value.", variable);
    _bskLog(configData->bskLogger, BSK_ERROR, info);

--- a/src/architecture/utilities/haslamBackgroundRadiation.cpp
+++ b/src/architecture/utilities/haslamBackgroundRadiation.cpp
@@ -140,7 +140,7 @@ bool HaslamMap::loadHaslamMap() {
                       this->brightnessTemperatures.data(), &anynull, &status)) {
         char err_text[256];
         fits_get_errstatus(status, err_text);
-        this->bskLogger.bskLog(BSK_ERROR, ("HaslamMap: Error reading data: " + std::string(err_text)).c_str());
+        this->bskLogger.bskLog(BSK_ERROR, "HaslamMap: Error reading data: %s", err_text);
         this->brightnessTemperatures.clear();
         closeFile();
         return false;

--- a/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
+++ b/src/fswAlgorithms/attGuidance/locationPointing/locationPointing.c
@@ -24,6 +24,7 @@
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <math.h>
+#include <stdio.h>
 
 /*!
     This method initializes the output messages for this module.
@@ -84,8 +85,8 @@ void Reset_locationPointing(locationPointingConfig *configData, uint64_t callTim
     /* compute an Eigen axis orthogonal to sHatBdyCmd */
     if (v3Norm(configData->pHat_B)  < 0.1) {
       char info[MAX_LOGGING_LENGTH];
-      sprintf(info, "locationPoint: vector pHat_B is not setup as a unit vector [%f, %f %f]",
-                configData->pHat_B[0], configData->pHat_B[1], configData->pHat_B[2]);
+      snprintf(info, sizeof(info), "locationPoint: vector pHat_B is not setup as a unit vector [%f, %f %f]",
+               configData->pHat_B[0], configData->pHat_B[1], configData->pHat_B[2]);
       _bskLog(configData->bskLogger, BSK_ERROR, info);
     } else {
         double v1[3];
@@ -103,16 +104,16 @@ void Reset_locationPointing(locationPointingConfig *configData, uint64_t callTim
     if (StripStateMsg_C_isLinked(&configData->locationstripInMsg)) {
         if (v3Norm(configData->cHat_B) < 0.1) {
             char info[MAX_LOGGING_LENGTH];
-            sprintf(info, "locationPointing: vector cHat_B is not setup as a unit vector [%f, %f, %f]",
-                          configData->cHat_B[0], configData->cHat_B[1], configData->cHat_B[2]);
+            snprintf(info, sizeof(info), "locationPointing: vector cHat_B is not setup as a unit vector [%f, %f, %f]",
+                     configData->cHat_B[0], configData->cHat_B[1], configData->cHat_B[2]);
             _bskLog(configData->bskLogger, BSK_ERROR, info);
         } else {
             v3Normalize(configData->cHat_B, configData->cHat_B);    /* ensure that this vector is a unit vector */
             double dotPHatCHat = fabs(v3Dot(configData->pHat_B, configData->cHat_B));
             if (dotPHatCHat > 1e-6) {
                 char info[MAX_LOGGING_LENGTH];
-                sprintf(info, "locationPointing: cHat_B is not perpendicular to pHat_B (dot product = %e). "
-                              "These vectors must be orthogonal for strip imaging.", dotPHatCHat);
+                snprintf(info, sizeof(info), "locationPointing: cHat_B is not perpendicular to pHat_B "
+                         "(dot product = %e). These vectors must be orthogonal for strip imaging.", dotPHatCHat);
                 _bskLog(configData->bskLogger, BSK_ERROR, info);
             }
         }

--- a/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.c
+++ b/src/fswAlgorithms/attGuidance/opNavPoint/opNavPoint.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
 #include "fswAlgorithms/attGuidance/opNavPoint/opNavPoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
@@ -61,8 +62,8 @@ void Reset_opNavPoint(OpNavPointConfig *configData, uint64_t callTime, int64_t m
     /* compute an Eigen axis orthogonal to alignAxis_C */
     if (v3Norm(configData->alignAxis_C)  < 0.1) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The module vector alignAxis_C is not setup as a unit vector [%f, %f %f]",
-          configData->alignAxis_C[0], configData->alignAxis_C[1], configData->alignAxis_C[2]);
+        snprintf(info, sizeof(info), "The module vector alignAxis_C is not setup as a unit vector [%f, %f %f]",
+                 configData->alignAxis_C[0], configData->alignAxis_C[1], configData->alignAxis_C[2]);
         _bskLog(configData->bskLogger, BSK_ERROR, info);
     } else {
         v3Set(1., 0., 0., v1);

--- a/src/fswAlgorithms/attGuidance/rasterManager/rasterManager.c
+++ b/src/fswAlgorithms/attGuidance/rasterManager/rasterManager.c
@@ -67,13 +67,14 @@ void Update_rasterManager(rasterManagerConfig *configData, uint64_t callTime, in
         configData->scanSelector += 1;
 
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "Raster: %i. AngleSet = [%f, %f, %f], RateSet = [%f, %f, %f] ", configData->scanSelector,
-               configData->attOutSet.state[0],
-               configData->attOutSet.state[1],
-               configData->attOutSet.state[2],
-               configData->attOutSet.rate[0],
-               configData->attOutSet.rate[1],
-               configData->attOutSet.rate[2]);
+        snprintf(info, sizeof(info), "Raster: %i. AngleSet = [%f, %f, %f], RateSet = [%f, %f, %f] ",
+                 configData->scanSelector,
+                 configData->attOutSet.state[0],
+                 configData->attOutSet.state[1],
+                 configData->attOutSet.state[2],
+                 configData->attOutSet.rate[0],
+                 configData->attOutSet.rate[1],
+                 configData->attOutSet.rate[2]);
         _bskLog(configData->bskLogger, BSK_INFORMATION, info);
     }
 

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.c
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include <math.h>
+#include <stdio.h>
 #include "fswAlgorithms/attGuidance/sunSafePoint/sunSafePoint.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
@@ -59,8 +60,8 @@ void Reset_sunSafePoint(sunSafePointConfig *configData, uint64_t callTime, int64
     /* compute an Eigen axis orthogonal to sHatBdyCmd */
     if (v3Norm(configData->sHatBdyCmd)  < 0.1) {
       char info[MAX_LOGGING_LENGTH];
-      sprintf(info, "The module vector sHatBdyCmd is not setup as a unit vector [%f, %f %f]",
-                configData->sHatBdyCmd[0], configData->sHatBdyCmd[1], configData->sHatBdyCmd[2]);
+      snprintf(info, sizeof(info), "The module vector sHatBdyCmd is not setup as a unit vector [%f, %f %f]",
+               configData->sHatBdyCmd[0], configData->sHatBdyCmd[1], configData->sHatBdyCmd[2]);
       _bskLog(configData->bskLogger, BSK_ERROR, info);
     } else {
         v3Set(1., 0., 0., v1);

--- a/src/fswAlgorithms/sensorInterfaces/CSSSensorData/cssComm.c
+++ b/src/fswAlgorithms/sensorInterfaces/CSSSensorData/cssComm.c
@@ -53,7 +53,9 @@ void Reset_cssProcessTelem(CSSConfigData *configData, uint64_t callTime, int64_t
     if(configData->numSensors > MAX_NUM_CSS_SENSORS)
     {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The configured number of CSS sensors exceeds the maximum, %d > %d! Changing the number of sensors to the max.", configData->numSensors, MAX_NUM_CSS_SENSORS);
+        snprintf(info, sizeof(info),
+                 "The configured number of CSS sensors exceeds the maximum, %d > %d! Changing the number of sensors to the max.",
+                 configData->numSensors, MAX_NUM_CSS_SENSORS);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
         configData->numSensors = MAX_NUM_CSS_SENSORS;
     }

--- a/src/fswAlgorithms/transDetermination/navAggregate/navAggregate.c
+++ b/src/fswAlgorithms/transDetermination/navAggregate/navAggregate.c
@@ -55,8 +55,9 @@ void Reset_aggregateNav(NavAggregateData *configData, uint64_t callTime, int64_t
     }
     if (configData->transMsgCount > MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The translation message count %d is larger than allowed (%d). Setting count to max value.",
-                  configData->transMsgCount, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The translation message count %d is larger than allowed (%d). Setting count to max value.",
+                 configData->transMsgCount, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->transMsgCount = MAX_AGG_NAV_MSG;
@@ -80,32 +81,36 @@ void Reset_aggregateNav(NavAggregateData *configData, uint64_t callTime, int64_t
     /*! - ensure the attitude message index locations are less than MAX_AGG_NAV_MSG */
     if (configData->attTimeIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The attTimeIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-              configData->attTimeIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The attTimeIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->attTimeIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->attTimeIdx = MAX_AGG_NAV_MSG - 1;
     }
     if (configData->attIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The attIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                  configData->attIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The attIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->attIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->attIdx = MAX_AGG_NAV_MSG - 1;
     }
     if (configData->rateIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The rateIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                  configData->rateIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The rateIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->rateIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->rateIdx = MAX_AGG_NAV_MSG - 1;
     }
     if (configData->sunIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The sunIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                configData->sunIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The sunIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->sunIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->sunIdx = MAX_AGG_NAV_MSG - 1;
@@ -114,32 +119,36 @@ void Reset_aggregateNav(NavAggregateData *configData, uint64_t callTime, int64_t
     /*! - ensure the translational message index locations are less than MAX_AGG_NAV_MSG */
     if (configData->transTimeIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The transTimeIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                configData->transTimeIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The transTimeIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->transTimeIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->transTimeIdx = MAX_AGG_NAV_MSG - 1;
     }
     if (configData->posIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The posIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                  configData->posIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The posIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->posIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->posIdx = MAX_AGG_NAV_MSG - 1;
     }
     if (configData->velIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The velIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                  configData->velIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The velIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->velIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->velIdx = MAX_AGG_NAV_MSG - 1;
     }
     if (configData->dvIdx >= MAX_AGG_NAV_MSG) {
         char info[MAX_LOGGING_LENGTH];
-        sprintf(info, "The dvIdx variable %d is too large. Must be less than %d. Setting index to max value.",
-                configData->dvIdx, MAX_AGG_NAV_MSG);
+        snprintf(info, sizeof(info),
+                 "The dvIdx variable %d is too large. Must be less than %d. Setting index to max value.",
+                 configData->dvIdx, MAX_AGG_NAV_MSG);
         _bskLog(configData->bskLogger, BSK_WARNING, info);
 
         configData->dvIdx = MAX_AGG_NAV_MSG - 1;

--- a/src/moduleTemplates/cModuleTemplate/cModuleTemplate.c
+++ b/src/moduleTemplates/cModuleTemplate/cModuleTemplate.c
@@ -24,6 +24,7 @@
 /* modify the path to reflect the new module names */
 #include "cModuleTemplate.h"
 #include "string.h"
+#include <stdio.h>
 
 
 
@@ -57,7 +58,7 @@ void Reset_cModuleTemplate(cModuleTemplateConfig *configData, uint64_t callTime,
     /*! reset any required variables */
     configData->dummy = 0.0;
     char info[MAX_LOGGING_LENGTH];
-    sprintf(info, "Variable dummy set to %f in reset.",configData->dummy);
+    snprintf(info, sizeof(info), "Variable dummy set to %f in reset.", configData->dummy);
     _bskLog(configData->bskLogger, BSK_INFORMATION, info);
 
     /* initialize the output message to zero on reset */
@@ -102,7 +103,8 @@ void Update_cModuleTemplate(cModuleTemplateConfig *configData, uint64_t callTime
     /* this logging statement is not typically required.  It is done here to see in the
      quick-start guide which module is being executed */
     char info[MAX_LOGGING_LENGTH];
-    sprintf(info, "C Module ID %lld ran Update at %fs", (long long int) moduleID, (double) callTime/(1e9));
+    snprintf(info, sizeof(info), "C Module ID %lld ran Update at %fs",
+             (long long int) moduleID, (double) callTime/(1e9));
     _bskLog(configData->bskLogger, BSK_INFORMATION, info);
 
     return;

--- a/src/simulation/communication/downlinkHandling/downlinkHandling.cpp
+++ b/src/simulation/communication/downlinkHandling/downlinkHandling.cpp
@@ -21,6 +21,7 @@ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado Bould
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 
 #include "architecture/utilities/macroDefinitions.h"
@@ -48,8 +49,7 @@ DownlinkHandling::DownlinkHandling()
     this->linkBudgetBuffer = {};
     this->downlinkOutBuffer = this->downlinkOutMsg.zeroMsgPayload;
 
-    std::strncpy(this->nodeDataName, "STORED DATA", sizeof(this->nodeDataName) - 1);
-    this->nodeDataName[sizeof(this->nodeDataName) - 1] = '\0';
+    std::snprintf(this->nodeDataName, sizeof(this->nodeDataName), "%s", "STORED DATA");
 }
 
 /*! Add a storage-status message to the module input list */
@@ -251,8 +251,10 @@ DownlinkHandling::evaluateDataModel(DataNodeUsageMsgPayload* dataUsageMsg, doubl
     const bool selectedDataNameValid =
       this->setDataNameFromStorageSelection(selection, this->nodeDataName, sizeof(this->nodeDataName));
 
-    std::strncpy(this->downlinkOutBuffer.dataName, this->nodeDataName, sizeof(this->downlinkOutBuffer.dataName) - 1);
-    this->downlinkOutBuffer.dataName[sizeof(this->downlinkOutBuffer.dataName) - 1] = '\0';
+    std::snprintf(this->downlinkOutBuffer.dataName,
+                  sizeof(this->downlinkOutBuffer.dataName),
+                  "%s",
+                  this->nodeDataName);
     this->downlinkOutBuffer.availableDataBits = this->availableDataBits;
     const bool safeStorageRemovalRoute = selectedDataNameValid && this->isStorageRemovalRouteSafe(selection);
     if (!safeStorageRemovalRoute && selection.storageUnitIndex >= 0) {
@@ -280,8 +282,7 @@ DownlinkHandling::evaluateDataModel(DataNodeUsageMsgPayload* dataUsageMsg, doubl
         this->lastBlockedStorageRemovalReason.clear();
     }
     if (safeStorageRemovalRoute) {
-        std::strncpy(dataUsageMsg->dataName, this->nodeDataName, sizeof(dataUsageMsg->dataName) - 1);
-        dataUsageMsg->dataName[sizeof(dataUsageMsg->dataName) - 1] = '\0';
+        std::snprintf(dataUsageMsg->dataName, sizeof(dataUsageMsg->dataName), "%s", this->nodeDataName);
     } else {
         // Leaving the removal message unnamed prevents DataStorageUnitBase from creating a synthetic partition.
         dataUsageMsg->dataName[0] = '\0';
@@ -295,23 +296,33 @@ DownlinkHandling::evaluateDataModel(DataNodeUsageMsgPayload* dataUsageMsg, doubl
     this->downlinkOutBuffer.cnr = this->sanitizeNonNegative(selectedCnr);
 
     // Record which antenna pair created the selected receiver path for downstream diagnostics and plotting.
+    auto copyAntennaName = [this](char* destination, size_t destinationSize, const char* source, size_t sourceSize) {
+        if (std::memchr(source, '\0', sourceSize) == nullptr) {
+            bskLogger.bskLog(BSK_ERROR,
+                             "DownlinkHandling: antenna name is not null-terminated within %zu characters.",
+                             sourceSize);
+        }
+        std::snprintf(destination, destinationSize, "%s", source);
+    };
     if (selectedReceiver == 1) {
-        std::strncpy(this->downlinkOutBuffer.receiverAntennaName,
-                     this->linkBudgetBuffer.antennaName1,
-                     sizeof(this->downlinkOutBuffer.receiverAntennaName) - 1);
-        std::strncpy(this->downlinkOutBuffer.transmitterAntennaName,
-                     this->linkBudgetBuffer.antennaName2,
-                     sizeof(this->downlinkOutBuffer.transmitterAntennaName) - 1);
+        copyAntennaName(this->downlinkOutBuffer.receiverAntennaName,
+                        sizeof(this->downlinkOutBuffer.receiverAntennaName),
+                        this->linkBudgetBuffer.antennaName1,
+                        sizeof(this->linkBudgetBuffer.antennaName1));
+        copyAntennaName(this->downlinkOutBuffer.transmitterAntennaName,
+                        sizeof(this->downlinkOutBuffer.transmitterAntennaName),
+                        this->linkBudgetBuffer.antennaName2,
+                        sizeof(this->linkBudgetBuffer.antennaName2));
     } else if (selectedReceiver == 2) {
-        std::strncpy(this->downlinkOutBuffer.receiverAntennaName,
-                     this->linkBudgetBuffer.antennaName2,
-                     sizeof(this->downlinkOutBuffer.receiverAntennaName) - 1);
-        std::strncpy(this->downlinkOutBuffer.transmitterAntennaName,
-                     this->linkBudgetBuffer.antennaName1,
-                     sizeof(this->downlinkOutBuffer.transmitterAntennaName) - 1);
+        copyAntennaName(this->downlinkOutBuffer.receiverAntennaName,
+                        sizeof(this->downlinkOutBuffer.receiverAntennaName),
+                        this->linkBudgetBuffer.antennaName2,
+                        sizeof(this->linkBudgetBuffer.antennaName2));
+        copyAntennaName(this->downlinkOutBuffer.transmitterAntennaName,
+                        sizeof(this->downlinkOutBuffer.transmitterAntennaName),
+                        this->linkBudgetBuffer.antennaName1,
+                        sizeof(this->linkBudgetBuffer.antennaName1));
     }
-    this->downlinkOutBuffer.receiverAntennaName[sizeof(this->downlinkOutBuffer.receiverAntennaName) - 1] = '\0';
-    this->downlinkOutBuffer.transmitterAntennaName[sizeof(this->downlinkOutBuffer.transmitterAntennaName) - 1] = '\0';
 
     // A valid RF path requires written link-budget data, a positive selected CNR, positive overlap bandwidth,
     // a positive requested bit rate, and a positive packet size.
@@ -487,7 +498,7 @@ DownlinkHandling::isStorageRemovalRouteSafe(const StorageSelection& selection) c
 bool
 DownlinkHandling::setDataNameFromStorageSelection(const StorageSelection& selection,
                                                   char* buffer,
-                                                  std::size_t bufferSize) const
+                                                  std::size_t bufferSize)
 {
     if (bufferSize == 0) {
         return false;
@@ -512,8 +523,13 @@ DownlinkHandling::setDataNameFromStorageSelection(const StorageSelection& select
     if (selectedPartition < storage.storedDataName.size()) {
         const auto& name = storage.storedDataName[selectedPartition];
         if (!name.empty()) {
-            std::strncpy(buffer, name.c_str(), bufferSize - 1);
-            buffer[bufferSize - 1] = '\0';
+            if (name.size() >= bufferSize) {
+                bskLogger.bskLog(BSK_ERROR,
+                                 "DownlinkHandling: selected storage partition name is %zu characters, but "
+                                 "the destination buffer supports at most %zu characters.",
+                                 name.size(), bufferSize - 1);
+            }
+            std::snprintf(buffer, bufferSize, "%s", name.c_str());
             return true;
         }
     }

--- a/src/simulation/communication/downlinkHandling/downlinkHandling.h
+++ b/src/simulation/communication/downlinkHandling/downlinkHandling.h
@@ -158,7 +158,7 @@ class DownlinkHandling : public DataNodeBase
 
     StorageSelection selectStorageSelection() const;
     bool isStorageRemovalRouteSafe(const StorageSelection& selection) const;
-    bool setDataNameFromStorageSelection(const StorageSelection& selection, char* buffer, std::size_t bufferSize) const;
+    bool setDataNameFromStorageSelection(const StorageSelection& selection, char* buffer, std::size_t bufferSize);
     void selectReceiver(double* cnrLinear, uint32_t* receiverIndex) const;
     bool validateConfiguration() const;
     bool isFinite(double value) const;

--- a/src/simulation/communication/linkBudget/linkBudget.cpp
+++ b/src/simulation/communication/linkBudget/linkBudget.cpp
@@ -26,6 +26,7 @@
 #include "simulation/communication/linkBudget/linkBudget.h"
 #include "simulation/communication/_GeneralModuleFiles/AntennaDefinitions.h"
 #include "architecture/utilities/ItuRefAtmosphere.h"
+#include <cstdio>
 #include <iostream>
 #include <cstring>
 #include <cmath>
@@ -393,7 +394,7 @@ void LinkBudget::generateLookupTable(LinkBudgetTypes::GasType gasType, LookupTab
     std::ifstream file(filePath);
     if (!file.is_open()) {
         std::string errorMsg = "LinkBudget: Unable to open lookup table file: " + filePath.string();
-        bskLogger.bskLog(BSK_ERROR, errorMsg.c_str());
+        bskLogger.bskLog(BSK_ERROR, "%s", errorMsg.c_str());
         return;
     }
 
@@ -502,7 +503,7 @@ void LinkBudget::generateLookupTable(LinkBudgetTypes::GasType gasType, LookupTab
 
     // Verify that data was loaded
     if (lookupTable->f_l.empty()) {
-        bskLogger.bskLog(BSK_WARNING, ("LinkBudget: No data loaded from " + filename).c_str());
+        bskLogger.bskLog(BSK_WARNING, "LinkBudget: No data loaded from %s", filename.c_str());
     }
 }
 void LinkBudget::precomputeAtmosphericAttenuationAtLayers(AttenuationLookupTable* attenuationLookup, double frequency)
@@ -610,10 +611,24 @@ void LinkBudget::writeOutputMessages(uint64_t CurrentSimNanos)
     // always zero the output message buffers before assigning values
     linkBudgetOutPayloadBuffer = this->linkBudgetOutPayload.zeroMsgPayload;
     // populate the output message buffer
-    std::strncpy(linkBudgetOutPayloadBuffer.antennaName1, this->antennaIn_1.antennaName, sizeof(linkBudgetOutPayloadBuffer.antennaName1) - 1); // [-]  ID of antenna 1
-    linkBudgetOutPayloadBuffer.antennaName1[sizeof(linkBudgetOutPayloadBuffer.antennaName1) - 1] = '\0';
-    std::strncpy(linkBudgetOutPayloadBuffer.antennaName2, this->antennaIn_2.antennaName, sizeof(linkBudgetOutPayloadBuffer.antennaName2) - 1); // [-]  ID of antenna 2
-    linkBudgetOutPayloadBuffer.antennaName2[sizeof(linkBudgetOutPayloadBuffer.antennaName2) - 1] = '\0';
+    if (std::memchr(this->antennaIn_1.antennaName, '\0', sizeof(this->antennaIn_1.antennaName)) == nullptr) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "LinkBudget: antennaName1 is not null-terminated within %zu characters.",
+                         sizeof(this->antennaIn_1.antennaName));
+    }
+    std::snprintf(linkBudgetOutPayloadBuffer.antennaName1,
+                  sizeof(linkBudgetOutPayloadBuffer.antennaName1),
+                  "%s",
+                  this->antennaIn_1.antennaName); // [-]  ID of antenna 1
+    if (std::memchr(this->antennaIn_2.antennaName, '\0', sizeof(this->antennaIn_2.antennaName)) == nullptr) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "LinkBudget: antennaName2 is not null-terminated within %zu characters.",
+                         sizeof(this->antennaIn_2.antennaName));
+    }
+    std::snprintf(linkBudgetOutPayloadBuffer.antennaName2,
+                  sizeof(linkBudgetOutPayloadBuffer.antennaName2),
+                  "%s",
+                  this->antennaIn_2.antennaName); // [-]  ID of antenna 2
     linkBudgetOutPayloadBuffer.antennaState1 = this->antennaIn_1.antennaState;                                                       // [-]  State of antenna 1 (Off/Tx/Rx/TxRx)
     linkBudgetOutPayloadBuffer.antennaState2 = this->antennaIn_2.antennaState;                                                       // [-]  State of antenna 2 (Off/Tx/Rx/TxRx)
     linkBudgetOutPayloadBuffer.CNR1          = this->CNR1;                                                                           // [-]  Carrier-to-Noise Ratio for antenna 1

--- a/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
@@ -48,7 +48,7 @@ void GravBodyData::initBody(int64_t moduleID)
     if (errorMessage) {
         std::string fullMsg =
             "Error initializating body '" + this->planetName + "'. " + errorMessage.value();
-        this->bskLogger.bskLog(BSK_ERROR, fullMsg.c_str());
+        this->bskLogger.bskLog(BSK_ERROR, "%s", fullMsg.c_str());
     }
 }
 
@@ -94,7 +94,7 @@ void GravBodyData::registerProperties(DynParamManager& statesIn)
 {
     if (this->planetName == "") {
         auto errorMessage = "You must specify a planetary body name in GravBodyData";
-        this->bskLogger.bskLog(BSK_ERROR, errorMessage);
+        this->bskLogger.bskLog(BSK_ERROR, "%s", errorMessage);
         throw std::invalid_argument(errorMessage);
     }
 
@@ -132,7 +132,7 @@ void GravityEffector::UpdateState(uint64_t currentSimNanos)
         if (this->centralBody) // A centralBody was already set
         {
             auto errorMessage = "Specified two central bodies at the same time";
-            this->bskLogger.bskLog(BSK_ERROR, errorMessage);
+            this->bskLogger.bskLog(BSK_ERROR, "%s", errorMessage);
             throw std::invalid_argument(errorMessage);
         }
         else {

--- a/src/simulation/dynamics/_GeneralModuleFiles/interpolator.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/interpolator.h
@@ -62,7 +62,7 @@ public:
         if (points.cols() != (nArgs + 1)) {
             auto error =
                 "Expected points to have exactly " + std::to_string(nArgs + 1) + " columns.";
-            this->bskLogger.bskLog(BSK_ERROR, error.c_str());
+            this->bskLogger.bskLog(BSK_ERROR, "%s", error.c_str());
             throw std::invalid_argument(error);
         }
 
@@ -70,7 +70,7 @@ public:
             auto error =
                 "Provided 'degrees' is higher or equal than number of data points (illegal for "
                 "interpolation).";
-            this->bskLogger.bskLog(BSK_ERROR, error);
+            this->bskLogger.bskLog(BSK_ERROR, "%s", error);
             throw std::invalid_argument(error);
         }
 
@@ -130,7 +130,7 @@ public:
         if (this->xMin == 0 && this->xMax == 0) {
             auto error = "Tried to call Reset or UpdateState on Interpolator before setDataPoints "
                          "was called.";
-            this->bskLogger.bskLog(BSK_ERROR, error);
+            this->bskLogger.bskLog(BSK_ERROR, "%s", error);
             throw std::invalid_argument(error);
         }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateData.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateData.cpp
@@ -69,7 +69,7 @@ void StateData::propagateState(double dt, std::vector<double> pseudoStep)
         auto errorMsg = "State " + this->getName() + " has stochastic dynamics, but "
             + "the integrator tried to propagate it without pseudoSteps. Are you sure "
             + "you are using a stochastic integrator?";
-        bskLogger.bskLog(BSK_ERROR, errorMsg.c_str());
+        bskLogger.bskLog(BSK_ERROR, "%s", errorMsg.c_str());
         throw std::invalid_argument(errorMsg);
     }
 
@@ -95,7 +95,7 @@ void StateData::setDiffusion(const Eigen::MatrixXd & newDiffusion, size_t index)
     {
         auto errorMsg = "Tried to set diffusion index greater than number of noise sources configured: "
             + std::to_string(index) + " >= " + std::to_string(stateDiffusion.size());
-        bskLogger.bskLog(BSK_ERROR, errorMsg.c_str());
+        bskLogger.bskLog(BSK_ERROR, "%s", errorMsg.c_str());
         throw std::out_of_range(errorMsg);
     }
 }

--- a/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.cpp
+++ b/src/simulation/dynamics/gravityEffector/sphericalHarmonicsGravityModel.cpp
@@ -96,7 +96,7 @@ SphericalHarmonicsGravityModel::computeField(const Eigen::Vector3d& position_pla
     if (degree > this->maxDeg) {
         auto errorMsg =
             "Requested degree greater than maximum degree in Spherical Harmonics gravity model";
-        bskLogger.bskLog(BSK_ERROR, errorMsg);
+        bskLogger.bskLog(BSK_ERROR, "%s", errorMsg);
     }
 
     double x = position_planetFixed[0];

--- a/src/simulation/environment/dentonFluxModel/_UnitTest/test_dentonFluxModel.py
+++ b/src/simulation/environment/dentonFluxModel/_UnitTest/test_dentonFluxModel.py
@@ -36,7 +36,7 @@ path = os.path.dirname(os.path.abspath(filename))
 bskPath = __path__[0]
 
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging, messaging
 from Basilisk.utilities import macros
 from Basilisk.simulation import dentonFluxModel
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
@@ -81,6 +81,30 @@ def test_dentonFluxModel(show_plots, param1_Kp, param2_LT, param3_z, param4_r_EN
     """
     dentonFluxModelTestFunction(show_plots, param1_Kp, param2_LT, param3_z, param4_r_EN,
                                                              accuracy)
+
+
+def test_dentonFluxModel_missing_file_format_string():
+    r"""
+    **Validation Test Description**
+
+    This test verifies that missing Denton data file paths are logged as string data, even when the path contains
+    format specifiers.
+    """
+    module = dentonFluxModel.DentonFluxModel()
+    module.ModelTag = "dentonFluxModule"
+    module.kpIndex = "1o"
+    module.numOutputEnergies = 6
+    missing_path = os.path.join(path, "missing_%s_%n_flux.txt")
+    module.configureDentonFiles(missing_path, missing_path)
+
+    module.scStateInMsg.subscribeTo(messaging.SCStatesMsg().write(messaging.SCStatesMsgPayload()))
+    module.earthStateInMsg.subscribeTo(messaging.SpicePlanetStateMsg().write(messaging.SpicePlanetStateMsgPayload()))
+    module.sunStateInMsg.subscribeTo(messaging.SpicePlanetStateMsg().write(messaging.SpicePlanetStateMsgPayload()))
+
+    with pytest.raises(bskLogging.BasiliskError) as err:
+        module.Reset(0)
+
+    assert missing_path in str(err.value)
 
 
 def dentonFluxModelTestFunction(show_plots, param1_Kp, param2_LT, param3_z, param4_r_EN, accuracy):

--- a/src/simulation/environment/dentonFluxModel/dentonFluxModel.cpp
+++ b/src/simulation/environment/dentonFluxModel/dentonFluxModel.cpp
@@ -353,7 +353,7 @@ void DentonFluxModel::readDentonDataFile(const std::string& fullPath,
             }
         }
     } else {
-        bskLogger.bskLog(BSK_ERROR, ("Could not open " + fullPath).c_str());
+        bskLogger.bskLog(BSK_ERROR, "Could not open %s", fullPath.c_str());
         return;
     }
 

--- a/src/simulation/environment/magneticFieldWMM/GeomagnetismLibrary.c
+++ b/src/simulation/environment/magneticFieldWMM/GeomagnetismLibrary.c
@@ -7,6 +7,10 @@
 #include <assert.h>
 #include "GeomagnetismHeader.h"
 
+#define MAG_ERROR_MESSAGE_LENGTH (255)
+#define MAG_DMS_STRING_LENGTH (30)
+#define MAG_GET_USER_QUERY_LENGTH (1028)
+
 /* $Id: GeomagnetismLibrary.c 1521 2017-01-24 17:52:41Z awoods $
  *
  * ABSTRACT
@@ -298,7 +302,7 @@ int MAG_robustReadMagneticModel_Large(char *filename, char *filenameSV, MAGtype_
     }
     MAG_readMagneticModel_Large(filename, filenameSV, *MagneticModel);
     (*MagneticModel)->CoefficientFileEndDate = (*MagneticModel)->epoch + epochlength;
-    strcpy((*MagneticModel)->ModelName, ModelName);
+    snprintf((*MagneticModel)->ModelName, sizeof((*MagneticModel)->ModelName), "%s", ModelName);
     (*MagneticModel)->EditionDate = (*MagneticModel)->epoch;
     return 1;
 } /*MAG_robustReadMagneticModel_Large*/
@@ -467,7 +471,7 @@ CALLS : none
     }else {
         sscanf(buffer, "%lf", &minimum->phi);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Please Enter Maximum Latitude (in decimal degrees):\n");
     if (NULL == fgets(buffer, 20, stdin)) {
         maximum->phi = 0;
@@ -475,7 +479,7 @@ CALLS : none
     } else {
         sscanf(buffer, "%lf", &maximum->phi);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Please Enter Minimum Longitude (in decimal degrees):\n");
     if (NULL == fgets(buffer, 20, stdin)) {
         minimum->lambda = 0;
@@ -483,7 +487,7 @@ CALLS : none
     } else {
         sscanf(buffer, "%lf", &minimum->lambda);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Please Enter Maximum Longitude (in decimal degrees):\n");
     if (NULL == fgets(buffer, 20, stdin)){
         maximum->lambda = 0;
@@ -491,7 +495,7 @@ CALLS : none
     } else {
         sscanf(buffer, "%lf", &maximum->lambda);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Please Enter Step Size (in decimal degrees):\n");
     if (NULL == fgets(buffer, 20, stdin)){
         *step_size = fmax(maximum->phi - minimum->phi, maximum->lambda - minimum->lambda);
@@ -499,7 +503,7 @@ CALLS : none
     } else {
         sscanf(buffer, "%lf", step_size);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Select height (default : above MSL) \n1. Above Mean Sea Level\n2. Above WGS-84 Ellipsoid \n");
     if (NULL == fgets(buffer, 20, stdin)) {
         Geoid->UseGeoid = 1;
@@ -509,7 +513,7 @@ CALLS : none
         if(dummy == 2) Geoid->UseGeoid = 0;
         else Geoid->UseGeoid = 1;
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     if(Geoid->UseGeoid == 1)
     {
         printf("Please Enter Minimum Height above MSL (in km):\n");
@@ -519,7 +523,7 @@ CALLS : none
         } else {
             sscanf(buffer, "%lf", &minimum->HeightAboveGeoid);
         }
-        strcpy(buffer, "");
+        buffer[0] = '\0';
         printf("Please Enter Maximum Height above MSL (in km):\n");
         if (NULL == fgets(buffer, 20, stdin)) {
             maximum->HeightAboveGeoid = 0;
@@ -527,7 +531,7 @@ CALLS : none
         } else {
             sscanf(buffer, "%lf", &maximum->HeightAboveGeoid);
         }
-        strcpy(buffer, "");
+        buffer[0] = '\0';
 
     } else
     {
@@ -540,7 +544,7 @@ CALLS : none
             sscanf(buffer, "%lf", &minimum->HeightAboveGeoid);
         }
         minimum->HeightAboveEllipsoid = minimum->HeightAboveGeoid;
-        strcpy(buffer, "");
+        buffer[0] = '\0';
         printf("Please Enter Maximum Height above the WGS-84 Ellipsoid (in km):\n");
         if (NULL == fgets(buffer, 20, stdin)) {
             maximum->HeightAboveGeoid = 0;
@@ -549,7 +553,7 @@ CALLS : none
             sscanf(buffer, "%lf", &maximum->HeightAboveGeoid);
         }
         maximum->HeightAboveEllipsoid = maximum->HeightAboveGeoid;
-        strcpy(buffer, "");
+        buffer[0] = '\0';
     }
     printf("Please Enter height step size (in km):\n");
     if (NULL == fgets(buffer, 20, stdin)) {
@@ -558,19 +562,19 @@ CALLS : none
     } else {
         sscanf(buffer, "%lf", a_step_size);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("\nPlease Enter the decimal year starting time:\n");
     while (NULL == fgets(buffer, 20, stdin)) {
         printf("\nUnrecognized input, please re-enter a decimal year\n");
     }
     sscanf(buffer, "%lf", &StartDate->DecimalYear);
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Please Enter the decimal year ending time:\n");
     while (NULL == fgets(buffer, 20, stdin)) {
         printf("\nUnrecognized input, please re-enter a decimal year\n");
     }
     sscanf(buffer, "%lf", &EndDate->DecimalYear);
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Please Enter the time step size:\n");
     if (NULL == fgets(buffer, 20, stdin)) {
         *step_time = EndDate->DecimalYear - StartDate->DecimalYear;
@@ -578,7 +582,7 @@ CALLS : none
     } else {
         sscanf(buffer, "%lf", step_time);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     printf("Enter a geomagnetic element to print. Your options are:\n");
     printf(" 1. Declination	9.   Ddot\n 2. Inclination	10. Idot\n 3. F		11. Fdot\n 4. H		12. Hdot\n 5. X		13. Xdot\n 6. Y		14. Ydot\n 7. Z		15. Zdot\n 8. GV		16. GVdot\nFor gradients enter: 17\n");
     if (NULL == fgets(buffer, 20, stdin)) {
@@ -586,21 +590,21 @@ CALLS : none
         printf("Unrecognized input, default of %d used\n", *ElementOption);
     }
     sscanf(buffer, "%d", ElementOption);
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     if(*ElementOption == 17)
     {
         printf("Enter a gradient element to print. Your options are:\n");
         printf(" 1. dX/dphi \t2. dY/dphi \t3. dZ/dphi\n");
         printf(" 4. dX/dlambda \t5. dY/dlambda \t6. dZ/dlambda\n");
         printf(" 7. dX/dz \t8. dY/dz \t9. dZ/dz\n");
-        strcpy(buffer, "");
+        buffer[0] = '\0';
         if (NULL == fgets(buffer, 20, stdin)) {
             *ElementOption=1;
             printf("Unrecognized input, default of %d used\n", *ElementOption);
         } else {
             sscanf(buffer, "%d", ElementOption);
         }
-        strcpy(buffer, "");
+        buffer[0] = '\0';
         *ElementOption+=16;
     }
     printf("Select output :\n");
@@ -611,24 +615,24 @@ CALLS : none
     } else {
         sscanf(buffer, "%d", PrintOption);
     }
-    strcpy(buffer, "");
+    buffer[0] = '\0';
     fileout = fopen(filename, "a");
     if(*PrintOption == 1)
     {
         printf("Please enter output filename\nfor default ('GridResults.txt') press enter:\n");
         if(NULL==fgets(buffer, 20, stdin) || strlen(buffer) <= 1)
         {
-            strcpy(OutputFile, "GridResults.txt");
+            snprintf(OutputFile, MAXLINELENGTH, "%s", "GridResults.txt");
             fprintf(fileout, "\nResults printed in: GridResults.txt\n");
-            strcpy(OutputFile, "GridResults.txt");
+            snprintf(OutputFile, MAXLINELENGTH, "%s", "GridResults.txt");
         } else
         {
-            sscanf(buffer, "%s", OutputFile);
+            sscanf(buffer, "%1023s", OutputFile);
             fprintf(fileout, "\nResults printed in: %s\n", OutputFile);
         }
-        /*strcpy(OutputFile, buffer);*/
-        strcpy(buffer, "");
-        /*sscanf(buffer, "%s", OutputFile);*/
+        /* Copying the output file from buffer is no longer used. */
+        buffer[0] = '\0';
+        /* Parsing the output file from buffer is no longer used. */
     } else
         fprintf(fileout, "\nResults printed in Console\n");
     fprintf(fileout, "Minimum Latitude: %f\t\tMaximum Latitude: %f\t\tStep Size: %f\nMinimum Longitude: %f\t\tMaximum Longitude: %f\t\tStep Size: %f\n", minimum->phi, maximum->phi, *step_size, minimum->lambda, maximum->lambda, *step_size);
@@ -678,23 +682,27 @@ CALLS: 	MAG_DMSstringToDegree(buffer, &CoordGeodetic->lambda); (The program uses
 	double lat_bound[2] = {LAT_BOUND_MIN, LAT_BOUND_MAX};
 	double lon_bound[2] = {LON_BOUND_MIN, LON_BOUND_MAX};
     int alt_bound[2] = {ALT_BOUND_MIN, NO_ALT_MAX};
-	char* Qstring = malloc(sizeof(char) * 1028);
-    strcpy(buffer, ""); /*Clear the input    */
-	strcpy(Qstring, "\nPlease enter latitude\nNorth latitude positive, For example:\n30, 30, 30 (D,M,S) or 30.508 (Decimal Degrees) (both are north)\n");
+	char* Qstring = malloc(sizeof(char) * MAG_GET_USER_QUERY_LENGTH);
+    if(Qstring == NULL)
+        return FALSE;
+    buffer[0] = '\0'; /*Clear the input    */
+	snprintf(Qstring, MAG_GET_USER_QUERY_LENGTH, "%s", "\nPlease enter latitude\nNorth latitude positive, For example:\n30, 30, 30 (D,M,S) or 30.508 (Decimal Degrees) (both are north)\n");
 	MAG_GetDeg(Qstring, &CoordGeodetic->phi, lat_bound);
-    strcpy(buffer, ""); /*Clear the input*/
-    strcpy(Qstring,"\nPlease enter longitude\nEast longitude positive, West negative.  For example:\n-100.5 or -100, 30, 0 for 100.5 degrees west\n");
+    buffer[0] = '\0'; /*Clear the input*/
+    snprintf(Qstring, MAG_GET_USER_QUERY_LENGTH, "%s", "\nPlease enter longitude\nEast longitude positive, West negative.  For example:\n-100.5 or -100, 30, 0 for 100.5 degrees west\n");
 	MAG_GetDeg(Qstring, &CoordGeodetic->lambda, lon_bound);
 
-	strcpy(Qstring,"\nPlease enter height above mean sea level (in kilometers):\n[For height above WGS-84 ellipsoid prefix E, for example (E20.1)]\n");
-    if(MAG_GetAltitude(Qstring, Geoid, CoordGeodetic, alt_bound, FALSE)==USER_GAVE_UP)
+	snprintf(Qstring, MAG_GET_USER_QUERY_LENGTH, "%s", "\nPlease enter height above mean sea level (in kilometers):\n[For height above WGS-84 ellipsoid prefix E, for example (E20.1)]\n");
+    if(MAG_GetAltitude(Qstring, Geoid, CoordGeodetic, alt_bound, FALSE)==USER_GAVE_UP) {
+        free(Qstring);
         return FALSE;
-    strcpy(buffer, "");
+    }
+    buffer[0] = '\0';
     printf("\nPlease enter the decimal year or calendar date\n (YYYY.yyy, MM DD YYYY or MM/DD/YYYY):\n");
     while (NULL == fgets(buffer, 40, stdin)) {
         printf("\nPlease enter the decimal year or calendar date\n (YYYY.yyy, MM DD YYYY or MM/DD/YYYY):\n");
     }
-    for(i = 0, done = 0; i <= 40 && !done; i++)
+    for(i = 0, done = 0; i < (int)sizeof(buffer) && !done; i++)
     {
         if(buffer[i] == '.')
         {
@@ -736,7 +744,7 @@ CALLS: 	MAG_DMSstringToDegree(buffer, &CoordGeodetic->lambda); (The program uses
                 if(!MAG_DateToYear(MagneticDate, Error_Message))
                 {
                     printf("%s", Error_Message);
-                    strcpy(buffer, "");
+                    buffer[0] = '\0';
                     printf("\nError encountered, please re-enter Date in MM/DD/YYYY or MM DD YYYY format, or as a decimal year\n");
                     while( NULL== fgets(buffer, 40, stdin)){
                         printf("\nError encountered, please re-enter Date in MM/DD/YYYY or MM DD YYYY format, or as a decimal year\n");
@@ -748,7 +756,7 @@ CALLS: 	MAG_DMSstringToDegree(buffer, &CoordGeodetic->lambda); (The program uses
         }
         if(buffer[i] == '\0' && i != -1 && done != 1)
         {
-            strcpy(buffer, "");
+            buffer[0] = '\0';
             printf("\nError encountered, please re-enter as MM/DD/YYYY, MM DD YYYY, or as YYYY.yyy:\n");
             while (NULL ==fgets(buffer, 40, stdin)) {
                 printf("\nError encountered, please re-enter as MM/DD/YYYY, MM DD YYYY, or as YYYY.yyy:\n");
@@ -761,11 +769,12 @@ CALLS: 	MAG_DMSstringToDegree(buffer, &CoordGeodetic->lambda); (The program uses
             {
                 switch(MAG_Warnings(4, MagneticDate->DecimalYear, MagneticModel)) {
                     case 0:
+                        free(Qstring);
                         return 0;
                     case 1:
                         done = 0;
                         i = -1;
-                        strcpy(buffer, "");
+                        buffer[0] = '\0';
                         printf("\nPlease enter the decimal year or calendar date\n (YYYY.yyy, MM DD YYYY or MM/DD/YYYY):\n");
                         while(NULL == fgets(buffer, 40, stdin)){
                             printf("\nPlease enter the decimal year or calendar date\n (YYYY.yyy, MM DD YYYY or MM/DD/YYYY):\n");
@@ -939,7 +948,7 @@ CALLS : none
     {
         if((input[i] < '0' || input[i] > '9') && (input[i] != ',' && input[i] != ' ' && input[i] != '-' && input[i] != '\0' && input[i] != '\n'))
         {
-            strcpy(Error, "\nError: Input contains an illegal character, legal characters for Degree, Minute, Second format are:\n '0-9' ',' '-' '[space]' '[Enter]'\n");
+            snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "%s", "\nError: Input contains an illegal character, legal characters for Degree, Minute, Second format are:\n '0-9' ',' '-' '[space]' '[Enter]'\n");
             return FALSE;
         }
         if(input[i] == ',')
@@ -957,26 +966,26 @@ CALLS : none
     }
     if(j != 3)
     {
-        strcpy(Error, "\nError: Not enough numbers used for Degrees, Minutes, Seconds format\n or they were incorrectly formatted\n The legal format is DD,MM,SS or DD MM SS\n");
+        snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "%s", "\nError: Not enough numbers used for Degrees, Minutes, Seconds format\n or they were incorrectly formatted\n The legal format is DD,MM,SS or DD MM SS\n");
         return FALSE;
     }
     if(degree > max || degree < min)
     {
-        sprintf(Error, "\nError: Degree input is outside legal range\n The legal range is from %d to %d\n", min, max);
+        snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "\nError: Degree input is outside legal range\n The legal range is from %d to %d\n", min, max);
         return FALSE;
     }
     if(degree == max || degree == min)
         max_minute = 0;
     if(minute > max_minute || minute < 0)
     {
-        strcpy(Error, "\nError: Minute input is outside legal range\n The legal minute range is from 0 to 60\n");
+        snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "%s", "\nError: Minute input is outside legal range\n The legal minute range is from 0 to 60\n");
         return FALSE;
     }
     if(minute == max_minute)
         max_second = 0;
     if(second > max_second || second < 0)
     {
-        strcpy(Error, "\nError: Second input is outside legal range\n The legal second range is from 0 to 60\n");
+        snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "%s", "\nError: Second input is outside legal range\n The legal second range is from 0 to 60\n");
         return FALSE;
     }
     return TRUE;
@@ -997,7 +1006,7 @@ CALLS : none
  */
 {
     char ans[20];
-    strcpy(ans, "");
+    ans[0] = '\0';
 
     switch(control) {
         case 1:/* Horizontal Field strength low */
@@ -1221,7 +1230,7 @@ CALLS : none
     }
     MagneticModel->CoefficientFileEndDate = 0;
     MagneticModel->EditionDate = 0;
-    strcpy(MagneticModel->ModelName, "");
+    MagneticModel->ModelName[0] = '\0';
     MagneticModel->SecularVariationUsed = 0;
     MagneticModel->epoch = 0;
     MagneticModel->nMax = 0;
@@ -1251,7 +1260,7 @@ MAGtype_SphericalHarmonicVariables* MAG_AllocateSphVarMemory(int nMax)
 void MAG_AssignHeaderValues(MAGtype_MagneticModel *model, char values[][MAXLINELENGTH])
 {
     /*    MAGtype_Date releasedate; */
-    strcpy(model->ModelName, values[MODELNAME]);
+    snprintf(model->ModelName, sizeof(model->ModelName), "%s", values[MODELNAME]);
     /*      releasedate.Year = 0;
             releasedate.Day = 0;
             releasedate.Month = 0;
@@ -1524,7 +1533,7 @@ void MAG_PrintWMMFormat(char *filename, MAGtype_MagneticModel *MagneticModel)
 
     Date.DecimalYear = MagneticModel->EditionDate;
     MAG_YearToDate(&Date);
-    sprintf(Datestring, "%d/%d/%d", Date.Month, Date.Day, Date.Year);
+    snprintf(Datestring, sizeof(Datestring), "%d/%d/%d", Date.Month, Date.Day, Date.Year);
     OUT = fopen(filename, "w");
     fprintf(OUT, "    %.1f               %s              %s\n", MagneticModel->epoch, MagneticModel->ModelName, Datestring);
     for(n = 1; n <= MagneticModel->nMax; n++)
@@ -1550,7 +1559,7 @@ void MAG_PrintEMMFormat(char *filename, char *filenameSV, MAGtype_MagneticModel 
 
     Date.DecimalYear = MagneticModel->EditionDate;
     MAG_YearToDate(&Date);
-    sprintf(Datestring, "%d/%d/%d", Date.Month, Date.Day, Date.Year);
+    snprintf(Datestring, sizeof(Datestring), "%d/%d/%d", Date.Month, Date.Day, Date.Year);
     OUT = fopen(filename, "w");
     fprintf(OUT, "    %.1f               %s              %s\n", MagneticModel->epoch, MagneticModel->ModelName, Datestring);
     for(n = 1; n <= MagneticModel->nMax; n++)
@@ -1673,7 +1682,7 @@ int MAG_readMagneticModel(char *filename, MAGtype_MagneticModel * MagneticModel)
         MAG_Error(20);
         return FALSE;
     }
-    sscanf(c_str, "%lf%s", &epoch, MagneticModel->ModelName);
+    sscanf(c_str, "%lf%31s", &epoch, MagneticModel->ModelName);
     MagneticModel->epoch = epoch;
     while(EOF_Flag == 0)
     {
@@ -1748,7 +1757,7 @@ int MAG_readMagneticModel_Large(char *filename, char *filenameSV, MAGtype_Magnet
         fclose(MAG_COFSV_File);
         return FALSE;
     }
-    sscanf(c_str, "%lf%s", &epoch, MagneticModel->ModelName);
+    sscanf(c_str, "%lf%31s", &epoch, MagneticModel->ModelName);
     MagneticModel->epoch = epoch;
     a = CALCULATE_NUMTERMS(MagneticModel->nMaxSecVar);
     b = CALCULATE_NUMTERMS(MagneticModel->nMax);
@@ -1892,13 +1901,12 @@ int MAG_readMagneticModel_SHDF(char *filename, MAGtype_MagneticModel *(*magnetic
             for(i = 0; i < NOOFPARAMS; i++)
             {
 
-                paramkeylength = (int) strlen(paramkeys[i]);
-                if(!strncmp(line, paramkeys[i], paramkeylength))
-                {
-                    paramvaluelength = (int) strlen(line) - paramkeylength;
-                    strncpy(paramvalue, line + paramkeylength, paramvaluelength);
-                    paramvalue[paramvaluelength] = '\0';
-                    strcpy(paramvalues[i], paramvalue);
+                    paramkeylength = (int) strlen(paramkeys[i]);
+                    if(!strncmp(line, paramkeys[i], paramkeylength))
+                    {
+                        paramvaluelength = (int) strlen(line) - paramkeylength;
+                        snprintf(paramvalue, sizeof(paramvalue), "%.*s", paramvaluelength, line + paramkeylength);
+                        snprintf(paramvalues[i], sizeof(paramvalues[i]), "%s", paramvalue);
                     if(!strcmp(paramkeys[i], paramkeys[INTSTATICDEG]) || !strcmp(paramkeys[i], paramkeys[EXTSTATICDEG]))
                     {
                         tempint = atoi(paramvalues[i]);
@@ -2237,13 +2245,13 @@ CALLS : none
     /******************Validation********************************/
     if(CalendarDate->Month <= 0 || CalendarDate->Month > 12)
     {
-        strcpy(Error, "\nError: The Month entered is invalid, valid months are '1 to 12'\n");
+        snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "%s", "\nError: The Month entered is invalid, valid months are '1 to 12'\n");
         return 0;
     }
     if(CalendarDate->Day <= 0 || CalendarDate->Day > MonthDays[CalendarDate->Month])
     {
         printf("\nThe number of days in month %d is %d\n", CalendarDate->Month, MonthDays[CalendarDate->Month]);
-        strcpy(Error, "\nError: The day entered is invalid\n");
+        snprintf(Error, MAG_ERROR_MESSAGE_LENGTH, "%s", "\nError: The day entered is invalid\n");
         return 0;
     }
     /****************Calculation of t***************************/
@@ -2271,7 +2279,7 @@ CALLS : none
     double temp = DegreesOfArc;
     char tempstring[36] = "";
     char tempstring2[32] = "";
-    strcpy(DMSstring, "");
+    DMSstring[0] = '\0';
     if(UnitDepth > 3)
         MAG_Error(21);
     for(i = 0; i < UnitDepth; i++)
@@ -2279,13 +2287,13 @@ CALLS : none
         DMS[i] = (int) temp;
         switch(i) {
             case 0:
-                strcpy(tempstring2, "Deg");
+                snprintf(tempstring2, sizeof(tempstring2), "%s", "Deg");
                 break;
             case 1:
-                strcpy(tempstring2, "Min");
+                snprintf(tempstring2, sizeof(tempstring2), "%s", "Min");
                 break;
             case 2:
-                strcpy(tempstring2, "Sec");
+                snprintf(tempstring2, sizeof(tempstring2), "%s", "Sec");
                 break;
         }
         temp = (temp - DMS[i])*60;
@@ -2293,8 +2301,9 @@ CALLS : none
             DMS[i]++;
         else if(i == UnitDepth - 1 && temp <= -30)
             DMS[i]--;
-        sprintf(tempstring, "%4d%4s", DMS[i], tempstring2);
-        strcat(DMSstring, tempstring);
+        snprintf(tempstring, sizeof(tempstring), "%4d%4s", DMS[i], tempstring2);
+        if(strlen(DMSstring) < MAG_DMS_STRING_LENGTH - 1)
+            strncat(DMSstring, tempstring, MAG_DMS_STRING_LENGTH - strlen(DMSstring) - 1);
     }
 } /*MAG_DegreeToDMSstring*/
 
@@ -3738,7 +3747,7 @@ CALLS : none
     TimedMagneticModel->nMaxSecVar = MagneticModel->nMaxSecVar;
     a = TimedMagneticModel->nMaxSecVar;
     b = (a * (a + 1) / 2 + a);
-    strcpy(TimedMagneticModel->ModelName, MagneticModel->ModelName);
+    snprintf(TimedMagneticModel->ModelName, sizeof(TimedMagneticModel->ModelName), "%s", MagneticModel->ModelName);
     for(n = 1; n <= MagneticModel->nMax; n++)
     {
         for(m = 0; m <= n; m++)
@@ -4036,7 +4045,7 @@ void MAG_GetDeg(char* Query_String, double* latitude, double bounds[2]) {
     while (NULL == fgets(buffer, 64, stdin)){
         printf("%s", Query_String);
     }
-    for(i = 0, done = 0, j = 0; i <= 64 && !done; i++)
+    for(i = 0, done = 0, j = 0; i < (int)sizeof(buffer) && !done; i++)
     {
         if(buffer[i] == '.')
         {
@@ -4074,7 +4083,7 @@ void MAG_GetDeg(char* Query_String, double* latitude, double bounds[2]) {
             } else
             {
                 printf("%s", Error_Message);
-                strcpy(buffer, "");
+                buffer[0] = '\0';
                 printf("\nError encountered, please re-enter as '(-)DDD,MM,SS' or in Decimal Degrees DD.ddd:\n");
                 while(NULL == fgets(buffer, 40, stdin)) {
                     printf("\nError encountered, please re-enter as '(-)DDD,MM,SS' or in Decimal Degrees DD.ddd:\n");
@@ -4101,7 +4110,7 @@ int MAG_GetAltitude(char* Query_String, MAGtype_Geoid *Geoid, MAGtype_CoordGeode
 
     while(!done)
     {
-        strcpy(buffer, "");
+        buffer[0] = '\0';
         while(NULL == fgets(buffer, 40, stdin)) {
             printf("%s", Query_String);
         }

--- a/src/simulation/environment/planetEphemeris/planetEphemeris.cpp
+++ b/src/simulation/environment/planetEphemeris/planetEphemeris.cpp
@@ -17,8 +17,8 @@
 
  */
 #include "simulation/environment/planetEphemeris/planetEphemeris.h"
+#include <cstdio>
 #include <iostream>
-#include <string.h>
 #include "architecture/utilities/astroConstants.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/macroDefinitions.h"
@@ -44,6 +44,15 @@ PlanetEphemeris::~PlanetEphemeris()
 /*! add list of planet names */
 void PlanetEphemeris::setPlanetNames(std::vector<std::string> names)
 {
+    for (const auto& name : names) {
+        if (name.size() >= MAX_BODY_NAME_LENGTH) {
+            bskLogger.bskLog(BSK_ERROR,
+                             "PlanetEphemeris: planet name is %zu characters, but the SPICE payload name "
+                             "supports at most %d characters.",
+                             name.size(), MAX_BODY_NAME_LENGTH - 1);
+        }
+    }
+
     this->planetNames = names;
 
     /* create corresponding output messages */
@@ -141,7 +150,7 @@ void PlanetEphemeris::UpdateState(uint64_t CurrentSimNanos)
         SpicePlanetStateMsgPayload newPlanet;
         newPlanet = this->planetOutMsgs.at(c)->zeroMsgPayload;
         //! - specify planet name in output message
-        strcpy(newPlanet.PlanetName, it->c_str());
+        std::snprintf(newPlanet.PlanetName, sizeof(newPlanet.PlanetName), "%s", it->c_str());
 
         //! - tag time to message
         newPlanet.J2000Current = time;

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -17,6 +17,7 @@
 
  */
 #include "simulation/environment/spiceInterface/spiceInterface.h"
+#include <cstdio>
 #include <sstream>
 #include "SpiceUsr.h"
 #include <string.h>
@@ -358,10 +359,12 @@ void SpiceInterface::addPlanetNames(std::vector<std::string> planetNames) {
         m33SetIdentity(newPlanet.J20002Pfix);
         if(it->size() >= MAX_BODY_NAME_LENGTH)
         {
-            bskLogger.bskLog(BSK_WARNING, "spiceInterface: Warning, your planet name is too long for me.  Ignoring: %s", (*it).c_str());
-            continue;
+            bskLogger.bskLog(BSK_ERROR,
+                             "spiceInterface: planet name is %zu characters, but the SPICE payload name "
+                             "supports at most %d characters.",
+                             it->size(), MAX_BODY_NAME_LENGTH - 1);
         }
-        strcpy(newPlanet.PlanetName, it->c_str());
+        std::snprintf(newPlanet.PlanetName, sizeof(newPlanet.PlanetName), "%s", it->c_str());
 
         this->planetData.push_back(newPlanet);
     }
@@ -410,10 +413,12 @@ void SpiceInterface::addSpacecraftNames(std::vector<std::string> spacecraftNames
         m33SetIdentity(newSpacecraft.J20002Pfix);
         if(it->size() >= MAX_BODY_NAME_LENGTH)
         {
-            bskLogger.bskLog(BSK_WARNING, "spiceInterface: Warning, your spacecraft name is too long for me.  Ignoring: %s", (*it).c_str());
-            continue;
+            bskLogger.bskLog(BSK_ERROR,
+                             "spiceInterface: spacecraft name is %zu characters, but the SPICE payload name "
+                             "supports at most %d characters.",
+                             it->size(), MAX_BODY_NAME_LENGTH - 1);
         }
-        strcpy(newSpacecraft.PlanetName, it->c_str());
+        std::snprintf(newSpacecraft.PlanetName, sizeof(newSpacecraft.PlanetName), "%s", it->c_str());
 
         std::string planetFrame = *it;
         cnmfrm_c(planetFrame.c_str(), this->charBufferSize, &frmCode, name, &frmFound);

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJQPosStateData.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJQPosStateData.cpp
@@ -40,7 +40,7 @@ void MJQPosStateData::propagateState(double dt, std::vector<double> pseudoStep)
         auto errorMsg = "State " + this->getName() + " has stochastic dynamics, but "
             + "the integrator tried to propagate it without pseudoSteps. Are you sure "
             + "you are using a stochastic integrator?";
-        bskLogger.bskLog(BSK_ERROR, errorMsg.c_str());
+        bskLogger.bskLog(BSK_ERROR, "%s", errorMsg.c_str());
         throw std::invalid_argument(errorMsg);
     }
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.cpp
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.cpp
@@ -32,7 +32,7 @@ logMujocoError(const char* err)
 void
 logMujocoWarning(const char* err)
 {
-    BSKLogger{}.bskLog(BSK_WARNING, ("MuJoCo internal warning: "s + err).c_str());
+    BSKLogger{}.bskLog(BSK_WARNING, "%s", ("MuJoCo internal warning: "s + err).c_str());
 }
 
 } // namespace MJBasilisk::detail

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.h
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/MJUtils.h
@@ -57,9 +57,9 @@ template <typename T = std::invalid_argument>
 [[noreturn]] inline void logAndThrow (const std::string& error, BSKLogger* logger = nullptr)
 {
     if (logger) {
-        logger->bskLog(BSK_ERROR, error.c_str());
+        logger->bskLog(BSK_ERROR, "%s", error.c_str());
     } else {
-        BSKLogger{}.bskLog(BSK_ERROR, error.c_str());
+        BSKLogger{}.bskLog(BSK_ERROR, "%s", error.c_str());
     }
     throw T(error);
 }

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/pythonUtils.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/pythonUtils.py
@@ -81,43 +81,38 @@ def visualize(
 
     tqpos = np.column_stack([time, qpos])
 
-    with tempfile.NamedTemporaryFile("w", delete=False) as fqpos:
-        np.savetxt(fqpos, tqpos)
+    with tempfile.TemporaryDirectory() as tempDir:
+        stateFile = os.path.join(tempDir, "state.txt")
+        np.savetxt(stateFile, tqpos)
 
-    if isinstance(modelFileOrScene, str):
-        modelFile = modelFileOrScene
-        fmodel = None
-    else:
-        with tempfile.NamedTemporaryFile("w", delete=False) as fmodel:
-            modelFileOrScene.saveToFile(fmodel.name)
-        modelFile = fmodel.name
+        if isinstance(modelFileOrScene, str):
+            modelFile = modelFileOrScene
+        else:
+            modelFile = os.path.join(tempDir, "model.xml")
+            modelFileOrScene.saveToFile(modelFile)
 
-    if platform.system() == "Windows":
-        script_fn = "replay.exe"
-    else:
-        script_fn = "replay"
-    script = os.path.join(bskPath, rf"utilities/mujocoUtils/bin/{script_fn}")
+        if platform.system() == "Windows":
+            script_fn = "replay.exe"
+        else:
+            script_fn = "replay"
+        script = os.path.join(bskPath, rf"utilities/mujocoUtils/bin/{script_fn}")
 
-    if not os.path.exists(script):
-        raise RuntimeError(f"Couldn't find the visualization tool at '{script}'."
-                            " Did you build Basilisk with the flag "
-                            "'--mujocoReplay True'? If so, did this tool build correctly?")
+        if not os.path.exists(script):
+            raise RuntimeError(f"Couldn't find the visualization tool at '{script}'."
+                               " Did you build Basilisk with the flag "
+                               "'--mujocoReplay True'? If so, did this tool build correctly?")
 
-    args = [script, "--model", modelFile, "--state", fqpos.name]
+        args = [script, "--model", modelFile, "--state", stateFile]
 
-    args.extend(["--speed", str(speedUp)])
+        args.extend(["--speed", str(speedUp)])
 
-    if track:
-        args.extend(["--track", track])
+        if track:
+            args.extend(["--track", track])
 
-    for file in files:
-        args.extend(["--file", file])
+        for file in files:
+            args.extend(["--file", file])
 
-    try:
-        subprocess.check_output(args)
-    except subprocess.CalledProcessError as e:
-        print(e)
-
-    os.unlink(fqpos.name)
-    if fmodel is not None:
-        os.unlink(fmodel.name)
+        try:
+            subprocess.check_output(args)
+        except subprocess.CalledProcessError as e:
+            print(e)

--- a/src/simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.cpp
+++ b/src/simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.cpp
@@ -20,6 +20,7 @@
 #include "dataStorageUnitBase.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 
 /*! This method initializes some basic parameters for the module.
@@ -165,6 +166,12 @@ void DataStorageUnitBase::integrateDataStatus(double currentTime){
     //! - loop over all the data nodes
     std::vector<DataNodeUsageMsgPayload>::iterator it;
     for(it = nodeBaudMsgs.begin(); it != nodeBaudMsgs.end(); it++) {
+        if (std::memchr(it->dataName, '\0', sizeof(it->dataName)) == nullptr) {
+            bskLogger.bskLog(BSK_ERROR,
+                             "DataStorageUnitBase: dataName is not null-terminated within %zu characters.",
+                             sizeof(it->dataName));
+            return;
+        }
         index = messageInStoredData(&(*it));
 
         //! - If the storage capacity has not been reached or the baudRate is less than 0 and won't take below 0, then add the data
@@ -180,11 +187,6 @@ void DataStorageUnitBase::integrateDataStatus(double currentTime){
                //! - if a dataNode does not exist in storedData, add it to storedData, integrate baud rate, and add amount
            }
            else if (strcmp(it->dataName, "") != 0) {
-               if (std::memchr(it->dataName, '\0', sizeof(it->dataName)) == nullptr) {
-                   bskLogger.bskLog(BSK_ERROR,
-                                    "DataStorageUnitBase: dataName is not null-terminated within %zu characters.",
-                                    sizeof(it->dataName));
-               }
                std::snprintf(tmpDataInstance.dataInstanceName,
                              sizeof(tmpDataInstance.dataInstanceName),
                              "%s",

--- a/src/simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.cpp
+++ b/src/simulation/onboardDataHandling/_GeneralModuleFiles/dataStorageUnitBase.cpp
@@ -180,6 +180,11 @@ void DataStorageUnitBase::integrateDataStatus(double currentTime){
                //! - if a dataNode does not exist in storedData, add it to storedData, integrate baud rate, and add amount
            }
            else if (strcmp(it->dataName, "") != 0) {
+               if (std::memchr(it->dataName, '\0', sizeof(it->dataName)) == nullptr) {
+                   bskLogger.bskLog(BSK_ERROR,
+                                    "DataStorageUnitBase: dataName is not null-terminated within %zu characters.",
+                                    sizeof(it->dataName));
+               }
                std::snprintf(tmpDataInstance.dataInstanceName,
                              sizeof(tmpDataInstance.dataInstanceName),
                              "%s",
@@ -282,6 +287,12 @@ void DataStorageUnitBase::setDataBuffer(std::string partitionName, int64_t data)
         }
         //! - if a dataNode does not exist in storedData, add it to storedData, and add amount
         else if (strcmp(partitionName.c_str(), "") != 0) {
+            if (partitionName.size() >= sizeof(tmpDataInstance.dataInstanceName)) {
+                bskLogger.bskLog(BSK_ERROR,
+                                 "DataStorageUnitBase: partitionName is %zu characters, but dataInstanceName "
+                                 "supports at most %zu characters.",
+                                 partitionName.size(), sizeof(tmpDataInstance.dataInstanceName) - 1);
+            }
             std::snprintf(tmpDataInstance.dataInstanceName,
                           sizeof(tmpDataInstance.dataInstanceName),
                           "%s",

--- a/src/simulation/onboardDataHandling/instrument/mappingInstrument/_UnitTest/test_mappingInstrument.py
+++ b/src/simulation/onboardDataHandling/instrument/mappingInstrument/_UnitTest/test_mappingInstrument.py
@@ -1,12 +1,12 @@
-# 
+#
 #  ISC License
-# 
+#
 #  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado Boulder
-# 
+#
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
 #  copyright notice and this permission notice appear in all copies.
-# 
+#
 #  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 #  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 #  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,11 +14,12 @@
 #  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-# 
-# 
+#
+#
 
 import numpy as np
-from Basilisk.architecture import messaging
+import pytest
+from Basilisk.architecture import bskLogging, messaging
 from Basilisk.simulation import mappingInstrument
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
@@ -36,6 +37,19 @@ def test_mappingInstrument():
     """
     [testResults, testMessage] = mappingInstrumentTestFunction()
     assert testResults < 1, testMessage
+
+
+def test_mappingInstrument_rejects_long_data_name():
+    r"""
+    This test checks that ``mappingInstrument`` rejects mapping point names that do not fit in the fixed
+    ``DataNodeUsageMsgPayload.dataName`` storage.
+    """
+    module = mappingInstrument.MappingInstrument()
+    accessInMsg = messaging.AccessMsg().write(messaging.AccessMsgPayload())
+    long_data_name = "mapping-point-" + "x" * 128
+
+    with pytest.raises(bskLogging.BasiliskError, match="dataName is 142 characters"):
+        module.addMappingPoint(accessInMsg, long_data_name)
 
 
 def mappingInstrumentTestFunction():
@@ -111,5 +125,3 @@ def mappingInstrumentTestFunction():
 
 if __name__ == "__main__":
     test_mappingInstrument()
-
-

--- a/src/simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.cpp
+++ b/src/simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.cpp
@@ -18,7 +18,8 @@
 */
 
 #include "simulation/onboardDataHandling/instrument/mappingInstrument/mappingInstrument.h"
-#include "string.h"
+
+#include <cstdio>
 
 /*! This is the constructor for the module class.  It sets default variable
     values and initializes the various parts of the model */
@@ -70,7 +71,10 @@ void MappingInstrument::UpdateState(uint64_t CurrentSimNanos)
             dataNodeOutMsgBuffer.at(c).baudRate = 0;
         }
 
-        strcpy(dataNodeOutMsgBuffer.at(c).dataName, mappingPoints[c].c_str());
+        std::snprintf(dataNodeOutMsgBuffer.at(c).dataName,
+                      sizeof(dataNodeOutMsgBuffer.at(c).dataName),
+                      "%s",
+                      mappingPoints[c].c_str());
 
         /* Write the output message */
         this->dataNodeOutMsgs.at(c)->write(&this->dataNodeOutMsgBuffer.at(c), this->moduleID, CurrentSimNanos);
@@ -84,6 +88,14 @@ void MappingInstrument::UpdateState(uint64_t CurrentSimNanos)
  *
 */
 void MappingInstrument::addMappingPoint(Message<AccessMsgPayload> *tmpAccessMsg, std::string dataName){
+    DataNodeUsageMsgPayload dataNodeUsageMsg = {};
+    if (dataName.size() >= sizeof(dataNodeUsageMsg.dataName)) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "MappingInstrument: dataName is %zu characters, but DataNodeUsageMsgPayload.dataName "
+                         "supports at most %zu characters.",
+                         dataName.size(), sizeof(dataNodeUsageMsg.dataName) - 1);
+    }
+
     /* Add the name of the mapping point */
     this->mappingPoints.push_back(dataName);
 
@@ -96,7 +108,6 @@ void MappingInstrument::addMappingPoint(Message<AccessMsgPayload> *tmpAccessMsg,
     this->dataNodeOutMsgs.push_back(msg);
 
     /* Expand the data node usage buffer vectors */
-    DataNodeUsageMsgPayload dataNodeUsageMsg;
     this->dataNodeOutMsgBuffer.push_back(dataNodeUsageMsg);
 
     return;

--- a/src/simulation/onboardDataHandling/instrument/simpleInstrument/simpleInstrument.cpp
+++ b/src/simulation/onboardDataHandling/instrument/simpleInstrument/simpleInstrument.cpp
@@ -18,6 +18,8 @@
  */
 
 #include "simpleInstrument.h"
+#include <cstdio>
+#include <cstring>
 
 /*! Constructor, which sets the default nodeDataOut to zero.
 
@@ -39,6 +41,11 @@ SimpleInstrument::~SimpleInstrument(){
 */
 void SimpleInstrument::evaluateDataModel(DataNodeUsageMsgPayload *dataUsageSimMsg, double currentTime){
     dataUsageSimMsg->baudRate = this->nodeBaudRate;
-    strncpy (dataUsageSimMsg->dataName, this->nodeDataName, sizeof(dataUsageSimMsg->dataName));
+    if (std::memchr(this->nodeDataName, '\0', sizeof(this->nodeDataName)) == nullptr) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "SimpleInstrument: nodeDataName is not null-terminated within %zu characters.",
+                         sizeof(this->nodeDataName));
+    }
+    std::snprintf(dataUsageSimMsg->dataName, sizeof(dataUsageSimMsg->dataName), "%s", this->nodeDataName);
     return;
 }

--- a/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
+++ b/src/simulation/onboardDataHandling/spaceToGroundTransmitter/spaceToGroundTransmitter.cpp
@@ -167,10 +167,17 @@ SpaceToGroundTransmitter::evaluateDataModel(DataNodeUsageMsgPayload* dataUsageSi
             //! - If we have not transmitted any of the packet, we select a new type of data to downlink
             if (this->packetTransmitted == 0.0) {
                 // Set nodeDataName to the maximum data name
+                const std::string& storedDataName = this->storageUnitMsgsBuffer.back().storedDataName[maxIndex];
+                if (storedDataName.size() >= sizeof(this->nodeDataName)) {
+                    bskLogger.bskLog(BSK_ERROR,
+                                     "SpaceToGroundTransmitter: storedDataName is %zu characters, but nodeDataName "
+                                     "supports at most %zu characters.",
+                                     storedDataName.size(), sizeof(this->nodeDataName) - 1);
+                }
                 std::snprintf(this->nodeDataName,
                               sizeof(this->nodeDataName),
                               "%s",
-                              this->storageUnitMsgsBuffer.back().storedDataName[maxIndex].c_str());
+                              storedDataName.c_str());
                 // strncpy nodeDataName to the name of the output message
                 std::snprintf(dataUsageSimMsg->dataName,
                               sizeof(dataUsageSimMsg->dataName),

--- a/src/simulation/onboardDataHandling/storageUnit/partitionedStorageUnit.cpp
+++ b/src/simulation/onboardDataHandling/storageUnit/partitionedStorageUnit.cpp
@@ -58,6 +58,12 @@ void PartitionedStorageUnit::customReset(uint64_t currentClock){
  */
 void PartitionedStorageUnit::addPartition(std::string dataName){
     dataInstance tmpDataInstance;
+    if (dataName.size() >= sizeof(tmpDataInstance.dataInstanceName)) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "PartitionedStorageUnit: dataName is %zu characters, but dataInstanceName "
+                         "supports at most %zu characters.",
+                         dataName.size(), sizeof(tmpDataInstance.dataInstanceName) - 1);
+    }
     std::snprintf(tmpDataInstance.dataInstanceName,
                   sizeof(tmpDataInstance.dataInstanceName),
                   "%s",

--- a/src/simulation/onboardDataHandling/transmitter/simpleTransmitter.cpp
+++ b/src/simulation/onboardDataHandling/transmitter/simpleTransmitter.cpp
@@ -92,10 +92,17 @@ void SimpleTransmitter::evaluateDataModel(DataNodeUsageMsgPayload *dataUsageSimM
         if (this->packetTransmitted == 0.0) {
 
             // Set nodeDataName to the maximum data name
+            const std::string& storedDataName = this->storageUnitMsgs.back().storedDataName[this->currentIndex];
+            if (storedDataName.size() >= sizeof(this->nodeDataName)) {
+                bskLogger.bskLog(BSK_ERROR,
+                                 "SimpleTransmitter: storedDataName is %zu characters, but nodeDataName "
+                                 "supports at most %zu characters.",
+                                 storedDataName.size(), sizeof(this->nodeDataName) - 1);
+            }
             std::snprintf(this->nodeDataName,
                           sizeof(this->nodeDataName),
                           "%s",
-                          this->storageUnitMsgs.back().storedDataName[this->currentIndex].c_str());
+                          storedDataName.c_str());
 
             // strncpy nodeDataName to the name of the output message
             std::snprintf(dataUsageSimMsg->dataName,

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -27,6 +27,7 @@
  */
 
 /* modify the path to reflect the new module names */
+#include <cstdio>
 #include <string.h>
 #include "camera.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
@@ -316,7 +317,12 @@ void Camera::UpdateState(uint64_t currentSimNanos)
 
     /*! - Populate the camera message */
     cameraMsg.cameraID = this->cameraID;
-    strcpy(cameraMsg.parentName, this->parentName);
+    if (memchr(this->parentName, '\0', sizeof(this->parentName)) == nullptr) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "Camera: parentName is not null-terminated within %zu characters.",
+                         sizeof(this->parentName));
+    }
+    std::snprintf(cameraMsg.parentName, sizeof(cameraMsg.parentName), "%s", this->parentName);
     cameraMsg.resolution[0] = this->resolution[0];
     cameraMsg.resolution[1] = this->resolution[1];
     cameraMsg.renderRate = this->renderRate;
@@ -324,7 +330,12 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraMsg.isOn = this->cameraIsOn;
     v3Copy(this->cameraPos_B, cameraMsg.cameraPos_B);
     v3Copy(this->sigma_CB, cameraMsg.sigma_CB);
-    strcpy(cameraMsg.skyBox, this->skyBox);
+    if (memchr(this->skyBox, '\0', sizeof(this->skyBox)) == nullptr) {
+        bskLogger.bskLog(BSK_ERROR,
+                         "Camera: skyBox is not null-terminated within %zu characters.",
+                         sizeof(this->skyBox));
+    }
+    std::snprintf(cameraMsg.skyBox, sizeof(cameraMsg.skyBox), "%s", this->skyBox);
     cameraMsg.postProcessingOn = this->postProcessingOn;
     cameraMsg.ppAperture = this->ppAperture;
     cameraMsg.ppFocalLength = this->ppFocalLength;

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -28,6 +28,7 @@
 
 /* modify the path to reflect the new module names */
 #include <cstdio>
+#include <limits>
 #include <string.h>
 #include "camera.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
@@ -387,7 +388,14 @@ void Camera::UpdateState(uint64_t currentSimNanos)
         std::vector<unsigned char> buf;
         std::vector<int> compression;
         compression.push_back(0);
-        cv::imencode(".png", blurred, buf, compression);
+        if (!cv::imencode(".png", blurred, buf, compression) || buf.empty()) {
+            bskLogger.bskLog(BSK_ERROR, "camera: failed to encode image output buffer.");
+            return;
+        }
+        if (buf.size() > (size_t)std::numeric_limits<int32_t>::max()) {
+            bskLogger.bskLog(BSK_ERROR, "camera: encoded image output buffer is too large.");
+            return;
+        }
         /*! - Output the saved image */
         imageOut.valid = 1;
         imageOut.timeTag = imageBuffer.timeTag;
@@ -395,7 +403,11 @@ void Camera::UpdateState(uint64_t currentSimNanos)
         imageOut.imageType = imageBuffer.imageType;
         imageOut.imageBufferLength = (int32_t)buf.size();
         this->pointImageOut = malloc(imageOut.imageBufferLength*sizeof(char));
-        memcpy(this->pointImageOut, &buf[0], imageOut.imageBufferLength*sizeof(char));
+        if (this->pointImageOut == nullptr) {
+            bskLogger.bskLog(BSK_ERROR, "camera: failed to allocate image output buffer.");
+            return;
+        }
+        memcpy(this->pointImageOut, buf.data(), imageOut.imageBufferLength*sizeof(char));
         imageOut.imagePointer = this->pointImageOut;
 
         this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);

--- a/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
+++ b/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
@@ -47,7 +47,7 @@ splitPath = path.split(bskName)
 from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport,
                                 vizSupport, simIncludeThruster)
 from Basilisk.simulation import spacecraft
-from Basilisk.architecture import messaging
+from Basilisk.architecture import messaging, bskLogging
 from Basilisk.simulation import thrusterDynamicEffector
 import pytest
 import time
@@ -83,6 +83,30 @@ def test_vizInterface(show_plots, accuracy):
     """
     [testResults, testMessage] = vizInterfaceTest(show_plots, accuracy)
     assert testResults < 1, testMessage
+
+
+def test_vizInterface_long_gravity_body_name_reset():
+    r"""
+    **Validation Test Description**
+
+    This test verifies that ``vizInterface`` can reset with a celestial body name longer than the fixed
+    ``SpicePlanetStateMsgPayload.PlanetName`` storage.  The full body name remains available to the Vizard
+    protocol buffer path, while the default SPICE payload name must be copied without overflowing its backing array.
+    """
+    if not vizSupport.vizFound:
+        pytest.skip("vizInterface is not configured.")
+
+    reset_time = 0  # [ns]
+    long_body_name = "body_" + "x" * 128
+
+    grav_body = vizInterface.GravBodyInfo()
+    grav_body.bodyName = long_body_name
+
+    viz = vizInterface.VizInterface()
+    viz.gravBodyInformation = vizInterface.GravBodyInfoVector([grav_body])
+
+    with pytest.raises(bskLogging.BasiliskError, match="celestial body name is 133 characters"):
+        viz.Reset(reset_time)
 
 
 def vizInterfaceTest(show_plots, accuracy):

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -218,7 +218,14 @@ void VizInterface::Reset(uint64_t CurrentSimNanos)
             /* set default zero translation and rotation states */
             SpicePlanetStateMsgPayload logMsg = {};
             m33SetIdentity(logMsg.J20002Pfix);
-            strcpy(logMsg.PlanetName, this->gravBodyInformation.at(c).bodyName.c_str());
+            const std::string& planetName = this->gravBodyInformation.at(c).bodyName;
+            if (planetName.size() >= sizeof(logMsg.PlanetName)) {
+                bskLogger.bskLog(BSK_ERROR,
+                                 "vizInterface: celestial body name is %zu characters, but the default SPICE "
+                                 "payload name supports at most %zu characters.",
+                                 planetName.size(), sizeof(logMsg.PlanetName) - 1);
+            }
+            std::snprintf(logMsg.PlanetName, sizeof(logMsg.PlanetName), "%s", planetName.c_str());
 
             this->spiceInMsgStatus.push_back(spiceStatus);
             this->spiceMessage.push_back(logMsg);

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1483,7 +1483,10 @@ void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
 void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
 {
     char buffer[10];
-    zmq_recv(this->requester_socket, buffer, 10, 0);
+    if (zmq_recv(this->requester_socket, buffer, 10, 0) == -1) {
+        bskLogger.bskLog(BSK_ERROR, "Vizard image request acknowledgement was not received.");
+        return;
+    }
     /*! -- Send request */
     std::string cmdMsg = "REQUEST_IMAGE_";
     cmdMsg += std::to_string(this->cameraConfigBuffers[camCounter].cameraID);
@@ -1503,8 +1506,19 @@ void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
         free(this->bskImagePtrs[camCounter]);
         this->bskImagePtrs[camCounter] = NULL;
     }
-    zmq_msg_recv(&length, this->requester_socket, 0);
-    zmq_msg_recv(&image, this->requester_socket, 0);
+    if (zmq_msg_recv(&length, this->requester_socket, 0) == -1
+        || zmq_msg_recv(&image, this->requester_socket, 0) == -1) {
+        zmq_msg_close(&length);
+        zmq_msg_close(&image);
+        bskLogger.bskLog(BSK_ERROR, "Vizard image response was not received.");
+        return;
+    }
+    if (zmq_msg_size(&length) < sizeof(int32_t)) {
+        zmq_msg_close(&length);
+        zmq_msg_close(&image);
+        bskLogger.bskLog(BSK_ERROR, "Vizard image response length field is invalid.");
+        return;
+    }
 
     int32_t *lengthPoint= (int32_t *)zmq_msg_data(&length);
     void *imagePoint= zmq_msg_data(&image);
@@ -1515,9 +1529,24 @@ void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
                                 ((length_unswapped>>8)&0xff00) | // move byte 2 to byte 1
                                 ((length_unswapped<<24)&0xff000000); // byte 0 to byte 3
 
+    if (imageBufferLength < 0 || (size_t)imageBufferLength != zmq_msg_size(&image)) {
+        zmq_msg_close(&length);
+        zmq_msg_close(&image);
+        bskLogger.bskLog(BSK_ERROR, "Vizard image response buffer length is invalid.");
+        return;
+    }
+
     /*!-Copy the image buffer pointer, so that it does not get freed by ZMQ*/
-    this->bskImagePtrs[camCounter] = malloc(imageBufferLength*sizeof(char));
-    memcpy(this->bskImagePtrs[camCounter], imagePoint, imageBufferLength*sizeof(char));
+    if (imageBufferLength > 0) {
+        this->bskImagePtrs[camCounter] = malloc(imageBufferLength*sizeof(char));
+        if (this->bskImagePtrs[camCounter] == NULL) {
+            zmq_msg_close(&length);
+            zmq_msg_close(&image);
+            bskLogger.bskLog(BSK_ERROR, "Vizard image response buffer allocation failed.");
+            return;
+        }
+        memcpy(this->bskImagePtrs[camCounter], imagePoint, imageBufferLength*sizeof(char));
+    }
 
     /*! -- Write out the image information to the Image message */
     CameraImageMsgPayload imageData = {};

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -86,11 +86,11 @@ void VizInterface::Reset(uint64_t CurrentSimNanos)
         if (broadcastConnect != 0) {
             int error_code = zmq_errno();
             text = "Broadcast socket did not connect correctly. ZMQ error code: " + std::to_string(error_code);
-            bskLogger.bskLog(BSK_ERROR, text.c_str());
+            bskLogger.bskLog(BSK_ERROR, "%s", text.c_str());
             return;
         }
         text = "Broadcasting at " + this->pubComProtocol + "://" + this->pubComAddress + ":" + this->pubPortNumber;
-        bskLogger.bskLog(BSK_INFORMATION, text.c_str());
+        bskLogger.bskLog(BSK_INFORMATION, "%s", text.c_str());
     }
 
     if (this->liveStream || this->noDisplay) {
@@ -109,7 +109,7 @@ void VizInterface::Reset(uint64_t CurrentSimNanos)
         if (twoWayConnect != 0) {
             int error_code = zmq_errno();
             text = "2-way socket did not connect correctly. ZMQ error code: " + std::to_string(error_code);
-            bskLogger.bskLog(BSK_ERROR, text.c_str());
+            bskLogger.bskLog(BSK_ERROR, "%s", text.c_str());
             return;
         }
 
@@ -118,7 +118,7 @@ void VizInterface::Reset(uint64_t CurrentSimNanos)
         zmq_msg_t request;
 
         text = "Waiting for Vizard at " + this->reqComProtocol + "://" + this->reqComAddress + ":" + this->reqPortNumber;
-        bskLogger.bskLog(BSK_INFORMATION, text.c_str());
+        bskLogger.bskLog(BSK_INFORMATION, "%s", text.c_str());
 
         zmq_msg_init_data(&request, message, 4, message_buffer_deallocate, NULL);
         zmq_msg_send(&request, this->requester_socket, 0);
@@ -1343,7 +1343,7 @@ void VizInterface::addCamMsgToModule(Message<CameraConfigMsgPayload> *tmpMsg)
 
     CameraConfigMsgPayload tmpCamConfigMsg = {};
     tmpCamConfigMsg.cameraID = -1;
-    strcpy(tmpCamConfigMsg.skyBox, "");
+    tmpCamConfigMsg.skyBox[0] = '\0';
     tmpCamConfigMsg.renderRate = 0;
     this->cameraConfigBuffers.push_back(tmpCamConfigMsg);
 

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -694,27 +694,14 @@ def SetCArray(InputList, VarType, ArrayPointer):
         raise TypeError(
             "Cannot set a C array if it is actually a python list.  Just assign the variable to the list directly."
         )
-    CmdString = (
-        "sim_model." + VarType + "Array_setitem(ArrayPointer, CurrIndex, CurrElem)"
-    )
-    CurrIndex = 0
-    for CurrElem in InputList:
-        exec(CmdString)
-        CurrIndex += 1
+    arraySetter = getattr(sim_model, VarType + "Array_setitem")
+    for currIndex, currElem in enumerate(InputList):
+        arraySetter(ArrayPointer, currIndex, currElem)
 
 
 def getCArray(varType, arrayPointer, arraySize):
-    CmdString = (
-        "outputList.append(sim_model."
-        + varType
-        + "Array_getitem(arrayPointer, currIndex))"
-    )
-    outputList = []
-    currIndex = 0
-    for currIndex in range(arraySize):
-        exec(CmdString)
-        currIndex += 1
-    return outputList
+    arrayGetter = getattr(sim_model, varType + "Array_getitem")
+    return [arrayGetter(arrayPointer, currIndex) for currIndex in range(arraySize)]
 
 
 def synchronizeTimeHistories(arrayList):

--- a/src/utilities/bskExamples.py
+++ b/src/utilities/bskExamples.py
@@ -18,15 +18,25 @@
 
 import os
 import requests
+from urllib.parse import urlparse
 
 # define the print color codes
 statusColor = '\033[92m'
 warningColor = '\033[93m'
 endColor = '\033[0m'
+REQUEST_TIMEOUT = 30  # [s]
 
 # this statement is needed to enable Windows to print ANSI codes in the Terminal
 # see https://stackoverflow.com/questions/287871/how-to-print-colored-text-in-terminal-in-python/3332860#3332860
 os.system("")
+
+
+def safe_join(dest_folder, child_name):
+    """Join a GitHub item name to a local folder without allowing path separators."""
+    if child_name in ("", ".", "..") or "/" in child_name or "\\" in child_name:
+        raise ValueError(f"Unsafe GitHub item name: {child_name}")
+    return os.path.join(dest_folder, child_name)
+
 
 # Function to download a single file
 def download_file(file_url, dest_folder):
@@ -34,8 +44,9 @@ def download_file(file_url, dest_folder):
     if not os.path.exists(dest_folder):
         os.makedirs(dest_folder)
 
-    local_filename = os.path.join(dest_folder, file_url.split("/")[-1])
-    with requests.get(file_url, stream=True) as response:
+    file_name = os.path.basename(urlparse(file_url).path)
+    local_filename = safe_join(dest_folder, file_name)
+    with requests.get(file_url, stream=True, timeout=REQUEST_TIMEOUT) as response:
         response.raise_for_status()
         with open(local_filename, "wb") as file:
             for chunk in response.iter_content(chunk_size=8192):
@@ -45,7 +56,7 @@ def download_file(file_url, dest_folder):
 # Function to process a folder or file via GitHub API
 def process_github_folder(api_url, dest_folder):
     """Process the BSK GitHub examples folder recursively and download all files."""
-    response = requests.get(api_url)
+    response = requests.get(api_url, timeout=REQUEST_TIMEOUT)
     if response.status_code != 200:
         print(f"Failed to fetch the URL: {api_url}")
         print(f"Response: {response.text}")
@@ -59,7 +70,7 @@ def process_github_folder(api_url, dest_folder):
         elif item["type"] == "dir":
             print(f"Entering folder: {item['name']}")
             subfolder_api_url = item["url"]
-            subfolder_dest = os.path.join(dest_folder, item["name"])
+            subfolder_dest = safe_join(dest_folder, item["name"])
             process_github_folder(subfolder_api_url, subfolder_dest)
 
 def main():

--- a/src/utilities/supportDataTools/checkSync.py
+++ b/src/utilities/supportDataTools/checkSync.py
@@ -34,28 +34,28 @@ registry_path = ROOT.joinpath(
 
 def main():
     # Regenerate registry into a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
-        tmp_path = Path(tmp.name)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir).joinpath("registrySnippet.py")
+        with tmp_path.open("w") as tmp:
+            result = subprocess.run(
+                [sys.executable, str(make_script)],
+                stdout=tmp,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
 
-    result = subprocess.run(
-        [sys.executable, str(make_script)],
-        stdout=tmp_path.open("w"),
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+        if result.returncode != 0:
+            print("Error running makeRegistry.py")
+            print(result.stderr)
+            return 1
 
-    if result.returncode != 0:
-        print("Error running makeRegistry.py")
-        print(result.stderr)
-        return 1
-
-    # Compare with committed registry
-    if not filecmp.cmp(tmp_path, registry_path, shallow=False):
-        print("❌ supportData/ changed, but registrySnippet.py is outdated.")
-        print(
-            "   Run: python src/utilities/supportDataTools/makeRegistry.py > src/utilities/supportDataTools/registrySnippet.py"
-        )
-        return 1
+        # Compare with committed registry
+        if not filecmp.cmp(tmp_path, registry_path, shallow=False):
+            print("❌ supportData/ changed, but registrySnippet.py is outdated.")
+            print(
+                "   Run: python src/utilities/supportDataTools/makeRegistry.py > src/utilities/supportDataTools/registrySnippet.py"
+            )
+            return 1
 
     return 0
 


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
This PR addresses the reported Basilisk security issues, reported by Daniel Miranda Barcelona ([github.com/ex-cal1bur](https://nam10.safelinks.protection.outlook.com/?url=http%3A%2F%2Fgithub.com%2Fex-cal1bur&data=05%7C02%7Chanspeter.schaub%40colorado.edu%7Ca288eaf1dac94e18d69808de9e496b7a%7C3ded8b1b070d462982e4c0b019f46057%7C1%7C1%7C639122235337510941%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C60000%7C%7C%7C&sdata=jiNKfVAhHbdwZlk9vAf2Dt2kJuZlvkc4ow2VjwkUU9A%3D&reserved=0)), and performs a related hardening pass across BSK modules and helper utilities.

Reported issues fixed:
- BSK-2026-001: rejects overlong `vizInterface` celestial body names before writing into fixed SPICE payload fields.
- BSK-2026-002: rejects overlong `mappingInstrument` data names before writing into fixed data node payload fields.
- BSK-2026-003: routes dynamic `dentonFluxModel` log text through literal format strings.

Additional hardening:
- Replaces unsafe fixed-buffer string writes and risky truncating copies across related BSK modules.
- Ensures printf-style Basilisk logging uses literal format strings, with dynamic text passed as data.
- Adds immediate `BSK_ERROR` failures when module-supplied strings exceed fixed payload storage.
- Validates camera and Vizard image buffer lengths before allocation/copy.
- Removes shell-based command construction from build/test helpers.
- Replaces avoidable Python `exec()` use in C-array helper accessors.
- Adds safer temporary file cleanup and bounded remote example downloads.
- Adds PR review guidance in `AGENTS.md` for future string/logging security checks.

Commits are organized by risk area:
- The first commits address the three reported findings individually.
- The next commits harden related BSK string/logging paths.
- Follow-up commits cover build/helper command execution, Python utility hardening, image buffer validation, PR review guidance, release notes, and known issues.

## Verification
Did a clean build and ran all tests successfully. 

Follow-up scans found no remaining hits in the searched BSK module paths for:
- `strcpy`, `strcat`, `sprintf`, `strncpy`, `gets`, `vsprintf`, or unbounded `%s` scans
- dynamic `bskLog()` format-string calls
- `shell=True` subprocess calls or non-literal `os.system()` command construction

Automated tests were added or updated for the reported module-level security failures where existing test structure was available. Broader helper hardening was validated with focused existing tests, Python compilation, and full build coverage.

## Documentation
Updated documentation artifacts:
- Added release-note snippets for BSK-2026-001, BSK-2026-002, and BSK-2026-003.
- Updated the broader security hardening release-note snippet.
- Updated `docs/source/Support/bskKnownIssues.rst` to mention the fixed security issues and additional hardening.
- Updated `AGENTS.md` with PR review instructions for fixed-buffer string handling and logging security checks.


## Future work
Remaining dynamic execution/deserialization patterns, such as event action/condition strings and Monte Carlo pickle loading, appear to be intentional trusted-user APIs and were left unchanged. A future design discussion could decide whether those APIs need explicit trust-boundary documentation, safer alternatives, or opt-in validation modes.
