### PR TITLE
Update hingedJointArrayMotor for full joint tracking control

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1379-joint-array-tracking.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1379-joint-array-tracking.rst
@@ -1,0 +1,1 @@
+- Updated the :ref:`hingedJointArrayMotor` module to perform full tracking control.

--- a/src/architecture/msgPayloadDefCpp/JointArrayStateMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/JointArrayStateMsgPayload.h
@@ -31,6 +31,7 @@ JointArrayStateMsgPayload
 {
     std::vector<double> states;                    //!< [-] list of joint states
     std::vector<double> stateDots;              //!< [-] list of joint state derivatives
+    std::vector<double> stateDDots;             //!< [-] list of joint state second derivatives
 } JointArrayStateMsgPayload;
 
 #endif

--- a/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/_UnitTest/test_hingedJointArrayMotor.py
+++ b/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/_UnitTest/test_hingedJointArrayMotor.py
@@ -24,7 +24,7 @@ from Basilisk.utilities import SimulationBaseClass, macros
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import hingedJointArrayMotor
 
-def jointTorques(M, K, P, theta, thetaDot, desTheta, desThetaDot, bias, maxTorque=None):
+def jointTorques(M, K, P, theta, thetaDot, desTheta, desThetaDot, desThetaDDot, bias, maxTorque=None):
     M = np.asarray(M, dtype=float)
     K = np.asarray(K, dtype=float)
     P = np.asarray(P, dtype=float)
