### PR TITLE
Fix incorrect thruster mapping for jointThrAllocation

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -30,6 +30,9 @@ Version |release|
 - BSK-1387: :ref:`linkBudget` could compute excessive pointing loss for non-identity antenna attitudes
   because the inertial line-of-sight vector was transformed using the antenna-to-inertial DCM. This is
   fixed in the current version.
+- BSK-1416 : :ref:`jointThrAllocation` was using a static value for the vector between the hub center of
+  mass (CoM) and system CoM. This caused the resulting thruster mapping to be incorrect for a given
+  set of joint angles. This is fixed in the current version.
 
 
 Version 2.10.0 (April 2, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/1416-jointThrAllocation-Fix.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1416-jointThrAllocation-Fix.rst
@@ -1,0 +1,1 @@
+- Fixed the use of a static vector between the hub center of mass and the system center of mass in :ref:`jointThrAllocation`. The vector is now computed from the current articulated-arm configuration, which corrects the thruster mapping and resulting optimization solution for a given set of joint angles.

--- a/examples/mujoco/mujocoModels/BSK_MujocoDynamics.py
+++ b/examples/mujoco/mujocoModels/BSK_MujocoDynamics.py
@@ -64,6 +64,8 @@ class BSKMujocoDynamicsModels():
     def setScene(self):
         self.scene.extraEoMCall = True
         self.scene.ModelTag = "mujocoScene"
+        self.integrator.setRelativeTolerance(1e-2)
+        self.integrator.setAbsoluteTolerance(1e-2)
         self.scene.setIntegrator(self.integrator)
 
     def setSystemCoM(self):

--- a/examples/mujoco/mujocoModels/BSK_MujocoFSW.py
+++ b/examples/mujoco/mujocoModels/BSK_MujocoFSW.py
@@ -56,30 +56,43 @@ class BSKMujocoFSWModels:
         # Define default values for the scenario
         self.numJoints = 8
         self.numThrusters = 2
-        self.thrForces = [2.5]*self.numThrusters # N
-        self.maxJointTorques = [22.5]*self.numJoints # Nm
+        self.thrForces = [2.5]*self.numThrusters # [N]
+        if fswRate == 0.01:
+            self.maxJointTorques = [5.0]*self.numJoints # [N*m]
+        else:
+            self.maxJointTorques = [22.5]*self.numJoints # [N*m]
+        self.hubMass = 330.0    # [kg]
         self.controlWeight = 1.0
         self.thrustWeight = 1e-6
 
         # Define the default control gains
-        self.Tpos = 27.0
-        self.Tatt = 10.0
-        self.omegaOuter = 2*np.pi/10
-        self.omegaInner = 5*self.omegaOuter
-        piRot = (2*1/3*330.0*(0.79**2+0.69**2))/self.Tatt
-        self.pRot = piRot
-        xiRot = 1.0
-        self.kRot = piRot**2/(4*xiRot**2*(1/3*330.0*(0.79**2+0.69**2)))
-        self.kiRot = -1.0
-        piPos = 2.0*350.0/self.Tpos
-        self.pTrans = (piPos * np.eye(3)).flatten().tolist()
-        xiPos = 1.0
-        self.kTrans = (piPos**2/(4*xiPos**2*350.0) * np.eye(3)).flatten().tolist()
-        kiMotor = self.omegaInner**2
-        self.kTheta = (kiMotor * np.eye(8)).flatten().tolist()
-        xiMotor = 1.5
-        piMotor = 2 * xiMotor * self.omegaInner
-        self.pTheta = (piMotor * np.eye(8)).flatten().tolist()
+        if fswRate == 0.01:
+            self.pTrans = (2.0*350.0/25.0 * np.eye(3)).flatten().tolist() #[N*s/m]
+            self.kTrans =((2.0*350.0/25.0)**2 / (4*350.0) * np.eye(3)).flatten().tolist()   #[N/m]
+            self.pRot = (2.0*1/3*330.0*(0.79**2+0.69**2))/15.0  #[N*m*s]
+            self.kRot = self.pRot**2/(4*(1/3*330.0*(0.79**2+0.69**2)))  #[N*m]
+            self.kiRot = -1.0
+            self.kTheta = (np.pi**2 * np.eye(8)).flatten().tolist() #[N*m/rad]
+            self.pTheta = (2.0*1.5*np.pi * np.eye(8)).flatten().tolist()    #[N*m*s/rad]
+        else:
+            self.Tpos = 15.0
+            self.Tatt = 10.0
+            self.omegaOuter = 2*np.pi/10
+            self.omegaInner = 5*self.omegaOuter
+            piRot = (2*1/3*330.0*(0.79**2+0.69**2))/self.Tatt
+            self.pRot = piRot #[N*m*s]
+            xiRot = 1.0
+            self.kRot = piRot**2/(4*xiRot**2*(1/3*330.0*(0.79**2+0.69**2))) #[N*m]
+            self.kiRot = -1.0
+            piPos = 2.0*350.0/self.Tpos
+            self.pTrans = (piPos * np.eye(3)).flatten().tolist() #[N*s/m]
+            xiPos = 1.0
+            self.kTrans = (piPos**2/(4*xiPos**2*350.0) * np.eye(3)).flatten().tolist() #[N/m]
+            kiMotor = self.omegaInner**2
+            self.kTheta = (kiMotor * np.eye(8)).flatten().tolist() #[N*m/rad]
+            xiMotor = 1.5
+            piMotor = 2 * xiMotor * self.omegaInner
+            self.pTheta = (piMotor * np.eye(8)).flatten().tolist() #[N*m*s/rad]
 
 
         # Define the XML object names for later use
@@ -263,14 +276,24 @@ class BSKMujocoFSWModels:
     def SetVehicleConfiguration(self):
         """Set the spacecraft configuration information"""
         vehicleConfigOut = messaging.VehicleConfigMsgPayload()
-        vehicleConfigOut.massSC = 350.0
+        vehicleConfigOut.massSC = 350.0 #[kg]
         # use the hub inertia for mrp feedback module since will not have instantaneous inertia otherwise
-        vehicleConfigOut.ISCPntB_B = [1/3*330.0*(0.69**2+0.52**2), 0.0, 0.0, 0.0, 1/3*330.0*(0.79**2+0.52**2), 0.0, 0.0, 0.0, 1/3*330.0*(0.79**2+0.69**2)]
+        vehicleConfigOut.ISCPntB_B = [1/3*self.hubMass*(0.69**2+0.52**2), 0.0, 0.0, 0.0, 1/3*self.hubMass*(0.79**2+0.52**2), 0.0, 0.0, 0.0, 1/3*self.hubMass*(0.79**2+0.69**2)] #[kg*m^2]
         self.vcMsg = messaging.VehicleConfigMsg().write(vehicleConfigOut)
 
     def SetThrArmConfig(self):
         """Set the thruster arm configuration information"""
         thrArmConfigOut = messaging.THRArmConfigMsgPayload()
+        r_BcB_B = [0.0, 0.0, 0.0] #[m]
+        bodyArmIdx = [0, 0, 1, 1]
+        bodyJointIdx = [1, 3, 1, 3]
+        bodyMass = [8.0, 2.0, 8.0, 2.0] #[kg]
+        r_LcP_P = [
+            0.5, 0.0, 0.0,
+            0.05, 0.0, 0.0,
+            0.5, 0.0, 0.0,
+            0.05, 0.0, 0.0,
+        ] #[m]
         thrArmIdx = [0, 1]
         thrArmJointIdx = [3, 3]
         armTreeIdx = [0, 0]
@@ -284,11 +307,11 @@ class BSKMujocoFSWModels:
             0.0, 0.0, 0.0,
             1.0, 0.0, 0.0,
             0.0, 0.0, 0.0,
-        ]
+        ] #[m]
         r_TP_P = [
             0.1, 0.0, 0.0,
             0.1, 0.0, 0.0,
-        ]
+        ] #[m]
         shat_P = [
             1.0, 0.0, 0.0,
             0.0, 1.0, 0.0,
@@ -318,6 +341,10 @@ class BSKMujocoFSWModels:
             + arm2BaseDcm + identity + identity + identity
         )
 
