### PR TITLE
Harden CI Third-Party Downloads with Retries and Backup Mirrors

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -80,6 +80,10 @@ runs:
         restore-keys: |
           conan-${{ runner.os }}-py${{ inputs.python-version }}-
 
+    - name: Configure Conan network retries
+      shell: bash
+      run: python .github/scripts/configure_conan_retries.py
+
     - name: Configure Conan profile
       shell: bash
       run: |

--- a/.github/scripts/configure_conan_retries.py
+++ b/.github/scripts/configure_conan_retries.py
@@ -19,16 +19,18 @@ from pathlib import Path
 from typing import Optional
 
 
-CONAN_DOWNLOAD_RETRIES = 8
-CONAN_HTTP_RETRIES = 8
-CONAN_RETRY_WAIT = 15  # [s]
-CONAN_HTTP_TIMEOUT = 120  # [s]
+CONAN_DOWNLOAD_RETRIES = 1
+CONAN_HTTP_RETRIES = 1
+CONAN_RETRY_WAIT = 5  # [s]
+CONAN_HTTP_TIMEOUT = 30  # [s]
+CONAN_SOURCE_BACKUP_URL = "https://hanspeterschaub.info/bskFiles/backup/conan-sources"
 
 CONAN_RETRY_SETTINGS = {
     "tools.files.download:retry": CONAN_DOWNLOAD_RETRIES,
     "tools.files.download:retry_wait": CONAN_RETRY_WAIT,
     "core.net.http:max_retries": CONAN_HTTP_RETRIES,
     "core.net.http:timeout": CONAN_HTTP_TIMEOUT,
+    "core.sources:download_urls": ["origin", CONAN_SOURCE_BACKUP_URL],
 }
 
 GLOBAL_CONF_PATH = Path.home() / ".conan2" / "global.conf"
@@ -42,7 +44,7 @@ def _conf_key(line: str) -> Optional[str]:
 
 
 def update_global_conf(path: Path = GLOBAL_CONF_PATH) -> None:
-    """Set Conan retry configuration in ``global.conf``."""
+    """Set Conan retry and source-backup configuration in ``global.conf``."""
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
 
@@ -63,7 +65,7 @@ def update_global_conf(path: Path = GLOBAL_CONF_PATH) -> None:
             updated_lines.append(f"{key}={value}")
 
     path.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
