### PR TITLE
Camera module handling of filename variable

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -18,6 +18,8 @@ Version |release|
   ``Vizard image request acknowledgement was not received`` error is fixed in the current version.
 - The camera module now passes PNG encoding options as OpenCV key-value pairs, fixing OpNav image
   processing failures with OpenCV 4.13.
+- The camera module filename input was only used to test filters and never published to imageOut. This is fixed
+  so images loaded from filename now follow the same processing and publishing pipeline as images from imageInMsg.
 - The MuJoCo dynamics wrapper now uses MuJoCo 3.7 element-name APIs, fixing builds after the MuJoCo
   3.7 upgrade.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.

--- a/docs/source/Support/bskReleaseNotesSnippets/1374-camera-filename-processing.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1374-camera-filename-processing.rst
@@ -1,0 +1,1 @@
+- Fixed camera module to properly process and publish images loaded from the filename parameter, ensuring they follow the same processing pipeline as images from imageInMsg.

--- a/src/simulation/sensors/camera/_UnitTest/test_camera.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_camera.py
@@ -26,6 +26,8 @@ import os
 import numpy as np
 import pytest
 
+from Basilisk.architecture.bskLogging import BasiliskError
+
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 bskName = 'Basilisk'
@@ -56,6 +58,228 @@ except ImportError:
 # Uncomment this line if this test has an expected failure, adjust message as needed.
 # @pytest.mark.xfail(conditionstring)
 # Provide a unique test method name, starting with 'test_'.
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_no_image_zero_msg():
+    """
+    **Validation Test Description**
+
+    This module tests that when no image is present (no filename and no input message),
+    the camera module properly outputs a zeroed-out message.
+
+    **Description of Variables Being Tested**
+
+    The camera output message should have all fields set to zero/empty when no image is available.
+    This ensures that downstream modules receive valid (though empty) data.
+
+    - ``imageOutMsg.valid`` should be 0
+    - ``imageOutMsg.imageBufferLength`` should be 0
+    - ``imageOutMsg.imagePointer`` should be nullptr
+    """
+    testFailCount = 0
+    testMessages = []
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    module = camera.Camera()
+    module.ModelTag = "cameras"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # Don't provide filename or input message - this should trigger zeroed output
+    module.filename = ""
+    module.cameraIsOn = 1
+
+    # Setup logging on the test module output message
+    dataLog = module.imageOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))
+
+    # Begin the simulation time run
+    unitTestSim.ExecuteSimulation()
+
+    # Check that the output message fields are zeroed
+    if len(dataLog.valid) == 0:
+        testFailCount += 1
+        testMessages.append("No image output message was written")
+    else:
+        # Check the last written message
+        if dataLog.valid[-1] != 0:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.valid should be 0, but got {dataLog.valid[-1]}")
+
+        if dataLog.imageBufferLength[-1] != 0:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.imageBufferLength should be 0, but got {dataLog.imageBufferLength[-1]}")
+
+        if dataLog.timeTag[-1] != 0:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.timeTag should be 0, but got {dataLog.timeTag[-1]}")
+
+        if dataLog.cameraID[-1] != 0:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.cameraID should be 0, but got {dataLog.cameraID[-1]}")
+
+        if dataLog.imageType[-1] != 0:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.imageType should be 0, but got {dataLog.imageType[-1]}")
+
+    assert testFailCount == 0, testMessages
+
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_filename_metadata():
+    """
+    **Validation Test Description**
+
+    This module tests that when using the filename parameter (without an input message),
+    the camera module outputs an image with correct metadata populated from deterministic sources.
+
+    **Description of Variables Being Tested**
+
+    When loading an image from a filename, the camera should set:
+    - ``imageOutMsg.timeTag`` to the current simulation time
+    - ``imageOutMsg.cameraID`` to the configured camera ID
+    - ``imageOutMsg.imageType`` to 3 (RGB channels)
+    - ``imageOutMsg.valid`` to 1 (image is valid)
+
+    This ensures that downstream consumers receive correct metadata for provenance and synchronization.
+    """
+    testFailCount = 0
+    testMessages = []
+
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    module = camera.Camera()
+    module.ModelTag = "cameras"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # Use filename to load image, with a specific camera ID
+    imagePath = path + '/mars.jpg'
+    module.filename = imagePath
+    module.cameraID = 42  # Use a non-default camera ID to verify it's used
+    module.cameraIsOn = 1
+
+    # Setup logging on the test module output message
+    dataLog = module.imageOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    # Need to call the self-init and cross-init methods
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time
+    simEndTime = macros.sec2nano(0.5)
+    unitTestSim.ConfigureStopTime(simEndTime)
+
+    # Begin the simulation time run
+    unitTestSim.ExecuteSimulation()
+
+    # Check that the output message has correct metadata
+    if len(dataLog.valid) == 0:
+        testFailCount += 1
+        testMessages.append("No image output message was written")
+    else:
+        # Check the last written message (filename path should produce output)
+        if dataLog.valid[-1] != 1:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.valid should be 1, but got {dataLog.valid[-1]}")
+
+        if dataLog.cameraID[-1] != 42:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.cameraID should be 42, but got {dataLog.cameraID[-1]}")
+
+        # mars.jpg is a color image, so it should have 3 channels
+        if dataLog.imageType[-1] != 3:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.imageType should be 3 (RGB) for mars.jpg, but got {dataLog.imageType[-1]}")
+
+        # timeTag should be close to the simulation end time (within the process rate)
+        if abs(dataLog.timeTag[-1] - simEndTime) > macros.sec2nano(0.1):
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.timeTag should be ~{simEndTime}, but got {dataLog.timeTag[-1]}")
+
+        if dataLog.imageBufferLength[-1] <= 0:
+            testFailCount += 1
+            testMessages.append(f"imageOutMsg.imageBufferLength should be > 0, but got {dataLog.imageBufferLength[-1]}")
+
+    assert testFailCount == 0, testMessages
+
+
+@pytest.mark.skipif(importErr, reason=reasonErr)
+def test_invalid_filename_error():
+    """
+    **Validation Test Description**
+
+    This module tests that when an invalid filename is provided, the camera module
+    detects the failed image load and emits a BSK_ERROR.
+
+    **Description of Variables Being Tested**
+
+    When a bad filename, unsupported file, or malformed input is provided:
+    - OpenCV's imread() or imdecode() returns an empty cv::Mat
+    - The camera module should check imageCV.empty() and emit BSK_ERROR
+    - BSK_ERROR throws an exception that stops execution
+    """
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    # Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.5)
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Construct algorithm and associated C++ container
+    module = camera.Camera()
+    module.ModelTag = "cameras"
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, module)
+
+    # Use an invalid filename that cannot be loaded
+    module.filename = "/nonexistent/path/to/image.png"
+    module.cameraIsOn = 1
+
+    # Add the module to the sim and initialize
+    unitTestSim.InitializeSimulation()
+
+    # Set the simulation time
+    unitTestSim.ConfigureStopTime(macros.sec2nano(0.5))
+
+    # Begin the simulation time run - should raise BSK_ERROR
+    with pytest.raises(BasiliskError):
+        unitTestSim.ExecuteSimulation()
+
 
 @pytest.mark.skipif(importErr, reason=reasonErr)
 @pytest.mark.parametrize("gauss, darkCurrent, saltPepper, cosmic, blurSize", [

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -348,6 +348,7 @@ void Camera::UpdateState(uint64_t currentSimNanos)
 
     cv::Mat imageCV;
     cv::Mat blurred;
+    bool usingFilename = false;
     if (this->saveDir != ""){
         localPath = this->saveDir + std::to_string(currentSimNanos*1E-9) + ".png";
     }
@@ -357,62 +358,71 @@ void Camera::UpdateState(uint64_t currentSimNanos)
         imageBuffer = this->imageInMsg();
         this->sensorTimeTag = this->imageInMsg.timeWritten();
     }
-    /* Added for debugging purposes*/
+
     if (!this->filename.empty()){
         imageCV = imread(this->filename, cv::IMREAD_COLOR);
-        this->applyFilters(imageCV, blurred);
-        if (this->saveImages == 1){
-            if (!cv::imwrite(localPath, blurred)) {
-                bskLogger.bskLog(BSK_WARNING, "camera: wasn't able to save the camera module image" );
-            }
-        }
+        usingFilename = true;
     }
     else if(imageBuffer.valid == 1 && imageBuffer.timeTag >= currentSimNanos){
         /*! - Recast image pointer to CV type*/
         std::vector<unsigned char> vectorBuffer((char*)imageBuffer.imagePointer,
                                                 (char*)imageBuffer.imagePointer + imageBuffer.imageBufferLength);
         imageCV = cv::imdecode(vectorBuffer, cv::IMREAD_COLOR);
-
-        this->applyFilters(imageCV, blurred);
-        if (this->saveImages == 1){
-            if (!cv::imwrite(localPath, blurred)) {
-                bskLogger.bskLog(BSK_WARNING, "camera: wasn't able to save the camera module image" );
-            }
-        }
-        /*! If the permanent image buffer is not populated, it will be equal to null*/
-        if (this->pointImageOut != nullptr) {
-            free(this->pointImageOut);
-            this->pointImageOut = nullptr;
-        }
-        /*! - Encode the cv mat into a png for the future modules to decode it the same way */
-        std::vector<unsigned char> buf;
-        std::vector<int> compression = {cv::IMWRITE_PNG_COMPRESSION, 0};
-        if (!cv::imencode(".png", blurred, buf, compression) || buf.empty()) {
-            bskLogger.bskLog(BSK_ERROR, "camera: failed to encode image output buffer.");
-            return;
-        }
-        if (buf.size() > (size_t)std::numeric_limits<int32_t>::max()) {
-            bskLogger.bskLog(BSK_ERROR, "camera: encoded image output buffer is too large.");
-            return;
-        }
-        /*! - Output the saved image */
-        imageOut.valid = 1;
-        imageOut.timeTag = imageBuffer.timeTag;
-        imageOut.cameraID = imageBuffer.cameraID;
-        imageOut.imageType = imageBuffer.imageType;
-        imageOut.imageBufferLength = (int32_t)buf.size();
-        this->pointImageOut = malloc(imageOut.imageBufferLength*sizeof(char));
-        if (this->pointImageOut == nullptr) {
-            bskLogger.bskLog(BSK_ERROR, "camera: failed to allocate image output buffer.");
-            return;
-        }
-        memcpy(this->pointImageOut, buf.data(), imageOut.imageBufferLength*sizeof(char));
-        imageOut.imagePointer = this->pointImageOut;
-
-        this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
     }
     else{
         /*! - If no image is present, write zeros in message */
         this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
+        return;
     }
+    /*! - Check if image was loaded successfully */
+    if (imageCV.empty()) {
+        if (usingFilename) {
+            this->bskLogger.bskLog(BSK_ERROR, "camera: failed to load image from %s.", this->filename.c_str());
+        } else {
+            this->bskLogger.bskLog(BSK_ERROR, "camera: failed to decode image from input buffer.");
+        }
+    }
+    this->applyFilters(imageCV, blurred);
+    if (this->saveImages == 1){
+        if (!cv::imwrite(localPath, blurred)) {
+            bskLogger.bskLog(BSK_WARNING, "camera: wasn't able to save the camera module image" );
+        }
+    }
+    /*! If the permanent image buffer is not populated, it will be equal to null*/
+    if (this->pointImageOut != nullptr) {
+        free(this->pointImageOut);
+        this->pointImageOut = nullptr;
+    }
+    /*! - Encode the cv mat into a png for the future modules to decode it the same way */
+    std::vector<unsigned char> buf;
+    std::vector<int> compression = {cv::IMWRITE_PNG_COMPRESSION, 0};
+    if (!cv::imencode(".png", blurred, buf, compression) || buf.empty()) {
+        bskLogger.bskLog(BSK_ERROR, "camera: failed to encode image output buffer.");
+        return;
+    }
+    if (buf.size() > (size_t)std::numeric_limits<int32_t>::max()) {
+        bskLogger.bskLog(BSK_ERROR, "camera: encoded image output buffer is too large.");
+        return;
+    }
+    /*! - Output the saved image */
+    imageOut.valid = 1;
+    if (usingFilename) {
+        imageOut.timeTag = currentSimNanos;
+        imageOut.cameraID = this->cameraID;
+        imageOut.imageType = blurred.channels();
+    } else {
+        imageOut.timeTag = imageBuffer.timeTag;
+        imageOut.cameraID = imageBuffer.cameraID;
+        imageOut.imageType = imageBuffer.imageType;
+    }
+    imageOut.imageBufferLength = (int32_t)buf.size();
+    this->pointImageOut = malloc(imageOut.imageBufferLength*sizeof(char));
+    if (this->pointImageOut == nullptr) {
+        bskLogger.bskLog(BSK_ERROR, "camera: failed to allocate image output buffer.");
+        return;
+    }
+    memcpy(this->pointImageOut, buf.data(), imageOut.imageBufferLength*sizeof(char));
+    imageOut.imagePointer = this->pointImageOut;
+
+    this->imageOutMsg.write(&imageOut, this->moduleID, currentSimNanos);
 }


### PR DESCRIPTION
* **Tickets addressed:** Issue #1374 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
Fixed camera module inconsistency with its documentation where images loaded via `filename` parameter were processed through filters but never published to `imageOutMsg`. Refactored `camera.cpp` to ensure filename-loaded images follow the same processing and publishing pipeline as images from `imageInMsg`.

## Verification
- Added new unit test `test_no_image_zero_msg()` in `test_camera.py` to verify zeroed-out output message when no image source is provided.
- Existing camera tests continue to validate the complete pipeline.

## Documentation
- Added release note snippet.
- Updated `docs/source/Support/bskKnownIssues.rst` to document the fix.

## Future work
Would be nice to have a module that loads images from a directory without having to manually change the `filename` variable.