### PR TITLE
Monte Carlo Dispersion Improvement

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -22,6 +22,8 @@ Version |release|
   so images loaded from filename now follow the same processing and publishing pipeline as images from imageInMsg.
 - The MuJoCo dynamics wrapper now uses MuJoCo 3.7 element-name APIs, fixing builds after the MuJoCo
   3.7 upgrade.
+- Monte Carlo now applies nested dispersion paths and randomized ``RNGSeed`` modifications to the actual
+  simulation objects.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
   for Basilisk and compatible plugins. If source builds fail with SWIG 4.4.0 or emit

--- a/docs/source/Support/bskReleaseNotesSnippets/1164-monte-carlo-dispersions.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1164-monte-carlo-dispersions.rst
@@ -1,0 +1,2 @@
+- Fixed Monte Carlo nested dispersion paths and randomized ``RNGSeed`` application.
+- Tuned :ref:`scenarioMonteCarloAttRW` dispersions to show subtler run-to-run variations without saturated response.

--- a/examples/scenarioMonteCarloAttRW.py
+++ b/examples/scenarioMonteCarloAttRW.py
@@ -88,37 +88,37 @@ The dispersions that are set are listed in the following table:
 +----------------+---------------------------+--------------------------------------------------+
 | Input          | Description of Element    | Distribution                                     |
 +================+===========================+==================================================+
-| Inertial       | Using Modified            | Uniform for all 3 rotations between [0, 2 pi]    |
-| attitude       | Rodrigues Parameters      |                                                  |
+| Inertial       | Using Modified            | Normal dispersions around the nominal MRP vector |
+| attitude       | Rodrigues Parameters      | [0.02, 0.04, -0.06] with 0.002 standard          |
+|                |                           | deviation per component                          |
 +----------------+---------------------------+--------------------------------------------------+
-| Inertial       | Using omega vector        | Normal dispersions for each of the rotation      |
-| rotation rate  |                           | components, each of mean 0 and standard          |
-|                |                           | deviation 0.25 deg/s                             |
+| Inertial       | Using omega vector        | Normal dispersions around the nominal rate with  |
+| rotation rate  |                           | standard deviation 0.01/3 deg/s                  |
 +----------------+---------------------------+--------------------------------------------------+
-| Mass of the    | Total Mass of the         | Uniform around +/-5% of expected values.         |
-| hub            | spacecraft                | Bounds are [712.5, 787.5]                        |
+| Mass of the    | Total Mass of the         | Uniform around +/-1% of expected values.         |
+| hub            | spacecraft                | Bounds are about [742.5, 757.5] kg               |
 +----------------+---------------------------+--------------------------------------------------+
-| Center of Mass | Position vector offset on | Normally around a mean [0, 0, 1], with standard  |
-| Offset         | the actual center of mass,| deviations of [0.05/3, 0.05/3, 0.1/3]            |
-|                | and its theoretical       |                                                  |
-|                | position                  |                                                  |
+| Center of Mass | Position vector offset on | Normally around a mean [0, 0, 0] m with standard |
+| Offset         | the actual center of mass,| deviations of [0.01/3, 0.01/3, 0.02/3] m         |
+|                | in body-frame components  |                                                  |
+|                |                           |                                                  |
 +----------------+---------------------------+--------------------------------------------------+
-| Inertia Tensor | 3x3 inertia tensor.       | Normally about mean value of diag(900, 800, 600).|
+| Inertia Tensor | 3x3 inertia tensor.       | Normally about mean diag(900, 800, 600) kg*m^2.  |
 |                | Dispersed by 3 rotations  | Each of the 3 rotations are normally distributed |
 |                |                           | with angles of mean 0 and standard deviation     |
-|                |                           | 0.1 deg.                                         |
+|                |                           | 0.25 deg.                                        |
 +----------------+---------------------------+--------------------------------------------------+
 | RW axes        | The rotation axis for     | Normally around a respective means [1,0,0],      |
 |                | each of the 3 wheels      | [0,1,0], and [0,0,1] with respective standard    |
-|                |                           | deviations [0.01/3, 0.005/3, 0.005/3],           |
-|                |                           | [0.005/3, 0.01/3, 0.005/3], and                  |
-|                |                           | [0.005/3, 0.005/3, 0.01/3].                      |
+|                |                           | deviations [0.002/3, 0.001/3, 0.001/3],          |
+|                |                           | [0.001/3, 0.002/3, 0.001/3], and                 |
+|                |                           | [0.001/3, 0.001/3, 0.002/3].                     |
 +----------------+---------------------------+--------------------------------------------------+
-| RW speeds      | The rotation speed for    | Uniform around  +/-5% of expected values. Bounds |
-|                | each of the 3 wheels      | are [95, 105], [190, 210], and [285, 315]        |
+| RW speeds      | The rotation speed for    | Uniform around +/-1% of expected values.         |
+|                | each of the 3 wheels      |                                                  |
 +----------------+---------------------------+--------------------------------------------------+
-| Voltage to     | The gain between the      | Uniform around  +/-5% of expected values. Bounds |
-| Torque Gain    | commanded torque and the  | are [0.019, 0.021]                               |
+| Voltage to     | The gain between the      | Uniform around +/-1% of expected values.         |
+| Torque Gain    | commanded torque and the  | Nominal value is 0.02 N*m/V                      |
 |                | actual voltage            |                                                  |
 +----------------+---------------------------+--------------------------------------------------+
 
@@ -165,6 +165,11 @@ This pattern is required for the Monte Carlo framework to:
 2. Properly retain data through the RetentionPolicy mechanism
 3. Ensure objects persist between simulation runs
 4. Allow the Controller class to track and manage simulation state
+
+Dispersion names can use nested attribute paths and integer list indices, such as
+``TaskList[0].TaskModels[0].hub.sigma_BNInit``. Each object referenced by
+these paths must exist on the simulation container before the Monte Carlo
+controller applies the run modifications.
 
 Without adding objects to scSim, the Monte Carlo framework wouldn't be able to properly manage
 the simulation across multiple runs and thus unexpected behavior will occur.
@@ -221,8 +226,8 @@ from Basilisk.fswAlgorithms import rwMotorVoltage
 from Basilisk.architecture import messaging
 
 from Basilisk.utilities.MonteCarlo.Controller import Controller, RetentionPolicy
-from Basilisk.utilities.MonteCarlo.Dispersions import (UniformEulerAngleMRPDispersion, UniformDispersion,
-                                                       NormalVectorCartDispersion, InertiaTensorDispersion)
+from Basilisk.utilities.MonteCarlo.Dispersions import (UniformDispersion, NormalVectorCartDispersion,
+                                                       InertiaTensorDispersion)
 
 # Add this import and check at the beginning of the file
 import importlib
@@ -323,20 +328,65 @@ def run(saveFigures, case, show_plots, delete_data=True, useBokeh=False):
     dispList = [dispMRPInit, dispOmegaInit, dispMass, dispCoMOff, dispInertia]
 
     # Add dispersions with their dispersion type