-    print(f"Configured Conan download retries in {path}")
+    print(f"Configured Conan download retries and source backups in {path}")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/configure_conan_retries.py
+++ b/.github/scripts/configure_conan_retries.py
@@ -1,0 +1,70 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+from pathlib import Path
+from typing import Optional
+
+
+CONAN_DOWNLOAD_RETRIES = 8
+CONAN_HTTP_RETRIES = 8
+CONAN_RETRY_WAIT = 15  # [s]
+CONAN_HTTP_TIMEOUT = 120  # [s]
+
+CONAN_RETRY_SETTINGS = {
+    "tools.files.download:retry": CONAN_DOWNLOAD_RETRIES,
+    "tools.files.download:retry_wait": CONAN_RETRY_WAIT,
+    "core.net.http:max_retries": CONAN_HTTP_RETRIES,
+    "core.net.http:timeout": CONAN_HTTP_TIMEOUT,
+}
+
+GLOBAL_CONF_PATH = Path.home() / ".conan2" / "global.conf"
+
+
+def _conf_key(line: str) -> Optional[str]:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    return stripped.split("=", 1)[0].strip()
+
+
+def update_global_conf(path: Path = GLOBAL_CONF_PATH) -> None:
+    """Set Conan retry configuration in ``global.conf``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+
+    updated_lines = []
+    seen_keys = set()
+    for line in lines:
+        key = _conf_key(line)
+        if key in CONAN_RETRY_SETTINGS:
+            if key in seen_keys:
+                continue
+            updated_lines.append(f"{key}={CONAN_RETRY_SETTINGS[key]}")
+            seen_keys.add(key)
+        else:
+            updated_lines.append(line)
+
+    for key, value in CONAN_RETRY_SETTINGS.items():
+        if key not in seen_keys:
+            updated_lines.append(f"{key}={value}")
+
+    path.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
+    print(f"Configured Conan download retries in {path}")
+
+
+if __name__ == "__main__":
+    update_global_conf()

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -42,6 +42,54 @@ jobs:
           name: nightly-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
+  notify-failure:
+    name: Notify Slack on Failure
+    needs: build-wheels
+    if: ${{ always() && needs.build-wheels.result == 'failure' }}
+    runs-on: ubuntu-24.04
+    permissions: {}
+
+    steps:
+      - name: Post failure to bsk_general
+        env:
+          HEAD_BRANCH: ${{ github.ref_name }}
+          HEAD_SHA: ${{ github.sha }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK_URL: ${{ secrets.BSK_GENERAL_SLACK_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          webhook_url = os.environ["SLACK_WEBHOOK_URL"].strip()
+          if not webhook_url:
+              print("::error::Missing BSK_GENERAL_SLACK_WEBHOOK_URL repository secret")
+              sys.exit(1)
+
+          run_url = os.environ["RUN_URL"]
+          run_number = os.environ["RUN_NUMBER"]
+          short_sha = os.environ["HEAD_SHA"][:7]
+          text = (
+              f":warning: {os.environ['WORKFLOW_NAME']} failed "
+              f"for `{os.environ['HEAD_BRANCH']}` at `{short_sha}`. "
+              f"<{run_url}|View run #{run_number}>"
+          )
+
+          timeout = 30  # [s]
+          request = urllib.request.Request(
+              webhook_url,
+              data=json.dumps({"text": text}).encode("utf-8"),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          with urllib.request.urlopen(request, timeout=timeout) as response:
+              print(f"Slack notification response: {response.status}")
+          PY
+
   publish-index:
     name: Publish Nightly Index
     needs: build-wheels

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-conan-download-retries.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-conan-download-retries.rst
@@ -1,1 +1,1 @@
-- Hardened CI builds by configuring Conan network retries for third-party source downloads.
+- Hardened CI builds by configuring short Conan network retries for third-party source downloads.

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-conan-download-retries.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-conan-download-retries.rst
@@ -1,0 +1,1 @@
+- Hardened CI builds by configuring Conan network retries for third-party source downloads.

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-conan-source-backups.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-conan-source-backups.rst
@@ -1,0 +1,1 @@
+- Added a Conan source backup URL so CI can fall back to mirrored third-party source archives.

--- a/docs/source/Support/bskReleaseNotesSnippets/nightly-wheels-slack-notification.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/nightly-wheels-slack-notification.rst
@@ -1,0 +1,1 @@
+- Added Slack failure notifications for the Nightly Wheels workflow.

--- a/docs/source/Support/bskReleaseNotesSnippets/support-data-backup-urls.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/support-data-backup-urls.rst
@@ -1,0 +1,1 @@
+- Added support-data backup URLs and shorter retries for externally hosted downloads used by CI.

--- a/docs/source/Support/bskReleaseNotesSnippets/support-data-download-retries.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/support-data-download-retries.rst
@@ -1,0 +1,1 @@
+- Added retry hardening for Basilisk support data downloads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ examples = [
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip  = ["*-win32", "*-musllinux_*"]
 build-verbosity = 1
-before-build = "pip install \"libclang>=15.0.6.1,<=18.1.1\""
+before-build = "python .github/scripts/configure_conan_retries.py && pip install \"libclang>=15.0.6.1,<=18.1.1\""
 test-extras = ["test"]
 test-command = "bskLargeData && pytest -v {project}/src/tests -m \"not ciSkip and not scenarioTest\""
 
@@ -90,7 +90,7 @@ MACOSX_DEPLOYMENT_TARGET = "11.0"
 CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"
 
 [tool.cibuildwheel.windows]
-before-build = "pip install \"libclang>=15.0.6.1,<=18.1.1\" delvewheel ninja"
+before-build = "python .github/scripts/configure_conan_retries.py && pip install \"libclang>=15.0.6.1,<=18.1.1\" delvewheel ninja"
 repair-wheel-command = "python -m delvewheel repair -v --ignore-existing --analyze-existing -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.linux]

--- a/src/tests/test_dataFetcher.py
+++ b/src/tests/test_dataFetcher.py
@@ -158,3 +158,42 @@ def test_retrying_http_downloader_does_not_retry_not_found():
         downloader("https://example.com/missing.dat", "unused", None)
 
     assert calls == ["https://example.com/missing.dat"]
+
+
+def test_retrying_http_downloader_uses_backup_after_primary_failure():
+    """RetryingHTTPDownloader must try backup URLs after primary failures."""
+    calls = []
+
+    def fail_primary(url, output_file, pooch_obj, check_only=False):
+        calls.append(url)
+        if url == "https://example.com/primary.dat":
+            raise RuntimeError("primary download failure")
+        return None
+
+    downloader = dataFetcher.RetryingHTTPDownloader(
+        attempts=1,
+        retry_wait=1,  # [s]
+        timeout=2,  # [s]
+        sleep=lambda wait: None,
+        downloader_factory=lambda **kwargs: fail_primary,
+        backup_urls_for=lambda url: ["https://example.com/backup.dat"],
+    )
+
+    downloader("https://example.com/primary.dat", "unused", None)
+
+    assert calls == [
+        "https://example.com/primary.dat",
+        "https://example.com/backup.dat",
+    ]
+
+
+def test_external_kernel_backup_urls_include_haslam_file():
+    """The Haslam map must have a mirrored support-data fallback URL."""
+    primary_url = dataFetcher.EXTERNAL_KERNEL_URLS[
+        "supportData/SkyBrightnessData/haslam408_dsds_Remazeilles2014.fits"
+    ]
+
+    assert dataFetcher.EXTERNAL_KERNEL_BACKUP_URLS[primary_url] == [
+        "https://hanspeterschaub.info/bskFiles/backup/"
+        "supportData/SkyBrightnessData/haslam408_dsds_Remazeilles2014.fits"
+    ]

--- a/src/tests/test_dataFetcher.py
+++ b/src/tests/test_dataFetcher.py
@@ -20,11 +20,12 @@
 Unit tests for Basilisk supportData fetching (Pooch + local fallback).
 """
 
