### PR TITLE
Deprecating AU2KM and adding AU2M

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1369-deprec-au2km-add-au2m.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1369-deprec-au2km-add-au2m.rst
@@ -1,0 +1,1 @@
+- Deprecated `AU2KM` in favor of `AU` and added `AU2M` for astronomical unit in meters in `astroConstants.h`.

--- a/src/architecture/utilities/astroConstants.h
+++ b/src/architecture/utilities/astroConstants.h
@@ -23,13 +23,28 @@
 #include <math.h>
 
 #ifndef G_UNIVERSIAL
-#define G_UNIVERSIAL    6.67259e-20 /* universial Gravitational Constant, units are in km^3/s^2/kg */
+#define G_UNIVERSIAL    6.67259e-20 /* [km^3/s^2/kg] universial Gravitational Constant */
 #endif
 #ifndef AU
-#define AU              149597870.693 /* astronomical unit in units of kilometers */
+#define AU              149597870.693 /* [km] astronomical unit */
 #endif
 #ifndef AU2KM
-#define AU2KM           149597870.693 /* convert astronomical unit to kilometers */
+  #if defined(SWIG)
+    /* Avoid deprecation noise in generated wrappers */
+    #define AU2KM AU
+  #elif defined(__cplusplus)
+    [[deprecated("AU2KM is deprecated in favor of AU. In C/C++ both names work until Apr 24, 2027. After that date, code must use AU exclusively.")]]
+    static constexpr double AU2KM_DEPRECATED = AU;
+    #define AU2KM AU2KM_DEPRECATED
+  #elif defined(__GNUC__) || defined(__clang__)
+    static const double AU2KM_DEPRECATED __attribute__((deprecated("AU2KM is deprecated in favor of AU. In C/C++ both names work until Apr 24, 2027. After that date, code must use AU exclusively."))) = AU;
+    #define AU2KM AU2KM_DEPRECATED
+  #else
+    #define AU2KM AU /* DEPRECATED: use AU. Works until Apr 24, 2027 */
+  #endif
+#endif
+#ifndef AU2M
+#define AU2M            149597870693.0 /* [m] astronomical unit in meters */
 #endif
 #ifndef SPEED_LIGHT
 #define SPEED_LIGHT     299792458 /* [m/s] convert astronomical unit to kilometers */

--- a/src/architecture/utilities/tests/test_AU2KM_cutoff_notice.py
+++ b/src/architecture/utilities/tests/test_AU2KM_cutoff_notice.py
@@ -1,0 +1,32 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, PIC4SeR & AVS Lab, Politecnico di Torino & Argotec S.R.L., University of Colorado Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+from datetime import date
+import warnings
+
+
+def test_AU2KM_cutoff_notice():
+    """Emit a visible reminder after the cutoff date without failing tests."""
+    if date.today() <= date(2027, 4, 24):
+        return
+
+    warnings.warn(
+        "The cutoff date for 'AU2KM' has passed. Please remove the deprecated AU2KM usage along with this test script.",
+        UserWarning,
+        stacklevel=1,
+    )


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR deprecates the `AU2KM` constant in favor of `AU` and introduces a new constant `AU2M` for the astronomical unit in meters. The deprecation is handled with compiler-specific attributes to provide clear warnings while maintaining backward compatibility until April 24, 2027.

## Verification
The changes were validated by ensuring the code compiles without errors and that the deprecation warnings are correctly triggered when .cpp files that use it are compiled. No automated tests were added or updated.

## Documentation
No documentation has been modified.

## Future work
1) After April 24, 2027, the `AU2KM` constant should be removed entirely, and all code should use `AU` exclusively.
2) Consider changing any use of AU*1000 to AU2M.