### PR TITLE
Fix Vizard plume placement for thrusters mounted on non-hub bodies

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/thruster-branching-viz-offset.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/thruster-branching-viz-offset.rst
@@ -1,0 +1,1 @@
+- Added Vizard plume placement for thrusters mounted on a non-hub body. :ref:`thrusterDynamicEffector` and :ref:`thrusterStateEffector` now expose a ``r_PcP_P`` member, and :ref:`simIncludeThruster`'s ``addToSpacecraftSubcomponent`` accepts a ``r_PcP_P`` argument.

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -36,6 +36,7 @@ ThrusterDynamicEffector::ThrusterDynamicEffector()
     forceExternal_B.fill(0.0);
     torqueExternalPntB_B.fill(0.0);
     forceExternal_N.fill(0.0);
+    this->r_PcP_P.setZero();
     this->stateDerivContribution.resize(1);
     this->stateDerivContribution.setZero();
 

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h
@@ -78,6 +78,7 @@ public:
     Eigen::MatrixXd* inertialPositionProperty;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialAttitudeProperty;  //!< attitude relative to inertial frame
     Eigen::MatrixXd* inertialAngVelocityProperty;  //!< [rad/s] inertial angular velocity relative to inertial frame
+    Eigen::Vector3d r_PcP_P;                     //!< [m] position vector of parent body CoM w.r.t. parent body frame origin (only used if thrusters attached to non-hub body)
 
     BSKLogger bskLogger;                      //!< -- BSK Logging
 

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -34,6 +34,7 @@ ThrusterStateEffector::ThrusterStateEffector()
     this->effProps.IEffPntB_B.fill(0.0);
     this->effProps.rEffPrime_CB_B.fill(0.0);
     this->effProps.IEffPrimePntB_B.fill(0.0);
+    this->r_PcP_P.setZero();
 
     // initialize the state derivative contribution for mass rate
     this->stateDerivContribution.resize(1);

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
@@ -78,6 +78,7 @@ public:
     StateData *hubOmega;        //!< pointer to hub angular velocity states
     StateData* kappaState;      //!< -- state manager of theta for hinged rigid body
     Eigen::MatrixXd* inertialPositionProperty;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
+    Eigen::Vector3d r_PcP_P;                    //!< [m] position vector of parent body CoM w.r.t. parent body frame origin (only used if thrusters attached to non-hub body)
 
     BSKLogger bskLogger;        //!< -- BSK Logging
 

--- a/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
+++ b/src/simulation/vizard/_GeneralModuleFiles/vizStructures.h
@@ -46,6 +46,7 @@ ThrClusterMap
 {
     std::string thrTag;   //!< ModelTag associated with the thruster grouping
     int color[4] = {-1};  //!< RGBA thruster plume color for all thrusters in this group
+    Eigen::Vector3d thrOffset = Eigen::Vector3d::Zero(); //!< [m] optional position offset for all thrusters in this group
 }ThrClusterMap;
 
 

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -923,7 +923,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                         }
                     }
                     for (int i=0; i<3; i++){
-                        thr->add_position(scIt->thrOutputMessage[idx].thrusterLocation[i]);
+                        thr->add_position(scIt->thrOutputMessage[idx].thrusterLocation[i] - scIt->thrInfo[idx].thrOffset[i]);
                         thr->add_thrustvector(scIt->thrOutputMessage[idx].thrusterDirection[i]);
                     }
                     //thrMsgID[idx].dataFresh = false;

--- a/src/utilities/simIncludeThruster.py
+++ b/src/utilities/simIncludeThruster.py
@@ -236,7 +236,7 @@ class thrusterFactory(object):
 
         return
 
-    def addToSpacecraftSubcomponent(self, modelTag, thEffector, baseEffector, segment=0):
+    def addToSpacecraftSubcomponent(self, modelTag, thEffector, baseEffector, segment=0, r_PcP_P=None):
         """
             This function is for adding a thruster cluster to intermediate bodies
 
@@ -264,6 +264,10 @@ class thrusterFactory(object):
             baseEffector.addStateEffector(thEffector, segment)
         else:
             print("This isn't a thruster effector. You did something wrong.")
+
+        # If visualizing the thruster plume, assign the CoM offset of the parent body here
+        if r_PcP_P is not None:
+            thEffector.r_PcP_P = r_PcP_P
 
         return
 

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -1335,9 +1335,10 @@ def enableUnityVisualization(
                     if thrColors:
                         if thrColors[c] is not None:
                             thSet.color = thrColors[c][clusterCounter]
-                    for thrLogMsg in (
-                        thrEff.thrusterOutMsgs
-                    ):  # loop over the THR cluster log message
+                    # optionally offset the thruster positions, useful for effector branching corrections
+                    if scData.parentSpacecraftName != "":
+                        thSet.thrOffset = thrEff.r_PcP_P
+                    for thrLogMsg in (thrEff.thrusterOutMsgs):  # loop over the THR cluster log message
                         thrList.append(thrLogMsg.addSubscriber())
                         thrInfo.append(thSet)
                     clusterCounter += 1


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Thrusters mounted to a branched body rendered their plumes at the wrong location in Vizard. The thruster output message reports `thrLoc_B` relative to the parent body frame origin, whereas the sub-body's config log places the body model at the parent body CoM. Vizard then treats `thrLoc_B` as an offset from the CoM, displacing the plume by `r_PcP_P`.

This work threads `r_PcP_P` through each thruster effector, the `ThrClusterMap`, and `vizSupport`, then subtracts it from `thrLoc_B` in `vizInterface` before the protobuf is written. Hub-attached thrusters are unaffected because `r_PcP_P` defaults to zero and the offset is only forwarded when a parent spacecraft is set.

The change is split into seven atomic commits, one per logical step.

## Verification

This work was tested visually using `scenarioThrusterArm` on the companion `feature/effector-branching-scenarios` branch, which mounts a thruster on the second segment of each two-DOF spinning-body arm. With the patch, the rendered plume sits at the segment CoM, which matches the configured thruster location relative to that CoM. Without the patch, the plume sat offset from the segment CoM by `r_Sc2S2_S2`. Hub-attached thruster scenarios were spot-checked and remain unchanged when no parent is present.

No new automated tests are added in this PR, as the change only affects values written into the Vizard protobuf, which the existing dynamics regression tests do not exercise.

## Documentation

A release notes snippet is added at `docs/source/Support/bskReleaseNotesSnippets/thruster-branching-viz-offset.rst`. The new `r_PcP_P` member on each thruster effector is documented inline in its header and exposed automatically through the existing SWIG interfaces. The new keyword argument on `simIncludeThruster.thrusterFactory.addToSpacecraftSubcomponent` is documented in its docstring.

## Future work

This branch supports the incoming feature/effector-branching-scenarios branch which has scenarios corresponding to an upcoming journal paper.