-import pytest
 from pathlib import Path
 
+import pytest
 import requests
 
+from Basilisk.utilities import bskLargeData
 from Basilisk.utilities.supportDataTools import dataFetcher
 
 
@@ -78,6 +79,21 @@ def test_get_path_uses_pooch_when_not_local(fake_fetch):
 
     assert isinstance(path, Path)
     assert path.exists(), "get_path() should return an existing dummy file"
+
+
+def test_bsk_large_data_quiet_fetch_keeps_warnings_visible(monkeypatch):
+    """quiet_fetch() must keep retry and backup warnings visible."""
+    logger_levels = []
+
+    def fake_fetch(rel):
+        logger_levels.append(bskLargeData.pooch.utils.get_logger().level)
+        return "dummy"
+
+    monkeypatch.setattr(bskLargeData, "fetch_support_data", fake_fetch)
+
+    assert bskLargeData.quiet_fetch("supportData/example.dat") == "dummy"
+
+    assert logger_levels == [bskLargeData.logging.WARNING]
 
 
 def test_fetch_support_data_uses_retrying_downloader(monkeypatch, tmp_path):

--- a/src/tests/test_dataFetcher.py
+++ b/src/tests/test_dataFetcher.py
@@ -22,14 +22,24 @@ Unit tests for Basilisk supportData fetching (Pooch + local fallback).
 
 import pytest
 from pathlib import Path
-from unittest.mock import patch
 
-from Basilisk.utilities.supportDataTools.dataFetcher import (
-    DataFile,
-    get_path,
-    relpath,
-    REGISTRY,
-)
+import requests
+
+from Basilisk.utilities.supportDataTools import dataFetcher
+
+
+class TransientDownloader:
+    """Fail a fixed number of times before succeeding."""
+
+    def __init__(self, failures_before_success: int):
+        self.failures_before_success = failures_before_success
+        self.calls = 0
+
+    def __call__(self, url, output_file, pooch_obj, check_only=False):
+        self.calls += 1
+        if self.calls <= self.failures_before_success:
+            raise RuntimeError("temporary download failure")
+        return None
 
 
 @pytest.fixture
@@ -39,9 +49,11 @@ def fake_fetch(monkeypatch, tmp_path):
     dummy.write_text("test")
 
     monkeypatch.setattr(
-        "Basilisk.utilities.supportDataTools.dataFetcher.POOCH.fetch",
-        lambda key: str(dummy),
+        dataFetcher.POOCH,
+        "fetch",
+        lambda key, downloader=None: str(dummy),
     )
