### PR TITLE
Update CI script to use latest Windows environment

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -52,13 +52,20 @@ runs:
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10
+      continue-on-error: true
+      with:
+        disable_annotations: true
 
     - name: Set sccache as compiler launcher
       shell: bash
       run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-        echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
-        echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+        if command -v sccache >/dev/null 2>&1; then
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_ENV
+        else
+          echo "sccache is unavailable; continuing without compiler caching"
+        fi
         if [[ "${{ runner.os }}" == 'Windows' ]]; then
           echo "CMAKE_BUILD_PARALLEL_LEVEL=$(python -c 'import os; print(os.cpu_count() or 1)')" >> $GITHUB_ENV
         fi

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - ubuntu-22.04-arm
-          - windows-latest
+        os: # keep these platforms in sync with the pull-request.yml file
+          - macos-26
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - windows-2025-vs2026
 
     steps:
       - name: Checkout develop
@@ -42,7 +42,7 @@ jobs:
   publish-index:
     name: Publish Nightly Index
     needs: build-wheels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-commit

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -24,9 +24,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest # ARM64
-          - ubuntu-latest # x86_64
-          - ubuntu-22.04-arm # ARM64
+          - macos-26 # ARM64
+          - ubuntu-24.04 # x86_64
+          - ubuntu-24.04-arm # ARM64
           - windows-2025-vs2026 # x86_64
 
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   make_sdist:
     name: Make SDist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
         with:
@@ -89,7 +89,7 @@ jobs:
   test-sdist:
     name: Test SDist
     needs: make_sdist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
 
@@ -111,7 +111,7 @@ jobs:
   publish:
     name: Publish
     needs: [build-wheels, test-sdist]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -27,7 +27,7 @@ jobs:
           - macos-latest # ARM64
           - ubuntu-latest # x86_64
           - ubuntu-22.04-arm # ARM64
-          - windows-latest # x86_64
+          - windows-2025-vs2026 # x86_64
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,7 @@ jobs:
           pip install pytest-error-for-skips pytest-timeout
           pytest -n auto -m "not ciSkip" -rs --error-for-skips --timeout=300 --timeout-method=thread -v
       - name: CTest
-        if: ${{ always() }}
+        if: ${{ always() && hashFiles('dist3/CTestTestfile.cmake') != '' }}
         working-directory: dist3
         run: ctest --output-on-failure
 
@@ -59,7 +59,7 @@ jobs:
           pytest -n auto -m "not ciSkip" -rs --error-for-skips --timeout=300 --timeout-method=thread -v
           if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) {exit 1}
       - name: CTest
-        if: ${{ always() }}
+        if: ${{ always() && hashFiles('dist3/CTestTestfile.cmake') != '' }}
         shell: pwsh
         working-directory: dist3
         run: |
@@ -103,7 +103,7 @@ jobs:
           pip install pytest-error-for-skips pytest-timeout
           pytest ${{ matrix.pytest_flags }}
       - name: CTest
-        if: ${{ always() }}
+        if: ${{ always() && hashFiles('dist3/CTestTestfile.cmake') != '' }}
         working-directory: dist3
         run: ctest -C Release --output-on-failure
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,13 +10,13 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/pre-commit
 
   build-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     needs: pre-commit
     name: Linux (MAX Python)
@@ -67,7 +67,7 @@ jobs:
           if(($LastExitCode -ne 0) -and ($LastExitCode -ne 5)) { exit 1 }
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 90
     needs: pre-commit
     strategy:
@@ -108,7 +108,7 @@ jobs:
         run: ctest -C Release --output-on-failure
 
   docs:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/data-cache

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,7 @@ jobs:
         run: ctest --output-on-failure
 
   build-windows:
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     timeout-minutes: 105
     needs: pre-commit
     name: Windows (MAX Python)

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-conan-2-28-1.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-conan-2-28-1.rst
@@ -1,0 +1,1 @@
+- Updated the development requirements to allow Conan 2.28.1.

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-python-dependencies-latest.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-python-dependencies-latest.rst
@@ -1,0 +1,1 @@
+- Updated Python requirement version caps to include the latest dependency releases.

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-runner-labels-2026.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-runner-labels-2026.rst
@@ -1,0 +1,1 @@
+- Pinned pull request and wheel CI runners to macOS 26, Ubuntu 24.04, and Windows 2025 with Visual Studio 2026.

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-sccache-optional-setup.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-sccache-optional-setup.rst
@@ -1,0 +1,1 @@
+- Made CI builds continue without ``sccache`` when compiler-cache setup is unavailable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-pandas>=2.0.3,<=2.3.3
-matplotlib>=3.7.5,<=3.10.7
-numpy>=1.24.4,<2.4.0; python_version < "3.13"
-numpy>=2.0,<2.4.0; python_version >= "3.13"
+pandas>=2.0.3,<=3.0.3
+matplotlib>=3.7.5,<=3.10.9
+numpy>=1.24.4,<=2.4.6; python_version < "3.13"
+numpy>=2.0,<=2.4.6; python_version >= "3.13"
 colorama==0.4.6
