### PR TITLE
Improve Python bskLogging API with convenience methods and level aliases

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-10.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-10.rst
@@ -1,10 +1,10 @@
 .. _bskPrinciples-10:
 
-Advanced: Handling ``BasiliskException`` in Simulations
-=======================================================
+Advanced: Handling ``BasiliskError`` in Simulations
+===================================================
 In Basilisk, when an error occurs during the simulation, it is raised as a ``BasiliskError`` exception in Python. This exception can be caught and handled from Python scripts, in order to gracefully manage errors. However, the simulation that raised the error should not continue to be used.
 
-A short example on how to handle the ``BasiliskError`` exception is shown below. In this case, a ``BSK_ERROR`` is raised from the Python interface to the Basilisk logger. It is more likely that this error would be raised from a C++ module, but the example here is simplified to show how the exception can be caught and handled.
+A short example on how to handle the ``BasiliskError`` exception is shown below. In this case, the Python logger's ``error()`` method raises the error. It is more likely that this error would be raised from a C++ module, but the example here is simplified to show how the exception can be caught and handled.
 
 .. code-block:: python
 
@@ -12,6 +12,6 @@ A short example on how to handle the ``BasiliskError`` exception is shown below.
     from Basilisk.architecture.bskLogging import BasiliskError
 
     try:
-        bskLogging.BSKLogger().bskLog(bskLogging.BSK_ERROR, "Uh oh! That isn't good!")
+        bskLogging.BSKLogger().error("Uh oh! That isn't good!")
     except BasiliskError as e:
         print(f"Caught a BasiliskError: {e}")

--- a/docs/source/Learn/makingModules/numbaModules.rst
+++ b/docs/source/Learn/makingModules/numbaModules.rst
@@ -217,8 +217,8 @@ Add ``bskLogger`` as a parameter to receive a Numba-compatible logging proxy::
 
     @staticmethod
     def UpdateStateImpl(dataOutMsgPayload, bskLogger, memory):
-        bskLogger.bskLog(bskLogging.BSK_INFORMATION, "tick")
-        bskLogger.bskLog1(bskLogging.BSK_WARNING, "step:", memory.step)
+        bskLogger.info("tick")
+        bskLogger.bskLog1(bskLogging.WARNING, "step:", memory.step)
 
 The proxy respects the log level set on ``self.bskLogger`` at ``Reset`` time:
 messages below the current threshold are suppressed.  Output goes to stdout via
@@ -232,6 +232,14 @@ Available methods:
 
    * - Method
      - Prints
+   * - ``debug(msg)``
+     - ``[TAG] msg``
+   * - ``info(msg)``
+     - ``[TAG] msg``
+   * - ``warning(msg)``
+     - ``[TAG] msg``
+   * - ``error(msg)``
+     - ``[TAG] msg``
    * - ``bskLog(level, msg)``
      - ``[TAG] msg``
    * - ``bskLog1(level, msg, v0)``

--- a/docs/source/Learn/makingModules/numbaModules.rst
+++ b/docs/source/Learn/makingModules/numbaModules.rst
@@ -249,9 +249,22 @@ Available methods:
    * - ``bskLog3(level, msg, v0, v1, v2)``
      - ``[TAG] msg v0 v1 v2``
 
-Level constants (``bskLogging.BSK_DEBUG``, ``BSK_INFORMATION``,
-``BSK_WARNING``, ``BSK_ERROR``) work inside ``UpdateStateImpl`` because Numba
-resolves module-level integer attributes at compile time.
+The ``debug(msg)``, ``info(msg)``, ``warning(msg)``, and ``error(msg)``
+convenience methods accept one complete message string.  Use ``bskLog1``,
+``bskLog2``, or ``bskLog3`` when a Numba module needs to log numeric values
+along with the message.
+
+.. note::
+
+   In Numba modules, ``bskLogger.error(msg)`` prints at the ``ERROR`` level but
+   does not raise ``BasiliskError`` or stop simulation execution.  This differs
+   from Python ``SysModel`` modules, where ``self.bskLogger.error(msg)`` is
+   equivalent to ``bskError()`` and raises immediately.
+
+Short level aliases (``bskLogging.DEBUG``, ``bskLogging.INFO``,
+``bskLogging.WARNING``, and ``bskLogging.ERROR``) work inside
+``UpdateStateImpl`` because Numba resolves module-level integer attributes at
+compile time.  The original ``BSK_``-prefixed constants remain supported.
 
 ``msg`` must be a **string literal** - variables of string type are not
 supported in nopython mode.  Values ``v0``–``v2`` can be any numeric type

--- a/docs/source/Support/bskReleaseNotesSnippets/bsk-logger-python-api.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/bsk-logger-python-api.rst
@@ -1,0 +1,3 @@
+- Added Pythonic ``BSKLogger`` convenience methods ``debug()``, ``info()``, ``warning()``, and ``error()`` to ``bskLogging``.
+- Added a ``setLevel()`` alias for ``setLogLevel()``.
+- Added a ``LogLevel`` ``IntEnum``, and short log-level aliases (ex. ``bskLogging.WARNING``) that mirror Python's standard ``logging`` module naming.

--- a/docs/source/codeSamples/making-numbaModules.py
+++ b/docs/source/codeSamples/making-numbaModules.py
@@ -104,7 +104,7 @@ class FilterModel(NumbaModel):
                         dataOutMsgPayload, bskLogger, memory):
         """Scale the input vector when linked and warn otherwise."""
         if not dataInMsgIsLinked:
-            bskLogger.bskLog(bskLogging.BSK_WARNING, "FilterModel: input not linked")
+            bskLogger.warning("FilterModel: input not linked")
             return
         for i in range(3):
             dataOutMsgPayload.dataVector[i] = dataInMsgPayload.dataVector[i] * memory.gain

--- a/docs/source/codeSamples/making-pyModules.py
+++ b/docs/source/codeSamples/making-pyModules.py
@@ -91,14 +91,14 @@ class TestPythonModule(sysModel.SysModel):
     def Reset(self, CurrentSimNanos):
         # Ensure that self.dataInMsg is linked
         if not self.dataInMsg.isLinked():
-            self.bskLogger.bskError("TestPythonModule.dataInMsg is not linked.")
+            self.bskLogger.error("TestPythonModule.dataInMsg is not linked.")
 
         # Initialiazing self.dataOutMsg
         payload = self.dataOutMsg.zeroMsgPayload
         payload.dataVector = np.array([0, 0, 0])
         self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
 
-        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, "Reset in TestPythonModule")
+        self.bskLogger.info("Reset in TestPythonModule")
 
     def UpdateState(self, CurrentSimNanos):
         # Read input message
@@ -112,9 +112,8 @@ class TestPythonModule(sysModel.SysModel):
         )
         self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
 