@@ -32,12 +32,13 @@ def jointTorques(M, K, P, theta, thetaDot, desTheta, desThetaDot, bias, maxTorqu
     thetaDot   = np.asarray(thetaDot, dtype=float).reshape(-1)
     desTheta   = np.asarray(desTheta, dtype=float).reshape(-1)
     desThetaDot= np.asarray(desThetaDot, dtype=float).reshape(-1)
+    desThetaDDot = np.asarray(desThetaDDot, dtype=float).reshape(-1)
     bias       = np.asarray(bias, dtype=float).reshape(-1)
 
     nj = theta.size
-    e    = theta - desTheta
+    e    = np.arctan2(np.sin(theta - desTheta), np.cos(theta - desTheta))
     edot = thetaDot - desThetaDot
-    theta_ddot_des = -(K @ e) - (P @ edot)
+    theta_ddot_des = desThetaDDot - (K @ e) - (P @ edot)
 
     Mtt = M[0:3,0:3]
     Mtth = M[0:3,6:6+nj]
@@ -149,14 +150,18 @@ def test_hingedJointArrayMotor(nonActForces, maxTorque, numJoints, numSpacecraft
 
     # create the desired joint state input message
     desJointStateInMsgData = messaging.JointArrayStateMsgPayload()
-    desTheta = [0.12] * (numJoints * numSpacecraft)
-    desThetaDot = [0.05] * (numJoints * numSpacecraft)
+    desTheta = [0.12] * (numJoints * numSpacecraft) #[rad]
+    desThetaDot = [0.05] * (numJoints * numSpacecraft)  #[rad/s]
+    desThetaDDot = [0.002] * (numJoints * numSpacecraft)    #[rad/s^2]
     desJointStateInMsgData.states.clear()
     desJointStateInMsgData.stateDots.clear()
+    desJointStateInMsgData.stateDDots.clear()
     for v in np.asarray(desTheta).flatten():
         desJointStateInMsgData.states.push_back(float(v))
     for v in np.asarray(desThetaDot).flatten():
         desJointStateInMsgData.stateDots.push_back(float(v))
+    for v in np.asarray(desThetaDDot).flatten():
+        desJointStateInMsgData.stateDDots.push_back(float(v))
 
     # create the joint reactions input message
     JointReactionsInMsgData = messaging.MJJointReactionsMsgPayload()
@@ -252,6 +257,7 @@ def test_hingedJointArrayMotor(nonActForces, maxTorque, numJoints, numSpacecraft
         thetaDot_sc = thetaDot[0:numJoints]
         desTheta_sc = desTheta[sc*numJoints:(sc+1)*numJoints]
         desThetaDot_sc = desThetaDot[sc*numJoints:(sc+1)*numJoints]
+        desThetaDDot_sc = desThetaDDot[sc*numJoints:(sc+1)*numJoints]
         bias_sc = -reactionForces[startIdx:startIdx+6+numJoints]
 
         if maxTorque:
@@ -260,7 +266,8 @@ def test_hingedJointArrayMotor(nonActForces, maxTorque, numJoints, numSpacecraft
             uMax_sc = None
 
         torques_sc = jointTorques(M_sc, K_sc, P_sc, theta_sc, thetaDot_sc,
-                                  desTheta_sc, desThetaDot_sc, bias_sc, maxTorque=uMax_sc)
+                                  desTheta_sc, desThetaDot_sc, desThetaDDot_sc,
+                                  bias_sc, maxTorque=uMax_sc)
         expectedTorques[sc*numJoints:(sc+1)*numJoints] = torques_sc
 
     # Assert the motor torques are correct

--- a/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.cpp
@@ -212,17 +212,19 @@ void HingedJointArrayMotor::UpdateState(uint64_t CurrentSimNanos)
         // Compute desired joint accelerations for this tree
         Eigen::VectorXd theta_ddot_des(nHingeJoints);
         theta_ddot_des.setZero();
-        Eigen::VectorXd theta(nHingeJoints), thetaDot(nHingeJoints), theta_des(nHingeJoints), thetaDot_des(nHingeJoints);
+        Eigen::VectorXd theta(nHingeJoints), thetaDot(nHingeJoints), theta_des(nHingeJoints), thetaDot_des(nHingeJoints), thetaDDot_des(nHingeJoints);
         theta.setZero();
         thetaDot.setZero();
         theta_des.setZero();
         thetaDot_des.setZero();
+        thetaDDot_des.setZero();
         for (int i = 0; i < nHingeJoints; ++i) {
             const int jointIdx = hingeGlobalIdxs[i];
             theta(i) = jointStates[jointIdx];
             thetaDot(i) = jointStateDots[jointIdx];
             theta_des(i) = desJointStatesIn.states[jointIdx];
             thetaDot_des(i) = desJointStatesIn.stateDots[jointIdx];
+            thetaDDot_des(i) = desJointStatesIn.stateDDots[jointIdx];
         }
 
         auto wrap = [](double a){ return std::atan2(std::sin(a), std::cos(a)); };
@@ -233,7 +235,7 @@ void HingedJointArrayMotor::UpdateState(uint64_t CurrentSimNanos)
             e(i) = wrap(theta(i) - theta_des(i));
             eDot(i) = thetaDot(i) - thetaDot_des(i);
         }
-        theta_ddot_des = -Ktheta_tree * e - Ptheta_tree * eDot;
+        theta_ddot_des = thetaDDot_des - Ktheta_tree * e - Ptheta_tree * eDot;
 
         // Use Schur complement to compute the motor torques
         Eigen::Vector3d rhs = -Mtth * theta_ddot_des + baseTransBias;

--- a/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.rst
+++ b/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.rst
@@ -1,6 +1,6 @@
 Executive Summary
 -----------------
-The ``hingedJointArrayMotor`` module determines the motor torques for an array of hinged joints based on commanded angles and the current system configuration.
+The ``hingedJointArrayMotor`` module utilizes a tracking controller to determine the motor torques for an array of hinged joints based on commanded angles, angular rates, angular accelerations, and the current system configuration.
 
 .. note::
   This module is designed to work for systems with multiple spacecraft, however, each spacecraft must be comprised of six degree-of-freedom rigid hub with attached hinged joints only. Additionally, the math assumes the reaction torques experienced by the hub due to the hinged joint motion are cancelled.

--- a/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.py
+++ b/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.py
@@ -367,7 +367,9 @@ class JointThrAllocation(sysModel.SysModel):
 
         self.jointAnglePayload.states.clear()
         self.jointAnglePayload.stateDots.clear()
+        self.jointAnglePayload.stateDDots.clear()
         for angleCmd in bestDecision[: self.nJoint]:
             self.jointAnglePayload.states.push_back(float(angleCmd))
             self.jointAnglePayload.stateDots.push_back(0.0)  # [rad/s]
+            self.jointAnglePayload.stateDDots.push_back(0.0)  # [rad/s^2]
         self.desJointAnglesOutMsg.write(self.jointAnglePayload, CurrentSimNanos, self.moduleID)


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR upgrades the `hingedJointArrayMotor` module to full tracking joint control.

The main additions are:

- `JointArrayStateMsgPayload` is extended with `stateDDots` to carry desired joint accelerations.
- `hingedJointArrayMotor` now uses reference joint acceleration feedforward in the commanded acceleration law
- `jointThrAllocation` output payload population is updated to provide `stateDDots` defaults (zero) so legacy/static-reference usage remains behaviorally consistent.
- `hingedJointArrayMotor` unit-test expected-torque helper was updated to match controller math (including wrapped angle error and acceleration feedforward).

## Verification
Changes were validated with an updated unit test and by ensuring a scenario that used the corresponding modules were was unaffected.

Validation included:

- updated unit test:
  - `src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/_UnitTest/test_hingedJointArrayMotor.py`
- unaffected scenario performance:
  - `scenarioThrArmControl`

## Documentation
This PR adds and updates documentation for the upgraded controller:

- `src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.rst`
- the release notes snippet in `docs/source/Support/bskReleaseNotesSnippets/1379-joint-array-tracking.rst`

## Future work
N/A
