### PR TITLE
Fix vizInterface regression communicating in opNav mode with Vizard

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -14,6 +14,8 @@ Version |release|
   logging issues are fixed in the current version.
 - Additional build-helper command execution, temporary file cleanup, remote example download, and image buffer
   validation hardening is included in the current version.
+- A Vizard ``noDisplay`` image request regression that caused OpNav scenarios to stop with a
+  ``Vizard image request acknowledgement was not received`` error is fixed in the current version.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   The development dependency range now excludes SWIG 4.4.0, and SWIG 4.4.1 has been verified to build
   successfully. If source builds fail with SWIG 4.4.0 or emit ``builtin type swigvarlink has no __module__ attribute``

--- a/docs/source/Support/bskReleaseNotesSnippets/vizInterface-image-request.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/vizInterface-image-request.rst
@@ -1,0 +1,1 @@
+- Fixed a :ref:`vizInterface` ``noDisplay`` image request regression that could stop OpNav scenarios when communicating with Vizard.

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1482,11 +1482,6 @@ void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
  */
 void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
 {
-    char buffer[10];
-    if (zmq_recv(this->requester_socket, buffer, 10, 0) == -1) {
-        bskLogger.bskLog(BSK_ERROR, "Vizard image request acknowledgement was not received.");
-        return;
-    }
     /*! -- Send request */
     std::string cmdMsg = "REQUEST_IMAGE_";
     cmdMsg += std::to_string(this->cameraConfigBuffers[camCounter].cameraID);


### PR DESCRIPTION
* **Tickets addressed:** bsk-1371
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Fixes a Vizard `noDisplay` OpNav regression introduced while hardening image-buffer handling. The image request path was checking a stale pre-request `zmq_recv()` on a `ZMQ_REQ` socket before sending `REQUEST_IMAGE_<cameraID>`, which caused OpNav scenarios to stop with `Vizard image request acknowledgement was not received`.

This PR removes that invalid pre-request receive while keeping validation on the actual image length and image payload response frames.

Commits are organized by dependency updates and the Vizard image-request regression fix.

## Verification
- Rebuilt the focused `vizInterface` target successfully:
  ```bash
  .venv/bin/cmake --build dist3 --target vizInterface -j 8
  ```
- Ran `git diff --check`.

No automated test was added because this path depends on live two-way communication with the external Vizard application.

## Documentation
Added a release-note snippet and updated known issues to document the Vizard `noDisplay` image request regression fix.

Reviewers should check:
- `src/simulation/vizard/vizInterface/vizInterface.cpp`
- `docs/source/Support/bskKnownIssues.rst`
- `docs/source/Support/bskReleaseNotesSnippets/vizInterface-image-request.rst`

## Future work
A follow-up could add an integration-style test or socket-level harness for the Vizard request/response protocol so future ZMQ sequencing regressions are caught without launching the full Vizard application.