-        self.bskLogger.bskLog(
-            bskLogging.BSK_INFORMATION,
-            f"Python Module ID {self.moduleID} ran Update at {CurrentSimNanos*1e-9}s",
+        self.bskLogger.info(
+            f"Python Module ID {self.moduleID} ran Update at {CurrentSimNanos * 1e-9}s",
         )
 
 

--- a/examples/scenarioAttitudePointingPy.py
+++ b/examples/scenarioAttitudePointingPy.py
@@ -355,10 +355,10 @@ class PythonMRPPD(sysModel.SysModel):
         # accessed from sysModel
         if False:
             """Sample Python module method"""
-            self.bskLogger.bskLog(sysModel.BSK_INFORMATION, f"Time: {CurrentSimNanos * 1.0E-9} s")
-            self.bskLogger.bskLog(sysModel.BSK_INFORMATION, f"TorqueRequestBody: {torqueOutMsgBuffer.torqueRequestBody}")
-            self.bskLogger.bskLog(sysModel.BSK_INFORMATION, f"sigma_BR: {guidMsgBuffer.sigma_BR}")
-            self.bskLogger.bskLog(sysModel.BSK_INFORMATION, f"omega_BR_B: {guidMsgBuffer.omega_BR_B}")
+            self.bskLogger.info(f"Time: {CurrentSimNanos * 1.0E-9} s")
+            self.bskLogger.info(f"TorqueRequestBody: {torqueOutMsgBuffer.torqueRequestBody}")
+            self.bskLogger.info(f"sigma_BR: {guidMsgBuffer.sigma_BR}")
+            self.bskLogger.info(f"omega_BR_B: {guidMsgBuffer.omega_BR_B}")
 
         return
 

--- a/examples/scenarioBskLog.py
+++ b/examples/scenarioBskLog.py
@@ -69,7 +69,7 @@ def run(case):
         # here the verbosity is set globally to WARNING or higher.
         # This call must be made at the beginning of the script, certainly before
         # SimulationBaseClass.SimBaseClass() is called.
-        bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+        bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
@@ -113,7 +113,7 @@ def run(case):
     elif case == 2:
         # here the bskLog verbosity is only changed for this module by setting a custom bskLog instance
         logger = bskLogging.BSKLogger()
-        logger.setLevel(bskLogging.BSK_ERROR)
+        logger.setLevel(bskLogging.ERROR)
         print("The verbosity is only changed for this module.")
         logger.printLogLevel()
         module.bskLogger = logger

--- a/examples/scenarioBskLog.py
+++ b/examples/scenarioBskLog.py
@@ -113,7 +113,7 @@ def run(case):
     elif case == 2:
         # here the bskLog verbosity is only changed for this module by setting a custom bskLog instance
         logger = bskLogging.BSKLogger()
-        logger.setLogLevel(bskLogging.BSK_ERROR)
+        logger.setLevel(bskLogging.BSK_ERROR)
         print("The verbosity is only changed for this module.")
         logger.printLogLevel()
         module.bskLogger = logger

--- a/src/architecture/messaging/_UnitTest/test_CMsgTimeWritten.py
+++ b/src/architecture/messaging/_UnitTest/test_CMsgTimeWritten.py
@@ -28,7 +28,7 @@ def test_CMsgTimeWritten():
     testing recording timeWritten in C-wrapped message
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty array to store test log messages
 
@@ -72,4 +72,3 @@ def test_CMsgTimeWritten():
 
 if __name__ == "__main__":
     CMsgTimeWritten()
-

--- a/src/architecture/messaging/_UnitTest/test_CMsgTypes.py
+++ b/src/architecture/messaging/_UnitTest/test_CMsgTypes.py
@@ -32,7 +32,7 @@ def test_cMsgTypes():
     Test the Python-side types of various message payload C types
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     test = messaging.TypesTestMsgPayload()
 

--- a/src/architecture/messaging/_UnitTest/test_NonSwigMessaging.py
+++ b/src/architecture/messaging/_UnitTest/test_NonSwigMessaging.py
@@ -36,7 +36,7 @@ def test_RecordingInputMessages():
     testing recording a C-wrapped input message with the recorder module
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty array to store test log messages
 

--- a/src/architecture/messaging/_UnitTest/test_RecordInputMessages.py
+++ b/src/architecture/messaging/_UnitTest/test_RecordInputMessages.py
@@ -34,7 +34,7 @@ def test_RecordingInputMessages():
     testing recording a C-wrapped input message with the recorder module
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty array to store test log messages
 

--- a/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
+++ b/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
@@ -930,7 +930,7 @@ def test_bsklogger():
             """Log two messages and publish the incremented step count."""
             memory.step += np.int32(1)
             bskLogger.info("step update")
-            bskLogger.bskLog1(bskLogging.BSK_WARNING, "step:", memory.step)
+            bskLogger.bskLog1(bskLogging.WARNING, "step:", memory.step)
             dataOutMsgPayload.dataVector[0] = float(memory.step)
 
     mod = LoggingModel(); mod.ModelTag = "logsimple"
@@ -1073,12 +1073,12 @@ def test_cacheLoggerLevelRuntime(monkeypatch, tmp_path, capfd):
     monkeypatch.setattr(numbaModelModule, "getCacheDir", lambda: tmp_path)
 
     modA = _LoggerCacheModel(); modA.ModelTag = "logCacheA"
-    _runWithLoggerLevel(modA, bskLogging.BSK_ERROR)
+    _runWithLoggerLevel(modA, bskLogging.ERROR)
     suppressed = capfd.readouterr()
     assert "logger cache warning" not in suppressed.out
 
     modB = _LoggerCacheModel(); modB.ModelTag = "logCacheB"
-    _runWithLoggerLevel(modB, bskLogging.BSK_WARNING)
+    _runWithLoggerLevel(modB, bskLogging.WARNING)
     emitted = capfd.readouterr()
     assert "logger cache warning" in emitted.out
     assert modA._cfunc is modB._cfunc

--- a/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
+++ b/src/architecture/numbaModel/_UnitTest/test_numbaModel.py
@@ -929,7 +929,7 @@ def test_bsklogger():
         def UpdateStateImpl(dataOutMsgPayload, bskLogger, memory):
             """Log two messages and publish the incremented step count."""
             memory.step += np.int32(1)
-            bskLogger.bskLog(bskLogging.BSK_INFORMATION, "step update")
+            bskLogger.info("step update")
             bskLogger.bskLog1(bskLogging.BSK_WARNING, "step:", memory.step)
             dataOutMsgPayload.dataVector[0] = float(memory.step)
 
@@ -992,14 +992,14 @@ class _LoggerCacheModel(NumbaModel):
     @staticmethod
     def UpdateStateImpl(dataOutMsgPayload, bskLogger):
         """Emit a warning and write a sentinel value."""
-        bskLogger.bskLog(bskLogging.BSK_WARNING, "logger cache warning")
+        bskLogger.warning("logger cache warning")
         dataOutMsgPayload.dataVector[0] = 1.0
 
 
 def _runWithLoggerLevel(model, logLevel, dt_ns=5, n_ticks=1):
     """Run one model while setting the owning simulation logger level."""
     scSim = SimulationBaseClass.SimBaseClass()
-    scSim.bskLogger.setLogLevel(logLevel)
+    scSim.bskLogger.setLevel(logLevel)
     proc = scSim.CreateNewProcess("proc")
     proc.addTask(scSim.CreateNewTask("task", dt_ns))
     scSim.AddModelToTask("task", model)

--- a/src/architecture/numbaModel/numbaModel.i
+++ b/src/architecture/numbaModel/numbaModel.i
@@ -76,7 +76,7 @@ import numpy as np
 import numba as nb
 from numba.experimental import jitclass as _nbJitclass
 
-from Basilisk.architecture import messaging
+from Basilisk.architecture import bskLogging, messaging
 from Basilisk.architecture.sysModel import SysModelMixin
 
 _NBMODEL_CFUNC_CACHE: dict = {} # idHash -> cfunc; keeps cfunc alive (prevents GC)
@@ -123,9 +123,9 @@ class BskLoggerProxy:
         self._t0 = t0; self._t1 = t1; self._t2 = t2; self._t3 = t3
 
     def _tag(self, level):
-        if   level == 0: return self._t0
-        elif level == 1: return self._t1
-        elif level == 2: return self._t2
+        if   level == bskLogging.DEBUG: return self._t0
+        elif level == bskLogging.INFO: return self._t1
+        elif level == bskLogging.WARNING: return self._t2
         else:            return self._t3
 
     def bskLog(self, level, msg):
@@ -133,17 +133,17 @@ class BskLoggerProxy:
             print(self._tag(level), msg)
 
     def debug(self, msg):
-        self.bskLog(0, msg)
+        self.bskLog(bskLogging.DEBUG, msg)
 
     def info(self, msg):
-        self.bskLog(1, msg)
+        self.bskLog(bskLogging.INFO, msg)
 
     def warning(self, msg):
-        self.bskLog(2, msg)
+        self.bskLog(bskLogging.WARNING, msg)
 
     def error(self, msg):
         # prints at BSK_ERROR level but does not throw — use bskError() outside numba context
-        self.bskLog(3, msg)
+        self.bskLog(bskLogging.ERROR, msg)
 
     def bskLog1(self, level, msg, v0):
         if level >= self._level:

--- a/src/architecture/numbaModel/numbaModel.i
+++ b/src/architecture/numbaModel/numbaModel.i
@@ -132,6 +132,19 @@ class BskLoggerProxy:
         if level >= self._level:
             print(self._tag(level), msg)
 
+    def debug(self, msg):
+        self.bskLog(0, msg)
+
+    def info(self, msg):
+        self.bskLog(1, msg)
+
+    def warning(self, msg):
+        self.bskLog(2, msg)
+
+    def error(self, msg):
+        # prints at BSK_ERROR level but does not throw — use bskError() outside numba context
+        self.bskLog(3, msg)
+
     def bskLog1(self, level, msg, v0):
         if level >= self._level:
             print(self._tag(level), msg, v0)

--- a/src/architecture/system_model/_UnitTest/test_PySysModel.py
+++ b/src/architecture/system_model/_UnitTest/test_PySysModel.py
@@ -92,7 +92,7 @@ def test_ErrorPySysModel():
 
     mod = ErroringPythonModule()
 
-    simulated_syserr_reset = io.StringIO("")    
+    simulated_syserr_reset = io.StringIO("")
 
     with contextlib.redirect_stderr(simulated_syserr_reset):
         try:
@@ -116,7 +116,7 @@ def test_ErrorPySysModel():
             pass
 
     error_update = simulated_syserr_update.getvalue()
-    
+
     if len(error_update) == 0:
         testMessage.append("Reset did not print its exception")
     elif not error_update.rstrip().endswith("ValueError: Error in UpdateState"):
@@ -134,13 +134,13 @@ class PythonModule(sysModel.SysModel):
         payload = self.dataOutMsg.zeroMsgPayload
         payload.dataVector = np.array([0,0,0])
         self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
-        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, "Reset in TestPythonModule")
+        self.bskLogger.info("Reset in TestPythonModule")
 
     def UpdateState(self, CurrentSimNanos):
         payload = self.dataOutMsg.zeroMsgPayload
         payload.dataVector = self.dataOutMsg.read().dataVector + np.array([0,1,0])
         self.dataOutMsg.write(payload, CurrentSimNanos, self.moduleID)
-        self.bskLogger.bskLog(bskLogging.BSK_INFORMATION, f"Python Module ID {self.moduleID} ran Update at {CurrentSimNanos*1e-9}s")
+        self.bskLogger.info(f"Python Module ID {self.moduleID} ran Update at {CurrentSimNanos*1e-9}s")
 
 class ErroringPythonModule(sysModel.SysModel):
 

--- a/src/architecture/utilities/bskLogging.h
+++ b/src/architecture/utilities/bskLogging.h
@@ -115,6 +115,23 @@ class BSKLogger
         $self->bskLog(BSK_ERROR, "%s", info);
         throw BasiliskError(info);
     }
+
+    /* Convenience methods that mirror the Python logging.Logger API. These are
+       defined here in the SWIG %extend block (rather than as Python monkey-patches
+       in bskLogging.i) so that every module which %includes this header gets them
+       on its own BSKLogger proxy class. A pure-Python patch attaches only to
+       bskLogging.BSKLogger; depending on import order the bskLogger handed back by
+       SysModel-derived modules can be wrapped by a different proxy class, which
+       would leave the patched methods unreachable. error() raises BasiliskError to
+       match bskError(). */
+    void debug(const char* info)   { $self->bskLog(BSK_DEBUG,       "%s", info); }
+    void info(const char* info)    { $self->bskLog(BSK_INFORMATION, "%s", info); }
+    void warning(const char* info) { $self->bskLog(BSK_WARNING,     "%s", info); }
+    void error(const char* info) {
+        $self->bskLog(BSK_ERROR, "%s", info);
+        throw BasiliskError(info);
+    }
+    void setLevel(logLevel_t logLevel) { $self->setLogLevel(logLevel); }
 }
 #endif
 

