### PR TITLE
Fix N-DoF state effector getter assertions

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -25,7 +25,8 @@ Version |release|
 - Monte Carlo now applies nested dispersion paths and randomized ``RNGSeed`` modifications to the actual
   simulation objects.
 - The :ref:`linearTranslationNDOFStateEffector` getter assertion no longer references the spinning-body-only
-  degree-of-freedom counter, fixing source builds where that assertion is compiled.
+  degree-of-freedom counter, fixing source builds where that assertion is compiled. The related
+  :ref:`spinningBodyNDOFStateEffector` getter assertion now rejects the first out-of-range index.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
   for Basilisk and compatible plugins. If source builds fail with SWIG 4.4.0 or emit

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -24,6 +24,8 @@ Version |release|
   3.7 upgrade.
 - Monte Carlo now applies nested dispersion paths and randomized ``RNGSeed`` modifications to the actual
   simulation objects.
+- The :ref:`linearTranslationNDOFStateEffector` getter assertion no longer references the spinning-body-only
+  degree-of-freedom counter, fixing source builds where that assertion is compiled.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
   for Basilisk and compatible plugins. If source builds fail with SWIG 4.4.0 or emit

--- a/docs/source/Support/bskReleaseNotesSnippets/linear-translation-ndof-getter-build.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/linear-translation-ndof-getter-build.rst
@@ -1,0 +1,1 @@
+- Fixed a source-build error in :ref:`linearTranslationNDOFStateEffector` from an invalid getter assertion.

--- a/docs/source/Support/bskReleaseNotesSnippets/linear-translation-ndof-getter-build.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/linear-translation-ndof-getter-build.rst
@@ -1,1 +1,1 @@
-- Fixed a source-build error in :ref:`linearTranslationNDOFStateEffector` from an invalid getter assertion.
+- Fixed N-DoF getter assertions in :ref:`linearTranslationNDOFStateEffector` and :ref:`spinningBodyNDOFStateEffector`.

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -110,7 +110,7 @@ void LinearTranslationNDOFStateEffector::addTranslatingBody(const std::shared_pt
 
 /*! This method is used to get a translating body. */
 std::shared_ptr<TranslatingBody> LinearTranslationNDOFStateEffector::getTranslatingBody(uint64_t index) {
-    assert(("Index can't be greater than the number of degrees of freedom of the effector", index <= this->numberOfDegreesOfFreedom));
+    assert(("Index must be less than the number of translating body axes", index < static_cast<uint64_t>(this->N)));
 
     return this->translatingBodyVec.at(index);
 }

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -113,7 +113,8 @@ void SpinningBodyNDOFStateEffector::addSpinningBody(const std::shared_ptr<Spinni
 }
 
 std::shared_ptr<SpinningBody> SpinningBodyNDOFStateEffector::getSpinningBody(uint64_t index) {
-    assert(("Index can't be greater than the number of degrees of freedom of the effector", index <= this->numberOfDegreesOfFreedom));
+    assert(("Index must be less than the number of degrees of freedom of the effector",
+            index < static_cast<uint64_t>(this->numberOfDegreesOfFreedom)));
 
     return this->spinningBodyVec.at(index);
 }


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Fixes invalid assertions in the N-DoF state effector getter methods.

The linear translation N-DoF getter assertion referenced `numberOfDegreesOfFreedom`, which belongs to the spinning-body N-DoF effector and is not a member of `LinearTranslationNDOFStateEffector`. This caused source builds with assertions enabled to fail at compile time.

While checking similar state effectors, the spinning-body N-DoF getter was found to have a related zero-based bounds issue: `index == numberOfDegreesOfFreedom` passed the assertion even though the subsequent vector access is out of range. This PR updates both getter assertions to use strict zero-based bounds.

## Verification

Validated with focused module builds:

- `.venv/bin/cmake --build dist3 --target linearTranslationNDOFStateEffector -- -j2`
- `.venv/bin/cmake --build dist3 --target spinningBodyNDOFStateEffector -- -j2`

Validated with focused unit tests:

- `MPLBACKEND=Agg MPLCONFIGDIR=/private/tmp/mpl .venv/bin/pytest -q src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_changeParameterslinearTranslatingBodyNDOF.py src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_changeParametersSpinningBodyNDOF.py src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFStateEffector.py`

Result: `8 passed`.

No tests were added because this is a compile/configuration-sensitive assertion fix. Existing tests already exercise the valid getter paths; the original issue appears only when assertions are compiled in.

## Documentation

Added/updated PR metadata documentation:

- Added a release-note snippet in `docs/source/Support/bskReleaseNotesSnippets/`
- Updated `docs/source/Support/bskKnownIssues.rst`

## Future work

N/A