### PR TITLE
Guard nonConservativeAccelpntB_B against zero time step

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -39,6 +39,10 @@ Version |release|
   double conversion set the wheel saturation speed about an order of magnitude too low, and since the
   derived wheel inertia is ``maxMomentum / Omega_max`` it came out about an order of magnitude too high.
   This is fixed in the current version.
+- BSK-968: :ref:`spacecraft` reported ``NaN`` for ``nonConservativeAccelpntB_B`` on the first integration
+  step because the accumulated velocity change was divided by a zero time step. The value is now set to
+  zero when the time step is zero, matching the existing ``omegaDot_BN_B`` guard. This is fixed in the
+  current version.
 
 
 Version 2.10.0 (April 2, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/968-nonconservative-accel-first-step.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/968-nonconservative-accel-first-step.rst
@@ -1,0 +1,1 @@
+- Fixed :ref:`spacecraft` reporting ``NaN`` for ``nonConservativeAccelpntB_B`` on the first integration step. The body-frame non-conservative acceleration divides the accumulated velocity change by the integration time step, which is zero on the first step; it is now set to zero when the time step is zero, matching the existing guard used for ``omegaDot_BN_B``.

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -508,8 +508,12 @@ void Spacecraft::postIntegration(uint64_t integrateToThisTimeNanos) {
     this->dvAccum_CN_N += newV_CN_N - this->BcGravVelocity->getState();
 
     // - non-conservative acceleration of the body frame in the body frame
-    this->nonConservativeAccelpntB_B = (newDcm_NB.transpose()*(newV_BN_N -
-                                                               this->hubGravVelocity->getState()))/this->timeStep;
+    if (fabs(this->timeStep) > 1e-10) {
+        this->nonConservativeAccelpntB_B = (newDcm_NB.transpose()*(newV_BN_N -
+                                                                   this->hubGravVelocity->getState()))/this->timeStep;
+    } else {
+        this->nonConservativeAccelpntB_B = {0., 0., 0.};
+    }
 
     // - angular acceleration in the body frame
     Eigen::Vector3d newOmega_BN_B;


### PR DESCRIPTION
* **Tickets addressed:** #968
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
`Spacecraft::postIntegration` divides the accumulated body-frame velocity change by `this->timeStep` to get `nonConservativeAccelpntB_B`. On the first step `timeStep` is zero, so the value is `NaN` and gets written to the state output message. The `omegaDot_BN_B` line just below already guards this case with `if (fabs(this->timeStep) > 1e-10) { ... } else { 0 }`. This applies the same guard, as suggested in the issue.

I also checked `SpacecraftSystem`, which has a structurally similar `/localTimeStep` division. It does not reproduce the NaN in a first-step test (there the velocity delta is zero and the step is non-zero on the first update), and the module is already marked for removal, so I left it unchanged.

## Verification
Built from source with the fix. On the first step, `nonConservativeAccelpntB_B` goes from `[nan, nan, nan]` (reproduced on the 2.10.2 wheel) to `[0, 0, 0]`, and it is unchanged afterward. I kept the diff to the guard itself instead of reformatting the legacy file.

## Documentation
Release-note snippet and a `BSK-968` entry in `bskKnownIssues.rst`.
