### PR TITLE
Fix BSK distribution wheel builds

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -17,6 +17,9 @@ jobs:
           - ubuntu-24.04
           - ubuntu-24.04-arm
           - windows-2025-vs2026
+        include:
+          - os: windows-2025-vs2026
+            extra-conan-args: --generator Ninja
 
     steps:
       - name: Checkout develop
@@ -30,7 +33,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          CONAN_ARGS: "--opNav True --mujoco True"
+          CONAN_ARGS: "--opNav True --mujoco True ${{ matrix.extra-conan-args }}"
           CIBW_TEST_SKIP: "*"
 
       - name: Upload wheels

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -22,10 +22,10 @@ jobs:
             extra-conan-args: --generator Ninja
 
     steps:
-      - name: Checkout develop
+      - name: Checkout source
         uses: actions/checkout@v5
         with:
-          ref: develop
+          ref: ${{ github.sha }}
 
       - name: Setup system dependencies
         uses: ./.github/actions/setup
@@ -45,6 +45,7 @@ jobs:
   publish-index:
     name: Publish Nightly Index
     needs: build-wheels
+    if: ${{ github.ref_name == 'develop' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -53,7 +54,7 @@ jobs:
       - name: Checkout scripts
         uses: actions/checkout@v5
         with:
-          ref: develop
+          ref: ${{ github.sha }}
           sparse-checkout: .github/scripts
 
       - name: Download all wheels

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -28,6 +28,9 @@ jobs:
           - ubuntu-24.04 # x86_64
           - ubuntu-24.04-arm # ARM64
           - windows-2025-vs2026 # x86_64
+        include:
+          - os: windows-2025-vs2026
+            extra-conan-args: --generator Ninja
 
     steps:
       - name: Checkout Code
@@ -57,7 +60,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:
-          CONAN_ARGS: "--opNav True --mujoco True"
+          CONAN_ARGS: "--opNav True --mujoco True ${{ matrix.extra-conan-args }}"
           CIBW_TEST_SKIP: "*"
 
       - name: Upload wheels

--- a/conanfile.py
+++ b/conanfile.py
@@ -242,6 +242,8 @@ class BasiliskConan(ConanFile):
             self.options['opencv'].with_openexr = False  # generate image in EXR format
             self.options['opencv'].with_quirc = False  # QR code lib
             self.options['opencv'].with_webp = False  # raster graphics file format for web
+            if self.settings.get_safe("os") == "Linux":
+                self.options['opencv'].with_wayland = False  # desktop display protocol
 
         # Other dependency options
         if self.options.get_safe("vizInterface") or self.options.get_safe("opNav"):

--- a/docs/source/Support/bskReleaseNotesSnippets/nightly-wheel-conan-environment.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/nightly-wheel-conan-environment.rst
@@ -1,0 +1,2 @@
+- Fixed Linux and Windows wheel builds by configuring Conan system package installation inside cibuildwheel's manylinux containers, disabling unused OpenCV Wayland support, and matching the PR Windows build's Ninja generator.
+- Distributed Linux and Windows wheels now have OpenCV and MuJoCo support included as well.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,12 @@ MACOSX_DEPLOYMENT_TARGET = "11.0"
 CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"
 
 [tool.cibuildwheel.windows]
-before-build = "pip install \"libclang>=15.0.6.1,<=18.1.1\" && pip install delvewheel"
+before-build = "pip install \"libclang>=15.0.6.1,<=18.1.1\" delvewheel ninja"
 repair-wheel-command = "python -m delvewheel repair -v --ignore-existing --analyze-existing -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.linux]
 archs = ["native"]
+before-all = "mkdir -p ~/.conan2 && printf '%s\\n' 'tools.system.package_manager:mode=install' 'tools.system.package_manager:sudo=False' >> ~/.conan2/global.conf"
 repair-wheel-command = [
   "auditwheel repair --strip -w {dest_dir} {wheel}"
 ]


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR fixes nightly wheel builds by aligning the nightly/publish wheel workflows with the working PR build behavior while keeping the changes scoped. It configures Conan package-manager behavior inside the manylinux container, uses Ninja for Windows wheel builds, allows manual nightly-wheel testing from a branch, and disables unused OpenCV Wayland support on Linux OpNav builds to avoid the `xkbcommon/bison/m4` manylinux x86_64 failure.

Commits are organized by fix area, so review by commit should be the easiest path.

## Verification
Validated workflow syntax and config parsing locally, compiled `conanfile.py`, and checked whitespace with `git diff --check`.

A manual `nightly-wheels.yml` run on the branch confirmed both Linux wheel jobs now pass. Windows also passed after the Ninja generator fix. No automated tests were added because this change affects CI wheel-build configuration and Conan dependency options, not Basilisk runtime behavior.

## Documentation
Added a release-note snippet describing the nightly wheel build fixes. Reviewers should check that snippet for accuracy.

## Future work
After merge, the scheduled nightly run on `develop` should exercise the same path automatically and publish the nightly index only from `develop`.