### PR TITLE
Add joint array reference generation module

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1386-joint-array-ref-profiler.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1386-joint-array-ref-profiler.rst
@@ -1,0 +1,1 @@
+- Added the :ref:`jointArrayRefProfiler` device-interface module to generate low-pass or time-profiled joint angle, rate, and acceleration references from scalar joint state inputs and a desired joint-array command.

--- a/src/simulation/deviceInterface/jointArrayRefProfiler/_UnitTest/test_jointArrayRefProfiler.py
+++ b/src/simulation/deviceInterface/jointArrayRefProfiler/_UnitTest/test_jointArrayRefProfiler.py
@@ -1,0 +1,425 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import numpy as np
+
+from Basilisk.architecture import messaging
+from Basilisk.simulation import jointArrayRefProfiler
+from Basilisk.utilities import macros
+
+
+JOINT_ANGLES = np.array([0.1, 0.2, -0.3])  # [rad]
+JOINT_RATES = np.array([0.05, -0.07, 0.04])  # [rad/s]
+DES_JOINT_ANGLES = np.array([1.0, -1.0, 1.5])  # [rad]
+DES_JOINT_RATES = np.zeros(3)  # [rad/s]
+DES_JOINT_ACCELS = np.zeros(3)  # [rad/s^2]
+
+
+def setup_joint_array_ref_profiler(profile_type: str):
+    """Create a jointArrayRefProfiler module with three joint inputs."""
+    module = jointArrayRefProfiler.JointArrayRefProfiler()
+    module.setProfileType(profile_type)
+    joint_state_in_msgs = []
+    joint_state_dot_in_msgs = []
+
+    for i in range(3):
+        module.addHingedJoint()
+
+        joint_state_in = messaging.ScalarJointStateMsgPayload()
+        joint_state_in.state = JOINT_ANGLES[i]
+        joint_state_in_msg = messaging.ScalarJointStateMsg().write(joint_state_in)
+        module.jointStatesInMsgs[i].subscribeTo(joint_state_in_msg)
+        joint_state_in_msgs.append(joint_state_in_msg)
+
+        joint_state_dot_in = messaging.ScalarJointStateMsgPayload()
+        joint_state_dot_in.state = JOINT_RATES[i]
+        joint_state_dot_in_msg = messaging.ScalarJointStateMsg().write(joint_state_dot_in)
+        module.jointStateDotsInMsgs[i].subscribeTo(joint_state_dot_in_msg)
+        joint_state_dot_in_msgs.append(joint_state_dot_in_msg)
+
+    des_payload = messaging.JointArrayStateMsgPayload()
+    des_payload.states.clear()
+    des_payload.stateDots.clear()
+    des_payload.stateDDots.clear()
+    for value in DES_JOINT_ANGLES:
+        des_payload.states.push_back(float(value))
+    for value in DES_JOINT_RATES:
+        des_payload.stateDots.push_back(float(value))
+    for value in DES_JOINT_ACCELS:
+        des_payload.stateDDots.push_back(float(value))
+    des_msg = messaging.JointArrayStateMsg().write(des_payload)
+    module.desJointStatesInMsg.subscribeTo(des_msg)
+
+    return module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg
+
+def test_joint_array_ref_profiler_filter():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`jointArrayRefProfiler.JointArrayRefProfiler` can be
+    constructed from the standard ``Basilisk.simulation`` import path and
+    that the low pass filter mode works correctly.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the outputs of ``desJointStatesOutMsg`` when using
+    the low pass filter mode.
+    """
+
+    # Set up the module and its parameters
+    module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg = setup_joint_array_ref_profiler("lowPass")
+    filter_dt = 0.1  # [s]
+    module.setFilterDt(filter_dt)  # [s]
+    filter_cutoff_freq = 0.5  # [Hz]
+    wc = 2.0 * np.pi * filter_cutoff_freq  # [rad/s]
+    module.setWc(wc)  # [rad/s]
+
+    module.Reset(0)
+    module.UpdateState(0)
+
+    refOut = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(refOut.states, JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(refOut.stateDots, JOINT_RATES)  # [rad/s]
+    np.testing.assert_allclose(refOut.stateDDots, np.zeros(3))  # [rad/s^2]
+
+    module.UpdateState(macros.sec2nano(filter_dt))
+
+    refOut = module.desJointStatesOutMsg.read()
+    beta = 1.0 - np.exp(-wc * filter_dt)
+    refAngles = np.zeros(3)
+    refRates = np.zeros(3)
+    refAccels = np.zeros(3)
+    for i in range(3):
+        refAngles[i] = JOINT_ANGLES[i] + beta * (DES_JOINT_ANGLES[i] - JOINT_ANGLES[i])
+        refRates[i] = (refAngles[i] - JOINT_ANGLES[i]) / filter_dt
+        refAccels[i] = (refRates[i] - JOINT_RATES[i]) / filter_dt
+    np.testing.assert_allclose(refOut.states, refAngles)  # [rad]
+    np.testing.assert_allclose(refOut.stateDots, refRates)  # [rad/s]
+    np.testing.assert_allclose(refOut.stateDDots, refAccels)  # [rad/s^2]
+
+    module.UpdateState(macros.sec2nano(2.0 * filter_dt))
+
+    refOut = module.desJointStatesOutMsg.read()
+    prev_ref_angles = refAngles.copy()
+    prev_ref_rates = refRates.copy()
+    for i in range(3):
+        refAngles[i] = prev_ref_angles[i] + beta * (DES_JOINT_ANGLES[i] - prev_ref_angles[i])
+        refRates[i] = (refAngles[i] - prev_ref_angles[i]) / filter_dt
+        refAccels[i] = (refRates[i] - prev_ref_rates[i]) / filter_dt
+    np.testing.assert_allclose(refOut.states, refAngles)  # [rad]
+    np.testing.assert_allclose(refOut.stateDots, refRates)  # [rad/s]
+    np.testing.assert_allclose(refOut.stateDDots, refAccels)  # [rad/s^2]
+
+
+def test_joint_array_ref_profiler_linear():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`jointArrayRefProfiler.JointArrayRefProfiler` can be
+    constructed from the standard ``Basilisk.simulation`` import path and
+    that the linear profile mode works correctly.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the outputs of ``desJointStatesOutMsg`` when using
+    the linear profile mode at the start of the profile, during the profile,
+    and after the profile completes.
+    """
+
+    module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg = setup_joint_array_ref_profiler("linear")
+    profile_duration = 0.4  # [s]
+    module.setProfileDuration(profile_duration)  # [s]
+
+    module.Reset(0)
+
+    module.UpdateState(0)
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, (DES_JOINT_ANGLES - JOINT_ANGLES) / profile_duration)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+    mid_time = profile_duration / 2.0  # [s]
+    module.UpdateState(macros.sec2nano(mid_time))
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, JOINT_ANGLES + (DES_JOINT_ANGLES - JOINT_ANGLES) * mid_time / profile_duration)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, (DES_JOINT_ANGLES - JOINT_ANGLES) / profile_duration)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+    module.UpdateState(macros.sec2nano(profile_duration + 0.1))  # [s]
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, DES_JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, np.zeros(3))  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+
+def test_joint_array_ref_profiler_cubic():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`jointArrayRefProfiler.JointArrayRefProfiler` can be
+    constructed from the standard ``Basilisk.simulation`` import path and
+    that the cubic profile mode works correctly.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the outputs of ``desJointStatesOutMsg`` when using
+    the cubic profile mode at the start of the profile, during the profile,
+    and after the profile completes.
+    """
+
+    module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg = setup_joint_array_ref_profiler("cubic")
+    profile_duration = 0.4  # [s]
+    module.setProfileDuration(profile_duration)  # [s]
+
+    module.Reset(0)
+
+    module.UpdateState(0)
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, JOINT_RATES)  # [rad/s]
+    expected_accels = np.zeros(3)
+    for i in range(3):
+        expected_accels[i] = (
+            2.0 * ((3.0 * (DES_JOINT_ANGLES[i] - JOINT_ANGLES[i])) / (profile_duration ** 2)
+            - (2.0 * JOINT_RATES[i]) / profile_duration)
+        )
+    np.testing.assert_allclose(ref_out.stateDDots, expected_accels)  # [rad/s^2]
+
+    tau = profile_duration / 2.0  # [s]
+    module.UpdateState(macros.sec2nano(tau))
+    ref_out = module.desJointStatesOutMsg.read()
+    expected_angles = np.zeros(3)
+    expected_rates = np.zeros(3)
+    expected_accels = np.zeros(3)
+    for i in range(3):
+        theta0 = JOINT_ANGLES[i]
+        thetaf = DES_JOINT_ANGLES[i]
+        theta_dot0 = JOINT_RATES[i]
+        a0 = theta0
+        a1 = theta_dot0
+        a2 = (3.0 * (thetaf - theta0)) / (profile_duration ** 2) - (2.0 * theta_dot0) / profile_duration
+        a3 = -(2.0 * (thetaf - theta0)) / (profile_duration ** 3) + theta_dot0 / (profile_duration ** 2)
+        expected_angles[i] = a0 + a1 * tau + a2 * tau ** 2 + a3 * tau ** 3
+        expected_rates[i] = a1 + 2.0 * a2 * tau + 3.0 * a3 * tau ** 2
+        expected_accels[i] = 2.0 * a2 + 6.0 * a3 * tau
+    np.testing.assert_allclose(ref_out.states, expected_angles)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, expected_rates)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, expected_accels)  # [rad/s^2]
+
+    module.UpdateState(macros.sec2nano(profile_duration + 0.1))  # [s]
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, DES_JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, np.zeros(3))  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+
+def test_joint_array_ref_profiler_quintic():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`jointArrayRefProfiler.JointArrayRefProfiler` can be
+    constructed from the standard ``Basilisk.simulation`` import path and
+    that the quintic profile mode works correctly.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the outputs of ``desJointStatesOutMsg`` when using
+    the quintic profile mode at the start of the profile, during the profile,
+    and after the profile completes.
+    """
+
+    module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg = setup_joint_array_ref_profiler("quintic")
+    profile_duration = 0.4  # [s]
+    module.setProfileDuration(profile_duration)  # [s]
+
+    module.Reset(0)
+
+    module.UpdateState(0)
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, JOINT_RATES)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+    tau = profile_duration / 2.0  # [s]
+    module.UpdateState(macros.sec2nano(tau))
+    ref_out = module.desJointStatesOutMsg.read()
+    expected_angles = np.zeros(3)
+    expected_rates = np.zeros(3)
+    expected_accels = np.zeros(3)
+    for i in range(3):
+        theta0 = JOINT_ANGLES[i]
+        thetaf = DES_JOINT_ANGLES[i]
+        theta_dot0 = JOINT_RATES[i]
+        delta_theta = thetaf - theta0
+        a0 = theta0
+        a1 = theta_dot0
+        a2 = 0.0
+        a3 = (20.0 * delta_theta - 12.0 * theta_dot0 * profile_duration) / (2.0 * profile_duration ** 3)
+        a4 = (-30.0 * delta_theta + 16.0 * theta_dot0 * profile_duration) / (2.0 * profile_duration ** 4)
+        a5 = (12.0 * delta_theta - 6.0 * theta_dot0 * profile_duration) / (2.0 * profile_duration ** 5)
+        expected_angles[i] = a0 + a1 * tau + a2 * tau ** 2 + a3 * tau ** 3 + a4 * tau ** 4 + a5 * tau ** 5
+        expected_rates[i] = a1 + 2.0 * a2 * tau + 3.0 * a3 * tau ** 2 + 4.0 * a4 * tau ** 3 + 5.0 * a5 * tau ** 4
+        expected_accels[i] = 2.0 * a2 + 6.0 * a3 * tau + 12.0 * a4 * tau ** 2 + 20.0 * a5 * tau ** 3
+    np.testing.assert_allclose(ref_out.states, expected_angles)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, expected_rates)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, expected_accels)  # [rad/s^2]
+
+    module.UpdateState(macros.sec2nano(profile_duration + 0.1))  # [s]
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, DES_JOINT_ANGLES)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, np.zeros(3))  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+
+def test_joint_array_ref_profiler_filter_reinitializes_on_new_command():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`jointArrayRefProfiler.JointArrayRefProfiler` can be
+    constructed from the standard ``Basilisk.simulation`` import path and
+    that the low pass filter mode reinitializes correctly when a new desired
+    joint state message is written after the filter has already stepped once.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the outputs of ``desJointStatesOutMsg`` when using
+    the low pass filter mode after a second desired joint state message is
+    written. The expected behavior is that the module reinitializes the
+    internal reference state to the current joint states instead of
+    continuing from the previous filtered reference.
+    """
+
+    module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg = setup_joint_array_ref_profiler("lowPass")
+    filter_dt = 0.1  # [s]
+    module.setFilterDt(filter_dt)  # [s]
+    filter_cutoff_freq = 0.5  # [Hz]
+    wc = 2.0 * np.pi * filter_cutoff_freq  # [rad/s]
+    module.setWc(wc)  # [rad/s]
+
+    module.Reset(0)
+    module.UpdateState(0)
+    module.UpdateState(macros.sec2nano(filter_dt))
+
+    new_joint_angles = np.array([0.3, -0.1, 0.8])  # [rad]
+    new_joint_rates = np.array([-0.02, 0.06, -0.01])  # [rad/s]
+    new_joint_state_in_msgs = []
+    new_joint_state_dot_in_msgs = []
+    for i in range(3):
+        joint_state_in = messaging.ScalarJointStateMsgPayload()
+        joint_state_in.state = new_joint_angles[i]
+        joint_state_in_msg = messaging.ScalarJointStateMsg().write(joint_state_in)
+        module.jointStatesInMsgs[i].subscribeTo(joint_state_in_msg)
+        new_joint_state_in_msgs.append(joint_state_in_msg)
+
+        joint_state_dot_in = messaging.ScalarJointStateMsgPayload()
+        joint_state_dot_in.state = new_joint_rates[i]
+        joint_state_dot_in_msg = messaging.ScalarJointStateMsg().write(joint_state_dot_in)
+        module.jointStateDotsInMsgs[i].subscribeTo(joint_state_dot_in_msg)
+        new_joint_state_dot_in_msgs.append(joint_state_dot_in_msg)
+
+    new_des_joint_angles = np.array([-0.4, 0.6, 0.9])  # [rad]
+    new_des_payload = messaging.JointArrayStateMsgPayload()
+    new_des_payload.states.clear()
+    new_des_payload.stateDots.clear()
+    new_des_payload.stateDDots.clear()
+    for value in new_des_joint_angles:
+        new_des_payload.states.push_back(float(value))
+    for value in DES_JOINT_RATES:
+        new_des_payload.stateDots.push_back(float(value))
+    for value in DES_JOINT_ACCELS:
+        new_des_payload.stateDDots.push_back(float(value))
+    new_des_msg = messaging.JointArrayStateMsg().write(new_des_payload, macros.sec2nano(2.0 * filter_dt))
+    module.desJointStatesInMsg.subscribeTo(new_des_msg)
+
+    module.UpdateState(macros.sec2nano(2.0 * filter_dt))
+
+    ref_out = module.desJointStatesOutMsg.read()
+    np.testing.assert_allclose(ref_out.states, new_joint_angles)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, new_joint_rates)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, np.zeros(3))  # [rad/s^2]
+
+
+def test_joint_array_ref_profiler_quintic_repeated_identical_writes():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :class:`jointArrayRefProfiler.JointArrayRefProfiler` can be
+    constructed from the standard ``Basilisk.simulation`` import path and
+    that repeated writes of an identical desired joint state message do not
+    restart the profile.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the outputs of ``desJointStatesOutMsg`` when using
+    the quintic profile mode after an identical desired joint state message is
+    rewritten at a later time. The expected behavior is that the profile
+    continues based on accumulated profile time instead of resetting to the
+    initial conditions.
+    """
+
+    module, joint_state_in_msgs, joint_state_dot_in_msgs, des_msg = setup_joint_array_ref_profiler("quintic")
+    profile_duration = 0.4  # [s]
+    module.setProfileDuration(profile_duration)  # [s]
+
+    module.Reset(0)
+    module.UpdateState(0)
+
+    first_tau = 0.1  # [s]
+    module.UpdateState(macros.sec2nano(first_tau))
+
+    identical_des_payload = messaging.JointArrayStateMsgPayload()
+    identical_des_payload.states.clear()
+    identical_des_payload.stateDots.clear()
+    identical_des_payload.stateDDots.clear()
+    for value in DES_JOINT_ANGLES:
+        identical_des_payload.states.push_back(float(value))
+    for value in DES_JOINT_RATES:
+        identical_des_payload.stateDots.push_back(float(value))
+    for value in DES_JOINT_ACCELS:
+        identical_des_payload.stateDDots.push_back(float(value))
+    identical_des_msg = messaging.JointArrayStateMsg().write(
+        identical_des_payload,
+        macros.sec2nano(0.2)
+    )
+    module.desJointStatesInMsg.subscribeTo(identical_des_msg)
+
+    second_tau = 0.2  # [s]
+    module.UpdateState(macros.sec2nano(second_tau))
+
+    ref_out = module.desJointStatesOutMsg.read()
+    expected_angles = np.zeros(3)
+    expected_rates = np.zeros(3)
+    expected_accels = np.zeros(3)
+    for i in range(3):
+        theta0 = JOINT_ANGLES[i]
+        thetaf = DES_JOINT_ANGLES[i]
+        theta_dot0 = JOINT_RATES[i]
+        delta_theta = thetaf - theta0
+        a0 = theta0
+        a1 = theta_dot0
+        a2 = 0.0
+        a3 = (20.0 * delta_theta - 12.0 * theta_dot0 * profile_duration) / (2.0 * profile_duration ** 3)
+        a4 = (-30.0 * delta_theta + 16.0 * theta_dot0 * profile_duration) / (2.0 * profile_duration ** 4)
+        a5 = (12.0 * delta_theta - 6.0 * theta_dot0 * profile_duration) / (2.0 * profile_duration ** 5)
+        expected_angles[i] = a0 + a1 * second_tau + a2 * second_tau ** 2 + a3 * second_tau ** 3 + a4 * second_tau ** 4 + a5 * second_tau ** 5
+        expected_rates[i] = a1 + 2.0 * a2 * second_tau + 3.0 * a3 * second_tau ** 2 + 4.0 * a4 * second_tau ** 3 + 5.0 * a5 * second_tau ** 4
+        expected_accels[i] = 2.0 * a2 + 6.0 * a3 * second_tau + 12.0 * a4 * second_tau ** 2 + 20.0 * a5 * second_tau ** 3
+
+    np.testing.assert_allclose(ref_out.states, expected_angles)  # [rad]
+    np.testing.assert_allclose(ref_out.stateDots, expected_rates)  # [rad/s]
+    np.testing.assert_allclose(ref_out.stateDDots, expected_accels)  # [rad/s^2]

