### PR TITLE
Add minimum firing times to thrFiringRound Python module

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1370-thrFiringRound-min-fire-time.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1370-thrFiringRound-min-fire-time.rst
@@ -1,0 +1,1 @@
+- Updated the :ref:`thrFiringRound` module to include an optional minimum fire time setting.

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRound/_UnitTest/test_thrFiringRound.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRound/_UnitTest/test_thrFiringRound.py
@@ -73,3 +73,33 @@ def test_thr_firing_round_configuration_helpers():
     module.setThrForceMax([1.0, 2.0])  # [N]
     assert module.resolveNumThrusters(forceCmd) == 2
     np.testing.assert_allclose(module.resolveThrForceMax(2), [1.0, 2.0])  # [N]
+
+
+def test_thr_firing_round_minimum_fire_time():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`thrFiringRound.ThrFiringRound` can
+    apply an optional minimum fire-time threshold to rounded on-time commands.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks that ``OnTimeRequest`` is set to zero when the
+    rounded on-time is less than ``thrMinFireTimeSec``.
+    """
+    module = thrFiringRound.ThrFiringRound()
+    module.setControlPeriodSec(1.0)  # [s]
+    module.setOnTimeResolutionSec(0.1)  # [s]
+    module.setThrMinFireTime(0.15)  # [s]
+    module.setThrForceMax(1.0)  # [N]
+
+    forcePayload = messaging.THRArrayCmdForceMsgPayload()
+    forcePayload.thrForce = [0.14, 0.16]  # [N]
+    forceMsg = messaging.THRArrayCmdForceMsg().write(forcePayload)
+    module.thrForceInMsg.subscribeTo(forceMsg)
+
+    module.Reset(0)
+    module.UpdateState(1)
+
+    onTimeOut = module.thrOnTimeOutMsg.read()
+    np.testing.assert_allclose(onTimeOut.OnTimeRequest[:2], [0.0, 0.2])  # [s]

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRound/thrFiringRound.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRound/thrFiringRound.py
@@ -26,7 +26,8 @@ class ThrFiringRound(sysModel.SysModel):
 
     Each thruster on-time is computed from the configured control period, force
     command, and maximum thruster force.  The result is rounded to the nearest
-    multiple of ``onTimeResolutionSec``.
+    multiple of ``onTimeResolutionSec``. The minimum fire time can be set to
+    prevent short pulses that may not be physically realizable.
     """
 
     def __init__(self):
@@ -40,6 +41,7 @@ class ThrFiringRound(sysModel.SysModel):
         # Configuration
         self.controlPeriodSec = 1.0  # [s]
         self.onTimeResolutionSec = 0.01  # [s]
+        self.thrMinFireTimeSec = 0.0  # [s]
         self.numThrusters = None
         self.thrForceMax = 1.0  # [N]
 
@@ -51,6 +53,9 @@ class ThrFiringRound(sysModel.SysModel):
 
     def setNumThrusters(self, numThrustersIn: int):
         self.numThrusters = int(numThrustersIn)
+
+    def setThrMinFireTime(self, thrMinFireTimeSecIn: float):
+        self.thrMinFireTimeSec = float(thrMinFireTimeSecIn)
 
     def setThrForceMax(self, thrForceMaxIn):
         """
@@ -111,6 +116,7 @@ class ThrFiringRound(sysModel.SysModel):
         onTimeRequest = self.controlPeriodSec * forceCmd / thrForceMax
         onTimeRequest = np.clip(onTimeRequest, 0.0, self.controlPeriodSec)  # [s]
         onTimeRequest = np.rint(onTimeRequest / self.onTimeResolutionSec) * self.onTimeResolutionSec
+        onTimeRequest[onTimeRequest < self.thrMinFireTimeSec] = 0.0  # [s]
         onTimeRequest = np.clip(onTimeRequest, 0.0, self.controlPeriodSec)  # [s]
 
         self.thrOnTimePayload.OnTimeRequest = onTimeRequest.tolist()

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRound/thrFiringRound.rst
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRound/thrFiringRound.rst
@@ -3,8 +3,9 @@ Executive Summary
 
 This module converts thruster force commands into thruster on-time commands.
 Each positive force command is normalized by the configured maximum thrust,
-scaled by the control period, clipped to the control period, and rounded to the
-nearest configured on-time resolution.
+scaled by the control period, clipped to the control period, rounded to the
+nearest configured on-time resolution, and checked to make sure it is longer
+than the minimum fire time.
 
 
 Message Connection Descriptions
@@ -41,12 +42,14 @@ The module is imported through the standard flight-software package:
     rounder = thrFiringRound.ThrFiringRound()
     rounder.ModelTag = "thrFiringRound"
 
-The control period, on-time resolution, number of thrusters, and maximum
-thruster force are configured with setter methods:
+The control period, on-time resolution, minimum thruster on-time,
+number of thrusters, and maximum thruster force are configured
+with setter methods:
 
 .. code-block:: python
 
     rounder.setControlPeriodSec(10.0)
     rounder.setOnTimeResolutionSec(0.1)
+    rounder.setThrMinFireTime(0.15)
     rounder.setNumThrusters(2)
     rounder.setThrForceMax([2.5, 2.5])


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR adds an optional minimum fire-time threshold to `thrFiringRound` (Python module). The default behavior of the module is unchanged with minimum fire time filtering only occuring if configured as `>0.0`

## Verification
The unit test `src/fswAlgorithms/effectorInterfaces/thrFiringRound/_UnitTest/test_thrFiringRound.py` was updated to verify minimum fire time behavior.

## Documentation
The module documentation was updated to detail how to configure a minimum fire time. New release notes were added detailing the new capability of the module. 

## Future work
N/A
