### PR TITLE
update minimum swig to 4.4.1

### DIFF
--- a/docs/source/Learn/makingModules/advancedTopics/mujocoDynObject.rst
+++ b/docs/source/Learn/makingModules/advancedTopics/mujocoDynObject.rst
@@ -29,7 +29,7 @@ By default, Basilisk will not build MuJoCo-related capabilities. To enable these
 
     (venv) $ python conanfile.py --mujoco True --mujocoReplay True
 
-Note that you will need SWIG version ``>=4.2.1``. Only the ``--mujoco True`` option is required. ``--mujocoReplay True`` will additionally build an
+Only the ``--mujoco True`` option is required. ``--mujocoReplay True`` will additionally build an
 independent tool that can be used to visualize the results of :ref:`MJScene<MJScene>` simulations. When
 using ``--mujocoReplay True``, you'll be able to call:
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -23,9 +23,10 @@ Version |release|
 - The MuJoCo dynamics wrapper now uses MuJoCo 3.7 element-name APIs, fixing builds after the MuJoCo
   3.7 upgrade.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
-  The development dependency range now excludes SWIG 4.4.0, and SWIG 4.4.1 has been verified to build
-  successfully. If source builds fail with SWIG 4.4.0 or emit ``builtin type swigvarlink has no __module__ attribute``
-  warnings, upgrade to SWIG 4.4.1 or newer.
+  Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
+  for Basilisk and compatible plugins. If source builds fail with SWIG 4.4.0 or emit
+  ``builtin type swigvarlink has no __module__ attribute`` warnings, upgrade to SWIG 4.4.1 or a newer
+  supported 4.x release.
 
 
 Version 2.10.0 (April 2, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/swig-441-abi5-support.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/swig-441-abi5-support.rst
@@ -1,0 +1,1 @@
+- Raised the supported SWIG 4.x build requirement to 4.4.1, providing SWIG ABI 5 support between BSK and BSK plugins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     # Requirements for building Basilisk through conanfile
     "conan>=2.0.5,<=2.23.0",
     "cmake>=3.26,<4.0",
-    "swig>=4.2.1,!=4.4.0,<5",  # Support Basilisk's established SWIG baseline while avoiding the known-bad 4.4.0 release.
+    "swig>=4.4.1,<5",  # Require SWIG ABI 5 support for Basilisk and compatible plugins.
     "libclang>=15.0.6.1,<=18.1.1"  # Required by generatePayloadMetaJson.py (message code generation)
 ]
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ conan>=2.0.5,<=2.23.0
 packaging>=24,<26
 setuptools>=70.1.0,<=80.9.0
 setuptools-scm>=8.0,<=9.2.2
-swig>=4.2.1,!=4.4.0,<5
+swig>=4.4.1,<5
 libclang>=15.0.6.1,<=18.1.1
 
 pytest>=8.3.5,<=9.0.1

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class BuildConanExtCommand(Command, SubCommand):
 
         # Set limited ABI compatibility by default, targeting the minimum required Python version.
         # See https://docs.python.org/3/c-api/stable.html
-        # NOTE: Swig 4.2.1 or higher is required. Newer 4.4.x releases avoid deprecated wrapper warnings on newer Python.
+        # NOTE: SWIG 4.4.1 or a newer supported 4.x release is required for SWIG ABI 5 support between Basilisk and compatible plugins.
         min_version = next(self.distribution.python_requires.filter([f"3.{i}" for i in range(2, 100)])).replace(".", "")
         wheel_py_limited = f"cp{min_version}"
         bdist_wheel = self.reinitialize_command("bdist_wheel", py_limited_api=wheel_py_limited)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,24 +33,7 @@ elseif(Python3_VERSION VERSION_LESS "3.10")
     message(WARNING "You are using Python ${Python3_VERSION}, but support for Python 3.9 is deprecated and will be removed in March 2027.")
 endif()
 
-# Find SWIG early (no version requirement yet)
-find_package(SWIG REQUIRED COMPONENTS python)
-
-# Check both versions
-if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
-  if(SWIG_VERSION VERSION_LESS "4.2.0")
-    message(FATAL_ERROR
-      "Python ${Python3_VERSION} requires SWIG 4.2.0 or newer, but found SWIG ${SWIG_VERSION}."
-    )
-  endif()
-endif()
-
-# Now safely require SWIG in the appropriate version range
-if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
-  find_package(SWIG 4.2...<5 REQUIRED COMPONENTS python)
-else()
-  find_package(SWIG 4.0...<5 REQUIRED COMPONENTS python)
-endif()
+find_package(SWIG 4.4.1...<5 REQUIRED COMPONENTS python)
 include(${SWIG_USE_FILE})
 
 # Set the Python module library to be linked to.
@@ -58,10 +41,6 @@ set(PYTHON3_MODULE Python3::Module)
 if(PY_LIMITED_API AND NOT PY_LIMITED_API STREQUAL "")
   message(STATUS "Requested Py_LIMITED_API=${PY_LIMITED_API}")
   message(STATUS "(Refer to https://docs.python.org/3/c-api/stable.html#limited-c-api for details)")
-
-  if(${SWIG_VERSION} VERSION_LESS 4.2)
-    message(FATAL_ERROR "Could not find a suitable version of SWIG (found ${SWIG_VERSION}, need SWIG>=4.2.0)")
-  endif()
 
   if(NOT Python3_Development.SABIModule_FOUND)
     message(FATAL_ERROR "Could not find the required Python3 Stable ABI module!")
@@ -71,7 +50,7 @@ if(PY_LIMITED_API AND NOT PY_LIMITED_API STREQUAL "")
   # compatibility (basically, we can build a single Python wheel to
   # support all future Python versions).
   # See https://docs.python.org/3/c-api/stable.html
-  # NOTE: Swig 4.2.0 is required. Swig 4.4.x avoids the deprecated wrapper warnings on newer Python releases.
+  # NOTE: SWIG 4.4.1 or a newer supported 4.x release is required for SWIG ABI 5 support between Basilisk and compatible plugins.
   add_definitions("-DPy_LIMITED_API=${PY_LIMITED_API}")  # Support for current Python version
 
   # Force libraries to link to the Stable ABI module instead.


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR raises the supported SWIG 4.x build requirement to SWIG 4.4.1 for Basilisk source builds and Python build requirements. The CMake SWIG detection was simplified to a single versioned `find_package(SWIG 4.4.1...<5 REQUIRED COMPONENTS python)` check now that the minimum SWIG version is unconditional.

This update provides SWIG ABI 5 support between BSK and BSK plugins.

## Verification
Validated locally using the repo `.venv` environment:
- `.venv/bin/swig -version` reports SWIG 4.4.1.
- `.venv/bin/python` successfully parses `pyproject.toml`.
- `.venv/bin/python -m py_compile setup.py` passes.
- The release-note snippet validates with `rst2pseudoxml`.
- `git diff --check` passes.
- A CMake configure smoke check confirms `.venv/bin/swig` satisfies the new `4.4.1...<5` requirement.

No runtime tests were added because this is a build dependency/configuration update.

## Documentation
Added a release-note snippet describing SWIG ABI 5 support between BSK and BSK plugins. Updated the known-issues SWIG 4.4.0 guidance. Removed the stale MuJoCo-specific SWIG dependency note so SWIG requirements remain centralized in the build configuration.

## Future work
None.