### PR TITLE
Enhance recorder with new features

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
@@ -53,7 +53,15 @@ The minimum recorder update time can also be changed after the simulation is sto
 
     scRec.updateTimeInterval(newMinUpdateTime)
 
-After this call, the next eligible recording time is recomputed from the last recorded message time using the updated interval.  If the updated interval has already elapsed when the simulation continues, the recorder samples on its next task execution.
+After this call, the next eligible recording time is recomputed from the last eligible recorder update using the updated interval.  For normal recording this is the last recorded message time.  For change-only recording this can be the last time the recorder checked the payload, even if the payload was unchanged and no record was stored.  If the updated interval has already elapsed when the simulation continues, the recorder samples on its next task execution.
+
+The recorder can also be configured to record only when the message payload content changes.  In this mode the first eligible recorder update is saved, and subsequent eligible updates are saved only when the payload data differs from the last recorded payload.  The ``minUpdateTime`` value is still respected while this mode is active, including eligible updates where the payload is unchanged.  For example, assume a message recorder ``scRec`` has already been set up.  Change-only recording is enabled with::
+
+    scRec.recordOnChange()
+
+To turn off this mode use ``scRec.recordOnChange(False)``.  The default argument of this method is ``True``.
+
+This change-only mode is only available for message payload types that support field-wise equality comparison.  Basilisk generates this support for payloads whose fields can be compared directly.  If a payload contains an unknown field type, or a pointer field that cannot be compared safely, then ``recordOnChange()`` emits an error instead of silently falling back to normal interval recording.  Use the regular recorder mode for these payloads, or add a ``PayloadEqualityTraits`` specialization when the payload can be compared safely.
 
 That is all that is required to set up message recording.  Next the code initializes the simulation and executes it.
 

--- a/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
@@ -61,7 +61,7 @@ The recorder can also be configured to record only when the message payload cont
 
 To turn off this mode use ``scRec.recordOnChange(False)``.  The default argument of this method is ``True``.
 
-This change-only mode is only available for message payload types that support field-wise equality comparison.  Basilisk generates this support for payloads whose fields can be compared directly.  If a payload contains an unknown field type, or a pointer field that cannot be compared safely, then ``recordOnChange()`` emits an error instead of silently falling back to normal interval recording.  Use the regular recorder mode for these payloads, or add a ``PayloadEqualityTraits`` specialization when the payload can be compared safely.
+This change-only mode is only available for message payload types that support field-wise equality comparison.  Basilisk generates this support for payloads whose fields can be compared directly.  If a payload contains an unknown field type, or a pointer field without explicit comparison semantics, then ``recordOnChange()`` emits an error instead of silently falling back to normal interval recording.  Use the regular recorder mode for these payloads, or add a ``PayloadEqualityTraits`` specialization only when the payload comparison behavior can be defined safely.  For example, ``CameraImageMsgPayload`` supports change-only recording through a shallow metadata comparison.  Its image pointer is compared by address, but the pointed-to image buffer is not deep-copied or compared by the recorder.
 
 That is all that is required to set up message recording.  Next the code initializes the simulation and executes it.
 

--- a/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-4.rst
@@ -49,6 +49,12 @@ Here ``minUpdateTime`` is the minimum time interval that must pass before this r
 
 In the full script above, the recorder module ``msgRec`` is set up to record the message at the ``dynamicsTask`` update rate.  In contrast, the module ``msgRec20`` is setup to record the message only after 20s have passed.  Note that the ``minUpdateTime`` argument must be provided again in nano-seconds.
 
+The minimum recorder update time can also be changed after the simulation is stopped and before it is continued.  For example, assume a message recorder ``scRec`` should use a new minimum update time ``newMinUpdateTime`` for the next segment of the simulation.  This is done with::
+
+    scRec.updateTimeInterval(newMinUpdateTime)
+
+After this call, the next eligible recording time is recomputed from the last recorded message time using the updated interval.  If the updated interval has already elapsed when the simulation continues, the recorder samples on its next task execution.
+
 That is all that is required to set up message recording.  Next the code initializes the simulation and executes it.
 
 

--- a/docs/source/Support/bskReleaseNotesSnippets/fsw-definitions-macos-boolean.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/fsw-definitions-macos-boolean.rst
@@ -1,0 +1,1 @@
+- Fixed ``fswDefinitions.h`` so it can be included on macOS without a ``boolean_t`` typedef redefinition error. On Apple platforms, ``boolean_t`` is now sourced from ``<mach/boolean.h>`` (which defines it idempotently) instead of redefining it as an enum that conflicts with the system type.

--- a/docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst
@@ -1,3 +1,4 @@
 - Updated message recorders so ``updateTimeInterval()`` reschedules the next recording opportunity when the minimum update time is changed between simulation runs.
 - Added a message recorder mode to record only when message payload content changes after the minimum update time has elapsed.
 - Added explicit errors when change-only recording is requested for payload types without supported equality comparison.
+- Added shallow metadata comparison support for ``CameraImageMsgPayload`` without comparing pointed-to image bytes.

--- a/docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst
@@ -1,0 +1,1 @@
+- Updated message recorders so ``updateTimeInterval()`` reschedules the next recording opportunity when the minimum update time is changed between simulation runs.

--- a/docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst
@@ -1,1 +1,3 @@
 - Updated message recorders so ``updateTimeInterval()`` reschedules the next recording opportunity when the minimum update time is changed between simulation runs.
+- Added a message recorder mode to record only when message payload content changes after the minimum update time has elapsed.
+- Added explicit errors when change-only recording is requested for payload types without supported equality comparison.

--- a/src/architecture/messaging/CMakeLists.txt
+++ b/src/architecture/messaging/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_policy(SET CMP0078 NEW)
 
-function(generate_messages searchDir generateCCode)
+function(generate_messages searchDir generateCCode outEqualityHeaders)
   file(
     GLOB_RECURSE message_files
     RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/"
@@ -14,6 +14,8 @@ function(generate_messages searchDir generateCCode)
   else()
     set(CLANG_LANG_FLAG "c++")
   endif()
+
+  set(local_equality_headers "")
 
   foreach(msgFile ${message_files})
     get_filename_component(TARGET_NAME ${msgFile} NAME_WE)
@@ -39,13 +41,27 @@ function(generate_messages searchDir generateCCode)
       VERBATIM
     )
 