--- a/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.cpp
+++ b/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.cpp
@@ -1,0 +1,333 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.h"
+
+void JointArrayRefProfiler::Reset(uint64_t CurrentSimNanos)
+{
+    // check that required input messages are connected
+    if (this->jointStatesInMsgs.empty()) {
+        bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.jointStatesInMsgs vector is empty.");
+    } else {
+        if (this->jointStatesInMsgs.size() != static_cast<std::size_t>(this->numHingedJoints)) {
+            bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.jointStatesInMsgs size does not match numHingedJoints.");
+        }
+        for (std::size_t i = 0; i < this->jointStatesInMsgs.size(); ++i) {
+            if (!this->jointStatesInMsgs[i].isLinked()) {
+                bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.jointStatesInMsgs[%zu] was not linked.", i);
+            }
+        }
+    }
+    if (this->jointStateDotsInMsgs.empty()) {
+        bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.jointStateDotsInMsgs vector is empty.");
+    } else {
+        if (this->jointStateDotsInMsgs.size() != static_cast<std::size_t>(this->numHingedJoints)) {
+            bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.jointStateDotsInMsgs size does not match numHingedJoints.");
+        }
+        for (std::size_t i = 0; i < this->jointStateDotsInMsgs.size(); ++i) {
+            if (!this->jointStateDotsInMsgs[i].isLinked()) {
+                bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.jointStateDotsInMsgs[%zu] was not linked.", i);
+            }
+        }
+    }
+    if (!this->desJointStatesInMsg.isLinked()) {
+        bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler.desJointStatesInMsg was not linked.");
+    }
+
+    // check that the profile type is set and valid
+    if (this->profileType.empty()) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "JointArrayRefProfiler.profileType is not set."
+        );
+    }
+    const std::vector<std::string> validProfileTypes = {"lowPass", "linear", "cubic", "quintic"};
+    if (std::find(validProfileTypes.begin(), validProfileTypes.end(), this->profileType) == validProfileTypes.end()) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "JointArrayRefProfiler.profileType is not valid."
+        );
+    }
+
+    // check that wc and filterDt are positive if the profile type is low pass
+    if (this->profileType == "lowPass") {
+        if (this->wc <= 0.0) {
+            this->bskLogger.bskLog(
+                BSK_ERROR,
+                "JointArrayRefProfiler.wc must be positive."
+            );
+        }
+        if (this->filterDt <= 0.0) {
+            this->bskLogger.bskLog(
+                BSK_ERROR,
+                "JointArrayRefProfiler.filterDt must be positive."
+            );
+        }
+    }
+
+    // check that profile duration is positive if the profile type is not low pass
+    if (this->profileType != "lowPass") {
+        if (this->profileDuration <= 0.0) {
+            this->bskLogger.bskLog(
+                BSK_ERROR,
+                "JointArrayRefProfiler.profileDuration must be positive."
+            );
+        }
+    }
+
+    this->profileStartTime = 0;  // [ns]
+    this->profileStartTimeSet = false;
+    this->refJointAngles = Eigen::VectorXd::Zero(this->numHingedJoints);
+    this->refJointRates = Eigen::VectorXd::Zero(this->numHingedJoints);
+    this->refJointAccels = Eigen::VectorXd::Zero(this->numHingedJoints);
+}
+
+void JointArrayRefProfiler::UpdateState(uint64_t CurrentSimNanos)
+{
+    if (!this->desJointStatesInMsg.isWritten()) {
+        this->bskLogger.bskLog(BSK_ERROR, "JointArrayRefProfiler called before desired joint states message was written.");
+    }
+
+    JointArrayStateMsgPayload desJointStatesIn = this->desJointStatesInMsg();
+    if (desJointStatesIn.states.size() != static_cast<std::size_t>(this->numHingedJoints)) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "JointArrayRefProfiler.desJointStatesInMsg.states size does not match numHingedJoints."
+        );
+    }
+    if (desJointStatesIn.stateDots.size() != static_cast<std::size_t>(this->numHingedJoints)) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "JointArrayRefProfiler.desJointStatesInMsg.stateDots size does not match numHingedJoints."
+        );
+    }
+    if (desJointStatesIn.stateDDots.size() != static_cast<std::size_t>(this->numHingedJoints)) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "JointArrayRefProfiler.desJointStatesInMsg.stateDDots size does not match numHingedJoints."
+        );
+    }
+
+    bool newDesiredStateMsg = false;
+    const uint64_t desMsgTime = this->desJointStatesInMsg.timeWritten();
+
+    if (!this->profileStartTimeSet) {
+        newDesiredStateMsg = true;
+    } else {
+        newDesiredStateMsg =
+            desJointStatesIn.states != this->prevDesJointStates.states ||
+            desJointStatesIn.stateDots != this->prevDesJointStates.stateDots ||
+            desJointStatesIn.stateDDots != this->prevDesJointStates.stateDDots;
+    }
+
+    if (newDesiredStateMsg) {
+        this->profileStartTime = CurrentSimNanos;  // [ns]
+        this->profileStartTimeSet = true;
+        this->startJointAngles = Eigen::VectorXd::Zero(this->numHingedJoints);
+        this->startJointRates = Eigen::VectorXd::Zero(this->numHingedJoints);
+        this->prevDesJointStates = desJointStatesIn;
+        for (std::size_t i = 0; i < this->jointStatesInMsgs.size(); ++i) {
+            ScalarJointStateMsgPayload jointStateIn = this->jointStatesInMsgs[i]();
+            ScalarJointStateMsgPayload jointStateDotIn = this->jointStateDotsInMsgs[i]();
+            this->startJointAngles[i] = jointStateIn.state;
+            this->startJointRates[i] = jointStateDotIn.state;
+        }
+
+        if (this->profileType == "lowPass") {
+            // for low pass filter, initialize the reference states to the current states when a new command is received
+            this->refJointAngles = this->startJointAngles;
+            this->refJointRates = this->startJointRates;
+            this->refJointAccels = Eigen::VectorXd::Zero(this->numHingedJoints);
+        }
+    }
+
+    // compute the current reference states based on the profile type
+    if (this->profileType == "lowPass" && !newDesiredStateMsg) {
+        this->computeLowPassFilter(CurrentSimNanos, desJointStatesIn);
+    }
+    else if (this->profileType == "linear") {
+        this->computeLinearProfile(CurrentSimNanos, desJointStatesIn);
+    }
+    else if (this->profileType == "cubic") {
+        this->computeCubicProfile(CurrentSimNanos, desJointStatesIn);
+    }
+    else if (this->profileType == "quintic") {
+        this->computeQuinticProfile(CurrentSimNanos, desJointStatesIn);
+    }
+
+    // write the current reference states to the output message
+    JointArrayStateMsgPayload desJointStatesOut = this->desJointStatesOutMsg.zeroMsgPayload;
+    desJointStatesOut.states.resize(static_cast<std::size_t>(this->numHingedJoints), 0.0);
+    desJointStatesOut.stateDots.resize(static_cast<std::size_t>(this->numHingedJoints), 0.0);
+    desJointStatesOut.stateDDots.resize(static_cast<std::size_t>(this->numHingedJoints), 0.0);
+    for (int i = 0; i < this->numHingedJoints; ++i) {
+        desJointStatesOut.states[static_cast<std::size_t>(i)] = this->refJointAngles[i];
+        desJointStatesOut.stateDots[static_cast<std::size_t>(i)] = this->refJointRates[i];
+        desJointStatesOut.stateDDots[static_cast<std::size_t>(i)] = this->refJointAccels[i];
+    }
+    this->desJointStatesOutMsg.write(&desJointStatesOut, this->moduleID, CurrentSimNanos);
+}
+
+void JointArrayRefProfiler::computeLowPassFilter(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn)
+{
+    double beta = 1.0 - std::exp(-this->wc * this->filterDt);
+
+    Eigen::VectorXd prevRefJointAngles = this->refJointAngles;
+    Eigen::VectorXd prevRefJointRates = this->refJointRates;
+    for (int i = 0; i < this->numHingedJoints; ++i) {
+        const double thetaCmd = desJointStatesIn.states[i];
+        this->refJointAngles[i] = prevRefJointAngles[i] + beta * (thetaCmd - prevRefJointAngles[i]);
+        this->refJointRates[i] = (this->refJointAngles[i] - prevRefJointAngles[i]) / this->filterDt;
+        this->refJointAccels[i] = (this->refJointRates[i] - prevRefJointRates[i]) / this->filterDt;
+    }
+}
+
+void JointArrayRefProfiler::computeLinearProfile(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn)
+{
+    double timeSec = CurrentSimNanos * NANO2SEC; // convert current time to seconds
+    double tau = timeSec - (this->profileStartTime * NANO2SEC); // time since profile start in seconds
+
+    this->refJointAngles.setZero(this->numHingedJoints);
+    this->refJointRates.setZero(this->numHingedJoints);
+    this->refJointAccels.setZero(this->numHingedJoints);
+    if (tau >= this->profileDuration) {
+        for (int i = 0; i < this->numHingedJoints; ++i) {
+            this->refJointAngles[i] = desJointStatesIn.states[i];
+            this->refJointRates[i] = 0.0;
+            this->refJointAccels[i] = 0.0;
+        }
+        return;
+    }
+
+    for (int i = 0; i < this->numHingedJoints; ++i) {
+        double theta0 = this->startJointAngles[i];
+        double thetaf = desJointStatesIn.states[i];
+        double T = this->profileDuration;
+
+        // compute reference angle, rate, and acceleration
+        this->refJointAngles[i] = theta0 + (thetaf - theta0) * tau / T;
+        this->refJointRates[i] = (thetaf - theta0) / T;
+        this->refJointAccels[i] = 0.0;
+    }
+}
+
+void JointArrayRefProfiler::computeCubicProfile(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn)
+{
+    double timeSec = CurrentSimNanos * NANO2SEC; // convert current time to seconds
+    double tau = timeSec - (this->profileStartTime * NANO2SEC); // time since profile start in seconds
+
+    this->refJointAngles.setZero(this->numHingedJoints);
+    this->refJointRates.setZero(this->numHingedJoints);
+    this->refJointAccels.setZero(this->numHingedJoints);
+    if (tau >= this->profileDuration) {
+        for (int i = 0; i < this->numHingedJoints; ++i) {
+            this->refJointAngles[i] = desJointStatesIn.states[i];
+            this->refJointRates[i] = 0.0;
+            this->refJointAccels[i] = 0.0;
+        }
+        return;
+    }
+
+    for (int i = 0; i < this->numHingedJoints; ++i) {
+        double theta0 = this->startJointAngles[i];
+        double thetaf = desJointStatesIn.states[i];
+        double thetaDot0 = this->startJointRates[i];
+        double T = this->profileDuration;
+
+        // cubic profile coefficients
+        double a0 = theta0;
+        double a1 = thetaDot0;
+        double a2 = (3 * (thetaf - theta0)) / (T * T) - (2 * thetaDot0) / T;
+        double a3 = -(2 * (thetaf - theta0)) / (T * T * T) + (thetaDot0) / (T * T);
+
+        // compute reference angle, rate, and acceleration
+        this->refJointAngles[i] = a0 + a1 * tau + a2 * tau * tau + a3 * tau * tau * tau;
+        this->refJointRates[i] = a1 + 2.0 * a2 * tau + 3.0 * a3 * tau * tau;
+        this->refJointAccels[i] = 2.0 * a2 + 6.0 * a3 * tau;
+    }
+}
+
+void JointArrayRefProfiler::computeQuinticProfile(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn)
+{
+    double timeSec = CurrentSimNanos * NANO2SEC; // convert current time to seconds
+    double tau = timeSec - (this->profileStartTime * NANO2SEC); // time since profile start in seconds
+
+    this->refJointAngles.setZero(this->numHingedJoints);
+    this->refJointRates.setZero(this->numHingedJoints);
+    this->refJointAccels.setZero(this->numHingedJoints);
+    if (tau >= this->profileDuration) {
+        for (int i = 0; i < this->numHingedJoints; ++i) {
+            this->refJointAngles[i] = desJointStatesIn.states[i];
+            this->refJointRates[i] = 0.0;
+            this->refJointAccels[i] = 0.0;
+        }
+        return;
+    }
+
+    for (int i = 0; i < this->numHingedJoints; ++i) {
+        double theta0 = this->startJointAngles[i];
+        double thetaf = desJointStatesIn.states[i];
+        double thetaDot0 = this->startJointRates[i];
+        double deltaTheta = thetaf - theta0;
+        double T = this->profileDuration;
+
+        // quintic profile coefficients
+        double a0 = theta0;
+        double a1 = thetaDot0;
+        double a2 = 0.0;
+        double a3 = (20 * deltaTheta - 12 * thetaDot0 * T) / (2 * T * T * T);
+        double a4 = (-30 * deltaTheta + 16 * thetaDot0 * T) / (2 * T * T * T * T);
+        double a5 = (12 * deltaTheta - 6 * thetaDot0 * T) / (2 * T * T * T * T * T);
+
+        // compute reference angle, rate, and acceleration
+        this->refJointAngles[i] = a0 + a1 * tau + a2 * tau * tau + a3 * tau * tau * tau + a4 * tau * tau * tau * tau + a5 * tau * tau * tau * tau * tau;
+        this->refJointRates[i] = a1 + 2.0 * a2 * tau + 3.0 * a3 * tau * tau + 4.0 * a4 * tau * tau * tau + 5.0 * a5 * tau * tau * tau * tau;
+        this->refJointAccels[i] = 2.0 * a2 + 6.0 * a3 * tau + 12.0 * a4 * tau * tau + 20.0 * a5 * tau * tau * tau;
+    }
+}
+
+void JointArrayRefProfiler::setProfileType(std::string profileType)
+{
+    this->profileType = profileType;
+}
+
+void JointArrayRefProfiler::setProfileDuration(double profileDuration)
+{
+    this->profileDuration = profileDuration;
+}
+
+void JointArrayRefProfiler::setWc(double wc)
+{
+    this->wc = wc;
+}
+
+void JointArrayRefProfiler::setFilterDt(double filterDt)
+{
+    this->filterDt = filterDt;
+}
+
+void JointArrayRefProfiler::addHingedJoint()
+{
+    // increase the number of hinged joints by 1
+    this->numHingedJoints++;
+
+    // add a new input message reader for the new hinged joint
+    this->jointStatesInMsgs.push_back(ReadFunctor<ScalarJointStateMsgPayload>());
+    this->jointStateDotsInMsgs.push_back(ReadFunctor<ScalarJointStateMsgPayload>());
+}