-    monteCarlo.addDispersion(UniformEulerAngleMRPDispersion(dispMRPInit))
-    monteCarlo.addDispersion(NormalVectorCartDispersion(dispOmegaInit, 0.0, 0.75 / 3.0 * np.pi / 180))
-    monteCarlo.addDispersion(UniformDispersion(dispMass, ([750.0 - 0.05*750, 750.0 + 0.05*750])))
-    monteCarlo.addDispersion(NormalVectorCartDispersion(dispCoMOff, [0.0, 0.0, 1.0], [0.05 / 3.0, 0.05 / 3.0, 0.1 / 3.0]))
-    monteCarlo.addDispersion(InertiaTensorDispersion(dispInertia, stdAngle=0.1))
-    monteCarlo.addDispersion(NormalVectorCartDispersion(dispRW1Axis, [1.0, 0.0, 0.0], [0.01 / 3.0, 0.005 / 3.0, 0.005 / 3.0]))
-    monteCarlo.addDispersion(NormalVectorCartDispersion(dispRW2Axis, [0.0, 1.0, 0.0], [0.005 / 3.0, 0.01 / 3.0, 0.005 / 3.0]))
-    monteCarlo.addDispersion(NormalVectorCartDispersion(dispRW3Axis, [0.0, 0.0, 1.0], [0.005 / 3.0, 0.005 / 3.0, 0.01 / 3.0]))
-    monteCarlo.addDispersion(UniformDispersion(dispRW1Omega, ([100.0 - 0.05*100, 100.0 + 0.05*100])))
-    monteCarlo.addDispersion(UniformDispersion(dispRW2Omega, ([200.0 - 0.05*200, 200.0 + 0.05*200])))
-    monteCarlo.addDispersion(UniformDispersion(dispRW3Omega, ([300.0 - 0.05*300, 300.0 + 0.05*300])))
-    monteCarlo.addDispersion(UniformDispersion(dispVoltageIO_0, ([0.2/10. - 0.05 * 0.2/10., 0.2/10. + 0.05 * 0.2/10.])))
-    monteCarlo.addDispersion(UniformDispersion(dispVoltageIO_1, ([0.2/10. - 0.05 * 0.2/10., 0.2/10. + 0.05 * 0.2/10.])))
-    monteCarlo.addDispersion(UniformDispersion(dispVoltageIO_2, ([0.2/10. - 0.05 * 0.2/10., 0.2/10. + 0.05 * 0.2/10.])))
+    sigmaMean = [0.02, 0.04, -0.06]  # [-]
+    sigmaStd = [0.002, 0.002, 0.002]  # [-]
+    omegaMean = [0.0002, -0.002, 0.006]  # [rad/s]
+    omegaStd = [0.01 / 3.0 * np.pi / 180.0] * 3  # [rad/s]
+    massNominal = 750.0  # [kg]
+    massVariation = 0.01  # [-]
+    massBounds = [
+        massNominal * (1.0 - massVariation),
+        massNominal * (1.0 + massVariation)
+    ]  # [kg]
+    comOffsetMean = [0.0, 0.0, 0.0]  # [m]
+    comOffsetStd = [0.01 / 3.0, 0.01 / 3.0, 0.02 / 3.0]  # [m]
+    inertiaAngleStd = 0.25 * np.pi / 180.0  # [rad]
+    rwAxisStdMinor = 0.001 / 3.0  # [-]
+    rwAxisStdMajor = 0.002 / 3.0  # [-]
+    rwOmegaVariation = 0.01  # [-]
+    rw1OmegaNominal = 100.0  # [RPM]
+    rw2OmegaNominal = 200.0  # [RPM]
+    rw3OmegaNominal = 300.0  # [RPM]
+    voltageToTorqueGain = 0.2 / 10.0  # [N*m/V]
+    voltageGainVariation = 0.01  # [-]
+    voltageGainBounds = [
+        voltageToTorqueGain * (1.0 - voltageGainVariation),
+        voltageToTorqueGain * (1.0 + voltageGainVariation)
+    ]  # [N*m/V]
+
+    monteCarlo.addDispersion(NormalVectorCartDispersion(dispMRPInit, sigmaMean, sigmaStd))
+    monteCarlo.addDispersion(NormalVectorCartDispersion(dispOmegaInit, omegaMean, omegaStd))
+    monteCarlo.addDispersion(UniformDispersion(dispMass, massBounds))
+    monteCarlo.addDispersion(NormalVectorCartDispersion(dispCoMOff, comOffsetMean, comOffsetStd))
+    monteCarlo.addDispersion(InertiaTensorDispersion(dispInertia, stdAngle=inertiaAngleStd))
+    monteCarlo.addDispersion(NormalVectorCartDispersion(
+        dispRW1Axis, [1.0, 0.0, 0.0], [rwAxisStdMajor, rwAxisStdMinor, rwAxisStdMinor]
+    ))
+    monteCarlo.addDispersion(NormalVectorCartDispersion(
+        dispRW2Axis, [0.0, 1.0, 0.0], [rwAxisStdMinor, rwAxisStdMajor, rwAxisStdMinor]
+    ))
+    monteCarlo.addDispersion(NormalVectorCartDispersion(
+        dispRW3Axis, [0.0, 0.0, 1.0], [rwAxisStdMinor, rwAxisStdMinor, rwAxisStdMajor]
+    ))
+    # RW factory creation accepts RPM, but the state effector stores RW*.Omega in rad/s.
+    rw1OmegaBounds = [
+        rw1OmegaNominal * (1.0 - rwOmegaVariation) * macros.RPM,
+        rw1OmegaNominal * (1.0 + rwOmegaVariation) * macros.RPM
+    ]  # [rad/s]
+    rw2OmegaBounds = [
+        rw2OmegaNominal * (1.0 - rwOmegaVariation) * macros.RPM,
+        rw2OmegaNominal * (1.0 + rwOmegaVariation) * macros.RPM
+    ]  # [rad/s]
+    rw3OmegaBounds = [
+        rw3OmegaNominal * (1.0 - rwOmegaVariation) * macros.RPM,
+        rw3OmegaNominal * (1.0 + rwOmegaVariation) * macros.RPM
+    ]  # [rad/s]
+    monteCarlo.addDispersion(UniformDispersion(dispRW1Omega, rw1OmegaBounds))
+    monteCarlo.addDispersion(UniformDispersion(dispRW2Omega, rw2OmegaBounds))
+    monteCarlo.addDispersion(UniformDispersion(dispRW3Omega, rw3OmegaBounds))
+    monteCarlo.addDispersion(UniformDispersion(dispVoltageIO_0, voltageGainBounds))
+    monteCarlo.addDispersion(UniformDispersion(dispVoltageIO_1, voltageGainBounds))
+    monteCarlo.addDispersion(UniformDispersion(dispVoltageIO_2, voltageGainBounds))
 
     # A `RetentionPolicy` is used to define what data from the simulation should be retained. A `RetentionPolicy`
     # is a list of messages and variables to log from each simulation run. It also has a callback,
@@ -350,15 +400,11 @@ def run(saveFigures, case, show_plots, delete_data=True, useBokeh=False):
     retentionPolicy.addMessageLog(voltMsgName, ["voltage"])
     for msgName in rwOutName:
         retentionPolicy.addMessageLog(msgName, ["u_current"])
-    if show_plots:
-        if useBokeh:
-            # Don't set a callback for Bokeh, we'll handle it separately
-            pass
-        else:
-            # Use matplotlib for plotting
-            retentionPolicy.setDataCallback(plotSim)
     if saveFigures:
         retentionPolicy.setDataCallback(plotSimAndSave)