+    set(EQUALITY_OUT_NAME "${CMAKE_BINARY_DIR}/autoSource/${TARGET_NAME}_equality.h")
+    add_custom_command(
+      OUTPUT ${EQUALITY_OUT_NAME}
+      COMMAND ${Python3_EXECUTABLE}
+              msgAutoSource/generatePayloadEqualityHeader.py
+              ${EQUALITY_OUT_NAME} ${MSG_META_OUTPUT} ${TARGET_NAME} ${searchDir}
+      DEPENDS ${MSG_META_OUTPUT} msgAutoSource/generatePayloadEqualityHeader.py
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+      COMMENT "Generating payload equality header for ${TARGET_NAME}"
+      VERBATIM
+    )
+    list(APPEND local_equality_headers "${TARGET_NAME}_equality.h")
+
     get_filename_component(TARGET_DIR ${msgFile} DIRECTORY)
     set(COMP_OUT_NAME "${CMAKE_BINARY_DIR}/autoSource/${TARGET_NAME}.i")
     add_custom_command(
       OUTPUT ${COMP_OUT_NAME}
       COMMAND ${Python3_EXECUTABLE} generateSWIGModules.py ${COMP_OUT_NAME} ${msgFile} ${TARGET_NAME} ${searchDir}
               ${generateCCode} ${MSG_META_OUTPUT} ${RECORDER_PROPERTY_ROLLBACK}
-      DEPENDS ${msgFile} ${MSG_META_OUTPUT} msgAutoSource/generateSWIGModules.py msgAutoSource/msgInterfacePy.i.in
+      DEPENDS ${msgFile} ${MSG_META_OUTPUT} ${EQUALITY_OUT_NAME}
+              msgAutoSource/generateSWIGModules.py msgAutoSource/msgInterfacePy.i.in
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/msgAutoSource/)
     set_property(SOURCE ${COMP_OUT_NAME} PROPERTY CPLUSPLUS ON)
 
@@ -87,6 +103,8 @@ function(generate_messages searchDir generateCCode)
                                                          "${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging")
     target_link_libraries(${SWIG_MODULE_${TARGET_NAME}_REAL_NAME} PUBLIC architectureLib)
   endforeach()
+
+  set(${outEqualityHeaders} ${local_equality_headers} PARENT_SCOPE)
 endfunction(generate_messages)
 
 # Copy the cMsgCInterfacePy wrapper module to support backwards-compatibility.
