### PR TITLE
Remove MuJoCo replay from published wheels

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          CONAN_ARGS: "--opNav True --mujoco True --mujocoReplay True"
+          CONAN_ARGS: "--opNav True --mujoco True"
           CIBW_TEST_SKIP: "*"
 
       - name: Upload wheels

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          CONAN_ARGS: "--opNav True --mujoco True --mujocoReplay True"
+          CONAN_ARGS: "--opNav True --mujoco True"
           CIBW_TEST_SKIP: "*"
 
       - name: Upload wheels

--- a/docs/source/Support/bskReleaseNotesSnippets/1406-remove-mujoco-replay-from-wheel-builds.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1406-remove-mujoco-replay-from-wheel-builds.rst
@@ -1,0 +1,1 @@
+- Removed ``--mujocoReplay True`` from wheel build ``CONAN_ARGS`` in ``publish-wheels.yml`` and ``nightly-wheels.yml``. The replay binary is not packaged into wheels and building it inside the manylinux container requires X11 devel packages that are not present there.


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
We should not be distributing the MuJoCo replay tool inside the wheels. It's a niche tool for the MuJoCo + bsk users that will be superseded by the upcoming Vizard integration. If we want to keep around and distribute it in the future it should be part of some "bsk-tools" or `pip install bsk[tools]` or something along those lines.

## Verification
N/A

## Documentation
N/A

## Future work
N/A