+    elif show_plots and not useBokeh:
+        # Use matplotlib for plotting
+        retentionPolicy.setDataCallback(plotSim)
     monteCarlo.addRetentionPolicy(retentionPolicy)
 
     if case == 1:
@@ -406,6 +452,11 @@ def run(saveFigures, case, show_plots, delete_data=True, useBokeh=False):
             # assert two different runs had different parameters.
             assert params1[dispName] != params2[dispName], "dispersion should be different in each run"
 
+        retainedData2 = monteCarloLoaded.getRetainedData(NUMBER_OF_RUNS-2)
+        runOutput2 = retainedData2["messages"][guidMsgName + ".sigma_BR"]
+        assert not np.allclose(newOutput, runOutput2, rtol=1e-12, atol=1e-12), \
+            "Dispersed runs should produce different attitude tracking histories"
+
         if useBokeh and bokeh_available:
             # Create the Bokeh application
             plotter = MonteCarloPlotter(dirName)
@@ -419,10 +470,11 @@ def run(saveFigures, case, show_plots, delete_data=True, useBokeh=False):
                 rwOutName[2] + ".u_current"
             ])
             plotter.show_plots()
-        elif show_plots:
+        elif show_plots or saveFigures:
             # Use matplotlib for plotting
             monteCarloLoaded.executeCallbacks()
-            plt.show()
+            if show_plots:
+                plt.show()
             plt.close("all")
 
     #########################################################
@@ -450,6 +502,8 @@ def run(saveFigures, case, show_plots, delete_data=True, useBokeh=False):
         if show_plots:
             plt.show()
             # close the plots being saved off to avoid over-writing old and new figures
+            plt.close("all")
+        elif saveFigures:
             plt.close("all")
 
         # Now we clean up data from this test
@@ -782,11 +836,37 @@ def plotSimAndSave(data, retentionPolicy):
     figureList = plotSim(data, retentionPolicy)
     for pltName, plt in list(figureList.items()):
         # plt.subplots_adjust(top = 0.6, bottom = 0.4)