--- a/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.h
+++ b/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.h
@@ -1,0 +1,118 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef JOINT_ARRAY_REF_PROFILER_H
+#define JOINT_ARRAY_REF_PROFILER_H
+
+#include "architecture/_GeneralModuleFiles/sys_model.h"
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/ScalarJointStateMsgPayload.h"
+#include "architecture/msgPayloadDefCpp/JointArrayStateMsgPayload.h"
+#include "architecture/utilities/bskLogging.h"
+#include "architecture/utilities/macroDefinitions.h"
+#include "architecture/utilities/avsEigenSupport.h"
+#include <Eigen/Dense>
+
+/*! @brief This module converts instantaneous reference angle changes for an array of joints to smooth profiles.
+ */
+class JointArrayRefProfiler : public SysModel {
+public:
+    JointArrayRefProfiler() = default; //!< This is the constructor for the module class.
+    ~JointArrayRefProfiler() = default; //!< This is the destructor for the module class.
+
+    /*!
+    * This method is used to reset the module and checks that required input messages are connected.
+    */
+    void Reset(uint64_t CurrentSimNanos);
+
+    /*!
+    * This is the main method that gets called every time the module is updated.
+    * It determines the current joint reference states based on the profile shape and duration.
+    * */
+    void UpdateState(uint64_t CurrentSimNanos);
+
+public:
+    std::vector<ReadFunctor<ScalarJointStateMsgPayload>> jointStatesInMsgs;     //!< vector of current joint state input messages
+    std::vector<ReadFunctor<ScalarJointStateMsgPayload>> jointStateDotsInMsgs;  //!< vector of current joint state-derivative input messages
+    ReadFunctor<JointArrayStateMsgPayload> desJointStatesInMsg;                 //!< Desired joint-array state input message
+
+    Message<JointArrayStateMsgPayload> desJointStatesOutMsg;                  //!< Joint-array reference output message
+
+    BSKLogger bskLogger;                                                        //!< BSK Logging
+    /** setter for the `profileType` property */
+    void setProfileType(std::string profileType);
+    /** getter for the `profileType` property */
+    std::string getProfileType() const {return this->profileType;}
+    /** setter for the `profileDuration` property */
+    void setProfileDuration(double profileDuration);
+    /** getter for the `profileDuration` property */
+    double getProfileDuration() const {return this->profileDuration;}
+    /** setter for the `wc` property */
+    void setWc(double wc);
+    /** getter for the `wc` property */
+    double getWc() const {return this->wc;}
+    /** setter for the `filterDt` property */
+    void setFilterDt(double filterDt);
+    /** getter for the `filterDt` property */
+    double getFilterDt() const {return this->filterDt;}
+    /** method for adding a new hinged joint to the system */
+    void addHingedJoint();
+
+private:
+    std::string profileType; //!< [-] Reference profile type
+    double profileDuration = -1.0;  //!< [s] Reference profile duration, used for all profile types except "lowPass"
+    double wc = -1.0;               //!< [rad/s] low pass filter cutoff frequency, only used if profileType is "lowPass"
+    double filterDt = -1.0;         //!< [s] low pass filter time step, only used if profileType is "lowPass"
+    int numHingedJoints = 0;  //!< number of hinged joints in the system
+    uint64_t profileStartTime = 0;  //!< [ns] simulation time at which the current profile started
+    bool profileStartTimeSet = false;  //!< flag indicating whether the profile start time has been set
+    Eigen::VectorXd startJointAngles;  //!< [rad] joint angles at the start of the current reference profile
+    Eigen::VectorXd startJointRates;  //!< [rad/s] joint angle rates at the start of the current reference profile
+    Eigen::VectorXd refJointAngles;  //!< [rad] current profiled joint angles
+    Eigen::VectorXd refJointRates;  //!< [rad/s] current profiled joint angle rates
+    Eigen::VectorXd refJointAccels;  //!< [rad/s^2] current profiled joint angle accelerations
+    JointArrayStateMsgPayload prevDesJointStates; //!< previous desired joint states, used to detect changes in the desired state command
+
+    /*! Method for computing the low pass filtered joint reference profile
+        * @param CurrentSimNanos current simulation time in nanoseconds
+        * @param desJointStatesIn desired joint states input message payload
+        * */
+    void computeLowPassFilter(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn);
+
+    /*! Method for computing the linear joint reference profile
+        * @param CurrentSimNanos current simulation time in nanoseconds
+        * @param desJointStatesIn desired joint states input message payload
+        * */
+    void computeLinearProfile(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn);
+
+    /*! Method for computing the cubic joint reference profile
+        * @param CurrentSimNanos current simulation time in nanoseconds
+        * @param desJointStatesIn desired joint states input message payload
+        * */
+    void computeCubicProfile(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn);
+
+    /*! Method for computing the quintic joint reference profile
+        * @param CurrentSimNanos current simulation time in nanoseconds
+        * @param desJointStatesIn desired joint states input message payload
+        * */
+    void computeQuinticProfile(uint64_t CurrentSimNanos, const JointArrayStateMsgPayload& desJointStatesIn);
+
+};
+
+#endif