--- a/src/architecture/utilities/bskLogging.i
+++ b/src/architecture/utilities/bskLogging.i
@@ -43,4 +43,25 @@ import sys
 protectAllClasses(sys.modules[__name__])
 
 BasiliskError = _bskLogging.BasiliskError
+
+import enum
+
+class LogLevel(enum.IntEnum):
+    DEBUG = BSK_DEBUG
+    INFO = BSK_INFORMATION
+    WARNING = BSK_WARNING
+    ERROR = BSK_ERROR
+    SILENT = BSK_SILENT
+
+DEBUG = LogLevel.DEBUG
+INFO = LogLevel.INFO
+WARNING = LogLevel.WARNING
+ERROR = LogLevel.ERROR
+SILENT = LogLevel.SILENT
+
+# The debug()/info()/warning()/error()/setLevel() convenience methods are defined
+# as SWIG %extend methods in bskLogging.h, not monkey-patched here. That way they
+# exist on every BSKLogger proxy class regardless of module import order; a Python
+# patch on this module's BSKLogger would not reach instances vended by other
+# modules that %include bskLogging.h (e.g. anything derived from SysModel).
 %}

--- a/src/architecture/utilities/bskLogging.rst
+++ b/src/architecture/utilities/bskLogging.rst
@@ -44,8 +44,8 @@ If the verbosity level is to be changed for a particular Basilisk script, then t
 Log Level Constants
 ^^^^^^^^^^^^^^^^^^^
 Log levels can be referenced using either the original ``BSK_``-prefixed
-constants or shorter aliases that mirror Python's standard ``logging`` module
-naming:
+constants or shorter aliases that use Python's standard ``logging`` module
+level names:
 
 .. code-block:: python
 
@@ -90,8 +90,8 @@ python script as the corresponding module is created and configured.
 
 Logging from Python Module Code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python-side module code can use convenience methods on ``bskLogger`` that mirror
-Python's standard ``logging`` API:
+Python-side module code can use convenience methods on ``bskLogger`` that use
+Python standard logging method names:
 
 .. code-block:: python
 
@@ -103,6 +103,10 @@ Python's standard ``logging`` API:
 These are equivalent to calling ``bskLog`` with the corresponding level and are
 the preferred form for Python call sites. ``error()`` is equivalent to
 ``bskError()`` and raises ``BasiliskError`` immediately.
+
+These convenience methods accept one complete message string.  They do not
+implement the full ``logging.Logger`` call signature with additional formatting
+arguments.  Compose values into the message first, for example with an f-string.
 
 Using ``bskLog`` and ``bskError`` in C++ Basilisk Modules
 ---------------------------------------------------------

--- a/src/architecture/utilities/bskLogging.rst
+++ b/src/architecture/utilities/bskLogging.rst
@@ -41,11 +41,31 @@ If the verbosity level is to be changed for a particular Basilisk script, then t
 
     from Basilisk.architecture import bskLogging
 
+Log Level Constants
+^^^^^^^^^^^^^^^^^^^
+Log levels can be referenced using either the original ``BSK_``-prefixed
+constants or shorter aliases that mirror Python's standard ``logging`` module
+naming:
+
+.. code-block:: python
+
+    bskLogging.BSK_WARNING  # original form
+    bskLogging.WARNING      # short alias (equivalent)
+
+A ``LogLevel`` enum is also available:
+
+.. code-block:: python
+
+    bskLogging.LogLevel.WARNING
+
+The available levels are ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, and
+``SILENT``.
+
 Setting Verbosity Globally for all BSK Modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The ``bskLog`` verbosity can be modified for all Basilisk modules by using::
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
 The verbosity options are listed in the table above.  Note that this command must be included at the very beginning of
 the Basilisk simulation script, certainly before the call for ``SimulationBaseClass.SimBaseClass()``.
@@ -57,16 +77,32 @@ It is possible to override the global verbosity setting and specify a different 
     sNavObject = simpleNav.SimpleNav()
     scSim.AddModelToTask(simTaskName, sNavObject)
     logger = bskLogging.BSKLogger()
-    logger.setLogLevel(bskLogging.BSK_INFORMATION)
+    logger.setLevel(bskLogging.INFO)
     sNavObject.bskLogger = logger
 
 Another option is to use the ``BSKLogger()`` constructor to provide the verbosity directly through::
 
     sNavObject = simpleNav.SimpleNav()
-    sNavObject.bskLogger = bskLogging.BSKLogger(bskLogging.BSK_INFORMATION)
+    sNavObject.bskLogger = bskLogging.BSKLogger(bskLogging.INFO)
 
 Unlike change the global verbosity level, the module specific verbosity can be changed later on in the Basilisk
 python script as the corresponding module is created and configured.
+
+Logging from Python Module Code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python-side module code can use convenience methods on ``bskLogger`` that mirror
+Python's standard ``logging`` API:
+
+.. code-block:: python
+
+    self.bskLogger.debug("message")
+    self.bskLogger.info("message")
+    self.bskLogger.warning("message")
+    self.bskLogger.error("message")   # raises BasiliskError
+
+These are equivalent to calling ``bskLog`` with the corresponding level and are
+the preferred form for Python call sites. ``error()`` is equivalent to
+``bskError()`` and raises ``BasiliskError`` immediately.
 
 Using ``bskLog`` and ``bskError`` in C++ Basilisk Modules
 ---------------------------------------------------------

--- a/src/architecture/utilities/tests/test_bskLogging.py
+++ b/src/architecture/utilities/tests/test_bskLogging.py
@@ -26,7 +26,7 @@ def test_bsk_error_treats_python_message_as_text():
     bsk_logger = bskLogging.BSKLogger()
 
     with pytest.raises(bskLogging.BasiliskError, match="preformatted %s message"):
-        bsk_logger.bskError("preformatted %s message")
+        bsk_logger.error("preformatted %s message")
 
 
 def test_warning_level_output_is_flushed(capfd):