-        simHelpers.saveScenarioFigure(
+        saveScenarioFigureWithoutClosing(
             fileNameString + "_" + pltName
             , plt, path + "/dataForExamples")
 
     return
+
+
+def saveScenarioFigureWithoutClosing(figureName, figure, savePath, extension=".svg"):
+    """
+    Save a scenario figure while preserving accumulated Monte Carlo traces.
+
+    :param figureName: Figure file base name.
+    :type figureName: str
+    :param figure: Matplotlib figure to save.
+    :param savePath: Scenario data path used to derive the documentation image folder.
+    :type savePath: str
+    :param extension: File extension to use for the image.
+    :type extension: str
+    """
+    imgFileName = os.path.join(
+        savePath,
+        "..",
+        "..",
+        "docs",
+        "source",
+        "_images",
+        "Scenarios",
+        figureName + extension,
+    )
+    os.makedirs(os.path.dirname(imgFileName), exist_ok=True)
+    figure.savefig(imgFileName, transparent=True)
 
 
 # Modify the __main__ section

--- a/src/utilities/MonteCarlo/Controller.py
+++ b/src/utilities/MonteCarlo/Controller.py
@@ -30,6 +30,7 @@ import shutil
 import sys
 import traceback
 import warnings
+import ast
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", category=DeprecationWarning)
@@ -849,7 +850,7 @@ class SimulationExecutor:
             for variable, value in list(modifications.items()):
                 if simParams.verbose:
                     print(f"Setting attribute {variable} to {value} on simInstance")
-                setattr(simInstance, variable, value)
+                cls.applyModification(simInstance, variable, value)
 
             # setup data logging
             if len(simParams.retentionPolicies) > 0:
@@ -896,6 +897,178 @@ class SimulationExecutor:
             return (False, simParams.index)  # there was an error
 
     @staticmethod
+    def _parseAttributePath(attributeString):
+        """
+        Split a nested attribute path into accessors and integer indices.
+
+        :param attributeString: Attribute path to parse.
+        :type attributeString: str
+        :return: Parsed attribute names, zero-argument method calls, and list indices.
+        :rtype: list
+        """
+        if not isinstance(attributeString, str) or attributeString == "":
+            raise ValueError("Attribute path must be a non-empty string")
+
+        pathParts = []
+        attributeName = ""
+        indexString = ""
+        parsingIndex = False
+
+        for character in attributeString:
+            if parsingIndex:
+                if character == "]":
+                    if indexString == "":
+                        raise ValueError("Attribute path contains an empty index")
+                    try:
+                        pathParts.append(int(indexString))
+                    except ValueError as err:
+                        raise ValueError("Attribute path indices must be integers") from err
+                    indexString = ""
+                    parsingIndex = False
+                else:
+                    indexString += character
+            elif character == ".":
+                if attributeName != "":
+                    pathParts.append(attributeName)
+                    attributeName = ""
+            elif character == "[":
+                if attributeName != "":
+                    pathParts.append(attributeName)
+                    attributeName = ""
+                parsingIndex = True
+            else:
+                attributeName += character
+
+        if parsingIndex:
+            raise ValueError("Attribute path contains an unterminated index")
+        if attributeName != "":
+            pathParts.append(attributeName)
+        if len(pathParts) == 0:
+            raise ValueError("Attribute path does not contain any parts")
+
+        return pathParts
+
+    @staticmethod
+    def _resolvePathPart(currentObj, pathPart):
+        """
+        Resolve one intermediate Monte Carlo path part.
+
+        :param currentObj: Object where this path part starts.
+        :param pathPart: Attribute name, zero-argument method call, or integer index.
+        :return: The object resolved by ``pathPart``.
+        """
+        if isinstance(pathPart, int):
+            return currentObj[pathPart]
+
+        if pathPart.endswith("()"):
+            methodName = pathPart[:-2]
+            if not methodName.isidentifier():
+                raise ValueError(
+                    "Only zero-argument method calls are supported in Monte Carlo paths"
+                )
+            method = getattr(currentObj, methodName)
+            if not callable(method):
+                raise ValueError("Monte Carlo path method part is not callable")
+            return method()
+
+        return getattr(currentObj, pathPart)
+
+    @staticmethod
+    def parseModificationValue(value):
+        """
+        Convert an archived Monte Carlo modification value to a Python value.
+
+        Dispersion values are commonly stored as strings so they can be written
+        to JSON.  If the value is already typed, it is returned unchanged.
+
+        :param value: The modification value to parse.
+        :return: The parsed Python value.
+        """
+        if not isinstance(value, str):
+            return value
+
+        try:
+            return ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            return value
+
+    @classmethod
+    def getNestedAttr(cls, obj, attrString):
+        """
+        Get a nested attribute or indexed item using a Monte Carlo path string.
+
+        :param obj: Object where path resolution starts.
+        :param attrString: Attribute path to get.
+        :type attrString: str
+        :return: Value found at ``attrString``.
+        """
+        currentObj = obj
+        for pathPart in cls._parseAttributePath(attrString):
+            currentObj = cls._resolvePathPart(currentObj, pathPart)
+        return currentObj
+
+    @classmethod
+    def _assignPathPart(cls, currentObj, pathPart, value):
+        """
+        Assign one final Monte Carlo path part.
+
+        :param currentObj: Object where this path part starts.
+        :param pathPart: Attribute name or integer index to assign.
+        :param value: Value to assign at ``pathPart``.
+        """
+        if isinstance(pathPart, int):
+            currentObj[pathPart] = value
+        elif pathPart.endswith("()"):
+            raise ValueError("Monte Carlo paths cannot assign to method calls")
+        else:
+            setattr(currentObj, pathPart, value)
+
+    @classmethod
+    def setNestedAttr(cls, obj, attrString, value):
+        """
+        Set a nested attribute or indexed item using a Monte Carlo path string.
+
+        :param obj: Object where path resolution starts.
+        :param attrString: Attribute path to set.
+        :type attrString: str
+        :param value: Value to set at ``attrString``.
+        """
+        pathParts = cls._parseAttributePath(attrString)
+        currentObj = obj
+
+        for pathPart in pathParts[:-1]:
+            currentObj = cls._resolvePathPart(currentObj, pathPart)
+
+        finalPathPart = pathParts[-1]
+        if isinstance(finalPathPart, int):
+            if len(pathParts) < 2:
+                raise ValueError("Indexed Monte Carlo paths require an owning attribute")
+            containerOwner = obj
+            for pathPart in pathParts[:-2]:
+                containerOwner = cls._resolvePathPart(containerOwner, pathPart)
+            containerPathPart = pathParts[-2]
+            container = cls._resolvePathPart(containerOwner, containerPathPart)
+            container[finalPathPart] = value
+            if not (
+                isinstance(containerPathPart, str) and containerPathPart.endswith("()")
+            ):
+                cls._assignPathPart(containerOwner, containerPathPart, container)
+        else:
+            cls._assignPathPart(currentObj, finalPathPart, value)
+
+    @classmethod
+    def applyModification(cls, simInstance, variable, value):
+        """
+        Apply one Monte Carlo modification to the simulation instance.
+
+        :param simInstance: Simulation object to modify.
+        :param variable: Nested attribute path to modify.
+        :type variable: str
+        :param value: Archived or typed modification value.
+        """
+        cls.setNestedAttr(simInstance, variable, cls.parseModificationValue(value))
+
+    @staticmethod
     def disperseSeeds(simInstance):
         """
         Disperses the RNG seeds of all the tasks in the sim, and returns a statement that contains the seeds.
@@ -917,17 +1090,13 @@ class SimulationExecutor:
         for i, task in enumerate(simInstance.TaskList):
             for j, model in enumerate(task.TaskModels):
                 taskVar = 'TaskList[' + str(i) + '].TaskModels' + '[' + str(j) + '].RNGSeed'
-                rand = str(random.randint(0, 1 << 32 - 1))
-                try:
-                    execStatement = "simInstance." + taskVar + "=" + str(rand)
-                    setattr(simInstance, taskVar, rand)  # if this fails don't add to the list of modification
+                if hasattr(model, "RNGSeed"):
+                    rand = str(random.randint(0, (1 << 32) - 1))
                     randomSeeds[taskVar] = rand
-                except:
-                    pass
         return randomSeeds
 
-    @staticmethod
-    def populateSeeds(simInstance, modifications):
+    @classmethod
+    def populateSeeds(cls, simInstance, modifications):
         """
         only populate the RNG seeds of all the tasks in the sim
 
@@ -938,6 +1107,5 @@ class SimulationExecutor:
                 A dictionary containing RNGSeeds to be populate for the sim, among other sim modifications.
         """
         for variable, value in modifications.items():
-            if ".RNGSeed" in variable:
-                rngStatement = "simInstance." + variable + "=" + value
-                setattr(simInstance, variable, value)
+            if variable.endswith(".RNGSeed"):
+                cls.applyModification(simInstance, variable, value)

--- a/src/utilities/MonteCarlo/Controller.py
+++ b/src/utilities/MonteCarlo/Controller.py
@@ -1034,26 +1034,42 @@ class SimulationExecutor:
         :param value: Value to set at ``attrString``.
         """
         pathParts = cls._parseAttributePath(attrString)
-        currentObj = obj
-
-        for pathPart in pathParts[:-1]:
-            currentObj = cls._resolvePathPart(currentObj, pathPart)
-
         finalPathPart = pathParts[-1]
         if isinstance(finalPathPart, int):
-            if len(pathParts) < 2:
+            trailingIndexStart = len(pathParts) - 1
+            while (
+                trailingIndexStart > 0
+                and isinstance(pathParts[trailingIndexStart - 1], int)
+            ):
+                trailingIndexStart -= 1
+            if trailingIndexStart == 0:
                 raise ValueError("Indexed Monte Carlo paths require an owning attribute")
+
             containerOwner = obj
-            for pathPart in pathParts[:-2]:
+            for pathPart in pathParts[:trailingIndexStart - 1]:
                 containerOwner = cls._resolvePathPart(containerOwner, pathPart)
-            containerPathPart = pathParts[-2]
+
+            containerPathPart = pathParts[trailingIndexStart - 1]
             container = cls._resolvePathPart(containerOwner, containerPathPart)
-            container[finalPathPart] = value
+            indexedOwners = []
+            indexedObj = container
+            for indexPathPart in pathParts[trailingIndexStart:-1]:
+                indexedOwners.append((indexedObj, indexPathPart))
+                indexedObj = cls._resolvePathPart(indexedObj, indexPathPart)
+
+            indexedObj[finalPathPart] = value
+            for indexedOwner, indexPathPart in reversed(indexedOwners):
+                indexedOwner[indexPathPart] = indexedObj
+                indexedObj = indexedOwner
+
             if not (
                 isinstance(containerPathPart, str) and containerPathPart.endswith("()")
             ):
                 cls._assignPathPart(containerOwner, containerPathPart, container)
         else:
+            currentObj = obj
+            for pathPart in pathParts[:-1]:
+                currentObj = cls._resolvePathPart(currentObj, pathPart)
             cls._assignPathPart(currentObj, finalPathPart, value)
 
     @classmethod

--- a/src/utilities/MonteCarlo/Dispersions.py
+++ b/src/utilities/MonteCarlo/Dispersions.py
@@ -301,8 +301,8 @@ class NormalVectorAngleDispersion(VectorVariableDispersion):
         meanPhi = vectorSphere[1] # Nominal phi
         meanTheta = vectorSphere[2] # Nominal theta
 
-        phiRnd = np.random.normal(meanPhi, self.phiStd, 1)
-        thetaRnd = np.random.normal(meanTheta, self.thetaStd, 1)
+        phiRnd = np.random.normal(meanPhi, self.phiStd)
+        thetaRnd = np.random.normal(meanTheta, self.thetaStd)
 
         self.phiBounds = [meanPhi + self.phiBoundsOffNom[0], meanPhi + self.phiBoundsOffNom[1]]
         self.thetaBounds = [meanTheta + self.thetaBoundsOffNom[0],  meanTheta + self.thetaBoundsOffNom[1]]

--- a/src/utilities/MonteCarlo/Dispersions.py
+++ b/src/utilities/MonteCarlo/Dispersions.py
@@ -218,12 +218,14 @@ class UniformVectorDispersion(VectorVariableDispersion):
 class NormalVectorDispersion(VectorVariableDispersion):
     def __init__(self, varName, mean=0.0, stdDeviation=0.5, bounds=None):
         VectorVariableDispersion.__init__(self, varName, bounds)
+        self.mean = mean
+        self.stdDeviation = stdDeviation
         if self.bounds is None:
             self.bounds = ([-1.0, 1.0])  # defines a hard floor/ceiling
 
     def generate(self, sim):
         vector = SimulationExecutor.getNestedAttr(sim, self.varName)
-        dispValue = self.perturbCartesianVectorNormal(vector, self.mean, self.stdDeviation)
+        dispValue = self.perturbCartesianVectorNormal(vector)
         return dispValue
 
 

--- a/src/utilities/MonteCarlo/Dispersions.py
+++ b/src/utilities/MonteCarlo/Dispersions.py
@@ -256,8 +256,8 @@ class UniformVectorAngleDispersion(VectorVariableDispersion):
         self.phiBounds = [meanPhi + self.phiBoundsOffNom[0], meanPhi + self.phiBoundsOffNom[1]]
         self.thetaBounds = [meanTheta + self.thetaBoundsOffNom[0],  meanTheta + self.thetaBoundsOffNom[1]]
 
-        phiRnd = np.random.uniform(meanPhi+self.phiBounds[0], meanPhi+self.phiBounds[1])
-        thetaRnd = np.random.uniform(meanTheta+self.thetaBounds[0], meanTheta+self.thetaBounds[1])
+        phiRnd = np.random.uniform(self.phiBounds[0], self.phiBounds[1])
+        thetaRnd = np.random.uniform(self.thetaBounds[0], self.thetaBounds[1])
 
         phiRnd = self.checkBounds(phiRnd, self.phiBounds)
         thetaRnd = self.checkBounds(thetaRnd, self.thetaBounds)

--- a/src/utilities/MonteCarlo/Dispersions.py
+++ b/src/utilities/MonteCarlo/Dispersions.py
@@ -24,6 +24,7 @@ import random
 import numpy as np
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import orbitalMotion
+from Basilisk.utilities.MonteCarlo.Controller import SimulationExecutor
 
 
 class SingleVariableDispersion(object):
@@ -209,7 +210,7 @@ class UniformVectorDispersion(VectorVariableDispersion):
             self.bounds = ([-1.0, 1.0])  # defines a hard floor/ceiling
 
     def generate(self, sim):
-        vector = getattr(sim, self.varName)
+        vector = SimulationExecutor.getNestedAttr(sim, self.varName)
         dispValue = self.perturbCartesianVectorUniform(vector)
         return dispValue
 
@@ -221,7 +222,7 @@ class NormalVectorDispersion(VectorVariableDispersion):
             self.bounds = ([-1.0, 1.0])  # defines a hard floor/ceiling
 
     def generate(self, sim):
-        vector = getattr(sim, self.varName)
+        vector = SimulationExecutor.getNestedAttr(sim, self.varName)
         dispValue = self.perturbCartesianVectorNormal(vector, self.mean, self.stdDeviation)
         return dispValue
 
@@ -243,7 +244,7 @@ class UniformVectorAngleDispersion(VectorVariableDispersion):
 
     def generate(self, sim=None):
         # Note this dispersion is applied off of the nominal
-        vectorCart = getattr(sim, self.varName)
+        vectorCart = SimulationExecutor.getNestedAttr(sim, self.varName)
         vectorCart = vectorCart/np.linalg.norm(vectorCart)
         vectorSphere = self.cart2Spherical(vectorCart)
 
@@ -291,7 +292,7 @@ class NormalVectorAngleDispersion(VectorVariableDispersion):
         self.magnitude = []
 
     def generate(self, sim=None):
-        vectorCart = getattr(sim, self.varName)
+        vectorCart = SimulationExecutor.getNestedAttr(sim, self.varName)
         vectorCart = vectorCart/np.linalg.norm(vectorCart)
         vectorSphere = self.cart2Spherical(vectorCart)
 
@@ -391,11 +392,7 @@ class NormalThrusterUnitDirectionVectorDispersion(VectorVariableDispersion):
                   + "()' dispersions will not be set for variable " + self.varName))
             return
         else:
-            separator = '.'
-            thrusterObject = getattr(sim, self.varNameComponents[0])
-            totalVar = separator.join(self.varNameComponents[0:-1])
-            simObject = getattr(sim, totalVar)  # sim.totalVar
-            dirVec = getattr(simObject, 'thrDir_B')  # sim.totalVar.thrDir_B
+            dirVec = SimulationExecutor.getNestedAttr(sim, self.getName())
             angle = np.random.normal(0, self.phiStd, 1)
             dirVec = np.array(dirVec).reshape(3).tolist()
             dispVec = self.perturbVectorByAngle(dirVec, angle)
@@ -477,11 +474,7 @@ class InertiaTensorDispersion:
                   + "()' dispersions will not be set for variable " + self.varName))
             return
         else:
-            vehDynObject = getattr(sim, self.varNameComponents[0])
-            parts = self.varName.split('.')
-            attr = sim
-            for part in parts:
-                attr = getattr(attr, part)
+            attr = SimulationExecutor.getNestedAttr(sim, self.varName)
             I = np.array(attr).reshape(3, 3)
 
             # generate random values for the diagonals

--- a/src/utilities/MonteCarlo/README.md
+++ b/src/utilities/MonteCarlo/README.md
@@ -1,6 +1,6 @@
 # MonteCarlo: Brief Guide
 
-*If you plan to use this it is highly recommended to read the documentation in the `MonteCarlo/Controller.py` source file and the example usage in `src/tests/scenarios/test_MonteCarloSimulation.py`. This guide offers only a brief overview of features*
+*If you plan to use this it is highly recommended to read the documentation in the `MonteCarlo/Controller.py` source file, the example usage in `examples/scenarioMonteCarloAttRW.py`, and the corresponding test in `src/tests/test_scenarioMonteCarloAttRW.py`. This guide offers only a brief overview of features*
 
 A MonteCarlo simulation can be created using the `MonteCarlo` module. This module is used to execute monte carlo simulations, and access retained data from previously executed MonteCarlo runs.
 
@@ -37,12 +37,13 @@ def myExecutionFunction(sim):
 monteCarlo.setExecutionFunction(myExecutionFunction)
 ```
 
-Optionally, there is a function that can be used to configure the simulation after all dispersions of random seeds and variables have been applied. This may be unused, it is only necessary to access the simulation at this time in some cases.
+Optionally, there is a function that can be used to configure the simulation after random seeds
+have been populated. Non-seed parameter dispersions are applied after this configuration step
+and before the execution function runs.
 
 ```
 def myConfigureFunction(sim):
