### PR TITLE
Update publish workflow to handle release candidates

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -5,6 +5,16 @@ on:
     tags:
       - "v[0-9]*"
       - "test*"
+  workflow_dispatch:
+    inputs:
+      destination:
+        description: "Publish destination"
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - testpypi
+          - pypi
 
 jobs:
   build-wheels:
@@ -76,7 +86,7 @@ jobs:
           name: cibw-sdist
           path: dist/*.tar.gz
 
-  test_sdist:
+  test-sdist:
     name: Test SDist
     needs: make_sdist
     runs-on: ubuntu-latest
@@ -99,19 +109,12 @@ jobs:
         run: pip install dist/*.tar.gz
 
   publish:
-    name: Publish to PyPI
-    needs: [build-wheels, test_sdist]
+    name: Publish
+    needs: [build-wheels, test-sdist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     steps:
-      - name: Checkout tagged source
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
@@ -125,17 +128,28 @@ jobs:
           name: cibw-sdist
           path: dist
 
-      - name: Publish to TestPyPI (test tags)
-        if: startsWith(github.ref, 'refs/tags/test')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist
-          skip-existing: true
-          verbose: true
+      - name: Resolve publish config
+        id: config
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            testpypi="${{ inputs.destination == 'testpypi' }}"
+          elif [[ "${{ github.ref }}" == refs/tags/test* || "${{ github.ref_name }}" == *rc* ]]; then
+            testpypi="true"
+          else
+            testpypi="false"
+          fi
+          if [[ "$testpypi" == "true" ]]; then
+            echo "repo-url=https://test.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
+            echo "skip-existing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "repo-url=https://upload.pypi.org/legacy/" >> "$GITHUB_OUTPUT"
+            echo "skip-existing=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Publish to PyPI (real releases)
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          repository-url: ${{ steps.config.outputs.repo-url }}
           packages-dir: dist
+          skip-existing: ${{ steps.config.outputs.skip-existing }}
+          verbose: true

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -131,9 +131,16 @@ jobs:
       - name: Resolve publish config
         id: config
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            testpypi="${{ inputs.destination == 'testpypi' }}"
-          elif [[ "${{ github.ref }}" == refs/tags/test* || "${{ github.ref_name }}" == *rc* ]]; then
+          ref="${{ github.ref_name }}"
+          # Guard: manual PyPI publish requires a non-RC version tag
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.destination }}" == "pypi" ]]; then
+            if [[ "${{ github.ref_type }}" != "tag" || "$ref" == *rc* || "$ref" != v* ]]; then
+              echo "::error::PyPI publish requires a non-RC version tag (e.g. vX.Y.Z). Got: $ref"
+              exit 1
+            fi
+          fi
+          # Route to TestPyPI for RC/test tags or manual testpypi dispatch
+          if [[ "$ref" == *rc* || "$ref" == test* || "${{ inputs.destination }}" == "testpypi" ]]; then
             testpypi="true"
           else
             testpypi="false"

--- a/docs/source/Support/Developer/releaseGuide.rst
+++ b/docs/source/Support/Developer/releaseGuide.rst
@@ -46,7 +46,14 @@ process; however, it must now be updated manually to prevent excessive version
 bumps.
 
 Update this file to reflect the new version number following semantic versioning
-guidelines (e.g., MAJOR.MINOR.PATCH).
+guidelines (e.g., ``MAJOR.MINOR.PATCH``).
+
+For a release candidate, set the version to ``MAJOR.MINOR.PATCHrcN``
+(e.g., ``2.10.2rc1``). This ensures artifacts built from an RC tag are
+correctly identified as pre-release and are published to TestPyPI rather than
+production PyPI. Once the release candidate is validated and a final release tag
+is pushed, reset ``bskVersion.txt`` to the plain ``MAJOR.MINOR.PATCH`` form
+(e.g., ``2.10.2``) before tagging.
 
 Updating the Release Notes
 --------------------------
@@ -72,17 +79,51 @@ back into ``develop`` to ensure they are included in future releases.
 
 Creating and Pushing Tags
 -------------------------
-Releases are published by pushing a git tag to the ``master`` branch. Our GitHub Actions workflow
-(``Publish Wheels``) is triggered on tag pushes matching:
+Releases are published by pushing a git tag. The ``Publish Wheels`` GitHub Actions
+workflow triggers on tag pushes and routes artifacts based on the tag name:
 
-- ``v[0-9]*``  (real releases, published to PyPI)
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Tag pattern
+     - Destination
+   * - ``vX.Y.Z`` (no ``rc``)
+     - PyPI (public release)
+   * - ``vX.Y.ZrcN``
+     - TestPyPI (release candidate)
+   * - ``test*``
+     - TestPyPI (ad-hoc testing)
 
 This means: **pushing a tag kicks off the wheel builds on all supported
 platforms, builds an sdist, and then publishes the artifacts**.
 
 Tag format
 ^^^^^^^^^^
-Release tags must follow the format ``vX.Y.Z`` (for example, ``v2.9.0``).
+- Full release tags must follow the format ``vX.Y.Z`` (for example, ``v2.9.0``).
+- Release candidate tags follow ``vX.Y.ZrcN`` (for example, ``v2.10.2rc1``).
+
+When to use a release candidate tag
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Push an RC tag when you want to publish a pre-release build to TestPyPI for
+validation before committing to a final release. Typical scenarios include:
+
+- Verifying that the wheel build pipeline works end-to-end for a new version.
+- Giving early adopters a chance to test a release before it is published to
+  production PyPI.
+- Debugging the publish workflow itself without touching the production index.
+
+The workflow for an RC release is:
+
+#. Set ``docs/source/bskVersion.txt`` to the RC version (e.g. ``2.10.2rc1``).
+#. Push an RC tag (e.g. ``v2.10.2rc1``) — CI builds wheels and publishes to
+   TestPyPI automatically.
+#. Validate the artifacts from TestPyPI.
+#. If further changes are needed, increment the RC counter (``rc2``, ``rc3``,
+   …) and repeat.
+#. Once the RC is validated, reset ``bskVersion.txt`` to the final version
+   (e.g. ``2.10.2``) and push the release tag (e.g. ``v2.10.2``) to trigger
+   the production PyPI publish.
 
 Where to tag
 ^^^^^^^^^^^^

--- a/docs/source/Support/bskReleaseNotesSnippets/publish-wheels-rc-routing.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/publish-wheels-rc-routing.rst
@@ -1,0 +1,2 @@
+- Updated ``publish-wheels`` CI workflow to route release candidate tags (``v*rc*``) to TestPyPI instead of PyPI.
+- Added a manual ``workflow_dispatch`` trigger so wheels can be published from the GitHub UI without requiring a tag push.


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
- Updates the release workflow so that release candidate tagged builds publish to TestPyPI
- Simplified a few things in the workflow
- Added support for manual dispatch of the workflow. Mainly useful for creating release candidates and debugging wheel workflows in case of error.

## Verification
N/A

## Documentation
N/A

## Future work
N/A