+    monkeypatch.setattr(dataFetcher, "LOCAL_SUPPORT", None)
 
     return dummy
 
@@ -50,11 +62,11 @@ def test_all_enum_entries_are_in_registry():
     """Every DataFile enum value must correspond to a key in REGISTRY."""
     missing = []
 
-    for category in DataFile.__dict__.values():
+    for category in dataFetcher.DataFile.__dict__.values():
         if isinstance(category, type) and hasattr(category, "__members__"):
             for enum_value in category:
-                key = relpath(enum_value)
-                if key not in REGISTRY:
+                key = dataFetcher.relpath(enum_value)
+                if key not in dataFetcher.REGISTRY:
                     missing.append(key)
 
     assert not missing, f"Registry missing entries: {missing}"
@@ -62,7 +74,87 @@ def test_all_enum_entries_are_in_registry():
 
 def test_get_path_uses_pooch_when_not_local(fake_fetch):
     """get_path() must return a Path backed by mocked Pooch."""
-    path = get_path(DataFile.MagneticFieldData.WMM)
+    path = dataFetcher.get_path(dataFetcher.DataFile.MagneticFieldData.WMM)
 
     assert isinstance(path, Path)
     assert path.exists(), "get_path() should return an existing dummy file"
+
+
+def test_fetch_support_data_uses_retrying_downloader(monkeypatch, tmp_path):
+    """fetch_support_data() must pass a retrying downloader to Pooch."""
+    dummy = tmp_path / "dummy.dat"
+    dummy.write_text("test")
+    captured = {}
+
+    def fake_pooch_fetch(key, downloader=None):
+        captured["key"] = key
+        captured["downloader"] = downloader
+        return str(dummy)
+
+    monkeypatch.setattr(dataFetcher.POOCH, "fetch", fake_pooch_fetch)
+
+    path = dataFetcher.fetch_support_data("supportData/MagneticField/WMM2025.COF")
+
+    assert path == str(dummy)
+    assert captured["key"] == "supportData/MagneticField/WMM2025.COF"
+    assert isinstance(captured["downloader"], dataFetcher.RetryingHTTPDownloader)
+
+
+def test_retrying_http_downloader_retries_transient_errors():
+    """RetryingHTTPDownloader must retry transient download failures."""
+    transient_downloader = TransientDownloader(failures_before_success=2)
+    retry_waits = []
+    downloader = dataFetcher.RetryingHTTPDownloader(
+        attempts=3,
+        retry_wait=1,  # [s]
+        timeout=2,  # [s]
+        sleep=retry_waits.append,
+        downloader_factory=lambda **kwargs: transient_downloader,
+    )
+
+    downloader("https://example.com/file.dat", "unused", None)
+
+    assert transient_downloader.calls == 3
+    assert retry_waits == [1, 1]
+
+
+def test_retrying_http_downloader_raises_after_last_attempt():
+    """RetryingHTTPDownloader must raise when retries are exhausted."""
+    transient_downloader = TransientDownloader(failures_before_success=3)
+    downloader = dataFetcher.RetryingHTTPDownloader(
+        attempts=3,
+        retry_wait=1,  # [s]
+        timeout=2,  # [s]
+        sleep=lambda wait: None,
+        downloader_factory=lambda **kwargs: transient_downloader,
+    )
+
+    with pytest.raises(RuntimeError, match="temporary download failure"):
+        downloader("https://example.com/file.dat", "unused", None)
+
+    assert transient_downloader.calls == 3
+
+
+def test_retrying_http_downloader_does_not_retry_not_found():
+    """RetryingHTTPDownloader must not retry hard HTTP client errors."""
+    response = requests.Response()
+    response.status_code = 404
+    not_found_error = requests.exceptions.HTTPError(response=response)
+    calls = []
+
+    def fail_with_not_found(url, output_file, pooch_obj, check_only=False):
+        calls.append(url)
+        raise not_found_error
+
+    downloader = dataFetcher.RetryingHTTPDownloader(
+        attempts=3,
+        retry_wait=1,  # [s]
+        timeout=2,  # [s]
+        sleep=lambda wait: None,
+        downloader_factory=lambda **kwargs: fail_with_not_found,
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        downloader("https://example.com/missing.dat", "unused", None)
+
+    assert calls == ["https://example.com/missing.dat"]

--- a/src/utilities/bskLargeData.py
+++ b/src/utilities/bskLargeData.py
@@ -23,7 +23,7 @@ import pooch
 from tqdm import tqdm
 
 from Basilisk.utilities.supportDataTools.dataFetcher import (
-    POOCH,
+    fetch_support_data,
     local_support_path,
 )
 from Basilisk.utilities.supportDataTools.registrySnippet import REGISTRY
@@ -41,7 +41,7 @@ def quiet_fetch(rel: str):
     pooch_logger.setLevel(logging.CRITICAL)
 
     try:
-        return POOCH.fetch(rel)
+        return fetch_support_data(rel)
     finally:
         pooch_logger.setLevel(old_level)
 

--- a/src/utilities/bskLargeData.py
+++ b/src/utilities/bskLargeData.py
@@ -34,11 +34,11 @@ endColor = "\033[0m"
 
 def quiet_fetch(rel: str):
     """
-    Silences Pooch logging for a single fetch call.
+    Suppress routine Pooch logging for a single fetch call.
     """
     pooch_logger = pooch.utils.get_logger()
     old_level = pooch_logger.level
-    pooch_logger.setLevel(logging.CRITICAL)
+    pooch_logger.setLevel(logging.WARNING)
 
     try:
         return fetch_support_data(rel)

--- a/src/utilities/supportDataTools/dataFetcher.py
+++ b/src/utilities/supportDataTools/dataFetcher.py
@@ -22,7 +22,7 @@ import functools
 import logging
 import os
 import time
-from typing import Callable, Optional
+from typing import Callable, Optional, Sequence
 
 import pooch
 import requests
@@ -33,9 +33,14 @@ from Basilisk import __version__
 pooch_logger = pooch.utils.get_logger()
 pooch_logger.setLevel(logging.INFO)
 
-SUPPORT_DATA_DOWNLOAD_ATTEMPTS = 5
-SUPPORT_DATA_DOWNLOAD_TIMEOUT = 120  # [s]
-SUPPORT_DATA_RETRY_WAIT = 15  # [s]
+SUPPORT_DATA_DOWNLOAD_ATTEMPTS = 2
+SUPPORT_DATA_DOWNLOAD_TIMEOUT = 30  # [s]
+SUPPORT_DATA_RETRY_WAIT = 5  # [s]
+DEFAULT_SUPPORT_DATA_BACKUP_BASE_URL = "https://hanspeterschaub.info/bskFiles/backup"
+SUPPORT_DATA_BACKUP_BASE_URL = os.environ.get(
+    "BSK_SUPPORT_DATA_BACKUP_BASE_URL",
+    DEFAULT_SUPPORT_DATA_BACKUP_BASE_URL,
+)
 
 # Override URLs for large NAIF kernels (not in GitHub repo)
 EXTERNAL_KERNEL_URLS = {
@@ -52,6 +57,25 @@ EXTERNAL_KERNEL_URLS = {
 # they may change without notice.
 for key in EXTERNAL_KERNEL_URLS:
     REGISTRY[key] = None
+
+
+def _join_url(base_url: str, rel: str) -> str:
+    """Return ``rel`` appended to ``base_url`` as a URL path."""
+    return f"{base_url.rstrip('/')}/{rel.lstrip('/')}"
+
+
+def _external_backup_url(rel: str) -> Optional[str]:
+    """Return the mirrored support-data URL for ``rel``, if enabled."""
+    if not SUPPORT_DATA_BACKUP_BASE_URL:
+        return None
+    return _join_url(SUPPORT_DATA_BACKUP_BASE_URL, rel)
+
+
+EXTERNAL_KERNEL_BACKUP_URLS = {
+    url: [_external_backup_url(rel)]
+    for rel, url in EXTERNAL_KERNEL_URLS.items()
+    if _external_backup_url(rel)
+}
 
 DATA_VERSION = f"v{__version__}"
 
@@ -127,8 +151,13 @@ def _is_retryable_error(error: Exception) -> bool:
     return True
 
 
+def _external_backup_urls_for(url: str) -> Sequence[str]:
+    """Return configured backup URLs for the given external support-data URL."""
+    return EXTERNAL_KERNEL_BACKUP_URLS.get(url, [])
+
+
 class RetryingHTTPDownloader:
-    """Retry transient HTTP failures during Pooch downloads."""
+    """Retry transient HTTP failures and fall back to mirrored support data."""
 
     def __init__(
         self,
@@ -138,6 +167,7 @@ class RetryingHTTPDownloader:
         progressbar: bool = False,
         sleep: Callable[[int], None] = time.sleep,
         downloader_factory: Callable[..., pooch.HTTPDownloader] = pooch.HTTPDownloader,
+        backup_urls_for: Callable[[str], Sequence[str]] = _external_backup_urls_for,
     ):
         self.attempts = attempts
         self.retry_wait = retry_wait
@@ -145,6 +175,7 @@ class RetryingHTTPDownloader:
         self.progressbar = progressbar
         self.sleep = sleep
         self.downloader_factory = downloader_factory
+        self.backup_urls_for = backup_urls_for
 
     def __call__(self, url, output_file, pooch_obj, check_only=False):
         last_error = None
@@ -152,22 +183,41 @@ class RetryingHTTPDownloader:
             progressbar=self.progressbar,
             timeout=self.timeout,
         )
-        for attempt in range(1, self.attempts + 1):
-            try:
-                return downloader(url, output_file, pooch_obj, check_only=check_only)
-            except Exception as error:
-                last_error = error
-                if attempt == self.attempts or not _is_retryable_error(error):
-                    raise
+        urls = [url]
+        for backup_url in self.backup_urls_for(url):
+            if backup_url not in urls:
+                urls.append(backup_url)
+
+        for url_index, candidate_url in enumerate(urls):
+            for attempt in range(1, self.attempts + 1):
+                try:
+                    return downloader(
+                        candidate_url,
+                        output_file,
+                        pooch_obj,
+                        check_only=check_only,
+                    )
+                except Exception as error:
+                    last_error = error
+                    if attempt == self.attempts or not _is_retryable_error(error):
+                        break
+                    pooch_logger.warning(
+                        "Download attempt %d/%d failed for %s: %s. Retrying in %d s.",
+                        attempt,
+                        self.attempts,
+                        candidate_url,
+                        error,
+                        self.retry_wait,
+                    )
+                    self.sleep(self.retry_wait)
+
+            if url_index < len(urls) - 1:
                 pooch_logger.warning(
-                    "Download attempt %d/%d failed for %s: %s. Retrying in %d s.",
-                    attempt,
-                    self.attempts,
-                    url,
-                    error,
-                    self.retry_wait,
+                    "Download failed for %s. Trying backup URL %s.",
+                    candidate_url,
+                    urls[url_index + 1],
                 )
-                self.sleep(self.retry_wait)
+
         raise last_error
 
 

--- a/src/utilities/supportDataTools/dataFetcher.py
+++ b/src/utilities/supportDataTools/dataFetcher.py
@@ -19,17 +19,23 @@
 from enum import Enum
 from pathlib import Path
 import functools
-import os
-import requests
-import pooch
 import logging
-from typing import Optional
+import os
+import time
+from typing import Callable, Optional
+
+import pooch
+import requests
 
 from Basilisk.utilities.supportDataTools.registrySnippet import REGISTRY
 from Basilisk import __version__
 
 pooch_logger = pooch.utils.get_logger()
 pooch_logger.setLevel(logging.INFO)
+
+SUPPORT_DATA_DOWNLOAD_ATTEMPTS = 5
+SUPPORT_DATA_DOWNLOAD_TIMEOUT = 120  # [s]
+SUPPORT_DATA_RETRY_WAIT = 15  # [s]
 
 # Override URLs for large NAIF kernels (not in GitHub repo)
 EXTERNAL_KERNEL_URLS = {
@@ -111,6 +117,66 @@ POOCH = pooch.create(
 )
 
 
+def _is_retryable_error(error: Exception) -> bool:
+    """Return ``True`` if a support data download error should be retried."""
+    if isinstance(error, requests.exceptions.HTTPError):
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code and 400 <= status_code < 500 and status_code not in (408, 429):
+            return False
+    return True
+
+
+class RetryingHTTPDownloader:
+    """Retry transient HTTP failures during Pooch downloads."""
+
+    def __init__(
+        self,
+        attempts: int = SUPPORT_DATA_DOWNLOAD_ATTEMPTS,
+        retry_wait: int = SUPPORT_DATA_RETRY_WAIT,
+        timeout: int = SUPPORT_DATA_DOWNLOAD_TIMEOUT,
+        progressbar: bool = False,
+        sleep: Callable[[int], None] = time.sleep,
+        downloader_factory: Callable[..., pooch.HTTPDownloader] = pooch.HTTPDownloader,
+    ):
+        self.attempts = attempts
+        self.retry_wait = retry_wait
+        self.timeout = timeout
+        self.progressbar = progressbar
+        self.sleep = sleep
+        self.downloader_factory = downloader_factory
+
+    def __call__(self, url, output_file, pooch_obj, check_only=False):
+        last_error = None
+        downloader = self.downloader_factory(
+            progressbar=self.progressbar,
+            timeout=self.timeout,
+        )
+        for attempt in range(1, self.attempts + 1):
+            try:
+                return downloader(url, output_file, pooch_obj, check_only=check_only)
+            except Exception as error:
+                last_error = error
+                if attempt == self.attempts or not _is_retryable_error(error):
+                    raise
+                pooch_logger.warning(
+                    "Download attempt %d/%d failed for %s: %s. Retrying in %d s.",
+                    attempt,
+                    self.attempts,
+                    url,
+                    error,
+                    self.retry_wait,
+                )
+                self.sleep(self.retry_wait)
+        raise last_error
+
+
+def fetch_support_data(rel: str, progressbar: bool = False) -> str:
+    """Fetch a support data file using retry-hardened HTTP downloads."""
+    downloader = RetryingHTTPDownloader(progressbar=progressbar)
+    return POOCH.fetch(rel, downloader=downloader)
+
+
 def _local_rel(rel: str) -> str:
     """Convert a registry-style key into a path relative to LOCAL_SUPPORT."""
     prefix = "supportData/"
@@ -141,7 +207,7 @@ def get_path(file_enum: Enum) -> Path:
 
     # No local repo or missing local file so fetch from remote
     try:
-        return Path(POOCH.fetch(rel))
+        return Path(fetch_support_data(rel))
     except Exception as e:
         raise FileNotFoundError(f"Support data file not found via pooch: {rel}") from e
 


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR hardens CI against intermittent third-party download failures.

The branch configures Conan with short network retries, a 30 s timeout, and a backup source mirror at `https://hanspeterschaub.info/bskFiles/backup/conan-sources`. The same Conan setup is applied in both the shared CI build action and cibuildwheel builds.

It also updates support-data fetching to use a retrying Pooch downloader with mirrored fallback URLs for externally hosted large data files, including NAIF kernels and the Haslam map. `bskLargeData` now goes through this retry-hardened fetch path.

Finally, the Nightly Wheels workflow now posts a Slack notification to `bsk_general` when wheel builds fail, using the `BSK_GENERAL_SLACK_WEBHOOK_URL` repository secret.

Commits are organized around the investigation sequence: Conan retry hardening, Slack notification, support-data retry hardening, Conan source backup configuration, and support-data backup URL support.

## Verification
Added and updated unit tests in `src/tests/test_dataFetcher.py` covering:

- retry downloader wiring through `fetch_support_data()`
- retry behavior for transient failures
- no retry for hard 404-style failures
- fallback to backup URLs after primary failure
- Haslam backup URL registration

Validated locally with:

- `.venv/bin/pytest -q src/tests/test_dataFetcher.py`
- Python compile checks for the modified support-data modules and tests
- `git diff --check`

GitHub PR CI passed on the branch. One Windows CI run also confirmed the Conan backup path worked in practice: `cfitsio` timed out against HEASARC, retried once, then successfully fetched from the backup mirror.

## Documentation
Release-note snippets were added for:

- Conan retry configuration
- Conan source backups
- Nightly Wheels Slack notification
- support-data retry hardening
- support-data backup URLs

No generated release notes were edited directly. Reviewers should also confirm the operational expectation that `BSK_GENERAL_SLACK_WEBHOOK_URL` is present as a repository secret for Slack notifications.

## Future work
Monitor future CI runs for any additional third-party sources that need mirroring. If new flaky external sources appear, add them to the existing backup workflow rather than increasing retry delays.