### PR TITLE
Raise maximum versions in pyproject to match requirements_dev

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1404-nightly-wheel-compiler-fixes.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1404-nightly-wheel-compiler-fixes.rst
@@ -1,0 +1,2 @@
+- Fixed nightly wheel builds on ``macos-26`` and ``windows-2025-vs2026`` runners. Conan 2.23.0 did not recognise apple-clang 21 or Visual Studio 2026. This would cause macOS builds to abort and Windows builds to fall back to MinGW gcc.
+- Aligned the ``cmake``, ``setuptools``, ``setuptools-scm``, and ``packaging`` upper bounds in ``pyproject.toml`` with ``requirements_dev.txt``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools>=77.0.3,<=80.9.0",   # Required for "bdist_wheel" to work correctly and for PEP 639 license metadata.
-    "setuptools-scm>=8.0,<=9.2.2",  # Automatically include all Git-controlled files in sdist
-    "packaging>=24.0,<26",
+    "setuptools>=77.0.3,<=82.0.1",   # Required for "bdist_wheel" to work correctly and for PEP 639 license metadata.
+    "setuptools-scm>=8.0,<=10.0.5",  # Automatically include all Git-controlled files in sdist
+    "packaging>=24.0,<=26.2",
 
     # needed to find the numpy include headers,
     # pin to lowest runtime allowed version to take advantage of backwards compatibility
@@ -11,8 +11,8 @@ requires = [
     "numpy>=2.0,<2.4.0;     python_version >= '3.13'",
 
     # Requirements for building Basilisk through conanfile
-    "conan>=2.0.5,<=2.23.0",
-    "cmake>=3.26,<4.0",
+    "conan>=2.0.5,<=2.28.1",
+    "cmake>=3.26,<=4.3.2",
     "swig>=4.4.1,<5",  # Require SWIG ABI 5 support for Basilisk and compatible plugins.
     "libclang>=15.0.6.1,<=18.1.1"  # Required by generatePayloadMetaJson.py (message code generation)
 ]


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
Fixed nightly wheel builds on ``macos-26`` and ``windows-2025-vs2026`` runners by aligning the pyproject.toml maximum version bounds to what we specify in the requirements_dev file. Conan 2.23.0 did not recognise apple-clang 21 or Visual Studio 2026. This would cause macOS builds to abort and Windows builds to fall back to MinGW gcc.

## Verification
Will keep an eye on the nightly builds to see if this resolves the issue.

## Documentation
N/A

## Future work
N/A