+        thrArmConfigOut.bodyArmIdx.clear()
+        thrArmConfigOut.bodyJointIdx.clear()
+        thrArmConfigOut.bodyMass.clear()
+        thrArmConfigOut.r_LcP_P.clear()
         thrArmConfigOut.thrArmIdx.clear()
         thrArmConfigOut.thrArmJointIdx.clear()
         thrArmConfigOut.armTreeIdx.clear()
@@ -327,6 +354,18 @@ class BSKMujocoFSWModels:
         thrArmConfigOut.shat_P.clear()
         thrArmConfigOut.fhat_P.clear()
         thrArmConfigOut.dcm_C0P.clear()
+
+        thrArmConfigOut.hubMass = self.hubMass
+        for v in r_BcB_B:
+            thrArmConfigOut.r_BcB_B.push_back(v)
+        for v in bodyArmIdx:
+            thrArmConfigOut.bodyArmIdx.push_back(v)
+        for v in bodyJointIdx:
+            thrArmConfigOut.bodyJointIdx.push_back(v)
+        for v in bodyMass:
+            thrArmConfigOut.bodyMass.push_back(v)
+        for v in r_LcP_P:
+            thrArmConfigOut.r_LcP_P.push_back(v)
         for v in thrArmIdx:
             thrArmConfigOut.thrArmIdx.push_back(v)
         for v in thrArmJointIdx:
@@ -350,9 +389,9 @@ class BSKMujocoFSWModels:
     def SetTransRef(self):
         """Set the translational reference state information"""
         transRefOut = messaging.TransRefMsgPayload()
-        transRefOut.r_RN_N = [0.0, 0.0, 0.0]
-        transRefOut.v_RN_N = [0.0, 0.0, 0.0]
-        transRefOut.a_RN_N = [0.0, 0.0, 0.0]
+        transRefOut.r_RN_N = [0.0, 0.0, 0.0] #[m]
+        transRefOut.v_RN_N = [0.0, 0.0, 0.0] #[m/s]
+        transRefOut.a_RN_N = [0.0, 0.0, 0.0] #[m/s^2]
         self.transRefMsg = messaging.TransRefMsg().write(transRefOut)
 
     def SetInertial3D(self):
