### PR TITLE
[#632] Fix SWIG re-registration bug in dataFileToViz

### DIFF
--- a/src/simulation/vizard/dataFileToViz/dataFileToViz.i
+++ b/src/simulation/vizard/dataFileToViz/dataFileToViz.i
@@ -22,6 +22,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 %{
    #include "dataFileToViz.h"
+   #include "simulation/vizard/_GeneralModuleFiles/vizStructures.h"
 %}
 
 %pythoncode %{
@@ -33,15 +34,16 @@ from Basilisk.architecture.swig_common_model import *
 %include "sys_model.i"
 %include "std_vector.i"
 
-
 %include "dataFileToViz.h"
-%include "simulation/vizard/_GeneralModuleFiles/vizStructures.h"
 
 %include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 struct SCStatesMsg_C;
 %include "architecture/msgPayloadDefC/RWConfigLogMsgPayload.h"
 struct RWConfigLogMsg_C;
 %include "architecture/msgPayloadDefCpp/THROutputMsgPayload.h"
+struct THROutputMsg_C;
+
+struct ThrClusterMap;
 
 
 // Instantiate templates used by example


### PR DESCRIPTION
* **Tickets addressed:** bsk-632
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
`dataFileToViz` SWIG file unintentionally caused SWIG type wrappers incompatible to the `vizInterface` ones to be generated. Some combinations of dataFileToViz and vizInterface imports will thus cause usage of one to fail due to generic SwigPyObjects getting emitted instead of the proper Python wrappers.

Instead of just including the `vizStructures.h` inside `dataFileToViz.i`, I included declared just what was needed for the SWIG build.

## Verification
Failing combinations of tests now pass, for example `pytest -vv tests/test_scenarioAttLocPoint.py tests/test_scenarioDataToViz.py tests/test_scenarioAttitudeConstrainedManeuver.py` now passes.

## Documentation
None

## Future work
None