-tqdm==4.67.1
-pillow>=10.4.0,<=12.0.0
-requests>=2.32.3,<=2.32.5
-bokeh>=3.1.1,<=3.8.1
-protobuf>=5.29.4,<=6.33.1
-pooch>=1.7.0,<1.9
-sgp4==2.23
+tqdm==4.67.3
+pillow>=10.4.0,<=12.2.0
+requests>=2.32.3,<=2.34.2
+bokeh>=3.1.1,<=3.9.0
+protobuf>=5.29.4,<=7.35.0
+pooch>=1.7.0,<=1.9.0
+sgp4==2.25

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,19 +1,19 @@
-wheel>=0.45.1,<=0.46.1
-cmake>=3.26,<=4.2.0
+wheel>=0.45.1,<=0.47.0
+cmake>=3.26,<=4.3.2
 conan>=2.0.5,<=2.28.1
-packaging>=24,<26
-setuptools>=70.1.0,<=80.9.0
-setuptools-scm>=8.0,<=9.2.2
+packaging>=24,<=26.2
+setuptools>=70.1.0,<=82.0.1
+setuptools-scm>=8.0,<=10.0.5
 swig>=4.4.1,<5
 libclang>=15.0.6.1,<=18.1.1
 
-pytest>=8.3.5,<=9.0.1
-pytest-html==4.1.1
+pytest>=8.3.5,<=9.0.3
+pytest-html==4.2.0
 pytest-xdist>=3.6.1,<=3.8.0
 pytest-timeout==2.4.0
-pytest-rerunfailures>=13.0,<=16.1
+pytest-rerunfailures>=13.0,<=16.2
 
-pre-commit>=3.5.0,<=4.5.0
-clang-format>=20.1.0,<=21.1.6
+pre-commit>=3.5.0,<=4.6.0
+clang-format>=20.1.0,<=22.1.5
 
-psutil>=7.0.0,<=7.1.3
+psutil>=7.0.0,<=7.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 wheel>=0.45.1,<=0.46.1
 cmake>=3.26,<=4.2.0
-conan>=2.0.5,<=2.23.0
+conan>=2.0.5,<=2.28.1
 packaging>=24,<26
 setuptools>=70.1.0,<=80.9.0
 setuptools-scm>=8.0,<=9.2.2

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 breathe==4.36.0
-docutils>=0.21.2,<0.22.0
+docutils>=0.21.2,<=0.22.4
 recommonmark==0.7.1
-sphinx>7.0.0,<=8.2.3
-sphinx_rtd_theme>=3.0.0,<=3.0.2
+sphinx>7.0.0,<=9.1.0
+sphinx_rtd_theme>=3.0.0,<=3.1.0
 sphinx-copybutton==0.5.2
-sphinxcontrib-youtube==1.4.1
+sphinxcontrib-youtube==1.5.0


### PR DESCRIPTION
## Description

This PR updates CI runner labels so the canary workflow continues testing the latest GitHub-hosted macOS environment, while regular pull request and wheel-building workflows use explicit runner images:

- macOS: `macos-26`
- Linux: `ubuntu-24.04` / `ubuntu-24.04-arm`
- Windows: `windows-2025-vs2026`

It also updates the root Python requirement files to include the latest dependency releases, including Conan `2.28.1`, which includes Visual Studio 2026 profile detection support needed for the new Windows runner.

## Testing

- Verified YAML parsing for the updated workflow files.
- Ran `git diff --check`.
- Verified the updated `requirements.txt`, `requirements_dev.txt`, and `requirements_doc.txt` resolve with Python 3.14 using `pip install --dry-run`.
- Verified the runtime/dev requirements resolve for the Python 3.9 CI path using a resolver dry run.
- Confirmed CI passes with the newer Conan version.