@@ -399,7 +438,6 @@ class BSKMujocoFSWModels:
         """Define the joint and thruster allocation module"""
         self.jointThrAllocation.ModelTag = "jointThrAllocation"
         self.jointThrAllocation.armConfigInMsg.subscribeTo(self.thrArmConfigMsg)
-        self.jointThrAllocation.CoMStatesInMsg.subscribeTo(SimBase.DynModels.systemCoM.comStatesOutMsg)
         self.jointThrAllocation.hubStatesInMsg.subscribeTo(SimBase.DynModels.scene.getBody(self.hubName).getOrigin().stateOutMsg)
         self.jointThrAllocation.transForceInMsg.subscribeTo(self.inertialCartFeedback.forceOutMsg)
         self.jointThrAllocation.rotTorqueInMsg.subscribeTo(self.mrpFeedback.cmdTorqueOutMsg)

--- a/examples/mujoco/sat_w_thruster_arms.xml
+++ b/examples/mujoco/sat_w_thruster_arms.xml
@@ -8,25 +8,25 @@
       <site name="hub_center" pos="0 0 0" />
 
       <body name="arm_1_base" pos="0.79 0 0">
-	  	<geom name="boom_1" type="capsule" size="0.1" fromto="0 0 0 1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="8" />
+        <geom name="boom_1" type="capsule" size="0.1" fromto="0 0 0 1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="8" />
         <joint name="arm_1_joint_1" axis="1 0 0" />
         <joint name="arm_1_joint_2" axis="0 1 0" />
 
         <body name="arm_1_tip" pos="1 0 0">
-		  <geom name="tip_1" type="capsule" size="0.05" fromto="0 0 0 0.1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="2" />
+		      <geom name="tip_1" type="capsule" size="0.05" fromto="0 0 0 0.1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="2" />
           <joint name="arm_1_joint_3" axis="0 0 1" />
           <joint name="arm_1_joint_4" axis="0 1 0" />
           <site name="thruster_1" pos="0.1 0 0" />
         </body>
-	  </body>
+      </body>
 
       <body name="arm_2_base" pos="-0.79 0 0" xyaxes="-1 0 0 0 -1 0">
-	  	<geom name="boom_2" type="capsule" size="0.1" fromto="0 0 0 1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="8" />
+        <geom name="boom_2" type="capsule" size="0.1" fromto="0 0 0 1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="8" />
         <joint name="arm_2_joint_1" axis="1 0 0" />
         <joint name="arm_2_joint_2" axis="0 1 0" />
 
-		<body name="arm_2_tip" pos="1 0 0">
-		  <geom name="tip_2" type="capsule" size="0.05" fromto="0 0 0 0.1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="2" />
+        <body name="arm_2_tip" pos="1 0 0">
+          <geom name="tip_2" type="capsule" size="0.05" fromto="0 0 0 0.1 0 0" rgba="1 0 0 1" contype="1" conaffinity="2" mass="2" />
           <joint name="arm_2_joint_3" axis="0 0 1" />
           <joint name="arm_2_joint_4" axis="0 1 0" />
           <site name="thruster_2" pos="0.1 0 0" />

--- a/examples/mujoco/scenarioThrArmControl.py
+++ b/examples/mujoco/scenarioThrArmControl.py
@@ -206,7 +206,7 @@ def runScenario(scenario, runTime: float = 320.0):
     scenario.ConfigureStopTime(simulationTime)
     scenario.ExecuteSimulation()
 