--- a/src/fswAlgorithms/attControl/mtbFeedforward/_UnitTest/test_mtbFeedforward.py
+++ b/src/fswAlgorithms/attControl/mtbFeedforward/_UnitTest/test_mtbFeedforward.py
@@ -46,8 +46,8 @@ def test_mtbFeedforward_module():     # update "module" in this function name to
     r"""
     **Validation Test Description**
 
-    This script tests that the torqueRequestBody vector is computed as 
-    expected and that the algorithm doesn't fail when given inputs with a 
+    This script tests that the torqueRequestBody vector is computed as
+    expected and that the algorithm doesn't fail when given inputs with a
     value of zero.
 
     **Description of Variables Being Tested**
@@ -60,13 +60,13 @@ def test_mtbFeedforward_module():     # update "module" in this function name to
     # pass on the testPlotFixture so that the main test function may set the DataStore attributes
     [testResults, testMessage] = mtbFeedforwardModuleTestFunction()
     assert testResults < 1, testMessage
-    
+
 def mtbFeedforwardModuleTestFunction():
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -80,17 +80,17 @@ def mtbFeedforwardModuleTestFunction():
     module = mtbFeedforward.mtbFeedforward()
     module.ModelTag = "mrpFeedback"           # update python name of test module
     unitTestSim.AddModelToTask(unitTaskName, module)
-    
+
     # Initialize CmdTorqueBodyMsg
     vehControlInMsgContainer = messaging.CmdTorqueBodyMsgPayload()
     vehControlInMsgContainer.torqueRequestBody = [0., 0., 0.]
     vehControlInMsg = messaging.CmdTorqueBodyMsg().write(vehControlInMsgContainer)
-    
+
     # Initialize DipoleRequestBodyMsg
     dipoleRequestMtbInMsgContainer = messaging.MTBCmdMsgPayload()
     dipoleRequestMtbInMsgContainer.mtbDipoleCmds = [1., 2., 3.]
-    dipoleRequestMtbInMsg = messaging.MTBCmdMsg().write(dipoleRequestMtbInMsgContainer) 
-    
+    dipoleRequestMtbInMsg = messaging.MTBCmdMsg().write(dipoleRequestMtbInMsgContainer)
+
     # Initialize TAMSensorBodyMsg
     tamSensorBodyInMsgContainer = messaging.TAMSensorBodyMsgPayload()
     tamSensorBodyInMsgContainer.tam_B = [ 1E-5, -3E-5, 5E-5]
@@ -100,90 +100,90 @@ def mtbFeedforwardModuleTestFunction():
     mtbArrayConfigParamsInMsgContainer = messaging.MTBArrayConfigMsgPayload()
     mtbArrayConfigParamsInMsgContainer.numMTB = 3
     mtbArrayConfigParamsInMsgContainer.maxMtbDipoles = [1E3, 1E3, 1E3]
-    mtbArrayConfigParamsInMsgContainer.GtMatrix_B = [1., 0., 0., 0., 1., 0., 0., 0., 1.]  
+    mtbArrayConfigParamsInMsgContainer.GtMatrix_B = [1., 0., 0., 0., 1., 0., 0., 0., 1.]
     mtbArrayConfigParamsInMsg = messaging.MTBArrayConfigMsg().write(mtbArrayConfigParamsInMsgContainer)
 
     # Setup logging on the test module output message so that we get all the writes to it
     resultVehControlOutMsg = module.vehControlOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, resultVehControlOutMsg)
-    
+
     # connect the message interfaces
     module.vehControlInMsg.subscribeTo(vehControlInMsg)
     module.dipoleRequestMtbInMsg.subscribeTo(dipoleRequestMtbInMsg)
     module.tamSensorBodyInMsg.subscribeTo(tamSensorBodyInMsg)
     module.mtbArrayConfigParamsInMsg.subscribeTo(mtbArrayConfigParamsInMsg)
-    
+
     # Set the simulation time.
     unitTestSim.ConfigureStopTime(macros.sec2nano(0.0))        # seconds to stop simulation
     unitTestSim.InitializeSimulation()
 
     '''
-        TEST 1: 
+        TEST 1:
             Check that dipoles are non-zero expected value.
     '''
     unitTestSim.ExecuteSimulation()
     m = np.array(dipoleRequestMtbInMsgContainer.mtbDipoleCmds[0:3])
     b = np.array(tamSensorBodyInMsgContainer.tam_B)
-    expectedTorque = -np.cross(m, b)    
+    expectedTorque = -np.cross(m, b)
     testFailCount, testMessages = unitTestSupport.compareVector(expectedTorque,
                                                                 resultVehControlOutMsg.torqueRequestBody[0],
                                                                 accuracy,
                                                                 "torqueRequestBody",
-                                                                testFailCount, testMessages)                        
-    
+                                                                testFailCount, testMessages)
+
     '''
-        TEST 2: 
+        TEST 2:
             Check that torqueRequestBody is zero when b field is zero.
     '''
     tamSensorBodyInMsgContainer.tam_B = [0., 0., 0.]
     tamSensorBodyInMsg = messaging.TAMSensorBodyMsg().write(tamSensorBodyInMsgContainer)
     module.tamSensorBodyInMsg.subscribeTo(tamSensorBodyInMsg)
-    
+
     unitTestSim.InitializeSimulation()
     unitTestSim.ExecuteSimulation()
-    expectedTorque = [0., 0., 0.]   
+    expectedTorque = [0., 0., 0.]
     testFailCount, testMessages = unitTestSupport.compareVector(expectedTorque,
                                                                 resultVehControlOutMsg.torqueRequestBody[0],
                                                                 accuracy,
                                                                 "torqueRequestBody",
                                                                 testFailCount, testMessages)
-    
+
     '''
-        TEST 3: 
+        TEST 3:
             Check that torqueRequestBody is zero when dipoles are zero.
     '''
     tamSensorBodyInMsgContainer.tam_B = [1E-5, -3E-5, 5E-5]
     tamSensorBodyInMsg = messaging.TAMSensorBodyMsg().write(tamSensorBodyInMsgContainer)
     module.tamSensorBodyInMsg.subscribeTo(tamSensorBodyInMsg)
-    
+
     dipoleRequestMtbInMsgContainer.mtbDipoleCmds = [0., 0., 0.]
-    dipoleRequestMtbInMsg = messaging.MTBCmdMsg().write(dipoleRequestMtbInMsgContainer) 
+    dipoleRequestMtbInMsg = messaging.MTBCmdMsg().write(dipoleRequestMtbInMsgContainer)
     module.dipoleRequestMtbInMsg.subscribeTo(dipoleRequestMtbInMsg)
-    
+
     unitTestSim.InitializeSimulation()
     unitTestSim.ExecuteSimulation()
-    expectedTorque = [0., 0., 0.]   
+    expectedTorque = [0., 0., 0.]
     testFailCount, testMessages = unitTestSupport.compareVector(expectedTorque,
                                                                 resultVehControlOutMsg.torqueRequestBody[0],
                                                                 accuracy,
                                                                 "torqueRequestBody",
                                                                 testFailCount, testMessages)
-    
+
     '''
-        TEST 4: 
-            Check that torqueRequestBody is non-zero expected value with 
+        TEST 4:
+            Check that torqueRequestBody is non-zero expected value with
             non-trivial Gt matrix.
     '''
     dipoleRequestMtbInMsgContainer.mtbDipoleCmds = [7., -3.]
-    dipoleRequestMtbInMsg = messaging.MTBCmdMsg().write(dipoleRequestMtbInMsgContainer) 
+    dipoleRequestMtbInMsg = messaging.MTBCmdMsg().write(dipoleRequestMtbInMsgContainer)
     module.dipoleRequestMtbInMsg.subscribeTo(dipoleRequestMtbInMsg)
-    
+
     beta = 45. * np.pi / 180.
     Gt = np.array([[np.cos(beta), -np.sin(beta)],[np.sin(beta),  np.cos(beta)], [0., 0.]])
     mtbArrayConfigParamsInMsgContainer.numMTB = 2
-    mtbArrayConfigParamsInMsgContainer.GtMatrix_B = [Gt[0, 0], Gt[0, 1], 
+    mtbArrayConfigParamsInMsgContainer.GtMatrix_B = [Gt[0, 0], Gt[0, 1],
                                                      Gt[1, 0], Gt[1, 1],
-                                                     Gt[2, 0], Gt[2, 1]]  
+                                                     Gt[2, 0], Gt[2, 1]]
     mtbArrayConfigParamsInMsg = messaging.MTBArrayConfigMsg().write(mtbArrayConfigParamsInMsgContainer)
     module.mtbArrayConfigParamsInMsg.subscribeTo(mtbArrayConfigParamsInMsg)
 
@@ -191,13 +191,13 @@ def mtbFeedforwardModuleTestFunction():
     unitTestSim.ExecuteSimulation()
     m = Gt @ np.array(dipoleRequestMtbInMsgContainer.mtbDipoleCmds[0:2])
     b = np.array(tamSensorBodyInMsgContainer.tam_B)
-    expectedTorque = -np.cross(m, b) 
+    expectedTorque = -np.cross(m, b)
     testFailCount, testMessages = unitTestSupport.compareVector(expectedTorque,
                                                                 resultVehControlOutMsg.torqueRequestBody[0],
                                                                 accuracy,
                                                                 "torqueRequestBody",
                                                                 testFailCount, testMessages)
-    
+
     print("Accuracy used: " + str(accuracy))
     if testFailCount == 0:
         print("PASSED: mtbFeedforward unit test")
@@ -212,4 +212,3 @@ def mtbFeedforwardModuleTestFunction():
 #
 if __name__ == "__main__":
     test_mtbFeedforward_module()
-    

--- a/src/fswAlgorithms/attControl/mtbMomentumManagement/_UnitTest/test_mtbMomentumManagement.py
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagement/_UnitTest/test_mtbMomentumManagement.py
@@ -46,7 +46,7 @@ def test_mtbMomentumManagement():     # update "module" in this function name to
     r"""
     **Validation Test Description**
 
-    This script tests that the module returns expected non-zero and zero 
+    This script tests that the module returns expected non-zero and zero
     outputs.
 
     **Description of Variables Being Tested**
@@ -67,7 +67,7 @@ def mtbMomentumManagementModuleTestFunction():
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -91,7 +91,7 @@ def mtbMomentumManagementModuleTestFunction():
     rwConfigParams.JsList = [0.002, 0.002, 0.002, 0.002]
     rwConfigParams.numRW = 4
     rwParamsInMsg = messaging.RWArrayConfigMsg().write(rwConfigParams)
-    
+
     # mtbConfigData message (array is ordered c11, c22, c33, c44, ...)
     mtbConfigParams = messaging.MTBArrayConfigMsgPayload()
     mtbConfigParams.numMTB = 3
@@ -103,12 +103,12 @@ def mtbMomentumManagementModuleTestFunction():
     ]
     mtbConfigParams.maxMtbDipoles = [10.]*mtbConfigParams.numMTB
     mtbParamsInMsg = messaging.MTBArrayConfigMsg().write(mtbConfigParams)
-    
+
     # TAMSensorBodyMsg message (leads to non-invertible matrix)
     tamSensorBodyInMsgContainer = messaging.TAMSensorBodyMsgPayload()
     tamSensorBodyInMsgContainer.tam_B = [ 5E3 * 0.03782347,  5E3 * 0.49170516, 5E3 * -0.8699399]
     tamSensorBodyInMsg = messaging.TAMSensorBodyMsg().write(tamSensorBodyInMsgContainer)
-    
+
     # rwSpeeds message
     rwSpeedsInMsgContainer = messaging.RWSpeedMsgPayload()
     rwSpeedsInMsgContainer.wheelSpeeds = [100., 200., 300., 400.]
@@ -118,7 +118,7 @@ def mtbMomentumManagementModuleTestFunction():
     rwMotorTorqueInMsgContainer = messaging.ArrayMotorTorqueMsgPayload()
     rwMotorTorqueInMsgContainer.motorTorque = [0., 0., 0., 0.]
     rwMotorTorqueInMsg = messaging.ArrayMotorTorqueMsg().write(rwMotorTorqueInMsgContainer)
-    
+
     # Setup logging on the test module output message so that we get all the writes to it
     resultMtbCmdOutMsg = module.mtbCmdOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, resultMtbCmdOutMsg)
@@ -131,7 +131,7 @@ def mtbMomentumManagementModuleTestFunction():
     module.tamSensorBodyInMsg.subscribeTo(tamSensorBodyInMsg)
     module.rwSpeedsInMsg.subscribeTo(rwSpeedsInMsg)
     module.rwMotorTorqueInMsg.subscribeTo(rwMotorTorqueInMsg)
-    
+
     # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
 
@@ -141,36 +141,36 @@ def mtbMomentumManagementModuleTestFunction():
     # simulation end time.
     unitTestSim.ConfigureStopTime(macros.sec2nano(0.0))        # seconds to stop simulation
     accuracy = 1E-8
-    
-    
+
+
     '''
-        TEST 0: 
+        TEST 0:
             Check that mtbDipoleCmds and are non-zero.
     '''
     unitTestSim.InitializeSimulation()
     unitTestSim.ExecuteSimulation()
-    
+
     testFailCount, testMessages = unitTestSupport.compareVector([0., 0., 0.],
                                                                 resultMtbCmdOutMsg.mtbDipoleCmds[0][0:3],
                                                                 accuracy,
                                                                 "tauMtbRequestOutMsg",
                                                                 testFailCount, testMessages, ExpectedResult=0)
-    
+
     testFailCount, testMessages = unitTestSupport.compareVector([0., 0., 0., 0.],
                                                                 resultRwMotorTorqueOutMsg.motorTorque[0][0:4],
                                                                 accuracy,
                                                                 "rwMotorTorqueOutMsg",
-                                                                testFailCount, testMessages, ExpectedResult=0)  
+                                                                testFailCount, testMessages, ExpectedResult=0)
     '''
 
-        TEST 1: 
+        TEST 1:
             Check that the mtbDipoleCmds are zero and that the resulting
             torque on the body is zero when the b field is zero.
     '''
     tamSensorBodyInMsgContainer.tam_B = [0., 0., 0.]
     tamSensorBodyInMsg = messaging.TAMSensorBodyMsg().write(tamSensorBodyInMsgContainer)
     module.tamSensorBodyInMsg.subscribeTo(tamSensorBodyInMsg)