@@ -114,6 +132,12 @@ endif(NOT "${EXTERNAL_MODULES_PATH}" STREQUAL "")
 # Custom target for establishing dependency
 add_custom_target(swigtrick DEPENDS ${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging/__init__.py)
 
-# Dependency
-generate_messages(msgPayloadDefCpp "False")
-generate_messages(msgPayloadDefC "True")
+# Generate per-payload equality headers and aggregate into a single umbrella.
+generate_messages(msgPayloadDefCpp "False" cpp_equality_headers)
+generate_messages(msgPayloadDefC "True" c_equality_headers)
+
+set(UMBRELLA "${CMAKE_BINARY_DIR}/autoSource/payloadEquality_generated.h")
+file(WRITE  ${UMBRELLA} "// AUTO-GENERATED — DO NOT EDIT\n#pragma once\n")
+foreach(eqHeader ${cpp_equality_headers} ${c_equality_headers})
+  file(APPEND ${UMBRELLA} "#if __has_include(\"${eqHeader}\")\n#  include \"${eqHeader}\"\n#endif\n")
+endforeach()

--- a/src/architecture/messaging/_UnitTest/test_RecorderUpdateTimeInterval.py
+++ b/src/architecture/messaging/_UnitTest/test_RecorderUpdateTimeInterval.py
@@ -177,61 +177,70 @@ def test_record_on_change_unsupported_payload():
 
 
 def test_record_on_change_camera_image_payload():
-    """CameraImageMsgPayload has a hand-written PayloadEqualityTraits specialization.
+    """Test CameraImageMsgPayload change-only recording with shallow metadata equality.
 
-    recordOnChange() should only store a frame when the scalar fields differ from the
-    last recorded payload. imagePointer is left null here, so equality reduces to
-    comparing timeTag, valid, cameraID, imageType, and imageBufferLength.
+    CameraImageMsgPayload equality compares payload fields, including the image
+    pointer address, but it does not compare the pointed-to image bytes.
     """
 
     sc_sim = SimulationBaseClass.SimBaseClass()
     sim_process = sc_sim.CreateNewProcess("testProcess")
-    sim_process.addTask(sc_sim.CreateNewTask("testTask", macros.sec2nano(1.0)))
+
+    task_time = macros.sec2nano(1.0)  # [ns]
+    sim_process.addTask(sc_sim.CreateNewTask("testTask", task_time))
 
     test_module = ChangingCameraModule()
     sc_sim.AddModelToTask("testTask", test_module)
 
-    minimum_record_time = macros.sec2nano(4.0)
+    minimum_record_time = macros.sec2nano(4.0)  # [ns]
     msg_recorder = test_module.cameraOutMsg.recorder(minimum_record_time)
     msg_recorder.recordOnChange()
     sc_sim.AddModelToTask("testTask", msg_recorder)
 
     sc_sim.InitializeSimulation()
-    sc_sim.ConfigureStopTime(macros.sec2nano(10.0))
+
+    final_stop_time = macros.sec2nano(10.0)  # [ns]
+    sc_sim.ConfigureStopTime(final_stop_time)
     sc_sim.ExecuteSimulation()
 
-    # cameraID changes at t = 5 s. With a 4 s minimum interval:
-    #   t = 0: recorded (cameraID = 0), next eligible = t = 4 s
-    #   t = 4: payload unchanged → skipped,  next eligible = t = 8 s
-    #   t = 8: payload changed (cameraID = 1) → recorded
+    first_record_time = macros.sec2nano(0.0)  # [ns]
+    first_eligible_change_time = macros.sec2nano(8.0)  # [ns]
     expected_times = np.array([
+        first_record_time,
+        first_eligible_change_time,
+    ])  # [ns]
+    expected_time_tags = np.array([
         macros.sec2nano(0.0),
-        macros.sec2nano(8.0),
-    ])
-    expected_camera_ids = np.array([0, 1])
+        test_module.image_time_tag,
+    ])  # [ns]
 
     np.testing.assert_array_equal(msg_recorder.times(), expected_times)
-    np.testing.assert_array_equal(msg_recorder.cameraID, expected_camera_ids)
+    np.testing.assert_array_equal(msg_recorder.timeTag, expected_time_tags)
 
 
 class ChangingCameraModule(sysModel.SysModel):
-    """Write a CameraImageMsgPayload whose cameraID steps up at a fixed simulation time."""
+    """Write a CameraImageMsgPayload whose metadata changes at a fixed time."""
 
     def __init__(self):
         super().__init__()
         self.cameraOutMsg = messaging.CameraImageMsg()
-        self.change_time = macros.sec2nano(5.0)
+        self.change_time = macros.sec2nano(5.0)  # [ns]
+        self.image_time_tag = macros.sec2nano(5.0)  # [ns]
 
     def Reset(self, CurrentSimNanos):
-        self._write(CurrentSimNanos)
+        self.write_payload(CurrentSimNanos)
 
     def UpdateState(self, CurrentSimNanos):
-        self._write(CurrentSimNanos)
+        self.write_payload(CurrentSimNanos)
 
-    def _write(self, CurrentSimNanos):
+    def write_payload(self, CurrentSimNanos):
         payload = self.cameraOutMsg.zeroMsgPayload
-        payload.cameraID = 1 if CurrentSimNanos >= self.change_time else 0
         payload.valid = 1
+        payload.cameraID = 7
+        payload.imageBufferLength = 10  # [bytes]
+        payload.imageType = 1
+        if CurrentSimNanos >= self.change_time:
+            payload.timeTag = self.image_time_tag
         self.cameraOutMsg.write(payload, CurrentSimNanos, self.moduleID)
 
 

--- a/src/architecture/messaging/_UnitTest/test_RecorderUpdateTimeInterval.py
+++ b/src/architecture/messaging/_UnitTest/test_RecorderUpdateTimeInterval.py
@@ -1,0 +1,73 @@
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import numpy as np
+
+from Basilisk.architecture import messaging
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+
+
+def test_update_time_interval():
+    """Test changing a recorder's minimum update time during a paused simulation."""
+
+    sc_sim = SimulationBaseClass.SimBaseClass()
+    sim_process = sc_sim.CreateNewProcess("testProcess")
+
+    task_time = macros.sec2nano(1.0)  # [ns]
+    sim_process.addTask(sc_sim.CreateNewTask("testTask", task_time))
+
+    msg_payload = messaging.CModuleTemplateMsgPayload()
+    msg = messaging.CModuleTemplateMsg().write(msg_payload)
+
+    initial_record_time = macros.sec2nano(10.0)  # [ns]
+    msg_recorder = msg.recorder(initial_record_time)
+    sc_sim.AddModelToTask("testTask", msg_recorder)
+
+    sc_sim.InitializeSimulation()
+
+    first_stop_time = macros.sec2nano(5.0)  # [ns]
+    sc_sim.ConfigureStopTime(first_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    short_record_time = macros.sec2nano(3.0)  # [ns]
+    second_stop_time = macros.sec2nano(12.0)  # [ns]
+    msg_recorder.updateTimeInterval(short_record_time)
+    sc_sim.ConfigureStopTime(second_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    long_record_time = macros.sec2nano(8.0)  # [ns]
+    final_stop_time = macros.sec2nano(20.0)  # [ns]
+    msg_recorder.updateTimeInterval(long_record_time)
+    sc_sim.ConfigureStopTime(final_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    first_record_time = macros.sec2nano(0.0)  # [ns]
+    resumed_record_time = macros.sec2nano(6.0)  # [ns]
+    second_resumed_record_time = macros.sec2nano(9.0)  # [ns]
+    expected_times = np.array([
+        first_record_time,
+        resumed_record_time,
+        second_resumed_record_time,
+        second_stop_time,
+        final_stop_time,
+    ])  # [ns]
+
+    np.testing.assert_array_equal(msg_recorder.times(), expected_times)
+
+
+if __name__ == "__main__":
+    test_update_time_interval()

--- a/src/architecture/messaging/_UnitTest/test_RecorderUpdateTimeInterval.py
+++ b/src/architecture/messaging/_UnitTest/test_RecorderUpdateTimeInterval.py
@@ -14,9 +14,11 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+import pytest
 import numpy as np
 
 from Basilisk.architecture import messaging
+from Basilisk.architecture import sysModel
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 
@@ -69,5 +71,204 @@ def test_update_time_interval():
     np.testing.assert_array_equal(msg_recorder.times(), expected_times)
 
 
+def test_record_on_change():
+    """Test recording changed message payloads after the minimum update time."""
+
+    sc_sim = SimulationBaseClass.SimBaseClass()
+    sim_process = sc_sim.CreateNewProcess("testProcess")
+
+    task_time = macros.sec2nano(1.0)  # [ns]
+    sim_process.addTask(sc_sim.CreateNewTask("testTask", task_time))
+
+    test_module = ChangingPayloadModule()
+    sc_sim.AddModelToTask("testTask", test_module)
+
+    minimum_record_time = macros.sec2nano(4.0)  # [ns]
+    msg_recorder = test_module.dataOutMsg.recorder(minimum_record_time)
+    msg_recorder.recordOnChange()
+    sc_sim.AddModelToTask("testTask", msg_recorder)
+
+    sc_sim.InitializeSimulation()
+
+    final_stop_time = macros.sec2nano(13.0)  # [ns]
+    sc_sim.ConfigureStopTime(final_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    first_record_time = macros.sec2nano(0.0)  # [ns]
+    first_eligible_change_time = macros.sec2nano(8.0)  # [ns]
+    second_eligible_change_time = macros.sec2nano(12.0)  # [ns]
+    expected_times = np.array([
+        first_record_time,
+        first_eligible_change_time,
+        second_eligible_change_time,
+    ])  # [ns]
+    expected_values = np.array([
+        [0, 0, 0],
+        [1, 0, 0],
+        [2, 0, 0],
+    ])
+
+    np.testing.assert_array_equal(msg_recorder.times(), expected_times)
+    np.testing.assert_array_equal(msg_recorder.dataVector, expected_values)
+
+
+def test_record_on_change_update_time_interval_after_skipped_record():
+    """Test interval updates after a change-only recorder skips an unchanged payload."""
+
+    sc_sim = SimulationBaseClass.SimBaseClass()
+    sim_process = sc_sim.CreateNewProcess("testProcess")
+
+    task_time = macros.sec2nano(1.0)  # [ns]
+    sim_process.addTask(sc_sim.CreateNewTask("testTask", task_time))
+
+    test_module = ChangingPayloadModule()
+    sc_sim.AddModelToTask("testTask", test_module)
+
+    initial_record_time = macros.sec2nano(4.0)  # [ns]
+    msg_recorder = test_module.dataOutMsg.recorder(initial_record_time)
+    msg_recorder.recordOnChange()
+    sc_sim.AddModelToTask("testTask", msg_recorder)
+
+    sc_sim.InitializeSimulation()
+
+    first_stop_time = macros.sec2nano(6.0)  # [ns]
+    sc_sim.ConfigureStopTime(first_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    updated_record_time = macros.sec2nano(10.0)  # [ns]
+    second_stop_time = macros.sec2nano(13.0)  # [ns]
+    msg_recorder.updateTimeInterval(updated_record_time)
+    sc_sim.ConfigureStopTime(second_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    first_record_time = macros.sec2nano(0.0)  # [ns]
+    np.testing.assert_array_equal(msg_recorder.times(), np.array([first_record_time]))
+
+    final_stop_time = macros.sec2nano(14.0)  # [ns]
+    sc_sim.ConfigureStopTime(final_stop_time)
+    sc_sim.ExecuteSimulation()
+
+    expected_times = np.array([
+        first_record_time,
+        final_stop_time,
+    ])  # [ns]
+    expected_values = np.array([
+        [0, 0, 0],
+        [2, 0, 0],
+    ])
+
+    np.testing.assert_array_equal(msg_recorder.times(), expected_times)
+    np.testing.assert_array_equal(msg_recorder.dataVector, expected_values)
+
+
+def test_record_on_change_unsupported_payload():
+    """recordOnChange() on a payload with no equality support raises BasiliskError.
+
+    VizUserInputMsgPayload contains std::vector<VizEventReply>, which the equality
+    generator rejects and no manual specialization exists. Enabling change-only
+    recording should fail explicitly instead of falling back to interval recording.
+    """
+    msg_recorder = messaging.VizUserInputMsg().recorder()
+
+    with pytest.raises(Exception, match="does not support equality comparison.*PayloadEqualityTraits"):
+        msg_recorder.recordOnChange()
+
+    msg_recorder.recordOnChange(False)
+
+
+def test_record_on_change_camera_image_payload():
+    """CameraImageMsgPayload has a hand-written PayloadEqualityTraits specialization.
+
+    recordOnChange() should only store a frame when the scalar fields differ from the
+    last recorded payload. imagePointer is left null here, so equality reduces to
+    comparing timeTag, valid, cameraID, imageType, and imageBufferLength.
+    """
+
+    sc_sim = SimulationBaseClass.SimBaseClass()
+    sim_process = sc_sim.CreateNewProcess("testProcess")
+    sim_process.addTask(sc_sim.CreateNewTask("testTask", macros.sec2nano(1.0)))
+
+    test_module = ChangingCameraModule()
+    sc_sim.AddModelToTask("testTask", test_module)
+
+    minimum_record_time = macros.sec2nano(4.0)
+    msg_recorder = test_module.cameraOutMsg.recorder(minimum_record_time)
+    msg_recorder.recordOnChange()
+    sc_sim.AddModelToTask("testTask", msg_recorder)
+
+    sc_sim.InitializeSimulation()
+    sc_sim.ConfigureStopTime(macros.sec2nano(10.0))
+    sc_sim.ExecuteSimulation()
+
+    # cameraID changes at t = 5 s. With a 4 s minimum interval:
+    #   t = 0: recorded (cameraID = 0), next eligible = t = 4 s
+    #   t = 4: payload unchanged → skipped,  next eligible = t = 8 s
+    #   t = 8: payload changed (cameraID = 1) → recorded
+    expected_times = np.array([
+        macros.sec2nano(0.0),
+        macros.sec2nano(8.0),
+    ])
+    expected_camera_ids = np.array([0, 1])
+
+    np.testing.assert_array_equal(msg_recorder.times(), expected_times)
+    np.testing.assert_array_equal(msg_recorder.cameraID, expected_camera_ids)
+
+
+class ChangingCameraModule(sysModel.SysModel):
+    """Write a CameraImageMsgPayload whose cameraID steps up at a fixed simulation time."""
+
+    def __init__(self):
+        super().__init__()
+        self.cameraOutMsg = messaging.CameraImageMsg()
+        self.change_time = macros.sec2nano(5.0)
+
+    def Reset(self, CurrentSimNanos):
+        self._write(CurrentSimNanos)
+
+    def UpdateState(self, CurrentSimNanos):
+        self._write(CurrentSimNanos)
+
+    def _write(self, CurrentSimNanos):
+        payload = self.cameraOutMsg.zeroMsgPayload
+        payload.cameraID = 1 if CurrentSimNanos >= self.change_time else 0
+        payload.valid = 1
+        self.cameraOutMsg.write(payload, CurrentSimNanos, self.moduleID)
+
+
+class ChangingPayloadModule(sysModel.SysModel):
+    """Write a payload that changes at fixed simulation times."""
+
+    def __init__(self):
+        super().__init__()
+        self.dataOutMsg = messaging.CModuleTemplateMsg()
+        self.first_change_time = macros.sec2nano(5.0)  # [ns]
+        self.second_change_time = macros.sec2nano(9.0)  # [ns]
+
+    def Reset(self, CurrentSimNanos):
+        self.write_payload(CurrentSimNanos)
+
+    def UpdateState(self, CurrentSimNanos):
+        self.write_payload(CurrentSimNanos)
+
+    def write_payload(self, CurrentSimNanos):
+        payload_value = 0
+        if CurrentSimNanos >= self.first_change_time:
+            payload_value = 1
+        if CurrentSimNanos >= self.second_change_time:
+            payload_value = 2
+
+        payload = self.dataOutMsg.zeroMsgPayload
+        payload.dataVector = np.array([
+            payload_value,
+            0,
+            0,
+        ])
+        self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
+
+
 if __name__ == "__main__":
     test_update_time_interval()
+    test_record_on_change()
+    test_record_on_change_update_time_interval_after_skipped_record()
+    test_record_on_change_unsupported_payload()
+    test_record_on_change_camera_image_payload()

--- a/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
+++ b/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
@@ -1,0 +1,145 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+"""Unit tests for ``generatePayloadEqualityHeader.py``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "msgAutoSource"))
+from generatePayloadEqualityHeader import generateEqualityHeader
+
+
+def test_payload_equality_generates_fixed_array_comparison():
+    """Generated equality compares fixed numeric array payloads element-wise."""
+
+    meta = {
+        "fields": [
+            {
+                "name": "dataVector",
+                "kind": "array",
+                "shape": [3],
+                "element": {"kind": "primitive", "ctype": "double"},
+            },
+        ],
+    }
+
+    generated = generateEqualityHeader(meta, "CModuleTemplateMsgPayload", "msgPayloadDefC")
+
+    assert generated is not None
+    assert "std::memcmp" not in generated
+    assert "struct PayloadEqualityTraits<CModuleTemplateMsgPayload>" in generated
+    assert '#include "architecture/msgPayloadDefC/CModuleTemplateMsgPayload.h"' in generated
+    assert "static constexpr bool supported = true" in generated
+    assert "for (int i0 = 0; i0 < 3; ++i0)" in generated
+    assert "if (!(lhs.dataVector[i0] == rhs.dataVector[i0]))" in generated
+    assert "return true;" in generated
+
+
+def test_payload_equality_generates_nested_struct_comparison():
+    """Generated equality walks nested struct arrays field by field."""
+
+    meta = {
+        "fields": [
+            {
+                "name": "reactionWheels",
+                "kind": "array",
+                "shape": [36],
+                "element": {
+                    "kind": "struct",
+                    "typeName": "RWConfigElementMsgPayload",
+                    "fields": [
+                        {
+                            "name": "gsHat_B",
+                            "kind": "array",
+                            "shape": [3],
+                            "element": {"kind": "primitive", "ctype": "double"},
+                        },
+                        {"name": "Js", "kind": "primitive", "ctype": "double"},
+                    ],
+                },
+            },
+        ],
+    }
+
+    generated = generateEqualityHeader(meta, "RWConstellationMsgPayload", "msgPayloadDefC")
+
+    assert generated is not None
+    assert "for (int i0 = 0; i0 < 36; ++i0)" in generated
+    assert "for (int i1 = 0; i1 < 3; ++i1)" in generated
+    assert "lhs.reactionWheels[i0].gsHat_B[i1] == rhs.reactionWheels[i0].gsHat_B[i1]" in generated
+    assert "lhs.reactionWheels[i0].Js == rhs.reactionWheels[i0].Js" in generated
+    assert "return true;" in generated
+
+
+def test_payload_equality_generates_eigen_comparison():
+    """Generated equality compares Eigen dimensions and coefficients."""
+
+    meta = {
+        "fields": [
+            {"name": "qpos", "kind": "unknown", "ctype": "Eigen::VectorXd"},
+        ],
+    }
+
+    generated = generateEqualityHeader(meta, "MJSceneStateMsgPayload", "msgPayloadDefCpp")
+
+    assert generated is not None
+    assert "lhs.qpos.rows() != rhs.qpos.rows()" in generated
+    assert "lhs.qpos.cols() != rhs.qpos.cols()" in generated
+    assert "if ((lhs.qpos.array() != rhs.qpos.array()).any())" in generated
+    assert "return true;" in generated
+
+
+def test_payload_equality_uses_operator_equal_for_safe_stl_fields():
+    """Generated equality uses ``operator==`` for supported STL payload fields."""
+
+    meta = {
+        "fields": [
+            {"name": "keyboardInput", "kind": "unknown", "ctype": "std::string"},
+            {"name": "samples", "kind": "unknown", "ctype": "std::vector<double>"},
+        ],
+    }
+
+    generated = generateEqualityHeader(meta, "StringVectorMsgPayload", "msgPayloadDefCpp")
+
+    assert generated is not None
+    assert "if (!(lhs.keyboardInput == rhs.keyboardInput))" in generated
+    assert "if (!(lhs.samples == rhs.samples))" in generated
+    assert "return true;" in generated
+
+
+def test_payload_equality_returns_none_for_unsupported_fields():
+    """Payloads with pointer or unsupported fields return None — no specialization generated."""
+
+    meta = {
+        "fields": [
+            {"name": "frameNumber", "kind": "primitive", "ctype": "int"},
+            {"name": "imagePointer", "kind": "pointer", "ctype": "void *"},
+            {
+                "name": "vizEventReplies",
+                "kind": "unknown",
+                "ctype": "std::vector<VizEventReply>",
+            },
+            {"name": "lateField", "kind": "primitive", "ctype": "int"},
+        ],
+    }
+
+    generated = generateEqualityHeader(meta, "VizUserInputMsgPayload", "msgPayloadDefCpp")
+
+    assert generated is None

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -316,7 +316,7 @@ public:
             this->msgRecordTimes.push_back(CurrentSimNanos);
             this->msgWrittenTimes.push_back(this->readMessage.timeWritten());
             this->msgRecord.push_back(this->readMessage());
-            this->nextUpdateTime += this->timeInterval;
+            this->nextUpdateTime = CurrentSimNanos + this->timeInterval;
         }
     };
     //! Reset method
@@ -366,6 +366,9 @@ public:
     //! method to update the minimum time interval before recording the next message
     void updateTimeInterval(uint64_t timeDiff) {
         this->timeInterval = timeDiff;
+        if (!this->msgRecordTimes.empty()) {
+            this->nextUpdateTime = this->msgRecordTimes.back() + this->timeInterval;
+        }
     };
 
 private:
@@ -373,7 +376,7 @@ private:
     std::vector<uint64_t> msgRecordTimes;         //!< vector of times at which messages are recorded
     std::vector<uint64_t> msgWrittenTimes;        //!< vector of times at which messages are written
     uint64_t nextUpdateTime = 0;                  //!< [ns] earliest time at which the msg is recorded again
-    uint64_t timeInterval;                        //!< [ns] recording time intervale
+    uint64_t timeInterval;                        //!< [ns] recording time interval
 
 private:
     ReadFunctor<messageType> readMessage;   //!< method description

--- a/src/architecture/messaging/messaging.h
+++ b/src/architecture/messaging/messaging.h
@@ -23,6 +23,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #include "architecture/utilities/bskLogging.h"
 #include <typeinfo>
 #include <stdlib.h>
+#include "architecture/messaging/payloadEqualityTraits.h"
 
 /*! forward-declare sim message for use by read functor */
 template<typename messageType>
@@ -308,15 +309,15 @@ public:
         if (CurrentSimNanos >= this->nextUpdateTime) {
             // Log warning if message is invalid but don't change behavior
             if (!this->readMessage.isLinked() || !this->readMessage.isWritten()) {
-                messageType var;
-                bskLogger.bskLog(BSK_WARNING, "Recording message of type %s that is not properly initialized or written", typeid(var).name());
+                this->logInvalidMessageWarning();
             }
 
-            // Record the message
-            this->msgRecordTimes.push_back(CurrentSimNanos);
-            this->msgWrittenTimes.push_back(this->readMessage.timeWritten());
-            this->msgRecord.push_back(this->readMessage());
-            this->nextUpdateTime = CurrentSimNanos + this->timeInterval;
+            const messageType& messageData = this->readMessage();
+            if (!this->recordOnlyOnChange || this->messagePayloadChanged(messageData)) {
+                this->recordMessage(CurrentSimNanos, messageData);
+            } else {
+                this->scheduleNextUpdate(CurrentSimNanos);
+            }
         }
     };
     //! Reset method
@@ -325,6 +326,7 @@ public:
         this->msgRecordTimes.clear();
         this->msgWrittenTimes.clear();
         this->nextUpdateTime = CurrentSimNanos;
+        this->hasLastUpdateTime = false;
     };
     //! time recorded method
     std::vector<uint64_t>& times(){return this->msgRecordTimes;}
@@ -366,9 +368,24 @@ public:
     //! method to update the minimum time interval before recording the next message
     void updateTimeInterval(uint64_t timeDiff) {
         this->timeInterval = timeDiff;
-        if (!this->msgRecordTimes.empty()) {
-            this->nextUpdateTime = this->msgRecordTimes.back() + this->timeInterval;
+        if (this->hasLastUpdateTime) {
+            this->nextUpdateTime = this->lastUpdateTime + this->timeInterval;
         }
+    };
+
+    //! method to record messages only when the payload content changes
+    void recordOnChange(bool enabled = true) {
+        if constexpr (!supportsPayloadEquality<messageType>()) {
+            if (enabled) {
+                bskLogger.bskLog(BSK_ERROR,
+                    "Recorder::recordOnChange() called for a payload type that does not "
+                    "support equality comparison. Add a PayloadEqualityTraits<messageType> "
+                    "specialization in the payload header file (guarded by #ifdef __cplusplus), "
+                    "or check whether generatePayloadEqualityHeader.py can cover all fields.");
+                return;
+            }
+        }
+        this->recordOnlyOnChange = enabled;
     };
 
 private:
@@ -377,8 +394,40 @@ private:
     std::vector<uint64_t> msgWrittenTimes;        //!< vector of times at which messages are written
     uint64_t nextUpdateTime = 0;                  //!< [ns] earliest time at which the msg is recorded again
     uint64_t timeInterval;                        //!< [ns] recording time interval
+    uint64_t lastUpdateTime = 0;                  //!< [ns] last time the msg was checked for recording
+    bool hasLastUpdateTime = false;               //!< flag indicating whether the msg was checked
+    bool recordOnlyOnChange = false;              //!< flag to record only changed message payloads
 
 private:
+    //! log warning if message is invalid but don't change behavior
+    void logInvalidMessageWarning(){
+        messageType var;
+        bskLogger.bskLog(BSK_WARNING, "Recording message of type %s that is not properly initialized or written", typeid(var).name());
+    };
+
+    //! record the supplied message payload
+    void recordMessage(uint64_t CurrentSimNanos, const messageType& messageData){
+        this->msgRecordTimes.push_back(CurrentSimNanos);
+        this->msgWrittenTimes.push_back(this->readMessage.timeWritten());
+        this->msgRecord.push_back(messageData);
+        this->scheduleNextUpdate(CurrentSimNanos);
+    };
+
+    //! schedule the next eligible recorder update
+    void scheduleNextUpdate(uint64_t CurrentSimNanos){
+        this->lastUpdateTime = CurrentSimNanos;
+        this->hasLastUpdateTime = true;
+        this->nextUpdateTime = CurrentSimNanos + this->timeInterval;
+    };
+
+    //! check if the payload differs from the last recorded payload
+    bool messagePayloadChanged(const messageType& messageData){
+        if constexpr (supportsPayloadEquality<messageType>()) {
+            return this->msgRecord.empty() || !payloadsAreEqual(messageData, this->msgRecord.back());
+        }
+        return true;
+    };
+
     ReadFunctor<messageType> readMessage;   //!< method description
 };
 

--- a/src/architecture/messaging/msgAutoSource/generatePayloadEqualityHeader.py
+++ b/src/architecture/messaging/msgAutoSource/generatePayloadEqualityHeader.py
@@ -1,0 +1,167 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+from __future__ import annotations
+
+import json
+import sys
+
+from generateSWIGModules import C_TYPE_TO_NPY_ENUM, _INT_CTYPES, _FLOAT_CTYPES
+
+
+def _normalizedTypeName(typeName: str) -> str:
+    return "".join(typeName.split())
+
+
+def _canUseOperatorEqual(typeName: str) -> bool:
+    typeName = _normalizedTypeName(typeName)
+    if typeName in C_TYPE_TO_NPY_ENUM or typeName in _INT_CTYPES or typeName in _FLOAT_CTYPES:
+        return True
+    if typeName in {"bool", "std::string"}:
+        return True
+    if typeName.startswith("std::vector<") and typeName.endswith(">"):
+        return _canUseOperatorEqual(typeName[len("std::vector<"):-1])
+    return False
+
+
+def _appendPayloadComparison(
+    lines: list[str],
+    field: dict,
+    lhsExpr: str,
+    rhsExpr: str,
+    indent: str = "        ",
+    loopDepth: int = 0,
+) -> bool:
+    """Append C++ statements comparing a field. Returns False if the field is unsupported."""
+    kind = field["kind"]
+
+    if kind in ("primitive", "enum"):
+        lines.append(f"{indent}if (!({lhsExpr} == {rhsExpr})) {{")
+        lines.append(f"{indent}    return false;")
+        lines.append(f"{indent}}}")
+        return True
+
+    if kind == "array":
+        lhsElement = lhsExpr
+        rhsElement = rhsExpr
+        for dimOffset, dim in enumerate(field["shape"]):
+            loopIndex = f"i{loopDepth + dimOffset}"
+            lines.append(f"{indent}for (int {loopIndex} = 0; {loopIndex} < {dim}; ++{loopIndex}) {{")
+            indent += "    "
+            lhsElement += f"[{loopIndex}]"
+            rhsElement += f"[{loopIndex}]"
+        allSupported = _appendPayloadComparison(
+            lines, field["element"], lhsElement, rhsElement, indent,
+            loopDepth + len(field["shape"]),
+        )
+        for _ in field["shape"]:
+            indent = indent[:-4]
+            lines.append(f"{indent}}}")
+        return allSupported
+
+    if kind == "struct":
+        for subfield in field.get("fields", []):
+            name = subfield["name"]
+            if not _appendPayloadComparison(
+                lines, subfield,
+                f"{lhsExpr}.{name}", f"{rhsExpr}.{name}",
+                indent, loopDepth,
+            ):
+                return False
+        return True
+
+    if kind == "unknown":
+        typeName = field.get("ctype", "")
+        if _normalizedTypeName(typeName).startswith("Eigen::"):
+            rowCheck = f"{lhsExpr}.rows() != {rhsExpr}.rows()"
+            colCheck = f"{lhsExpr}.cols() != {rhsExpr}.cols()"
+            lines.append(f"{indent}if ({rowCheck} || {colCheck}) {{")
+            lines.append(f"{indent}    return false;")
+            lines.append(f"{indent}}}")
+            lines.append(f"{indent}if (({lhsExpr}.array() != {rhsExpr}.array()).any()) {{")
+            lines.append(f"{indent}    return false;")
+            lines.append(f"{indent}}}")
+            return True
+        if _canUseOperatorEqual(typeName):
+            lines.append(f"{indent}if (!({lhsExpr} == {rhsExpr})) {{")
+            lines.append(f"{indent}    return false;")
+            lines.append(f"{indent}}}")
+            return True
+
+    return False  # pointer or unsupported unknown type
+
+
+def generateEqualityHeader(meta: dict, payloadType: str, searchDir: str) -> str | None:
+    """
+    Generate a C++ header with a PayloadEqualityTraits<payloadType> specialization.
+
+    Returns the header text when all fields are supported, or None when any field is
+    unsupported (e.g., raw pointers). Callers should write a comment-only placeholder
+    when None is returned so CMake custom_command outputs are always satisfied.
+    """
+    bodyLines: list[str] = []
+    for field in meta.get("fields", []):
+        if not _appendPayloadComparison(bodyLines, field, f"lhs.{field['name']}", f"rhs.{field['name']}"):
+            return None
+
+    lines = [
+        "// AUTO-GENERATED — DO NOT EDIT",
+        "#pragma once",
+        '#include "architecture/messaging/payloadEqualityTraits.h"',
+        f'#include "architecture/{searchDir}/{payloadType}.h"',
+        "",
+        "template<>",
+        f"struct PayloadEqualityTraits<{payloadType}> {{",
+        "    static constexpr bool supported = true;",
+        f"    static bool equal(const {payloadType}& lhs, const {payloadType}& rhs) {{",
+    ]
+    lines.extend(bodyLines)
+    lines += [
+        "        return true;",
+        "    }",
+        "};",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    outputPath = sys.argv[1]
+    metaJsonPath = sys.argv[2]
+    payloadTypeName = sys.argv[3]
+    searchDir = sys.argv[4]
+
+    with open(metaJsonPath) as f:
+        meta = json.load(f)
+
+    content = generateEqualityHeader(meta, payloadTypeName, searchDir)
+
+    with open(outputPath, "w") as f:
+        if content is not None:
+            f.write(content)
+        else:
+            # Always write the output file so CMake's custom_command output is satisfied.
+            # Payloads with unsupported fields should define a manual specialization
+            # in their header file, guarded by #ifdef __cplusplus.
+            f.write(
+                "// AUTO-GENERATED — DO NOT EDIT\n"
+                "#pragma once\n"
+                f"// No PayloadEqualityTraits specialization for {payloadTypeName}:\n"
+                "// one or more fields have unsupported types (e.g., raw pointers).\n"
+                "// To support recordOnChange() for this payload, add a manual\n"
+                f"// PayloadEqualityTraits<{payloadTypeName}> specialization\n"
+                "// in the payload header file, guarded by #ifdef __cplusplus.\n"
+            )

--- a/src/architecture/messaging/msgAutoSource/generatePayloadEqualityHeader.py
+++ b/src/architecture/messaging/msgAutoSource/generatePayloadEqualityHeader.py
@@ -163,5 +163,6 @@ if __name__ == "__main__":
                 "// one or more fields have unsupported types (e.g., raw pointers).\n"
                 "// To support recordOnChange() for this payload, add a manual\n"
                 f"// PayloadEqualityTraits<{payloadTypeName}> specialization\n"
-                "// in the payload header file, guarded by #ifdef __cplusplus.\n"
+                "// in the payload header file, guarded by #ifdef __cplusplus, only\n"
+                "// when the comparison semantics can be defined safely.\n"
             )

--- a/src/architecture/messaging/payloadEqualityTraits.h
+++ b/src/architecture/messaging/payloadEqualityTraits.h
@@ -24,7 +24,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  *  To enable recordOnChange() for a payload type, provide a specialization either:
  *   - automatically, via generatePayloadEqualityHeader.py (for fully-supported struct fields), or
  *   - manually, as a PayloadEqualityTraits<T> specialization in the payload header file
- *     (guarded by \#ifdef __cplusplus).
+ *     (guarded by \#ifdef __cplusplus) when the comparison semantics can be defined safely.
  */
 template<typename T>
 struct PayloadEqualityTraits {

--- a/src/architecture/messaging/payloadEqualityTraits.h
+++ b/src/architecture/messaging/payloadEqualityTraits.h
@@ -1,0 +1,65 @@
+/*
+ISC License
+
+Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+Permission to use, copy, modify, and/or distribute this software for any
+        purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+        ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+        OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef PAYLOAD_EQUALITY_TRAITS_H
+#define PAYLOAD_EQUALITY_TRAITS_H
+
+/*! Primary template: equality comparison not supported for this payload type by default.
+ *
+ *  To enable recordOnChange() for a payload type, provide a specialization either:
+ *   - automatically, via generatePayloadEqualityHeader.py (for fully-supported struct fields), or
+ *   - manually, as a PayloadEqualityTraits<T> specialization in the payload header file
+ *     (guarded by \#ifdef __cplusplus).
+ */
+template<typename T>
+struct PayloadEqualityTraits {
+    /// @brief Indicates whether equality comparison is supported for this payload type.
+    static constexpr bool supported = false;
+};
+
+/*! Returns true if a field-wise equality comparison is defined for payload type T. */
+template<typename T>
+constexpr bool supportsPayloadEquality() noexcept {
+    return PayloadEqualityTraits<T>::supported;
+}
+
+/*! Compare two payloads field-wise.
+ *
+ *  Will not compile for payload types that lack a PayloadEqualityTraits<T> specialization.
+ *  Guard calls with supportsPayloadEquality<T>() via if constexpr, or add a specialization.
+ */
+template<typename T>
+bool payloadsAreEqual(const T& lhs, const T& rhs) {
+    static_assert(
+        PayloadEqualityTraits<T>::supported,
+        "payloadsAreEqual: no equality comparison is defined for this payload type. "
+        "Add a PayloadEqualityTraits<T> specialization in the payload header file "
+        "(guarded by #ifdef __cplusplus), or check whether generatePayloadEqualityHeader.py "
+        "can cover all fields automatically."
+    );
+    return PayloadEqualityTraits<T>::equal(lhs, rhs);
+}
+
+// Auto-generated specializations, produced by generatePayloadEqualityHeader.py for each
+// fully-supported payload type, and aggregated into payloadEquality_generated.h at build time.
+// The __has_include guard prevents a hard failure during IDE indexing before the first build.
+#if __has_include("payloadEquality_generated.h")
+#  include "payloadEquality_generated.h"
+#endif
+
+#endif /* PAYLOAD_EQUALITY_TRAITS_H */

--- a/src/architecture/msgPayloadDefC/CameraImageMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/CameraImageMsgPayload.h
@@ -36,24 +36,30 @@ typedef struct {
     int8_t imageType;         //!< -- Number of channels in each pixel, RGB = 3, RGBA = 4
 }CameraImageMsgPayload;
 
-#ifdef __cplusplus
-#include <cstring>
+#if defined(__cplusplus) && !defined(SWIG)
 #include "architecture/messaging/payloadEqualityTraits.h"
 
+/*! @brief Enable shallow payload equality for CameraImageMsgPayload.
+ *
+ * The image pointer is compared by address only.  The recorder stores this
+ * payload structure, but it does not deep-copy or compare the pointed-to image
+ * buffer.  Thus, recordOnChange() detects changes in image metadata, such as
+ * timeTag, cameraID, imageBufferLength, imageType, valid, or imagePointer
+ * address, but it does not detect in-place changes to image bytes behind a
+ * reused imagePointer.
+ */
 template<>
 struct PayloadEqualityTraits<CameraImageMsgPayload> {
     static constexpr bool supported = true;
     static bool equal(const CameraImageMsgPayload& lhs, const CameraImageMsgPayload& rhs) {
-        if (lhs.timeTag != rhs.timeTag)                     return false;
-        if (lhs.valid != rhs.valid)                         return false;
-        if (lhs.cameraID != rhs.cameraID)                   return false;
-        if (lhs.imageType != rhs.imageType)                 return false;
-        if (lhs.imageBufferLength != rhs.imageBufferLength) return false;
-        if (lhs.imagePointer == rhs.imagePointer)           return true;
-        if (!lhs.imagePointer || !rhs.imagePointer)         return false;
-        return std::memcmp(lhs.imagePointer, rhs.imagePointer, lhs.imageBufferLength) == 0;
+        return lhs.timeTag == rhs.timeTag
+            && lhs.valid == rhs.valid
+            && lhs.cameraID == rhs.cameraID
+            && lhs.imagePointer == rhs.imagePointer
+            && lhs.imageBufferLength == rhs.imageBufferLength
+            && lhs.imageType == rhs.imageType;
     }
 };
-#endif /* __cplusplus */
+#endif /* defined(__cplusplus) && !defined(SWIG) */
 
 #endif

--- a/src/architecture/msgPayloadDefC/CameraImageMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/CameraImageMsgPayload.h
@@ -36,5 +36,24 @@ typedef struct {
     int8_t imageType;         //!< -- Number of channels in each pixel, RGB = 3, RGBA = 4
 }CameraImageMsgPayload;
 
+#ifdef __cplusplus
+#include <cstring>
+#include "architecture/messaging/payloadEqualityTraits.h"
+
+template<>
+struct PayloadEqualityTraits<CameraImageMsgPayload> {
+    static constexpr bool supported = true;
+    static bool equal(const CameraImageMsgPayload& lhs, const CameraImageMsgPayload& rhs) {
+        if (lhs.timeTag != rhs.timeTag)                     return false;
+        if (lhs.valid != rhs.valid)                         return false;
+        if (lhs.cameraID != rhs.cameraID)                   return false;
+        if (lhs.imageType != rhs.imageType)                 return false;
+        if (lhs.imageBufferLength != rhs.imageBufferLength) return false;
+        if (lhs.imagePointer == rhs.imagePointer)           return true;
+        if (!lhs.imagePointer || !rhs.imagePointer)         return false;
+        return std::memcmp(lhs.imagePointer, rhs.imagePointer, lhs.imageBufferLength) == 0;
+    }
+};
+#endif /* __cplusplus */
 
 #endif

--- a/src/fswAlgorithms/fswUtilities/fswDefinitions.h
+++ b/src/fswAlgorithms/fswUtilities/fswDefinitions.h
@@ -18,7 +18,7 @@
  */
 /*
 * ADCSDefinitions.h
-* 
+*
 * Provide generation defintions related to the ADCS Algorithms
 *
 * University of Colorado, Autonomous Vehicle Systems (AVS) Lab
@@ -30,10 +30,18 @@
 
 
 /* Boolean Definition */
+#ifdef __APPLE__
+/* <mach/boolean.h> defines boolean_t and is idempotent; including it here
+ * prevents a redefinition conflict when system headers pull it in later. */
+#  include <mach/boolean.h>
+#  define BOOL_FALSE 0
+#  define BOOL_TRUE  1
+#else
 typedef enum {
     BOOL_FALSE = 0,
     BOOL_TRUE
 } boolean_t;
+#endif
 
 /*! @brief Structure used to define the output definition for component availability */
  typedef enum {


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR improves message recorder behavior in two ways.

First, recorders now reschedule the next recording opportunity when `updateTimeInterval()` is called after stopping a simulation and before continuing it. The next update time is recomputed from the last actual record time plus the new interval.

Second, this adds `recordOnChange()` support. When enabled, the recorder still respects `minUpdateTime`, but only stores an eligible sample if the payload differs from the last recorded payload. Payload comparison is generated field-by-field in the SWIG message generation path using C++17-compatible code, avoiding raw `memcmp()` and conservatively treating unsupported fields as changed.

## Verification
Added recorder tests covering:
- changing `minUpdateTime` between simulation runs
- recording only changed payloads after the minimum update time has elapsed

Added generator tests covering payload equality generation for:
- fixed numeric arrays
- nested struct arrays
- Eigen fields
- supported STL fields
- unsupported fields that conservatively record

Local checks run:
- `.venv/bin/pytest src/architecture/messaging/_UnitTest/test_generateSWIGModules.py`
- `git diff --check`

The full clean build / full messaging integration test should be run before merge.

## Documentation
Updated recorder documentation in `docs/source/Learn/bskPrinciples/bskPrinciples-4.rst` to describe:
- changing recorder update intervals between simulation runs
- using `recordOnChange()`
- `minUpdateTime` still being respected in change-only mode

Added a release note snippet:
`docs/source/Support/bskReleaseNotesSnippets/recorder-update-time-interval.rst`

## Future work
No required follow-up. If change-only recording is later needed for payloads with unsupported custom STL member types, those payload comparisons can be expanded beyond the current conservative “record as changed” fallback.
