### PR TITLE
Add missing libclang dependency to wheel build action

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/nightly-wheels-libclang-ci-fix.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/nightly-wheels-libclang-ci-fix.rst
@@ -1,0 +1,1 @@
+- Fixed ``libclang`` not being available to cmake on macOS and Windows CI runners by installing it via ``CIBW_BEFORE_BUILD`` in the shared setup action, resolving nightly and release wheel build failures on those platforms.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ examples = [
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip  = ["*-win32", "*-musllinux_*"]
 build-verbosity = 1
+before-build = "pip install \"libclang>=15.0.6.1,<=18.1.1\""
 test-extras = ["test"]
 test-command = "bskLargeData && pytest -v {project}/src/tests -m \"not ciSkip and not scenarioTest\""
 
@@ -88,7 +89,7 @@ MACOSX_DEPLOYMENT_TARGET = "11.0"
 CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel"
+before-build = "pip install \"libclang>=15.0.6.1,<=18.1.1\" && pip install delvewheel"
 repair-wheel-command = "python -m delvewheel repair -v --ignore-existing --analyze-existing -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
cmake resolves `Python3_EXECUTABLE` to the cibuildwheel target Python not the isolated build environment where libclang is installed from pyproject.toml. Installing libclang via CIBW_BEFORE_BUILD in the setup action ensures it is available to whichever Python cmake invokes during the messaging code generation step.

## Verification
CI

## Documentation
N/A

## Future work
N/A