-  # do something with the sim now that random seeds have been applied
-  # and variables are dispersed ...
+  # do something with the sim now that random seeds have been applied ...
 
 monteCarlo.setConfigureFunction(myConfigureFunction)
 ```
@@ -52,6 +53,12 @@ Statistical dispersions can be applied to initial parameters using the MonteCarl
 ```
 monteCarlo.addDispersion(UniformEulerAngleMRPDispersion("taskName.hub.sigma_BNInit"))
 ```
+
+Dispersion names can reference nested simulation attributes with dotted names, integer list
+indices, and zero-argument accessor methods. For example,
+`TaskList[0].TaskModels[0].hub.sigma_BNInit` updates the `sigma_BNInit` attribute
+on the first model's hub object, while `get_DynModel().scObject.hub.r_CN_NInit`
+resolves the object returned by `get_DynModel()` before applying the dispersion.
 
 If data is being retained, a archive directory to store retained data must be specified. This directory is later used to reload the retained data from an executed Monte Carlo simulation.
 

--- a/src/utilities/MonteCarlo/README.md
+++ b/src/utilities/MonteCarlo/README.md
@@ -58,7 +58,9 @@ Dispersion names can reference nested simulation attributes with dotted names, i
 indices, and zero-argument accessor methods. For example,
 `TaskList[0].TaskModels[0].hub.sigma_BNInit` updates the `sigma_BNInit` attribute
 on the first model's hub object, while `get_DynModel().scObject.hub.r_CN_NInit`
-resolves the object returned by `get_DynModel()` before applying the dispersion.
+resolves the object returned by `get_DynModel()` before applying the dispersion. Repeated
+indices can be used for matrix-like attributes, such as
+`scObject.hub.IHubPntBc_B[0][1]`.
 
 If data is being retained, a archive directory to store retained data must be specified. This directory is later used to reload the retained data from an executed Monte Carlo simulation.
 

--- a/src/utilities/MonteCarlo/_UnitTests/test_controller.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_controller.py
@@ -1,0 +1,275 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import numpy as np
+
+from Basilisk.simulation import motorVoltageInterface
+from Basilisk.utilities.MonteCarlo.Controller import SimulationExecutor, SimulationParameters
+from Basilisk.utilities.MonteCarlo.Dispersions import UniformDispersion, UniformVectorAngleDispersion
+
+
+class DummyHub:
+    def __init__(self):
+        self.mHub = 1.0  # [kg]
+        self.r_BcB_B = [0.0, 0.0, 0.0]  # [m]
+        self.unitVector = np.array([[1.0], [0.0], [0.0]])  # [-]
+
+
+class DummyModel:
+    def __init__(self):
+        self.RNGSeed = 0
+        self.hub = DummyHub()
+
+
+class DummyModelWithoutSeed:
+    pass
+
+
+class DummyTask:
+    def __init__(self):
+        self.TaskModels = [DummyModel(), DummyModelWithoutSeed()]
+
+
+class DummyVectorContainer:
+    def __init__(self):
+        self.values = [0.0, 0.0, 0.0]
+
+
+class DummyDynModel:
+    def __init__(self):
+        self.scObject = DummyModel()
+
+
+class DummySimulation:
+    def __init__(self):
+        self.TaskList = [DummyTask()]
+        self.vectorContainer = DummyVectorContainer()
+        self.dynModel = DummyDynModel()
+
+    def get_DynModel(self):
+        return self.dynModel
+
+
+def test_apply_modification_updates_nested_attributes():
+    """Verify Monte Carlo path strings update the nested object."""
+    sim = DummySimulation()
+
+    mass_path = "TaskList[0].TaskModels[0].hub.mHub"
+    SimulationExecutor.applyModification(sim, mass_path, "25.0")
+
+    assert sim.TaskList[0].TaskModels[0].hub.mHub == 25.0
+    assert not hasattr(sim, mass_path)
+
+    center_of_mass_path = "TaskList[0].TaskModels[0].hub.r_BcB_B"
+    SimulationExecutor.applyModification(sim, center_of_mass_path, "[1.0, 2.0, 3.0]")
+
+    assert sim.TaskList[0].TaskModels[0].hub.r_BcB_B == [1.0, 2.0, 3.0]
+
+    indexed_path = "vectorContainer.values[1]"
+    SimulationExecutor.applyModification(sim, indexed_path, "7.5")
+
+    assert sim.vectorContainer.values == [0.0, 7.5, 0.0]
+
+    method_path = "get_DynModel().scObject.hub.mHub"
+    SimulationExecutor.applyModification(sim, method_path, "35.0")
+
+    assert sim.get_DynModel().scObject.hub.mHub == 35.0
+    assert not hasattr(sim, method_path)
+
+
+def test_indexed_modification_updates_swig_copy_on_read_container():
+    """Verify indexed paths write back copy-on-read SWIG containers."""
+    sim = DummySimulation()
+    sim.rwVoltageIO = motorVoltageInterface.MotorVoltageInterface()
+    initial_gains = [0.02, 0.02, 0.02]  # [N*m/V]
+    new_gain = 0.123  # [N*m/V]
+
+    sim.rwVoltageIO.setGains(initial_gains)
+    SimulationExecutor.applyModification(
+        sim,
+        "rwVoltageIO.voltage2TorqueGain[0]",
+        str(new_gain)
+    )
+
+    assert sim.rwVoltageIO.voltage2TorqueGain[0][0] == new_gain
+
+
+def test_vector_angle_dispersion_reads_nested_method_path():
+    """Verify vector dispersions read nested zero-argument method paths."""
+    sim = DummySimulation()
+    vector_path = "get_DynModel().scObject.hub.unitVector"
+    phi_bounds = [-0.001, 0.001]  # [rad]
+    theta_bounds = [-0.001, 0.001]  # [rad]
+
+    dispersion = UniformVectorAngleDispersion(
+        vector_path,
+        phiBoundsOffNom=phi_bounds,
+        thetaBoundsOffNom=theta_bounds
+    )
+
+    dispersed_vector = dispersion.generate(sim)
+
+    assert np.isclose(np.linalg.norm(dispersed_vector), 1.0)
+
+
+def test_populate_seeds_applies_before_configure_function():
+    """Verify archived RNGSeed modifications are set before configuration."""
+    configured_seeds = []
+
+    def create_sim():
+        return DummySimulation()
+
+    def configure_sim(sim):
+        configured_seeds.append(sim.TaskList[0].TaskModels[0].RNGSeed)
+
+    def execute_sim(sim):
+        assert sim.TaskList[0].TaskModels[0].RNGSeed == 8675309
+        assert sim.TaskList[0].TaskModels[0].hub.mHub == 42.0
+
+    sim_params = SimulationParameters(
+        creationFunction=create_sim,
+        executionFunction=execute_sim,
+        configureFunction=configure_sim,
+        retentionPolicies=[],
+        dispersions=[],
+        shouldDisperseSeeds=False,
+        shouldArchiveParameters=False,
+        filename="",
+        icfilename="",
+        index=0,
+        modifications={
+            "TaskList[0].TaskModels[0].RNGSeed": "8675309",
+            "TaskList[0].TaskModels[0].hub.mHub": "42.0",
+        }
+    )
+
+    result = SimulationExecutor()([sim_params, None])
+
+    assert result == (True, 0)
+    assert configured_seeds == [8675309]
+
+
+def test_uniform_dispersion_randomizes_nested_sim_parameter():
+    """Verify generated dispersions update the live simulation parameter."""
+    mass_path = "TaskList[0].TaskModels[0].hub.mHub"
+    mass_bounds = [24.0, 26.0]  # [kg]
+    observed_masses = []
+    generated_masses = []
+
+    def create_sim():
+        return DummySimulation()
+
+    def execute_sim(sim):
+        observed_masses.append(sim.TaskList[0].TaskModels[0].hub.mHub)
+
+    for run_index in range(2):
+        sim_params = SimulationParameters(
+            creationFunction=create_sim,
+            executionFunction=execute_sim,
+            configureFunction=None,
+            retentionPolicies=[],
+            dispersions=[UniformDispersion(mass_path, mass_bounds)],
+            shouldDisperseSeeds=False,
+            shouldArchiveParameters=False,
+            filename="",
+            icfilename="",
+            index=run_index,
+            modifications={}
+        )
+
+        result = SimulationExecutor()([sim_params, None])
+        generated_mass = SimulationExecutor.parseModificationValue(
+            sim_params.modifications[mass_path]
+        )
+
+        assert result == (True, run_index)
+        generated_masses.append(generated_mass)
+
+    assert observed_masses == generated_masses
+    assert observed_masses[0] != observed_masses[1]
+    for observed_mass in observed_masses:
+        assert mass_bounds[0] <= observed_mass <= mass_bounds[1]
+        assert observed_mass != DummyHub().mHub
+
+
+def test_uniform_dispersion_randomizes_method_path_parameter():
+    """Verify generated dispersions update a zero-argument method path."""
+    mass_path = "get_DynModel().scObject.hub.mHub"
+    mass_bounds = [34.0, 36.0]  # [kg]
+    observed_masses = []
+    generated_masses = []
+
+    def create_sim():
+        return DummySimulation()
+
+    def execute_sim(sim):
+        observed_masses.append(sim.get_DynModel().scObject.hub.mHub)
+
+    for run_index in range(2):
+        sim_params = SimulationParameters(
+            creationFunction=create_sim,
+            executionFunction=execute_sim,
+            configureFunction=None,
+            retentionPolicies=[],
+            dispersions=[UniformDispersion(mass_path, mass_bounds)],
+            shouldDisperseSeeds=False,
+            shouldArchiveParameters=False,
+            filename="",
+            icfilename="",
+            index=run_index,
+            modifications={}
+        )
+
+        result = SimulationExecutor()([sim_params, None])
+        generated_mass = SimulationExecutor.parseModificationValue(
+            sim_params.modifications[mass_path]
+        )
+
+        assert result == (True, run_index)
+        generated_masses.append(generated_mass)
+
+    assert observed_masses == generated_masses
+    assert observed_masses[0] != observed_masses[1]
+    for observed_mass in observed_masses:
+        assert mass_bounds[0] <= observed_mass <= mass_bounds[1]
+        assert observed_mass != DummyHub().mHub
+
+
+def test_disperse_seeds_only_records_seeded_models():
+    """Verify random seed dispersions are recorded only for seeded models."""
+    sim = DummySimulation()
+
+    random_seeds = SimulationExecutor.disperseSeeds(sim)
+
+    seed_path = "TaskList[0].TaskModels[0].RNGSeed"
+
+    assert set(random_seeds.keys()) == {seed_path}
+    assert isinstance(
+        SimulationExecutor.parseModificationValue(random_seeds[seed_path]),
+        int
+    )
+
+
+if __name__ == "__main__":
+    test_apply_modification_updates_nested_attributes()
+    test_indexed_modification_updates_swig_copy_on_read_container()
+    test_vector_angle_dispersion_reads_nested_method_path()
+    test_populate_seeds_applies_before_configure_function()
+    test_uniform_dispersion_randomizes_nested_sim_parameter()
+    test_uniform_dispersion_randomizes_method_path_parameter()
+    test_disperse_seeds_only_records_seeded_models()

--- a/src/utilities/MonteCarlo/_UnitTests/test_controller.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_controller.py
@@ -21,7 +21,11 @@ import numpy as np
 from Basilisk.simulation import motorVoltageInterface, spacecraft
 from Basilisk.utilities import simHelpers
 from Basilisk.utilities.MonteCarlo.Controller import SimulationExecutor, SimulationParameters
-from Basilisk.utilities.MonteCarlo.Dispersions import UniformDispersion, UniformVectorAngleDispersion
+from Basilisk.utilities.MonteCarlo.Dispersions import (
+    NormalVectorDispersion,
+    UniformDispersion,
+    UniformVectorAngleDispersion
+)
 
 
 class DummyHub:
@@ -147,6 +151,23 @@ def test_vector_angle_dispersion_reads_nested_method_path():
     dispersed_vector = dispersion.generate(sim)
 
     assert np.isclose(np.linalg.norm(dispersed_vector), 1.0)
+
+
+def test_normal_vector_dispersion_uses_configured_statistics():
+    """Verify normal vector dispersions retain mean and standard deviation."""
+    sim = DummySimulation()
+    vector_path = "TaskList[0].TaskModels[0].hub.r_BcB_B"
+    mean = 2.5  # [m]
+    std_deviation = 0.0  # [m]
+
+    dispersion = NormalVectorDispersion(
+        vector_path,
+        mean=mean,
+        stdDeviation=std_deviation
+    )
+    dispersed_vector = dispersion.generate(sim)
+
+    assert np.allclose(dispersed_vector, [mean, mean, mean])
 
 
 def test_populate_seeds_applies_before_configure_function():
@@ -292,6 +313,7 @@ if __name__ == "__main__":
     test_indexed_modification_updates_swig_copy_on_read_container()
     test_double_indexed_modification_updates_swig_matrix3d()
     test_vector_angle_dispersion_reads_nested_method_path()
+    test_normal_vector_dispersion_uses_configured_statistics()
     test_populate_seeds_applies_before_configure_function()
     test_uniform_dispersion_randomizes_nested_sim_parameter()
     test_uniform_dispersion_randomizes_method_path_parameter()

--- a/src/utilities/MonteCarlo/_UnitTests/test_controller.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_controller.py
@@ -153,6 +153,46 @@ def test_vector_angle_dispersion_reads_nested_method_path():
     assert np.isclose(np.linalg.norm(dispersed_vector), 1.0)
 
 
+def test_uniform_vector_angle_dispersion_uses_bounds_off_nominal(monkeypatch):
+    """Verify angle dispersions use bounds centered on the nominal vector."""
+    sim = DummySimulation()
+    vector_path = "get_DynModel().scObject.hub.unitVector"
+    sim.get_DynModel().scObject.hub.unitVector = np.array([
+        [1.0], [1.0], [1.0]
+    ])  # [-]
+    phi_bounds = [-0.02, 0.03]  # [rad]
+    theta_bounds = [-0.04, 0.05]  # [rad]
+    uniform_calls = []
+
+    def record_uniform(lower_bound, upper_bound):
+        uniform_calls.append((lower_bound, upper_bound))
+        return (lower_bound + upper_bound) / 2.0
+
+    monkeypatch.setattr(np.random, "uniform", record_uniform)
+
+    dispersion = UniformVectorAngleDispersion(
+        vector_path,
+        phiBoundsOffNom=phi_bounds,
+        thetaBoundsOffNom=theta_bounds
+    )
+    dispersion.generate(sim)
+
+    nominal_vector = sim.get_DynModel().scObject.hub.unitVector
+    nominal_vector = nominal_vector / np.linalg.norm(nominal_vector)
+    nominal_spherical = dispersion.cart2Spherical(nominal_vector)
+    expected_phi_bounds = [
+        nominal_spherical[1] + phi_bounds[0],
+        nominal_spherical[1] + phi_bounds[1]
+    ]
+    expected_theta_bounds = [
+        nominal_spherical[2] + theta_bounds[0],
+        nominal_spherical[2] + theta_bounds[1]
+    ]
+
+    assert np.allclose(uniform_calls[0], expected_phi_bounds)
+    assert np.allclose(uniform_calls[1], expected_theta_bounds)
+
+
 def test_normal_vector_dispersion_uses_configured_statistics():
     """Verify normal vector dispersions retain mean and standard deviation."""
     sim = DummySimulation()

--- a/src/utilities/MonteCarlo/_UnitTests/test_controller.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_controller.py
@@ -22,6 +22,7 @@ from Basilisk.simulation import motorVoltageInterface, spacecraft
 from Basilisk.utilities import simHelpers
 from Basilisk.utilities.MonteCarlo.Controller import SimulationExecutor, SimulationParameters
 from Basilisk.utilities.MonteCarlo.Dispersions import (
+    NormalVectorAngleDispersion,
     NormalVectorDispersion,
     UniformDispersion,
     UniformVectorAngleDispersion
@@ -191,6 +192,42 @@ def test_uniform_vector_angle_dispersion_uses_bounds_off_nominal(monkeypatch):
 
     assert np.allclose(uniform_calls[0], expected_phi_bounds)
     assert np.allclose(uniform_calls[1], expected_theta_bounds)
+
+
+def test_normal_vector_angle_dispersion_uses_scalar_angle_samples(monkeypatch):
+    """Verify normal angle dispersions draw scalar angle samples."""
+    sim = DummySimulation()
+    vector_path = "get_DynModel().scObject.hub.unitVector"
+    sim.get_DynModel().scObject.hub.unitVector = np.array([
+        [1.0], [1.0], [1.0]
+    ])  # [-]
+    phi_std = 0.02  # [rad]
+    theta_std = 0.03  # [rad]
+    normal_calls = []
+
+    def record_normal(mean, standard_deviation):
+        normal_calls.append((mean, standard_deviation))
+        return mean
+
+    monkeypatch.setattr(np.random, "normal", record_normal)
+
+    dispersion = NormalVectorAngleDispersion(
+        vector_path,
+        phiStd=phi_std,
+        thetaStd=theta_std,
+        phiBoundsOffNom=[-0.1, 0.1],
+        thetaBoundsOffNom=[-0.1, 0.1]
+    )
+    dispersed_vector = dispersion.generate(sim)
+
+    nominal_vector = sim.get_DynModel().scObject.hub.unitVector
+    nominal_vector = nominal_vector / np.linalg.norm(nominal_vector)
+    nominal_spherical = dispersion.cart2Spherical(nominal_vector)
+
+    assert np.isclose(np.linalg.norm(dispersed_vector), 1.0)
+    assert np.allclose(normal_calls[0], [nominal_spherical[1], phi_std])
+    assert np.allclose(normal_calls[1], [nominal_spherical[2], theta_std])
+    assert dispersion.getDispersionMag() == [r"0.0 $\sigma$", r"0.0 $\sigma$"]
 
 
 def test_normal_vector_dispersion_uses_configured_statistics():

--- a/src/utilities/MonteCarlo/_UnitTests/test_controller.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_controller.py
@@ -18,7 +18,8 @@
 
 import numpy as np
 
-from Basilisk.simulation import motorVoltageInterface
+from Basilisk.simulation import motorVoltageInterface, spacecraft
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.MonteCarlo.Controller import SimulationExecutor, SimulationParameters
 from Basilisk.utilities.MonteCarlo.Dispersions import UniformDispersion, UniformVectorAngleDispersion
 
@@ -107,6 +108,27 @@ def test_indexed_modification_updates_swig_copy_on_read_container():
     )
 
     assert sim.rwVoltageIO.voltage2TorqueGain[0][0] == new_gain
+
+
+def test_double_indexed_modification_updates_swig_matrix3d():
+    """Verify double-indexed paths write back SWIG Matrix3d attributes."""
+    sim = DummySimulation()
+    sim.scObject = spacecraft.Spacecraft()
+    inertia = [
+        900.0, 0.0, 0.0,
+        0.0, 800.0, 0.0,
+        0.0, 0.0, 600.0
+    ]  # [kg*m^2]
+    new_cross_inertia = 12.5  # [kg*m^2]
+
+    sim.scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(inertia)
+    SimulationExecutor.applyModification(
+        sim,
+        "scObject.hub.IHubPntBc_B[0][1]",
+        str(new_cross_inertia)
+    )
+
+    assert sim.scObject.hub.IHubPntBc_B[0][1] == new_cross_inertia
 
 
 def test_vector_angle_dispersion_reads_nested_method_path():
@@ -268,6 +290,7 @@ def test_disperse_seeds_only_records_seeded_models():
 if __name__ == "__main__":
     test_apply_modification_updates_nested_attributes()
     test_indexed_modification_updates_swig_copy_on_read_container()
+    test_double_indexed_modification_updates_swig_matrix3d()
     test_vector_angle_dispersion_reads_nested_method_path()
     test_populate_seeds_applies_before_configure_function()
     test_uniform_dispersion_randomizes_nested_sim_parameter()


### PR DESCRIPTION
* **Tickets addressed:** bsk-1164
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Fixes BSK issue #1164 reported by [ruthubotica](https://github.com/ruthubotica) by replacing the Monte Carlo executor’s direct `setattr(simInstance, path, value)` call with a nested path resolver. The resolver now applies dispersions and archived modifications to the actual simulation objects, including dotted attributes, integer list indices, and existing zero-argument accessor paths such as `get_DynModel().scObject.hub.r_CN_NInit`.

The branch also routes saved `RNGSeed` updates through the same application helper, ensures seeds are populated before `configureFunction`, and tunes `scenarioMonteCarloAttRW` dispersions/plot saving so the documented Monte Carlo results show subtle run-to-run variation rather than overlapping or saturated responses.

Commits are organized as controller/test fix, scenario/documentation update, and release-note/known-issue updates.

## Verification
Added focused unit tests in `src/utilities/MonteCarlo/_UnitTests/test_controller.py` covering nested attribute updates, indexed list updates, zero-argument accessor paths, archived `RNGSeed` application before configuration, and generated `UniformDispersion` values reaching the live simulation object.

Validated with:

```text
MPLBACKEND=Agg MPLCONFIGDIR=/private/tmp/mpl .venv/bin/pytest -q src/utilities/MonteCarlo/_UnitTests/test_controller.py
MPLBACKEND=Agg MPLCONFIGDIR=/private/tmp/mpl .venv/bin/pytest -q src/utilities/MonteCarlo/_UnitTests/test_scenarioBasicOrbitMC.py
MPLBACKEND=Agg MPLCONFIGDIR=/private/tmp/mpl .venv/bin/pytest -q 'src/tests/test_scenarioMonteCarloAttRW.py::test_MonteCarloSimulation[1]'
.venv/bin/python -m py_compile src/utilities/MonteCarlo/Controller.py src/utilities/MonteCarlo/_UnitTests/test_controller.py examples/scenarioMonteCarloAttRW.py
git diff --check origin/develop...HEAD
```

## Documentation
Updated Monte Carlo README guidance to describe when seeds and non-seed dispersions are applied, and to document nested path support including zero-argument accessor methods.

Updated `scenarioMonteCarloAttRW` documentation/table to match the revised subtler dispersions and clarify nested dispersion paths. Added a release note snippet and updated known issues to mention the Monte Carlo dispersion application fix.

Reviewers should check the updated scenario dispersion table and the README’s description of configure/dispersal ordering.

## Future work
No required follow-up is known. 