-    
+
     unitTestSim.InitializeSimulation()
     unitTestSim.ExecuteSimulation()
 
@@ -179,14 +179,14 @@ def mtbMomentumManagementModuleTestFunction():
                                                                 accuracy,
                                                                 "tauMtbRequestOutMsg",
                                                                 testFailCount, testMessages, ExpectedResult=1)
-    
+
     Gs = np.array(rwConfigParams.GsMatrix_B[0:12]).reshape(4, 3).T
     tauBody = Gs @ np.array(resultRwMotorTorqueOutMsg.motorTorque[0][0:4])
     testFailCount, testMessages = unitTestSupport.compareVector([0., 0., 0.],
                                                                 tauBody,
                                                                 accuracy,
                                                                 "rwMotorTorqueOutMsg",
-                                                                testFailCount, testMessages, ExpectedResult=1)  
+                                                                testFailCount, testMessages, ExpectedResult=1)
 
 
     # reset the module to test this functionality

--- a/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/_UnitTest/test_mtbMomentumManagementSimple.py
+++ b/src/fswAlgorithms/attControl/mtbMomentumManagementSimple/_UnitTest/test_mtbMomentumManagementSimple.py
@@ -44,7 +44,7 @@ def test_mtbMomentumManagementSimple():     # update "module" in this function n
     r"""
     **Validation Test Description**
 
-    This script tests that the module returns expected non-zero and zero 
+    This script tests that the module returns expected non-zero and zero
     outputs.
 
     **Description of Variables Being Tested**
@@ -63,7 +63,7 @@ def mtbMomentumManagementSimpleTestFunction():
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -86,7 +86,7 @@ def mtbMomentumManagementSimpleTestFunction():
     rwConfigParams.JsList = [0.002, 0.002, 0.002, 0.002]
     rwConfigParams.numRW = 4
     rwParamsInMsg = messaging.RWArrayConfigMsg().write(rwConfigParams)
-    
+
     # rwSpeeds message
     rwSpeedsInMsgContainer = messaging.RWSpeedMsgPayload()
     rwSpeedsInMsgContainer.wheelSpeeds = [100., 200., 300., 400.]
@@ -99,7 +99,7 @@ def mtbMomentumManagementSimpleTestFunction():
     # connect the message interfaces
     module.rwParamsInMsg.subscribeTo(rwParamsInMsg)
     module.rwSpeedsInMsg.subscribeTo(rwSpeedsInMsg)
-    
+
     # Need to call the self-init and cross-init methods
     unitTestSim.InitializeSimulation()
 
@@ -111,7 +111,7 @@ def mtbMomentumManagementSimpleTestFunction():
     accuracy = 1E-8
 
     '''
-        TEST 1: 
+        TEST 1:
             Check that tauMtbRequestOutMsg is non-zero when the wheel speeds
             are non-zero.
     '''
@@ -125,7 +125,7 @@ def mtbMomentumManagementSimpleTestFunction():
     hWheels_W = wheelSpeeds * rwConfigParams.JsList[0]
     hWheels_B  = Gs @ hWheels_W
     tauExpected = - module.Kp * hWheels_B
-    
+
     testFailCount, testMessages = unitTestSupport.compareVector(tauExpected,
                                                             resultTauMtbRequestOutMsg.torqueRequestBody[0][0:3],
                                                             accuracy,
@@ -133,44 +133,44 @@ def mtbMomentumManagementSimpleTestFunction():
                                                             testFailCount, testMessages, ExpectedResult=1)
 
     '''
-        TEST 2: 
+        TEST 2:
             Check that tauMtbRequestOutMsg is the zero vector when the wheels
             speeds are zero.
     '''
     rwSpeedsInMsgContainer.wheelSpeeds = [0., 0., 0., 0.]
     rwSpeedsInMsg = messaging.RWSpeedMsg().write(rwSpeedsInMsgContainer)
     module.rwSpeedsInMsg.subscribeTo(rwSpeedsInMsg)
-    
+
     unitTestSim.InitializeSimulation()
     unitTestSim.ExecuteSimulation()
-    
+
     testFailCount, testMessages = unitTestSupport.compareVector([0., 0., 0.],
                                                             resultTauMtbRequestOutMsg.torqueRequestBody[0][0:3],
                                                             accuracy,
                                                             "tauMtbRequestOutMsg",
                                                             testFailCount, testMessages, ExpectedResult=1)
-    
+
     '''
-        TEST 3: 
+        TEST 3:
             Check that tauMtbRequestOutMsg is the zero vector when the wheels
             speeds are non-zero and the feedback gain is zero.
     '''
     rwSpeedsInMsgContainer.wheelSpeeds = [100., 200., 300., 400.]
     rwSpeedsInMsg = messaging.RWSpeedMsg().write(rwSpeedsInMsgContainer)
     module.rwSpeedsInMsg.subscribeTo(rwSpeedsInMsg)
-    
+
     module.Kp = 0.
-    
+
     unitTestSim.InitializeSimulation()
     unitTestSim.ExecuteSimulation()
-    
+
     testFailCount, testMessages = unitTestSupport.compareVector([0., 0., 0.],
                                                             resultTauMtbRequestOutMsg.torqueRequestBody[0][0:3],
                                                             accuracy,
                                                             "tauMtbRequestOutMsg",
                                                             testFailCount, testMessages, ExpectedResult=1)
-    
-    
+
+
     # reset the module to test this functionality
     module.Reset(0)     # this module reset function needs a time input (in NanoSeconds)
 

--- a/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
+++ b/src/fswAlgorithms/attGuidance/oneAxisSolarArrayPoint/_UnitTest/test_oneAxisSolarArrayPoint.py
@@ -149,7 +149,7 @@ def oneAxisSolarArrayPointTestFunction(show_plots, alpha, delta, bodyAxisInput, 
     testMessages = []                                        # create empty array to store test log messages
     unitTaskName = "unitTask"                                # arbitrary name (don't change)
     unitProcessName = "TestProcess"                          # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/attGuidance/waypointReference/_UnitTest/test_WaypointReference.py
+++ b/src/fswAlgorithms/attGuidance/waypointReference/_UnitTest/test_WaypointReference.py
@@ -102,7 +102,7 @@ def test_waypointReference(show_plots, attType, MRPswitching, useReferenceFrame,
 
 def waypointReferenceTestFunction(attType, MRPswitching, useReferenceFrame, accuracy):
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/fswAlgorithms/effectorInterfaces/dipoleMapping/_UnitTest/test_dipoleMapping.py
+++ b/src/fswAlgorithms/effectorInterfaces/dipoleMapping/_UnitTest/test_dipoleMapping.py
@@ -65,7 +65,7 @@ def dipoleMappingModuleTestFunction():
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/_UnitTest/test_hingedRigidBodyPIDMotor.py
+++ b/src/fswAlgorithms/effectorInterfaces/hingedRigidBodyPIDMotor/_UnitTest/test_hingedRigidBodyPIDMotor.py
@@ -106,7 +106,7 @@ def hingedRigidBodyPIDMotorTestFunction(show_plots, thetaR, thetaDotR, theta, th
     testMessages = []                        # create empty array to store test log messages
     unitTaskName = "unitTask"                # arbitrary name (don't change)
     unitProcessName = "TestProcess"          # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -118,7 +118,7 @@ def hingedRigidBodyPIDMotorTestFunction(show_plots, thetaR, thetaDotR, theta, th
 
     # Construct algorithm and associated C++ container
     motor = hingedRigidBodyPIDMotor.hingedRigidBodyPIDMotor()
-    motor.ModelTag = "hingedRigidBodyPIDMotor"  
+    motor.ModelTag = "hingedRigidBodyPIDMotor"
     motor.K = K
     motor.P = P
     motor.I = I
@@ -171,7 +171,7 @@ def hingedRigidBodyPIDMotorTestFunction(show_plots, thetaR, thetaDotR, theta, th
 # stand-along python script
 #
 if __name__ == "__main__":
-    test_hingedRigidBodyPIDMotor( 
+    test_hingedRigidBodyPIDMotor(
                  False,
                  np.pi/3,
                  0,

--- a/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.py
+++ b/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.py
@@ -33,7 +33,9 @@ def _get_optimizer():
     return minimize
 
 
-def mapMatrix(rVec_B: np.ndarray, fHatVec_B: np.ndarray, r_ComB_B: np.ndarray) -> np.ndarray:
+def mapMatrix(
+    rVec_B: np.ndarray, fHatVec_B: np.ndarray, r_ComB_B: np.ndarray
+) -> np.ndarray:
     """
     Build the thruster force-to-wrench map.
 
@@ -115,7 +117,7 @@ class JointThrAllocation(sysModel.SysModel):
         ]
         for msgName, msgReader in requiredInputMessages:
             if not msgReader.isLinked():