--- a/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.i
+++ b/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.i
@@ -1,0 +1,49 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+%module jointArrayRefProfiler
+
+%include "architecture/utilities/bskException.swg"
+%default_bsk_exception();
+
+%{
+    #include "jointArrayRefProfiler.h"
+%}
+
+%include "std_string.i"
+%include "std_vector.i"
+%include "swig_conly_data.i"
+
+%pythoncode %{
+from Basilisk.architecture.swig_common_model import *
+%}
+
+%include "sys_model.i"
+
+%include "architecture/msgPayloadDefC/ScalarJointStateMsgPayload.h"
+struct ScalarJointStateMsg_C;
+
+%include "architecture/msgPayloadDefCpp/JointArrayStateMsgPayload.h"
+
+%include "jointArrayRefProfiler.h"
+
+%pythoncode %{
+import sys
+protectAllClasses(sys.modules[__name__])
+%}

--- a/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.rst
+++ b/src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.rst
@@ -1,0 +1,78 @@
+Executive Summary
+-----------------
+This module converts instantaneous reference joint angle changes to either
+filtered or time-profiled reference joint angles, rates, and accelerations.
+
+Message Connection Descriptions
+-------------------------------
+The following diagram and table list the module input and output messages.
+
+.. bsk-module-io:: jointArrayRefProfiler
+    :caption: Module I/O Messages
+
+    input jointStatesInMsgs ScalarJointStateMsgPayload
+        Vector of current joint state input messages.
+    input jointStateDotsInMsgs ScalarJointStateMsgPayload
+        Vector of current joint state-derivative input messages.
+    input desJointStatesInMsg JointArrayStateMsgPayload
+        Desired joint-array state input message.
+    output desJointStatesOutMsg JointArrayStateMsgPayload
+        Joint-array reference output message.
+
+Module Assumptions and Limitations
+----------------------------------
+This module assumes the desired joint-array command remains constant
+between message updates and that a new profile should begin whenever
+The values within the ``desJointStatesInMsg`` are updated. In instances where
+there is a timing mismatch between the write time of
+``desJointStatesInMsg`` and the module update time, the new profile
+begins based on the module update time rather than the time the message
+was written.
+
+The ``lowPass`` mode applies a first-order discrete low-pass filter
+to the desired joint angles using the user-specified ``wc`` and ``filterDt``
+parameters. This mode smooths the reference command but does not guarantee
+finite-time convergence like the time-profiled modes.
+
+For the ``linear``, ``cubic``, and ``quintic`` modes, the module is
+designed to drive each joint to the desired final angle over the
+specified ``profileDuration``. The ``cubic`` and ``quintic``
+implementations assume the terminal joint rate and terminal joint
+acceleration are zero. The ``linear`` mode does not preserve the
+initial joint rates, performs constant-rate interpolation, and only
+reaches zero rate once the profile completes.
+
+User Guide
+----------
+This section outlines the steps needed to set up the ``jointArrayRefProfiler`` module in
+Python using Basilisk.
+
+#. Import the module::
+
+    from Basilisk.simulation import jointArrayRefProfiler
+
+#. Create an instance of the module::
+
+    module = jointArrayRefProfiler.JointArrayRefProfiler()
+    module.ModelTag = "jointArrayRefProfiler"
+
+#. Set the profile type to either ``linear``, ``cubic``, ``quintic``, or ``lowPass``::
+
+    module.setProfileType("linear")
+
+#. For the low pass filter mode, set the cutoff frequency and filter time step::
+
+    module.setWc(1.0)  # [rad/s]
+    module.setFilterDt(0.01)  # [s]
+
+#. For the time-profiled modes, set the profile duration::
+
+    module.setProfileDuration(2.0)  # [s]
+
+#. For each hinged joint in the system, add a hinged joint to the module::
+
+    module.addHingedJoint()
+
+#. Add the module to the task list::
+
+    unitTestSim.AddModelToTask(unitTaskName, module)


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