-def run(showPlots: bool = False, timeStep: float = 0.01, runTime: float = 320.0):
+def run(showPlots: bool = False, timeStep: float = 0.01, runTime: float = 500.0):
    """
     The scenarios can be run with the following setups parameters:
 
@@ -241,7 +241,7 @@ if __name__ == "__main__":
         parser.add_argument(
         "--runTime",
         type=float,
-        default=320.0,
+        default=500.0,
         help="Simulation run time [s]."
         )
 

--- a/src/architecture/msgPayloadDefCpp/THRArmConfigMsgPayload.h
+++ b/src/architecture/msgPayloadDefCpp/THRArmConfigMsgPayload.h
@@ -20,6 +20,7 @@
 #ifndef THR_ARM_CONFIG_MESSAGE_H
 #define THR_ARM_CONFIG_MESSAGE_H
 
+#include <array>
 #include <vector>
 
 /*! @brief Structure used by the messaging system to communicate details about the spacecraft system configuration
@@ -29,15 +30,24 @@ typedef struct
 THRArmConfigMsgPayload
 //@endcond
 {
-    std::vector<int> thrArmIdx;              //!< [-] index for which arm a thruster belongs to
-    std::vector<int> thrArmJointIdx;        //!< [-] index for which hinged joint in an arm is the closest parent joint
-    std::vector<int> armTreeIdx;           //!< [-] index for which kinematic tree each thruster arm belongs to
+    double hubMass;                       //!< [kg] mass of the spacecraft's hub
+    std::vector<double> r_BcB_B;          //!< [m] position vector from the hub body frame origin to the hub center of mass (body frame)
+
+    std::vector<int> bodyArmIdx;          //!< [-] index for which arm a body belongs to
+    std::vector<int> bodyJointIdx;        //!< [-] local joint index of the closest parent joint for each body
+    std::vector<double> bodyMass;         //!< [kg] mass of each arm body
+    std::vector<double> r_LcP_P;          //!< [m] position vector from the parent joint to the body center of mass (parent joint's frame), column-major order
+
     std::vector<int> armJointCount;       //!< [-] list of the number of hinged joints in each thruster arm
     std::vector<double> r_CP_P;           //!< [m] position vector from the parent joint to the child joint(parent joint's frame), column-major order
-    std::vector<double> r_TP_P;           //!< [m] position vector from the closest parent joint to the thruster (parent joint's frame), column-major order
     std::vector<double> shat_P;           //!< [-] spin axis unit vector of a child joint (parent joint's frame), column-major order
+    std::vector<double> dcm_C0P;          //!< [-] direction cosine matrix from the child joint frame zero angle orientation to the parent joint frame, column-major order
+
+    std::vector<int> armTreeIdx;          //!< [-] index for which kinematic tree each thruster arm belongs to
+    std::vector<int> thrArmIdx;           //!< [-] index for which arm a thruster belongs to
+    std::vector<int> thrArmJointIdx;      //!< [-] local joint index of the closest parent joint for each thruster
+    std::vector<double> r_TP_P;           //!< [m] position vector from the closest parent joint to the thruster (parent joint's frame), column-major order
     std::vector<double> fhat_P;           //!< [-] force axis unit vector of a thruster (parent joint's frame), column-major order
-    std::vector<double> dcm_C0P;           //!< [-] direction cosine matrix from the child joint frame zero angle orientation to the parent joint frame, column-major order
 } THRArmConfigMsgPayload;
 
 #endif

--- a/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/_UnitTest/test_jointThrAllocation.py
+++ b/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/_UnitTest/test_jointThrAllocation.py
@@ -20,21 +20,156 @@ import pytest
 
 from Basilisk.architecture import bskLogging, messaging
 from Basilisk.fswAlgorithms import jointThrAllocation
+from Basilisk.utilities import RigidBodyKinematics as rbk
 
 
 def _linked_input_messages():
     armConfigMsg = messaging.THRArmConfigMsg().write(messaging.THRArmConfigMsgPayload())
-    comStatesMsg = messaging.SCStatesMsg().write(messaging.SCStatesMsgPayload())
     hubStatesMsg = messaging.SCStatesMsg().write(messaging.SCStatesMsgPayload())
     transForceMsg = messaging.CmdForceInertialMsg().write(messaging.CmdForceInertialMsgPayload())
     rotTorqueMsg = messaging.CmdTorqueBodyMsg().write(messaging.CmdTorqueBodyMsgPayload())
     return {
         "armConfigInMsg": armConfigMsg,
-        "CoMStatesInMsg": comStatesMsg,
         "hubStatesInMsg": hubStatesMsg,
         "transForceInMsg": transForceMsg,
         "rotTorqueInMsg": rotTorqueMsg,
     }
+
+
+def _configured_allocation():
+    allocation = jointThrAllocation.JointThrAllocation()
+    allocation.nArms = 2
+    allocation.nThr = 2
+    allocation.nJoint = 8
+    allocation.armJointCount = np.array([4, 4], dtype=int)
+    allocation.armJointStart = np.array([0, 4], dtype=int)
+    allocation.thrArmIdx = np.array([0, 1], dtype=int)
+    allocation.thrArmJointIdx = np.array([3, 3], dtype=int)
+    allocation.r_CP_P = np.array(
+        [
+            [0.79, 0.0, 0.0],  # [m]
+            [0.0, 0.0, 0.0],  # [m]
+            [1.0, 0.0, 0.0],  # [m]
+            [0.0, 0.0, 0.0],  # [m]
+            [-0.79, 0.0, 0.0],  # [m]
+            [0.0, 0.0, 0.0],  # [m]
+            [1.0, 0.0, 0.0],  # [m]
+            [0.0, 0.0, 0.0],  # [m]
+        ]
+    )
+    allocation.r_TP_P = np.array(
+        [
+            [0.1, 0.0, 0.0],  # [m]
+            [0.1, 0.0, 0.0],  # [m]
+        ]
+    )
+    allocation.sHat_P = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+    allocation.fHat_P = np.array(
+        [
+            [-1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ]
+    )
+    arm2_base_dcm = np.array(
+        [
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    allocation.dcm_C0P = np.array(
+        [
+            np.eye(3),
+            np.eye(3),
+            np.eye(3),
+            np.eye(3),
+            arm2_base_dcm,
+            np.eye(3),
+            np.eye(3),
+            np.eye(3),
+        ]
+    )
+    allocation.hubMass = 980.0  # [kg]
+    allocation.r_BcB_B = np.array([0.0, 0.0, 0.0])  # [m]
+    allocation.bodyArmIdx = np.array([0, 0, 1, 1], dtype=int)
+    allocation.bodyJointIdx = np.array([1, 3, 1, 3], dtype=int)
+    allocation.bodyMass = np.array([8.0, 2.0, 8.0, 2.0])  # [kg]
+    allocation.r_LcP_P = np.array(
+        [
+            [0.5, 0.0, 0.0],  # [m]
+            [0.05, 0.0, 0.0],  # [m]
+            [0.5, 0.0, 0.0],  # [m]
+            [0.05, 0.0, 0.0],  # [m]
+        ]
+    )
+    return allocation
+
+
+def _expected_four_joint_layout(theta):
+    theta = np.asarray(theta, dtype=float)
+    arm2_base_dcm = np.array(
+        [
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+    def rot_x(angle):
+        return rbk.PRV2C(np.array([angle, 0.0, 0.0]))
+
+    def rot_y(angle):
+        return rbk.PRV2C(np.array([0.0, angle, 0.0]))
+
+    def rot_z(angle):
+        return rbk.PRV2C(np.array([0.0, 0.0, angle]))
+
+    dcm_CB = [np.eye(3) for _ in range(8)]
+    r_CB_B = [np.zeros(3) for _ in range(8)]
+
+    dcm_CB[0] = rot_x(theta[0])
+    r_CB_B[0] = np.array([0.79, 0.0, 0.0])  # [m]
+    dcm_CB[1] = rot_y(theta[1]) @ dcm_CB[0]
+    r_CB_B[1] = r_CB_B[0].copy()
+    dcm_CB[2] = rot_z(theta[2]) @ dcm_CB[1]
+    r_CB_B[2] = r_CB_B[1] + dcm_CB[1].T @ np.array([1.0, 0.0, 0.0])  # [m]
+    dcm_CB[3] = rot_y(theta[3]) @ dcm_CB[2]
+    r_CB_B[3] = r_CB_B[2].copy()
+
+    dcm_CB[4] = rot_x(theta[4]) @ arm2_base_dcm
+    r_CB_B[4] = np.array([-0.79, 0.0, 0.0])  # [m]
+    dcm_CB[5] = rot_y(theta[5]) @ dcm_CB[4]
+    r_CB_B[5] = r_CB_B[4].copy()
+    dcm_CB[6] = rot_z(theta[6]) @ dcm_CB[5]
+    r_CB_B[6] = r_CB_B[5] + dcm_CB[5].T @ np.array([1.0, 0.0, 0.0])  # [m]
+    dcm_CB[7] = rot_y(theta[7]) @ dcm_CB[6]
+    r_CB_B[7] = r_CB_B[6].copy()
+
+    boom_mass = 8.0  # [kg]
+    tip_mass = 2.0  # [kg]
+    hub_mass = 980.0  # [kg]
+    boom_com_p = np.array([0.5, 0.0, 0.0])  # [m]
+    tip_com_p = np.array([0.05, 0.0, 0.0])  # [m]
+
+    com_numerator = np.zeros(3)
+    com_numerator += boom_mass * (r_CB_B[1] + dcm_CB[1].T @ boom_com_p)  # [kg*m]
+    com_numerator += tip_mass * (r_CB_B[3] + dcm_CB[3].T @ tip_com_p)  # [kg*m]
+    com_numerator += boom_mass * (r_CB_B[5] + dcm_CB[5].T @ boom_com_p)  # [kg*m]
+    com_numerator += tip_mass * (r_CB_B[7] + dcm_CB[7].T @ tip_com_p)  # [kg*m]
+    r_ComB_B = com_numerator / (hub_mass + 2.0 * (boom_mass + tip_mass))  # [m]
+
+    return dcm_CB, r_CB_B, r_ComB_B
 
 
 def test_map_matrix():
@@ -67,6 +202,109 @@ def test_map_matrix():
     )
 
     np.testing.assert_allclose(mapping, expected)
+
+@pytest.mark.parametrize(
+    "theta",
+    [
+        np.zeros(8),  # [rad]
+        np.array([0.0, np.pi / 2.0, 0.0, 0.0, 0.0, -np.pi / 2.0, 0.0, 0.0]),  # [rad]
+        np.array([np.pi / 6.0, -np.pi / 4.0, np.pi / 3.0, -np.pi / 6.0,
+                  -np.pi / 5.0, np.pi / 7.0, -np.pi / 8.0, np.pi / 9.0]),  # [rad]
+    ],
+)
+def test_spacecraft_layout(theta):
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :func:`jointThrAllocation.jointPoseFromTheta`
+    computes the correct joint frame poses and vectors for a given set of
+    joint angles. It also verifies that :func:`jointThrAllocation.computeComFromTheta`
+    computes the correct center of mass vector for a given set of joint angles.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the DCM and position vectors for each joint. It
+    also checks the computed center of mass vector.
+    """
+    allocation = _configured_allocation()
+
+    dcm_CB, r_CB_B = allocation.jointPoseFromTheta(theta)
+    r_ComB_B = allocation.computeComFromTheta(dcm_CB, r_CB_B)
+    expected_dcm, expected_r_CB_B, expected_r_ComB_B = _expected_four_joint_layout(theta)
+
+    for dcm_actual, dcm_expected in zip(dcm_CB, expected_dcm):
+        np.testing.assert_allclose(dcm_actual, dcm_expected)
+    for pos_actual, pos_expected in zip(r_CB_B, expected_r_CB_B):
+        np.testing.assert_allclose(pos_actual, pos_expected)
+    np.testing.assert_allclose(r_ComB_B, expected_r_ComB_B)
+
+
+def test_spacecraft_layout_includes_hub_com_offset():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :func:`jointThrAllocation.computeComFromTheta`
+    includes the hub center-of-mass offset contribution when computing the
+    system center of mass.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the computed center-of-mass vector for a nonzero hub
+    center-of-mass offset.
+    """
+    allocation = _configured_allocation()
+    allocation.r_BcB_B = np.array([0.12, -0.04, 0.03])  # [m]
+    theta = np.zeros(allocation.nJoint)  # [rad]
+
+    dcm_CB, r_CB_B = allocation.jointPoseFromTheta(theta)
+    r_ComB_B = allocation.computeComFromTheta(dcm_CB, r_CB_B)
+
+    total_mass = allocation.hubMass + np.sum(allocation.bodyMass)  # [kg]
+    expected_r_ComB_B = allocation.hubMass * allocation.r_BcB_B  # [kg*m]
+    for body_idx in range(allocation.bodyMass.size):
+        arm_idx = int(allocation.bodyArmIdx[body_idx])
+        joint_local_idx = int(allocation.bodyJointIdx[body_idx])
+        joint_flat_idx = int(allocation.armJointStart[arm_idx] + joint_local_idx)
+        expected_r_ComB_B += allocation.bodyMass[body_idx] * (
+            r_CB_B[joint_flat_idx] + dcm_CB[joint_flat_idx].T @ allocation.r_LcP_P[body_idx]
+        )  # [kg*m]
+    expected_r_ComB_B = expected_r_ComB_B / total_mass  # [m]
+
+    np.testing.assert_allclose(r_ComB_B, expected_r_ComB_B)
+
+
+def test_spacecraft_layout_asymmetric_body_masses_shift_com():
+    """
+    **Validation Test Description**
+
+    This unit test verifies that :func:`jointThrAllocation.computeComFromTheta`
+    responds correctly to asymmetric arm-body masses by shifting the system
+    center of mass toward the heavier side.
+
+    **Description of Variables Being Tested**
+
+    This unit test checks the computed center-of-mass vector for an asymmetric
+    set of arm-body masses.
+    """
+    allocation = _configured_allocation()
+    allocation.bodyMass = np.array([12.0, 3.0, 4.0, 1.0])  # [kg]
+    theta = np.zeros(allocation.nJoint)  # [rad]
+
+    dcm_CB, r_CB_B = allocation.jointPoseFromTheta(theta)
+    r_ComB_B = allocation.computeComFromTheta(dcm_CB, r_CB_B)
+
+    total_mass = allocation.hubMass + np.sum(allocation.bodyMass)  # [kg]
+    expected_r_ComB_B = allocation.hubMass * allocation.r_BcB_B  # [kg*m]
+    for body_idx in range(allocation.bodyMass.size):
+        arm_idx = int(allocation.bodyArmIdx[body_idx])
+        joint_local_idx = int(allocation.bodyJointIdx[body_idx])
+        joint_flat_idx = int(allocation.armJointStart[arm_idx] + joint_local_idx)
+        expected_r_ComB_B += allocation.bodyMass[body_idx] * (
+            r_CB_B[joint_flat_idx] + dcm_CB[joint_flat_idx].T @ allocation.r_LcP_P[body_idx]
+        )  # [kg*m]
+    expected_r_ComB_B = expected_r_ComB_B / total_mass  # [m]
+
+    np.testing.assert_allclose(r_ComB_B, expected_r_ComB_B)
 
 
 def test_allocation_configuration_helpers():
@@ -107,7 +345,6 @@ def test_allocation_configuration_helpers():
     "missing_msg_name",
     [
         "armConfigInMsg",
-        "CoMStatesInMsg",
         "hubStatesInMsg",
         "transForceInMsg",
         "rotTorqueInMsg",

--- a/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.py
+++ b/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.py
@@ -69,7 +69,6 @@ class JointThrAllocation(sysModel.SysModel):
 
         # Input messages
         self.armConfigInMsg = messaging.THRArmConfigMsgReader()
-        self.CoMStatesInMsg = messaging.SCStatesMsgReader()
         self.hubStatesInMsg = messaging.SCStatesMsgReader()
         self.transForceInMsg = messaging.CmdForceInertialMsgReader()
         self.rotTorqueInMsg = messaging.CmdTorqueBodyMsgReader()
@@ -110,7 +109,6 @@ class JointThrAllocation(sysModel.SysModel):
         """Raise ``BasiliskError`` if a required input message is not linked."""
         requiredInputMessages = [
             ("armConfigInMsg", self.armConfigInMsg),
-            ("CoMStatesInMsg", self.CoMStatesInMsg),
             ("hubStatesInMsg", self.hubStatesInMsg),
             ("transForceInMsg", self.transForceInMsg),
             ("rotTorqueInMsg", self.rotTorqueInMsg),
@@ -231,6 +229,13 @@ class JointThrAllocation(sysModel.SysModel):
         self.fHat_P = np.asarray(cfgMsg.fhat_P, dtype=float).reshape(-1, 3)
         self.dcm_C0P = np.asarray(cfgMsg.dcm_C0P, dtype=float).reshape(-1, 9)
 
+        self.hubMass = float(cfgMsg.hubMass)
+        self.r_BcB_B = np.asarray(cfgMsg.r_BcB_B, dtype=float).reshape(3)
+        self.bodyArmIdx = np.asarray(cfgMsg.bodyArmIdx, dtype=int)
+        self.bodyJointIdx = np.asarray(cfgMsg.bodyJointIdx, dtype=int)
+        self.bodyMass = np.asarray(cfgMsg.bodyMass, dtype=float)
+        self.r_LcP_P = np.asarray(cfgMsg.r_LcP_P, dtype=float).reshape(-1, 3)
+
         # Convert each flat 9-entry block from column-major to 3x3 matrix.
         self.dcm_C0P = np.array([dcmFlat.reshape(3, 3, order="F") for dcmFlat in self.dcm_C0P], dtype=float)
 
@@ -293,8 +298,39 @@ class JointThrAllocation(sysModel.SysModel):
 
         return dcm_CB, r_CB_B
 
-    def mapping(self, theta: np.ndarray, r_ComB_B: np.ndarray):
+    def computeComFromTheta(self, dcm_CB, r_CB_B):
+        """
+        Compute the position of the system CoM relative to the body frame origin.
+
+        :param dcm_CB: List of direction cosine matrices for each joint.
+        :param r_CB_B: List of joint-frame origins in body-frame coordinates.
+        :return: Position vector of the system CoM relative to the body frame origin.
+        """
+        totalMass = self.hubMass + np.sum(self.bodyMass)  # [kg]
+        if totalMass <= 0.0:
+            raise ValueError("Total spacecraft mass must be positive.")
+        comNumerator = self.hubMass * self.r_BcB_B  # [kg*m]
+
+        for bodyIdx in range(self.bodyMass.size):
+            armIdx = int(self.bodyArmIdx[bodyIdx])
+            jointLocalIdx = int(self.bodyJointIdx[bodyIdx])
+            jointFlatIdx = int(self.armJointStart[armIdx] + jointLocalIdx)
+
+            comNumerator += self.bodyMass[bodyIdx] * (
+                r_CB_B[jointFlatIdx] + dcm_CB[jointFlatIdx].T @ self.r_LcP_P[bodyIdx]
+            )  # [kg*m]
+
+        return comNumerator / totalMass  # [m]
+
+    def mapping(self, theta: np.ndarray,):
+        """
+        Compute the thruster force-to-wrench map for given joint angles.
+
+        :param theta: Joint angle vector.
+        :return: Thruster force-to-wrench map for the given joint angles.
+        """
         dcm_CB, r_CB_B = self.jointPoseFromTheta(theta)
+        r_ComB_B = self.computeComFromTheta(dcm_CB, r_CB_B)
 
         r_TB_B = np.zeros((self.nThr, 3))
         fHatVec_B = np.zeros((self.nThr, 3))
@@ -309,10 +345,17 @@ class JointThrAllocation(sysModel.SysModel):
 
         return mapMatrix(r_TB_B, fHatVec_B, r_ComB_B)
 
-    def cost(self, decisionVar: np.ndarray, r_ComB_B: np.ndarray, desiredWrench_B: np.ndarray) -> float:
+    def cost(self, decisionVar: np.ndarray, desiredWrench_B: np.ndarray) -> float:
+        """
+        Compute the cost function for the given decision variables and desired wrench.
+
+        :param decisionVar: Concatenated vector of joint angles and thruster forces.
+        :param desiredWrench_B: Desired force and torque in body-frame coordinates.
+        :return: Cost function value.
+        """
         theta = decisionVar[: self.nJoint]
         thrForces = decisionVar[self.nJoint:]
-        wrenchMap = self.mapping(theta, r_ComB_B)
+        wrenchMap = self.mapping(theta)
         wrenchError = desiredWrench_B - wrenchMap @ thrForces
         return float(wrenchError.T @ self.Wc @ wrenchError + self.Wf.T @ thrForces)
 
@@ -328,13 +371,9 @@ class JointThrAllocation(sysModel.SysModel):
     def UpdateState(self, CurrentSimNanos):
         minimize = _get_optimizer()
 
-        comStates = self.CoMStatesInMsg()
         hubStates = self.hubStatesInMsg()
-
-        r_ComB_N = np.array(comStates.r_CN_N).reshape(3) - np.array(hubStates.r_BN_N).reshape(3)
         sigmaBN = np.array(hubStates.sigma_BN).reshape(3)
         dcm_BN = rbk.MRP2C(sigmaBN)
-        r_ComB_B = dcm_BN @ r_ComB_N
 
         forceInertialMsg = self.transForceInMsg()
         torqueBodyMsg = self.rotTorqueInMsg()
@@ -352,7 +391,7 @@ class JointThrAllocation(sysModel.SysModel):
 
         for initialDecision in self.x0:
             optResult = minimize(
-                fun=lambda decision: self.cost(decision, r_ComB_B, desiredWrench_B),
+                fun=lambda decision: self.cost(decision, desiredWrench_B),
                 x0=initialDecision,
                 bounds=boundTuple,
                 method="SLSQP",
@@ -364,7 +403,7 @@ class JointThrAllocation(sysModel.SysModel):
             decisionOpt = optResult.x
             wrenchError = (
                 desiredWrench_B
-                - self.mapping(decisionOpt[: self.nJoint], r_ComB_B) @ decisionOpt[self.nJoint:]
+                - self.mapping(decisionOpt[: self.nJoint]) @ decisionOpt[self.nJoint:]
             )
             errInf = float(np.linalg.norm(wrenchError, ord=np.inf))
             if errInf < bestErrInf:

--- a/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.rst
+++ b/src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.rst
@@ -2,9 +2,15 @@ Executive Summary
 -----------------
 
 This module allocates commanded translational force and body torque across
-thrusters mounted on articulated arms.  It solves for joint angle commands and
+thrusters mounted on articulated arms. It solves for joint angle commands and
 thruster force commands using the arm configuration message and spacecraft
 state messages.
+
+The vector from the hub body-frame origin to the instantaneous spacecraft
+center of mass is computed internally from the current joint configuration.
+As a result, the articulated arm configuration message must provide both
+the arm kinematics and the mass properties needed to reconstruct the system
+center of mass.
 
 The optimizer uses SciPy.  Importing the module from
 ``Basilisk.fswAlgorithms`` does not require SciPy, but executing
@@ -19,10 +25,7 @@ The following diagram and table list the module input and output messages.
     :caption: Module I/O Messages
 
     input armConfigInMsg THRArmConfigMsgPayload
-        Input articulated thruster-arm configuration message.
-
-    input CoMStatesInMsg SCStatesMsgPayload
-        Input spacecraft center-of-mass state message.
+        Input articulated thruster-arm configuration and mass-property message.
 
     input hubStatesInMsg SCStatesMsgPayload
         Input spacecraft hub state message.
@@ -57,6 +60,29 @@ The module is imported through the standard flight-software package:
 
     allocation = jointThrAllocation.JointThrAllocation()
     allocation.ModelTag = "jointThrAllocation"
+
+The ``armConfigInMsg`` input must define both the articulated thruster-arm
+kinematics and the body mass properties used to compute the instantaneous
+spacecraft center of mass. The required message fields are:
+
+- ``hubMass``: hub mass :math:`[\text{kg}]`
+- ``r_BcB_B``: hub center of mass relative to the hub body-frame origin
+  :math:`[\text{m}]`
+- ``bodyArmIdx``: arm index for each mass-carrying body
+- ``bodyJointIdx``: local parent-joint index for each mass-carrying body
+- ``bodyMass``: mass of each arm body :math:`[\text{kg}]`
+- ``r_LcP_P``: body center of mass relative to the parent joint, expressed in
+  the parent-joint frame :math:`[\text{m}]`
+- ``armJointCount``: number of joints in each arm
+- ``r_CP_P``: parent-joint to child-joint position vectors :math:`[\text{m}]`
+- ``shat_P``: child-joint spin axes
+- ``dcm_C0P``: zero-angle child-to-parent direction cosine matrices
+- ``armTreeIdx``: kinematic-tree index for each arm
+- ``thrArmIdx``: arm index for each thruster
+- ``thrArmJointIdx``: local parent-joint index for each thruster
+- ``r_TP_P``: thruster position relative to the parent joint
+  :math:`[\text{m}]`
+- ``fhat_P``: thruster force direction unit vectors
 
 The thrust upper bound can be provided as either a scalar or a per-thruster
 vector:

--- a/src/tests/test_scenarioMujoco.py
+++ b/src/tests/test_scenarioMujoco.py
@@ -49,7 +49,7 @@ SCENARIO_FILES = [
 ]
 
 SCENARIO_RUN_KWARGS = {
-    "scenarioThrArmControl": {"showPlots": False, "timeStep": 0.075, "runTime": 270.0},
+    "scenarioThrArmControl": {"showPlots": False, "timeStep": 0.08, "runTime": 240.0},
 }
 OPTIONAL_EXAMPLE_DEPENDENCIES = {"scipy"}
 


### PR DESCRIPTION
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
This PR updates `jointThrAllocation` so the spacecraft center of mass (CoM) used in the thruster wrench map is computed from articulated-arm geometry and body mass properties instead of relying on a separate static CoM state input.

The main changes are:

- updated `THRArmConfigMsgPayload` to include the kinematic and mass-property data needed to represent articulated spacecraft bodies
- removed `CoMStatesInMsg` from `jointThrAllocation`, since it is no longer used
- updated `jointThrAllocation` to compute `r_ComB_B` dynamically during the optimization based on the current joint-angle solution

## Verification
Changes were validated with updated unit-test coverage and an integrated MuJoCo scenario.

Validation included:

- updated `test_jointThrAllocation.py`:
  - added tests for `jointPoseFromTheta` and `computeComFromTheta` across multiple spacecraft configurations
- updated `scenarioThrArmControl.py` / MuJoCo FSW setup:
  - passed the new required arm/body mass-property message data
  - removed the unused CoM state message dependency
  - updated non-pytest default simulation parameters to improve direct-run performance
  - added an integration tolerance to improve runtime
  - updated pytest scenario parameters to improve runtime

## Documentation
This PR updates documentation for the revised allocation behavior:

- removed the unused input message from `src/fswAlgorithms/effectorInterfaces/jointThrAllocation/jointThrAllocation.rst`
- updated `docs/source/Support/bskKnownIssues.rst`
- added the release-note snippet `docs/source/Support/bskReleaseNotesSnippets/1416-JointThrAllocation-Fix.rst`

## Future work
N/A