-                self.bskLogger.bskError(f"JointThrAllocation.{msgName} was not linked.")
+                self.bskLogger.error(f"JointThrAllocation.{msgName} was not linked.")
 
     def setWf(self, wfIn):
         """
@@ -173,7 +175,9 @@ class JointThrAllocation(sysModel.SysModel):
             self.Wf = np.full(self.nThr, float(wfArr[0]), dtype=float)
             return
         if wfArr.size != self.nThr:
-            raise ValueError(f"Wf vector length {wfArr.size} does not match nThr {self.nThr}.")
+            raise ValueError(
+                f"Wf vector length {wfArr.size} does not match nThr {self.nThr}."
+            )
         self.Wf = wfArr.copy()
 
     def setThrForceMax(self, thrForceMaxIn):
@@ -203,7 +207,9 @@ class JointThrAllocation(sysModel.SysModel):
         if thrForceMaxArr.size == 1:
             return np.full(self.nThr, float(thrForceMaxArr[0]), dtype=float)
         if thrForceMaxArr.size != self.nThr:
-            raise ValueError(f"thrForceMax vector length {thrForceMaxArr.size} does not match nThr {self.nThr}.")
+            raise ValueError(
+                f"thrForceMax vector length {thrForceMaxArr.size} does not match nThr {self.nThr}."
+            )
         return thrForceMaxArr.copy()
 
     def parseArmConfig(self):
@@ -237,20 +243,22 @@ class JointThrAllocation(sysModel.SysModel):
         self.r_LcP_P = np.asarray(cfgMsg.r_LcP_P, dtype=float).reshape(-1, 3)
 
         # Convert each flat 9-entry block from column-major to 3x3 matrix.
-        self.dcm_C0P = np.array([dcmFlat.reshape(3, 3, order="F") for dcmFlat in self.dcm_C0P], dtype=float)
+        self.dcm_C0P = np.array(
+            [dcmFlat.reshape(3, 3, order="F") for dcmFlat in self.dcm_C0P], dtype=float
+        )
 
     def initialGuesses(self):
         nDecision = self.nJoint + self.nThr
         seedList = []
 
         guess = np.zeros(nDecision)
-        guess[self.nJoint:] = 1.0  # [N]
+        guess[self.nJoint :] = 1.0  # [N]
         seedList.append(guess)
 
         for angleSeed in (np.pi / 4.0, -np.pi / 4.0, np.pi / 2.0, -np.pi / 2.0):
             guess = np.zeros(nDecision)
             guess[: self.nJoint] = angleSeed
-            guess[self.nJoint:] = 1.0  # [N]
+            guess[self.nJoint :] = 1.0  # [N]
             seedList.append(guess)
 
         self.x0 = np.vstack(seedList)
@@ -261,9 +269,11 @@ class JointThrAllocation(sysModel.SysModel):
         upperBound = np.zeros(nDecision)
         lowerBound[: self.nJoint] = -np.pi  # [rad]
         upperBound[: self.nJoint] = np.pi  # [rad]
-        lowerBound[self.nJoint:] = 0.0  # [N]
-        upperBound[self.nJoint:] = self.resolveThrForceMax()
-        return tuple((float(low), float(high)) for low, high in zip(lowerBound, upperBound))
+        lowerBound[self.nJoint :] = 0.0  # [N]
+        upperBound[self.nJoint :] = self.resolveThrForceMax()
+        return tuple(
+            (float(low), float(high)) for low, high in zip(lowerBound, upperBound)
+        )
 
     def jointPoseFromTheta(self, theta: np.ndarray):
         """
@@ -340,7 +350,9 @@ class JointThrAllocation(sysModel.SysModel):
             jointLocalIdx = int(self.thrArmJointIdx[thrIdx])
             jointFlatIdx = int(self.armJointStart[armIdx] + jointLocalIdx)
 
-            r_TB_B[thrIdx] = r_CB_B[jointFlatIdx] + dcm_CB[jointFlatIdx].T @ self.r_TP_P[thrIdx]
+            r_TB_B[thrIdx] = (
+                r_CB_B[jointFlatIdx] + dcm_CB[jointFlatIdx].T @ self.r_TP_P[thrIdx]
+            )
             fHatVec_B[thrIdx] = dcm_CB[jointFlatIdx].T @ self.fHat_P[thrIdx]
 
         return mapMatrix(r_TB_B, fHatVec_B, r_ComB_B)
@@ -415,7 +427,7 @@ class JointThrAllocation(sysModel.SysModel):
         if bestDecision is None:
             bestDecision = np.zeros(self.nJoint + self.nThr)
 
-        self.thrForcePayload.thrForce = bestDecision[self.nJoint:].tolist()
+        self.thrForcePayload.thrForce = bestDecision[self.nJoint :].tolist()
         self.thrForceOutMsg.write(self.thrForcePayload, CurrentSimNanos, self.moduleID)
 
         self.jointAnglePayload.states.clear()
@@ -425,4 +437,6 @@ class JointThrAllocation(sysModel.SysModel):
             self.jointAnglePayload.states.push_back(float(angleCmd))
             self.jointAnglePayload.stateDots.push_back(0.0)  # [rad/s]
             self.jointAnglePayload.stateDDots.push_back(0.0)  # [rad/s^2]
-        self.desJointAnglesOutMsg.write(self.jointAnglePayload, CurrentSimNanos, self.moduleID)
+        self.desJointAnglesOutMsg.write(
+            self.jointAnglePayload, CurrentSimNanos, self.moduleID
+        )