This PR adds the `jointArrayRefProfiler` module in `deviceInterface` to generate smooth joint-array reference states from scalar joint state inputs and a desired joint-array command.

The module supports four reference-generation modes:

- `lowPass` for first-order discrete low-pass filtering of desired joint angles
- `linear` for constant-rate interpolation over a specified profile duration
- `cubic` for time-profiled motion using the current joint angle/rate as initial conditions and zero terminal rate/acceleration assumptions
- `quintic` for time-profiled motion using the current joint angle/rate as initial conditions and zero terminal rate/acceleration assumptions

The main additions are:

- new `jointArrayRefProfiler` device-interface module with vectorized `ScalarJointStateMsgPayload` joint state and joint rate inputs plus a `JointArrayStateMsgPayload` desired-state input
- `JointArrayStateMsgPayload` reference output containing profiled joint angles, rates, and accelerations
- mode-specific configuration through `setProfileType()`, `setProfileDuration()`, `setWc()`, and `setFilterDt()`
- reinitialization logic so a newly written desired joint-state command starts a new profile from the current measured joint states
- unit tests covering low-pass, linear, cubic, and quintic profile behavior, including reinitialization on a new command

## Verification

The module was validated using a new unit test.

Validation included:

- `src/simulation/deviceInterface/jointArrayRefProfiler/_UnitTest/test_jointArrayRefProfiler.py`

The test coverage checks:

- low-pass initialization and recursive filter updates
- linear profile behavior at the start, during the profile, and after completion
- cubic profile behavior at the start, during the profile, and after completion
- quintic profile behavior at the start, during the profile, and after completion
- reinitialization when a second desired joint-state message is written

## Documentation

This PR adds and updates documentation for the new reference-profiler module:

- `src/simulation/deviceInterface/jointArrayRefProfiler/jointArrayRefProfiler.rst`
- the release notes snippet in `docs/source/Support/bskReleaseNotesSnippets/joint-array-ref-profiler.rst`

## Future work
N/A