--- a/src/fswAlgorithms/effectorInterfaces/prescribedRot2DOF/_UnitTest/test_prescribedRot2DOF.py
+++ b/src/fswAlgorithms/effectorInterfaces/prescribedRot2DOF/_UnitTest/test_prescribedRot2DOF.py
@@ -94,7 +94,7 @@ def PrescribedRot2DOFTestFunction(show_plots, thetaInit, thetaRef1a, thetaRef2a,
     testMessages = []
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/effectorInterfaces/solarArrayReference/_UnitTest/test_solarArrayReference.py
+++ b/src/fswAlgorithms/effectorInterfaces/solarArrayReference/_UnitTest/test_solarArrayReference.py
@@ -130,7 +130,7 @@ def solarArrayRotationTestFunction(show_plots, rHat_SB_N, sigma_BN, sigma_RN, at
     testMessages = []                        # create empty array to store test log messages
     unitTaskName = "unitTask"                # arbitrary name (don't change)
     unitProcessName = "TestProcess"          # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRound/thrFiringRound.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRound/thrFiringRound.py
@@ -94,13 +94,15 @@ class ThrFiringRound(sysModel.SysModel):
         if thrForceMaxArr.size == 1:
             return np.full(nThr, float(thrForceMaxArr[0]), dtype=float)
         if thrForceMaxArr.size != nThr:
-            raise ValueError(f"thrForceMax vector length {thrForceMaxArr.size} does not match nThr {nThr}.")
+            raise ValueError(
+                f"thrForceMax vector length {thrForceMaxArr.size} does not match nThr {nThr}."
+            )
         return thrForceMaxArr.copy()
 
     def validateInputMessages(self):
         """Raise ``BasiliskError`` if a required input message is not linked."""
         if not self.thrForceInMsg.isLinked():
-            self.bskLogger.bskError("ThrFiringRound.thrForceInMsg was not linked.")
+            self.bskLogger.error("ThrFiringRound.thrForceInMsg was not linked.")
 
     def Reset(self, CurrentSimNanos):
         self.validateInputMessages()
@@ -121,9 +123,13 @@ class ThrFiringRound(sysModel.SysModel):
         onTimeRequest = np.zeros(nThr)
         onTimeRequest = self.controlPeriodSec * forceCmd / thrForceMax
         onTimeRequest = np.clip(onTimeRequest, 0.0, self.controlPeriodSec)  # [s]
-        onTimeRequest = np.rint(onTimeRequest / self.onTimeResolutionSec) * self.onTimeResolutionSec
+        onTimeRequest = (
+            np.rint(onTimeRequest / self.onTimeResolutionSec) * self.onTimeResolutionSec
+        )
         onTimeRequest[onTimeRequest < self.thrMinFireTimeSec] = 0.0  # [s]
         onTimeRequest = np.clip(onTimeRequest, 0.0, self.controlPeriodSec)  # [s]
 
         self.thrOnTimePayload.OnTimeRequest = onTimeRequest.tolist()
-        self.thrOnTimeOutMsg.write(self.thrOnTimePayload, CurrentSimNanos, self.moduleID)
+        self.thrOnTimeOutMsg.write(
+            self.thrOnTimePayload, CurrentSimNanos, self.moduleID
+        )

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/_UnitTest/test_thrusterPlatformReference.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformReference/_UnitTest/test_thrusterPlatformReference.py
@@ -103,7 +103,7 @@ def platformRotationTestFunction(show_plots, delta_CM, K, thetaMax, seed, accura
 
     unitTaskName = "unitTask"                # arbitrary name (don't change)
     unitProcessName = "TestProcess"          # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/_UnitTest/test_thrusterPlatformState.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrusterPlatformState/_UnitTest/test_thrusterPlatformState.py
@@ -83,7 +83,7 @@ def platformRotationTestFunction(show_plots, theta1, theta2, accuracy):
 
     unitTaskName = "unitTask"                # arbitrary name (don't change)
     unitProcessName = "TestProcess"          # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -166,7 +166,7 @@ def test_reset():
     testMessages = []
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/effectorInterfaces/torque2Dipole/_UnitTest/test_torque2Dipole.py
+++ b/src/fswAlgorithms/effectorInterfaces/torque2Dipole/_UnitTest/test_torque2Dipole.py
@@ -65,7 +65,7 @@ def torque2DipoleModuleTestFunction():
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/effectorInterfaces/torqueScheduler/_UnitTest/test_torqueScheduler.py
+++ b/src/fswAlgorithms/effectorInterfaces/torqueScheduler/_UnitTest/test_torqueScheduler.py
@@ -84,7 +84,7 @@ def torqueSchedulerTestFunction(lockFlag, tSwitch, accuracy):
     testMessages = []                        # create empty array to store test log messages
     unitTaskName = "unitTask"                # arbitrary name (don't change)
     unitProcessName = "TestProcess"          # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()
@@ -198,7 +198,7 @@ def test_reset():
     testMessages = []
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/formationFlying/etSphericalControl/_UnitTest/test_etSphericalControl.py
+++ b/src/fswAlgorithms/formationFlying/etSphericalControl/_UnitTest/test_etSphericalControl.py
@@ -75,7 +75,7 @@ def etSphericalControlTestFunction(show_plots, accuracy):
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/fswAlgorithms/sensorInterfaces/scanningInstrumentController/_UnitTest/test_scanningInstrumentController.py
+++ b/src/fswAlgorithms/sensorInterfaces/scanningInstrumentController/_UnitTest/test_scanningInstrumentController.py
@@ -1,12 +1,12 @@
-# 
+#
 #  ISC License
-# 
+#
 #  Copyright (c) 2023, Autonomous Vehicle Systems Lab, University of Colorado Boulder
-# 
+#
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
 #  copyright notice and this permission notice appear in all copies.
-# 
+#
 #  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 #  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 #  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,7 +14,7 @@
 #  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-# 
+#
 
 import pytest
 import os
@@ -39,35 +39,35 @@ splitPath = path.split(bskName)
 #4: attitude compliant, rate disabled, device status of 1, controller status of 0
 #5: attitude compliant, rate disabled, device status of 0, controller status of 1
 #6: attitude compliant, rate disabled, device status not written, controller status of 1
-#7: attitude compliant, rate disabled, rate noncompliant, device status not written, no 
+#7: attitude compliant, rate disabled, rate noncompliant, device status not written, no
 # controller status
-#8: attitude compliant, rate enabled, rate noncompliant, device status not written, no 
+#8: attitude compliant, rate enabled, rate noncompliant, device status not written, no
 # controller status
-#9: attitude compliant, rate enabled, rate compliant, device status not written, no 
+#9: attitude compliant, rate enabled, rate compliant, device status not written, no
 # controller status
 #10: attitude noncompliant, rate enabled, rate compliant
-tests = [(0.1, 0.01, 0, 0, 0, 1, 1, [1, 1, 1]), 
-         (0.1, 0.2, 0, 0, 0, 1, 1, [0, 0, 0]), 
-         (0.1, 0.01, 0, 0, 0, None, None, [0, 0, 0]), 
-         (0.1, 0.01, 0, 0, 0, 1, 0, [1, 1, 1]), 
-         (0.1, 0.01, 0, 0, 0, 0, 1, [0, 0, 0]), 
-         (0.1, 0.01, 0, 0, 0, None, 1, [1, 1, 1]), 
-         (0.1, 0.01, 0, 0.01, 0.1, None, 1, [1, 1, 1]), 
-         (0.1, 0.01, 1, 0.01, 0.1, None, 1, [0, 0, 0]), 
-         (0.1, 0.01, 1, 0.01, 0.001, 1, None, [1, 1, 1]), 
-         (0.1, 0.2, 1, 0.01, 0.001, 1, None, [0, 0, 0]) 
+tests = [(0.1, 0.01, 0, 0, 0, 1, 1, [1, 1, 1]),
+         (0.1, 0.2, 0, 0, 0, 1, 1, [0, 0, 0]),
+         (0.1, 0.01, 0, 0, 0, None, None, [0, 0, 0]),
+         (0.1, 0.01, 0, 0, 0, 1, 0, [1, 1, 1]),
+         (0.1, 0.01, 0, 0, 0, 0, 1, [0, 0, 0]),
+         (0.1, 0.01, 0, 0, 0, None, 1, [1, 1, 1]),
+         (0.1, 0.01, 0, 0.01, 0.1, None, 1, [1, 1, 1]),
+         (0.1, 0.01, 1, 0.01, 0.1, None, 1, [0, 0, 0]),
+         (0.1, 0.01, 1, 0.01, 0.001, 1, None, [1, 1, 1]),
+         (0.1, 0.2, 1, 0.01, 0.001, 1, None, [0, 0, 0])
         ]
 
-@pytest.mark.parametrize('att_limit, att_mag, use_rate_limit,rate_limit,omega_mag' + 
+@pytest.mark.parametrize('att_limit, att_mag, use_rate_limit,rate_limit,omega_mag' +
                          ',deviceStatus,controlStatus,expected_result', tests)
-def test_scanningInstrumentController(att_limit, att_mag, use_rate_limit, rate_limit, 
-                                    omega_mag, deviceStatus, controlStatus, 
+def test_scanningInstrumentController(att_limit, att_mag, use_rate_limit, rate_limit,
+                                    omega_mag, deviceStatus, controlStatus,
                                     expected_result):
     r"""
     **Validation Test Description**
 
     This test verifies if the module is working properly checking for input conditions
-    such as rate limit, attitude error, and device status. 
+    such as rate limit, attitude error, and device status.
 
     **Test Parameters**
 
@@ -83,24 +83,24 @@ def test_scanningInstrumentController(att_limit, att_mag, use_rate_limit, rate_l
 
     **Description of Variables Being Tested**
 
-    The test checks the data stored in deviceCmdOutMsg and compares it to the expected 
-    result. 
+    The test checks the data stored in deviceCmdOutMsg and compares it to the expected
+    result.
     """
-    
-    module_results = scanningInstrumentControllerTestFunction(att_limit, 
-                                        att_mag, use_rate_limit, rate_limit, omega_mag, 
+
+    module_results = scanningInstrumentControllerTestFunction(att_limit,
+                                        att_mag, use_rate_limit, rate_limit, omega_mag,
                                         deviceStatus, controlStatus, expected_result)
 
     np.testing.assert_array_equal(module_results, expected_result)
 
 
-def scanningInstrumentControllerTestFunction(att_limit = 0.1, att_mag = 0.1, 
-                        use_rate_limit=1, rate_limit=0.01, omega_mag=0.001, 
+def scanningInstrumentControllerTestFunction(att_limit = 0.1, att_mag = 0.1,
+                        use_rate_limit=1, rate_limit=0.01, omega_mag=0.001,
                         deviceStatus=None, controlStatus=None, expected_result=None):
     """Test method"""
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     unitTestSim = SimulationBaseClass.SimBaseClass()
     testProcessRate = macros.sec2nano(1.0)

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
@@ -110,7 +110,7 @@ def simpleInstrumentControllerTestFunction(show_plots, use_rate_limit=1, rate_li
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplate.py
+++ b/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplate.py
@@ -82,7 +82,7 @@ def fswModuleTestFunction(show_plots):
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplateParametrized.py
+++ b/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplateParametrized.py
@@ -127,7 +127,7 @@ def fswModuleTestFunction(show_plots, param1, param2, accuracy):
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/moduleTemplates/cppModuleTemplate/_UnitTest/test_cppModuleTemplateParametrized.py
+++ b/src/moduleTemplates/cppModuleTemplate/_UnitTest/test_cppModuleTemplateParametrized.py
@@ -127,7 +127,7 @@ def cppModuleTestFunction(show_plots, param1, param2, accuracy):
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"               # arbitrary name (don't change)
     unitProcessName = "TestProcess"         # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/simulation/deviceInterface/prescribedLinearTranslation/_UnitTest/test_prescribedLinearTranslation.py
+++ b/src/simulation/deviceInterface/prescribedLinearTranslation/_UnitTest/test_prescribedLinearTranslation.py
@@ -97,7 +97,7 @@ def test_prescribedLinearTranslation(show_plots,
 
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/_UnitTest/test_prescribedRotation1DOF.py
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/_UnitTest/test_prescribedRotation1DOF.py
@@ -95,7 +95,7 @@ def test_prescribedRotation1DOF(show_plots,
 
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/simulation/environment/TabularAtmosphere/_UnitTest/test_unitTestTabularAtmosphere.py
+++ b/src/simulation/environment/TabularAtmosphere/_UnitTest/test_unitTestTabularAtmosphere.py
@@ -98,7 +98,7 @@ def tabularAtmosphereTestFunction(altitude, accuracy, useMinReach, useMaxReach):
     testFailCount = 0  # zero unit test result counter
     unitTaskName = "unitTask"  # arbitrary name (don't change)
     unitProcessName = "TestProcess"  # arbitrary name (don't change)
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     # Create a sim module as an empty container
     unitTestSim = SimulationBaseClass.SimBaseClass()

--- a/src/simulation/environment/albedo/_UnitTest/test_albedo.py
+++ b/src/simulation/environment/albedo/_UnitTest/test_albedo.py
@@ -239,7 +239,7 @@ def test_albedo_invalid_file(tmp_path):
     """
     albModule = albedo.Albedo()
     # silence expected error message
-    albModule.bskLogger.setLevel(bskLogging.BSK_SILENT)
+    albModule.bskLogger.setLevel(bskLogging.SILENT)
 
     gravFactory = simIncludeGravBody.gravBodyFactory()
     gravFactory.createEarth()

--- a/src/simulation/environment/albedo/_UnitTest/test_albedo.py
+++ b/src/simulation/environment/albedo/_UnitTest/test_albedo.py
@@ -239,7 +239,7 @@ def test_albedo_invalid_file(tmp_path):
     """
     albModule = albedo.Albedo()
     # silence expected error message
-    albModule.bskLogger.setLogLevel(bskLogging.BSK_SILENT)
+    albModule.bskLogger.setLevel(bskLogging.BSK_SILENT)
 
     gravFactory = simIncludeGravBody.gravBodyFactory()
     gravFactory.createEarth()

--- a/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemeris.py
+++ b/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemeris.py
@@ -70,7 +70,7 @@ def test_module(show_plots, setRAN, setDEC, setLST, setRate):
 
 
 def planetEphemerisTest(show_plots, setRAN, setDEC, setLST, setRate):
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_SILENT)
+    bskLogging.setDefaultLogLevel(bskLogging.SILENT)
 
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
+++ b/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
@@ -50,7 +50,7 @@ def test_space_weather_data_celestrak_example_columns():
     the epoch ``2026-03-04 21:48:00``.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 
@@ -105,7 +105,7 @@ def test_space_weather_data_stops_at_first_invalid_row():
     as the valid CelesTrak example set.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 
@@ -170,7 +170,7 @@ def test_space_weather_data_missing_required_column():
     The test checks all 23 weather outputs and verifies every value is zero.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
@@ -204,7 +204,7 @@ def test_space_weather_data_duplicate_date_rows():
     The test checks all 23 weather outputs and verifies every value is zero.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
@@ -238,7 +238,7 @@ def test_space_weather_data_unsorted_rows():
     The test checks all 23 weather outputs and verifies every value is zero.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
@@ -275,7 +275,7 @@ def test_reset_error_when_epoch_before_table():
     ``"simulation start date is not covered"``.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 
@@ -317,7 +317,7 @@ def test_stale_output_retained_on_missing_day():
     - ``swDataOutMsgs[21]`` (``f107_1944_0``, F10.7c81): 138.5 after both stages.
     """
     # Suppress the expected BSK_WARNING, not testing them at the moment.
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_ERROR)
+    bskLogging.setDefaultLogLevel(bskLogging.ERROR)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 
@@ -373,7 +373,7 @@ def test_space_weather_data_epoch_update():
     and propagating the simulation for 1 day and 3 hours.
     """
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 
@@ -431,7 +431,7 @@ def test_space_weather_data_rejects_date_with_trailing_chars():
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
-    module.bskLogger.setLevel(bskLogging.BSK_ERROR)
+    module.bskLogger.setLevel(bskLogging.ERROR)
 
     csv_text = "\n".join([
         "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
@@ -463,7 +463,7 @@ def test_space_weather_data_rejects_numeric_with_trailing_chars():
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
-    module.bskLogger.setLevel(bskLogging.BSK_ERROR)
+    module.bskLogger.setLevel(bskLogging.ERROR)
 
     csv_text = "\n".join([
         "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
@@ -486,7 +486,7 @@ def _load_single_row_csv(row: str) -> spaceWeatherData.SpaceWeatherData:
     """Helper: write a single-data-row CSV and call loadSpaceWeatherFile."""
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
-    module.bskLogger.setLevel(bskLogging.BSK_ERROR)
+    module.bskLogger.setLevel(bskLogging.ERROR)
     csv_text = _MINIMAL_HEADER + "\n" + row
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "sw.csv"
@@ -594,7 +594,7 @@ def test_valid_date_feb_29_leap_accepted():
 
     ``swDataOutMsgs[0].dataValue`` is non-zero after a successful look-up.
     """
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 
@@ -648,7 +648,7 @@ def test_valid_date_feb_29_quad_century_leap_accepted():
 
     No exception from ``loadSpaceWeatherFile``.
     """
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     csv_text = "\n".join([
         _MINIMAL_HEADER,
@@ -734,7 +734,7 @@ def test_failed_reload_preserves_previous_table():
     ``swDataOutMsgs[0].dataValue`` equals the expected AP_AVG value from the
     first table after the failed reload.
     """
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     unit_task_name = "unitTask"
     unit_process_name = "unitProcess"
 

--- a/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
+++ b/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
@@ -431,7 +431,7 @@ def test_space_weather_data_rejects_date_with_trailing_chars():
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
-    module.bskLogger.setLogLevel(bskLogging.BSK_ERROR)
+    module.bskLogger.setLevel(bskLogging.BSK_ERROR)
 
     csv_text = "\n".join([
         "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
@@ -463,7 +463,7 @@ def test_space_weather_data_rejects_numeric_with_trailing_chars():
 
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
-    module.bskLogger.setLogLevel(bskLogging.BSK_ERROR)
+    module.bskLogger.setLevel(bskLogging.BSK_ERROR)
 
     csv_text = "\n".join([
         "DATE,AP1,AP2,AP3,AP4,AP5,AP6,AP7,AP8,AP_AVG,F10.7_OBS,F10.7_OBS_CENTER81",
@@ -486,7 +486,7 @@ def _load_single_row_csv(row: str) -> spaceWeatherData.SpaceWeatherData:
     """Helper: write a single-data-row CSV and call loadSpaceWeatherFile."""
     module = spaceWeatherData.SpaceWeatherData()
     module.ModelTag = "spaceWeatherData"
-    module.bskLogger.setLogLevel(bskLogging.BSK_ERROR)
+    module.bskLogger.setLevel(bskLogging.BSK_ERROR)
     csv_text = _MINIMAL_HEADER + "\n" + row
     with tempfile.TemporaryDirectory() as temp_dir:
         file_path = Path(temp_dir) / "sw.csv"

--- a/src/simulation/navigation/stateMerge/stateMerge.py
+++ b/src/simulation/navigation/stateMerge/stateMerge.py
@@ -45,7 +45,7 @@ class StateMerge(sysModel.SysModel):
         ]
         for msgName, msgReader in requiredInputMessages:
             if not msgReader.isLinked():
-                self.bskLogger.bskError(f"StateMerge.{msgName} was not linked.")
+                self.bskLogger.error(f"StateMerge.{msgName} was not linked.")
 
     def Reset(self, CurrentSimNanos):
         self.validateInputMessages()

--- a/src/simulation/power/ReactionWheelPower/_UnitTest/test_unitReactionWheelPower.py
+++ b/src/simulation/power/ReactionWheelPower/_UnitTest/test_unitReactionWheelPower.py
@@ -99,7 +99,7 @@ def test_module(show_plots, setRwMsg, setDeviceStatusMsg, setEta_e2m, OmegaValue
 
 def powerRW(show_plots, setRwMsg, setDeviceStatusMsg, setEta_e2m, OmegaValue, setEta_m2c, accuracy):
     if not setRwMsg:
-        bskLogging.setDefaultLogLevel(bskLogging.BSK_ERROR)
+        bskLogging.setDefaultLogLevel(bskLogging.ERROR)
 
     """Module Unit Test"""
     testFailCount = 0                       # zero unit test result counter

--- a/src/simulation/vizard/dataFileToViz/_UnitTest/test_dataFileToViz.py
+++ b/src/simulation/vizard/dataFileToViz/_UnitTest/test_dataFileToViz.py
@@ -155,7 +155,7 @@ def test_module(show_plots, convertPosUnits, attType, checkThruster, checkRW):
 def run(show_plots, convertPosUnits, attType, checkThruster, checkRW, verbose):
 
     if not verbose:
-        bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+        bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/tests/test_bskPrinciples.py
+++ b/src/tests/test_bskPrinciples.py
@@ -59,7 +59,7 @@ def test_scenarioBskPrinciples(show_plots, bskScript):
     if bskScript == "making-numbaModules.py":
         pytest.importorskip("numba")
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
     # import the bskSim script to be tested

--- a/src/tests/test_bskTestOpNav.py
+++ b/src/tests/test_bskTestOpNav.py
@@ -78,7 +78,7 @@ except ImportError:
 @pytest.mark.scenarioTest
 @pytest.mark.ciSkip
 def test_opnavBskScenarios(show_plots):
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_SILENT)
+    bskLogging.setDefaultLogLevel(bskLogging.SILENT)
 
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/tests/test_messaging.py
+++ b/src/tests/test_messaging.py
@@ -53,7 +53,7 @@ def messaging_unit_tests():
 def test_cpp_msg_subscription_check():
     # Check whether python-wrapped C++ messages are properly checked for subscription
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
 
@@ -119,7 +119,7 @@ def test_cpp_msg_subscription_check():
 def test_c_msg_subscription_check():
     # Check whether python-wrapped C++ messages are properly checked for subscription
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
 
@@ -177,7 +177,7 @@ def test_c_msg_subscription_check():
 
 def test_c_2_cpp_msg_subscription_check():
 
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
 
@@ -246,7 +246,7 @@ def test_c_2_cpp_msg_subscription_check():
 
 
 def test_cpp_2_c_msg_subscription_check():
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
 

--- a/src/tests/test_scenarioCustomGravBody.py
+++ b/src/tests/test_scenarioCustomGravBody.py
@@ -37,7 +37,7 @@ def test_simplePowerDemo(show_plots):
     """This function is called by the py.test environment."""
 
     # suppress printing out BSK_INFORMATION states
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/tests/test_scenarioDataToViz.py
+++ b/src/tests/test_scenarioDataToViz.py
@@ -38,7 +38,7 @@ def test_simplePowerDemo(show_plots, attType):
     """This function is called by the py.test environment."""
 
     # suppress printing out BSK_INFORMATION states
-    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+    bskLogging.setDefaultLogLevel(bskLogging.WARNING)
 
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages

--- a/src/utilities/pythonVariableLogger.py
+++ b/src/utilities/pythonVariableLogger.py
@@ -52,8 +52,7 @@ class PythonVariableLogger(sysModel.SysModel):
 
         if name not in variables:
             raise KeyError(
-                f"Logger is not logging '{name}'. "
-                f"Available: {', '.join(variables)}"
+                f"Logger is not logging '{name}'. Available: {', '.join(variables)}"
             )
         return np.array(variables[name])
 
@@ -78,7 +77,7 @@ class PythonVariableLogger(sysModel.SysModel):
             try:
                 val = np.array(fn(CurrentSimNanos)).squeeze()
             except Exception as ex:
-                self.bskLogger.bskError(
+                self.bskLogger.error(
                     f"Error logging '{name}' in '{self.ModelTag}': {ex}"
                 )
             self._variables[name].append(val)


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The bskLogger Python API doesn't match the conventions of Python's standard logging module. This is just a consequence of the SWIG code generation used to expose the C++ class. This PR adds purely additive aliases and convenience methods so users can interact with bskLogger in a more natural and Pythonic way:
- `debug()`, `info()`, `warning()`, `error()` convenience methods on `BSKLogger` which mirror the `logging.Logger` API.
- `setLevel()` as an alias for `setLogLevel()`
- A `LogLevel` IntEnum for typed level references

All existing APIs remain unchanged so this is fully backward compatible.
Also some minor formatting fixes were applied to the files that were updated. Generally I think when updating these older files its okay to allow the formatter to make some cleanup as long as we don't go overboard and muddle the diff with 1000s of LOC changes.

## Verification
Tests passing

## Documentation
Updated the bskLogging related documentation.

## Future work
- We could deprecate the existing API.
- Generally I think we should make sure the API we expose feels very Pythonic and not just like python flavored C++. I am sure there are other spots like this we could improve the feel of the API.
