### PR TITLE
[#1410] Decouple pytest from user-facing utilities

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -48,6 +48,12 @@ Version |release|
   before the simulation runs. Consumers then read zeros or unwritten data. Retain such messages on the
   simulation object or another persistent scope so they survive for the life of the simulation. This
   affected :ref:`scenarioRoboticArm` and :ref:`scenarioFlexiblePanel` and is fixed in the current version.
+- BSK-1410: user-facing utilities such as :ref:`simIncludeGravBody` and :ref:`vizSupport` imported the
+  test-support module :ref:`unitTestSupport`, which imports the test-only ``pytest`` package at module
+  load time. Scripts run against the Basilisk wheels (which do not ship ``pytest``) therefore failed to
+  import these utilities. The few general-purpose helpers those utilities needed have been moved into a
+  new :ref:`simHelpers` module, so user-facing code no longer depends on ``unitTestSupport`` (or ``pytest``)
+  at all. This is fixed in the current version.
 
 
 Version 2.10.0 (April 2, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/1410-decouple-pytest-from-utilities.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1410-decouple-pytest-from-utilities.rst
@@ -1,0 +1,1 @@
+- Scenario simulation, plotting, data-shaping, and Eigen conversion helpers now live in the pytest-free :ref:`simHelpers` module while remaining available from ``unitTestSupport`` as deprecated compatibility wrappers, so example scenarios no longer require the ``pytest`` package just to import or run.

--- a/docs/source/codeSamples/bsk-4.py
+++ b/docs/source/codeSamples/bsk-4.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 from Basilisk.moduleTemplates import cModuleTemplate
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 def run():
@@ -64,11 +64,11 @@ def run():
     figureList = {}
     for idx in range(3):
         plt.plot(msgRec.times() * macros.NANO2SEC, msgRec.dataVector[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$x_{' + str(idx) + '}$')
         plt.plot(msgRec2.times() * macros.NANO2SEC, msgRec2.dataVector[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\hat x_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [sec]')

--- a/docs/source/codeSamples/bsk-5.py
+++ b/docs/source/codeSamples/bsk-5.py
@@ -23,7 +23,7 @@ from Basilisk.architecture import messaging
 from Basilisk.moduleTemplates import cppModuleTemplate
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 def run():
@@ -75,7 +75,7 @@ def run():
     plt.figure(1)
     for idx in range(3):
         plt.plot(msgRec.times() * macros.NANO2SEC, msgRec.dataVector[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [sec]')

--- a/docs/source/codeSamples/bsk-5a.py
+++ b/docs/source/codeSamples/bsk-5a.py
@@ -24,7 +24,7 @@ from Basilisk.architecture import messaging
 from Basilisk.moduleTemplates import cppModuleTemplate
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 def make_graphviz_figure(scSim, inputMsg, show_plots=False):
@@ -32,7 +32,7 @@ def make_graphviz_figure(scSim, inputMsg, show_plots=False):
     if shutil.which("dot") is None:
         return None
 
-    return unitTestSupport.saveScenarioGraphvizFigure(
+    return simHelpers.saveScenarioGraphvizFigure(
         "bsk-5a-graphviz",
         scSim,
         os.path.dirname(os.path.abspath(__file__)),

--- a/examples/BskSim/models/BSK_Dynamics.py
+++ b/examples/BskSim/models/BSK_Dynamics.py
@@ -33,7 +33,7 @@ from Basilisk.simulation import (
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import macros as mc
 from Basilisk.utilities import simIncludeGravBody, simIncludeRW, simIncludeThruster
-from Basilisk.utilities import unitTestSupport as sp
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 bskPath = __path__[0]
@@ -135,7 +135,7 @@ class BSKDynamicModels():
                      0., 0., 600.]
         self.scObject.hub.mHub = 750.0  # kg - spacecraft mass
         self.scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-        self.scObject.hub.IHubPntBc_B = sp.np2EigenMatrix3d(self.I_sc)
+        self.scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(self.I_sc)
 
     def SetGravityBodies(self):
         """

--- a/examples/BskSim/models/BSK_Faults.py
+++ b/examples/BskSim/models/BSK_Faults.py
@@ -47,7 +47,11 @@ Indexing conventions:
 
 import numpy as np
 from Basilisk.simulation import encoder, tempMeasurement, magnetometer
-from Basilisk.utilities import macros, unitTestSupport, orbitalMotion, vizSupport
+from Basilisk.utilities import (
+    macros,
+    orbitalMotion,
+    vizSupport,
+)
 
 
 def faultTypeInList(faultList, faultType):

--- a/examples/BskSim/models/BSK_FormationDynamics.py
+++ b/examples/BskSim/models/BSK_FormationDynamics.py
@@ -23,7 +23,7 @@ from Basilisk.simulation import (spacecraft, extForceTorque, simpleNav,
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import macros as mc
 from Basilisk.utilities import simIncludeRW, simIncludeGravBody
-from Basilisk.utilities import unitTestSupport as sp
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 
@@ -83,7 +83,7 @@ class BSKDynamicModels():
                      0., 0., 600.]
         self.scObject.hub.mHub = 750.0  # kg - spacecraft mass
         self.scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-        self.scObject.hub.IHubPntBc_B = sp.np2EigenMatrix3d(self.I_sc)
+        self.scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(self.I_sc)
 
         self.scObject2.ModelTag = "deputy"
         self.I_sc2 = [900., 0., 0.,
@@ -91,7 +91,7 @@ class BSKDynamicModels():
                       0., 0., 600.]
         self.scObject2.hub.mHub = 750.0  # kg - spacecraft mass
         self.scObject2.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-        self.scObject2.hub.IHubPntBc_B = sp.np2EigenMatrix3d(self.I_sc2)
+        self.scObject2.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(self.I_sc2)
 
     def SetSimpleNavObject(self):
         self.simpleNavObject.ModelTag = "SimpleNavigation_chief"
@@ -140,4 +140,3 @@ class BSKDynamicModels():
         self.SetSimpleNavObject()
         self.SetReactionWheelDynEffector()
         self.SetExternalForceTorqueObject()
-

--- a/examples/BskSim/plotting/BSK_Plotting.py
+++ b/examples/BskSim/plotting/BSK_Plotting.py
@@ -20,8 +20,8 @@ import numpy as np
 from Basilisk.utilities import RigidBodyKinematics
 from Basilisk.utilities import macros as mc
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 # --------------------------------- COMPONENTS & SUBPLOT HANDLING ----------------------------------------------- #
 color_x = 'dodgerblue'
@@ -167,10 +167,10 @@ def plot_attitude_error(timeLineSet, dataSigmaBR, id=None):
     plt.figure(id)
     fig = plt.gcf()
     ax = fig.gca()
-    vectorData = unitTestSupport.pullVectorSetFromData(dataSigmaBR)
+    vectorData = simHelpers.pullVectorSetFromData(dataSigmaBR)
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Attitude Error Norm $|\sigma_{B/R}|$')
@@ -181,7 +181,7 @@ def plot_control_torque(timeLineSet, dataLr, id=None, livePlot=False):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeLineSet, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     if not livePlot:
         plt.legend(loc='lower right')
@@ -193,7 +193,7 @@ def plot_rate_error(timeLineSet, dataOmegaBR, id=None, livePlot=False):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeLineSet, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     if not livePlot:
         plt.legend(loc='lower right')
@@ -217,7 +217,7 @@ def plot_orientation(timeLineSet, vectorPosData, vectorVelData, vectorMRPData, i
                     , r'$\hat\imath_h\cdot \hat b_3$')
     for idx in range(0, 3):
         plt.plot(timeLineSet, data[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=labelStrings[idx])
     if not livePlot:
         plt.legend(loc='lower right')
@@ -230,7 +230,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW, id=None, livePlot=False):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     if not livePlot:
         plt.legend(loc='lower right')
@@ -244,10 +244,10 @@ def plot_rw_cmd_actual_torque(timeData, dataUsReq, dataRW, numRW, id=None, liveP
     for idx in range(numRW):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -258,7 +258,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW, id=None, livePlot=False):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / mc.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     if not livePlot:
         plt.legend(loc='upper right')
@@ -269,7 +269,7 @@ def plot_rw_friction(timeData, dataFrictionRW, numRW, dataFaultLog=[],  id=None,
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataFrictionRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$RW_{' + str(idx+1) + '} Friction$')
     if dataFaultLog:
         # fourth column of dataFaultLog is the fault times
@@ -413,7 +413,7 @@ def plot_magnetic_field(timeData, dataMagField, id=None):
         plt.plot(
             timeData,
             dataMagField[:, idx] * 1e9,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$B\_N_{" + str(idx) + "}$",
         )
     plt.legend(loc="lower right")
@@ -428,7 +428,7 @@ def plot_data_tam(timeData, dataTam, id=None):
         plt.plot(
             timeData,
             dataTam[:, idx] * 1e9,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$TAM\_S_{" + str(idx) + "}$",
         )
     plt.legend(loc="lower right")

--- a/examples/BskSim/scenarios/scenario_FeedbackRW.py
+++ b/examples/BskSim/scenarios/scenario_FeedbackRW.py
@@ -149,7 +149,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Import utilities
-from Basilisk.utilities import macros, orbitalMotion, unitTestSupport, vizSupport
+from Basilisk.utilities import (
+    macros,
+    orbitalMotion,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -276,7 +281,7 @@ class scenario_AttitudeFeedbackRW(BSKSim, BSKScenario):
         )
 
         if "pytest" in sys.modules:
-            unitTestSupport.saveScenarioGraphvizFigure(
+            simHelpers.saveScenarioGraphvizFigure(
                 pltName,
                 self,
                 path,

--- a/examples/BskSim/scenarios/scenario_LambertGuidance.py
+++ b/examples/BskSim/scenarios/scenario_LambertGuidance.py
@@ -89,7 +89,12 @@ import sys
 
 import numpy as np
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, vizSupport, unitTestSupport
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    orbitalMotion,
+    macros,
+    vizSupport,
+)
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -249,12 +254,12 @@ def runScenario(scenario):
 
     # Next, the state manager objects are called to retrieve the latest inertial position and
     # velocity vector components:
-    vm_N = unitTestSupport.EigenVector3d2np(velRef.getState())
+    vm_N = simHelpers.EigenVector3d2np(velRef.getState())
 
     dv_N = scenario.dv1Cmd_recorder.dvInrtlCmd[-1, :]
 
     # After reading the Delta-V command, the state managers velocity is updated through
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vm_N + dv_N))
+    velRef.setState(simHelpers.np2EigenVectorXd(vm_N + dv_N))
     # Configure FSW mode for second Lambert maneuver
     scenario.modeRequest = 'lambertSecondDV'
 
@@ -266,12 +271,12 @@ def runScenario(scenario):
 
     # Next, the state manager objects are called to retrieve the latest inertial position and
     # velocity vector components:
-    vm_N = unitTestSupport.EigenVector3d2np(velRef.getState())
+    vm_N = simHelpers.EigenVector3d2np(velRef.getState())
 
     dv_N = scenario.dv2Cmd_recorder.dvInrtlCmd[-1, :]
 
     # After reading the Delta-V command, the state managers velocity is updated through
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vm_N + dv_N))
+    velRef.setState(simHelpers.np2EigenVectorXd(vm_N + dv_N))
     # disable flight software after maneuver
     scenario.modeRequest = 'standby'
 

--- a/examples/MultiSatBskSim/modelsMultiSat/BSK_MultiSatDynamics.py
+++ b/examples/MultiSatBskSim/modelsMultiSat/BSK_MultiSatDynamics.py
@@ -21,8 +21,13 @@ from Basilisk import __path__
 from Basilisk.simulation import (spacecraft, simpleNav, simpleMassProps, reactionWheelStateEffector,
                                  thrusterDynamicEffector, simpleSolarPanel, simplePowerSink, simpleBattery, fuelTank,
                                  ReactionWheelPower)
-from Basilisk.utilities import (macros as mc, unitTestSupport as sp, RigidBodyKinematics as rbk,
-                                simIncludeRW, simIncludeThruster)
+from Basilisk.utilities import (
+    macros as mc,
+    RigidBodyKinematics as rbk,
+    simIncludeRW,
+    simIncludeThruster,
+)
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 
@@ -93,7 +98,7 @@ class BSKDynamicModels:
                      0., 0., 600.]
         self.scObject.hub.mHub = 750.0  # kg - spacecraft mass
         self.scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-        self.scObject.hub.IHubPntBc_B = sp.np2EigenMatrix3d(self.I_sc)
+        self.scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(self.I_sc)
 
     def SetGravityBodies(self, SimBase):
         """

--- a/examples/MultiSatBskSim/plottingMultiSat/BSK_MultiSatPlotting.py
+++ b/examples/MultiSatBskSim/plottingMultiSat/BSK_MultiSatPlotting.py
@@ -18,7 +18,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # --------------------------------- COMPONENTS & SUBPLOT HANDLING ----------------------------------------------- #
 
@@ -47,7 +47,7 @@ def plot_attitude(timeData, dataSigmaBN, id=None):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx+1) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -59,7 +59,7 @@ def plot_attitude_error(timeData, dataSigmaBR, id=None):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx+1) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -71,7 +71,7 @@ def plot_attitude_reference(timeData, dataSigmaRN, id=None):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeData, dataSigmaRN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx+1) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -83,7 +83,7 @@ def plot_rate(timeData, dataOmegaBN, id=None):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BN,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -95,7 +95,7 @@ def plot_rate_error(timeData, dataOmegaBR, id=None):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -107,7 +107,7 @@ def plot_rate_reference(timeData, dataOmegaRN, id=None):
     plt.figure(id)
     for idx in range(3):
         plt.plot(timeData, dataOmegaRN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{RN,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -120,10 +120,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW, id=None):
     for idx in range(numRW):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx+1) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -135,7 +135,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW, id=None):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -147,7 +147,7 @@ def plot_rw_voltages(timeData, dataVolt, numRW, id=None):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataVolt[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$V_{' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -159,7 +159,7 @@ def plot_rw_power(timeData, dataRwPower, numRW, id=None):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataRwPower[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$p_{rw,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -191,7 +191,7 @@ def plot_rw_temperature(timeData, tempData, numRW, id=None):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, tempData[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$T_{rw,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -203,7 +203,7 @@ def plot_thrust(timeData, thrustData, numThr, id=None):
     plt.figure(id)
     for idx in range(numThr):
         plt.plot(timeData, thrustData[idx],
-                 color=unitTestSupport.getLineColor(idx, numThr),
+                 color=simHelpers.getLineColor(idx, numThr),
                  label='$F_{thr,' + str(idx + 1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -215,7 +215,7 @@ def plot_thrust_percentage(timeData, thrustData, numThr, id=None):
     plt.figure(id)
     for idx in range(numThr):
         plt.plot(timeData, thrustData[idx],
-                 color=unitTestSupport.getLineColor(idx, numThr),
+                 color=simHelpers.getLineColor(idx, numThr),
                  label='$F_{thr,' + str(idx + 1) + '}$')
     plt.legend(loc='lower right')
     plt.ylim([0, 1.1])
@@ -255,7 +255,7 @@ def plot_orbits(r_BN, numberSpacecraft, id=None):
     for i in range(numberSpacecraft):
         ax.plot(r_BN[i][:, 0] * m2km, r_BN[i][:, 1] * m2km, r_BN[i][:, 2] * m2km,
                 label="Spacecraft " + str(i),
-                c=unitTestSupport.getLineColor(i, numberSpacecraft))
+                c=simHelpers.getLineColor(i, numberSpacecraft))
     ax.set_xlim3d(-8000, 8000)
     ax.set_ylim3d(-8000, 8000)
     ax.set_zlim3d(-8000, 8000)
@@ -274,7 +274,7 @@ def plot_relative_orbits(r_BN, numberSpacecraft, id=None):
     for i in range(numberSpacecraft):
         ax.plot(r_BN[i][:, 0] * m2km, r_BN[i][:, 1] * m2km, r_BN[i][:, 2] * m2km,
                 label="Spacecraft " + str(i),
-                c=unitTestSupport.getLineColor(i, numberSpacecraft))
+                c=simHelpers.getLineColor(i, numberSpacecraft))
     ax.set_box_aspect((np.ptp(r_BN[i][:, 0]), np.ptp(r_BN[i][:, 1]), np.ptp(r_BN[i][:, 2])))
     ax.scatter(0, 0, 0, c=color_x)
     ax.set_title('Spacecraft Relative Orbits in Hill Frame')
@@ -296,4 +296,3 @@ def plot_orbital_element_differences(timeData, oed, id=None):
     plt.legend()
     plt.xlabel("time [orbit]")
     plt.ylabel("Orbital Element Difference")
-

--- a/examples/OpNavScenarios/modelsOpNav/BSK_OpNavDynamics.py
+++ b/examples/OpNavScenarios/modelsOpNav/BSK_OpNavDynamics.py
@@ -48,8 +48,8 @@ from Basilisk.topLevelModules import pyswice
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import macros as mc
 from Basilisk.utilities import simIncludeThruster, simIncludeRW, simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 bskPath = __path__[0]
@@ -232,7 +232,7 @@ class BSKDynamicModels:
             [0.0],
             [0.0],
         ]  # m - position vector of body-fixed point B relative to CM
-        self.scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(self.I_sc)
+        self.scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(self.I_sc)
 
     def SetGravityEffector(self):
         """

--- a/examples/OpNavScenarios/plottingOpNav/OpNav_Plotting.py
+++ b/examples/OpNavScenarios/plottingOpNav/OpNav_Plotting.py
@@ -29,7 +29,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 # import scipy.optimize
 from Basilisk.utilities import macros as mc
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from matplotlib.patches import Ellipse
 
 color_x = 'dodgerblue'
@@ -341,10 +341,10 @@ def nav_percentages(truth, states, covar, valid, string):
     print(RMSVelCov)
     print('------------------------')
     # RMS Errors Computed for heading and rate
-    # unitTestSupport.writeTeXSnippet('RMSPos_'+ string, str(round(RMSPos,3)), os.path.dirname(__file__))
-    # unitTestSupport.writeTeXSnippet('RMSPosCov_'+ string, str(round(RMSPosCov,3)),os.path.dirname(__file__))
-    # unitTestSupport.writeTeXSnippet('RMSVel_'+ string, str(round(RMSVel,3)), os.path.dirname(__file__))
-    # unitTestSupport.writeTeXSnippet('RMSVelCov_'+ string, str(round(RMSVelCov,3)),os.path.dirname(__file__))
+    # simHelpers.writeTeXSnippet('RMSPos_'+ string, str(round(RMSPos,3)), os.path.dirname(__file__))
+    # simHelpers.writeTeXSnippet('RMSPosCov_'+ string, str(round(RMSPosCov,3)),os.path.dirname(__file__))
+    # simHelpers.writeTeXSnippet('RMSVel_'+ string, str(round(RMSVel,3)), os.path.dirname(__file__))
+    # simHelpers.writeTeXSnippet('RMSVelCov_'+ string, str(round(RMSVelCov,3)),os.path.dirname(__file__))
     return
 
 def plot_orbit(r_BN):
@@ -406,7 +406,7 @@ def plot_attitude_error(timeLineSet, dataSigmaBR):
     plt.rcParams["font.size"] = "8"
     fig = plt.gcf()
     ax = fig.gca()
-    vectorData = unitTestSupport.pullVectorSetFromData(dataSigmaBR)
+    vectorData = simHelpers.pullVectorSetFromData(dataSigmaBR)
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
              color=colorList[0],
@@ -444,7 +444,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(1, 4):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time (min)')
@@ -455,7 +455,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure()
     for idx in range(1, numRW + 1):
         plt.plot(timeData, dataOmegaRW[:, idx] / mc.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='upper right')
     plt.xlabel('Time [min]')
@@ -1069,7 +1069,7 @@ def StateErrorCovarPlot(x, Pflat, FilterType, show_plots):
             plt.ylabel('$d_' + str(i+1) + '$ Error (-)')
             plt.ylim([-0.1,0.1])
             plt.xlabel('Time (min)')
-            unitTestSupport.saveFigurePDF('StateCovarHeading'+ FilterType + str(i) , plt, './')
+            simHelpers.saveFigurePDF('StateCovarHeading'+ FilterType + str(i) , plt, './')
             if show_plots:
                 plt.show()
             plt.close("all")
@@ -1081,7 +1081,7 @@ def StateErrorCovarPlot(x, Pflat, FilterType, show_plots):
             plt.ylabel('$d_' + str(i+1) + '$ Error (-)')
             plt.xlabel('Time (min)')
             plt.ylim([-0.1,0.1])
-            unitTestSupport.saveFigurePDF('StateCovarHeading'+ FilterType + str(i) , plt, './')
+            simHelpers.saveFigurePDF('StateCovarHeading'+ FilterType + str(i) , plt, './')
             if show_plots:
                 plt.show()
             plt.close("all")
@@ -1100,7 +1100,7 @@ def StateErrorCovarPlot(x, Pflat, FilterType, show_plots):
                 else:
                     plt.ylabel(r'$d\'_' + str(i-2) + r'$ Error (-)')
                 plt.xlabel('Time (min)')
-                unitTestSupport.saveFigurePDF('StateCovarRate' + FilterType + str(i), plt, './')
+                simHelpers.saveFigurePDF('StateCovarRate' + FilterType + str(i), plt, './')
                 if show_plots:
                     plt.show()
                 plt.close("all")
@@ -1115,7 +1115,7 @@ def StateErrorCovarPlot(x, Pflat, FilterType, show_plots):
                 else:
                     plt.ylabel(r'$d\'_' + str(i-2) + r'$ Error (-)')
                 plt.xlabel('Time (min)')
-                unitTestSupport.saveFigurePDF('StateCovarRate' + FilterType + str(i), plt, './')
+                simHelpers.saveFigurePDF('StateCovarRate' + FilterType + str(i), plt, './')
                 if show_plots:
                     plt.show()
                 plt.close("all")
@@ -1164,7 +1164,7 @@ def PostFitResiduals(Res, covar_B, FilterType, show_plots):
             plt.ylabel('$r_' + str(i + 1) + '$ (-)')
             plt.xlabel('Time (min)')
             plt.ylim([-2*MeasNoise[-1,i], 2*MeasNoise[-1,i]])
-            unitTestSupport.saveFigurePDF('PostFit' + FilterType + str(i), plt, './')
+            simHelpers.saveFigurePDF('PostFit' + FilterType + str(i), plt, './')
             if show_plots:
                 plt.show()
             plt.close("all")
@@ -1176,7 +1176,7 @@ def PostFitResiduals(Res, covar_B, FilterType, show_plots):
             plt.ylabel('$r_' + str(i + 1) + '$ (-)')
             plt.xlabel('Time min')
             plt.ylim([-2*MeasNoise[-1,i], 2*MeasNoise[-1,i]])
-            unitTestSupport.saveFigurePDF('PostFit' + FilterType + str(i), plt, './')
+            simHelpers.saveFigurePDF('PostFit' + FilterType + str(i), plt, './')
             if show_plots:
                 plt.show()
             plt.close("all")

--- a/examples/OpNavScenarios/scenariosOpNav/CNN_ImageGen/OpNavMonteCarlo.py
+++ b/examples/OpNavScenarios/scenariosOpNav/CNN_ImageGen/OpNavMonteCarlo.py
@@ -48,7 +48,7 @@ from Basilisk.utilities.MonteCarlo.Dispersions import OrbitalElementDispersion, 
 
 # import simulation related support
 from Basilisk.utilities import RigidBodyKinematics as rbk
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import macros
 import matplotlib.pyplot as plt
 import numpy as np
@@ -132,11 +132,11 @@ def run(show_plots):
         writer.writerow(['Filename', 'Valid', 'X_p', 'Y_p', 'rho_p', 'r_BN_N_1', 'r_BN_N_2', 'r_BN_N_3'])
 
         timeAxis = monteCarloData["messages"][retainedMessageName1 + ".times"]
-        position_N = unitTestSupport.addTimeColumn(timeAxis,
+        position_N = simHelpers.addTimeColumn(timeAxis,
                                                    monteCarloData["messages"][retainedMessageName1 + "." + var1])
-        sigma_BN = unitTestSupport.addTimeColumn(timeAxis,
+        sigma_BN = simHelpers.addTimeColumn(timeAxis,
                                                  monteCarloData["messages"][retainedMessageName1 + "." + var2])
-        validCircle = unitTestSupport.addTimeColumn(timeAxis,
+        validCircle = simHelpers.addTimeColumn(timeAxis,
                                                     monteCarloData["messages"][retainedMessageName2 + "." + var3])
 
         renderRate = 60*1E9

--- a/examples/OpNavScenarios/scenariosOpNav/CNN_ImageGen/scenario_CNNImages.py
+++ b/examples/OpNavScenarios/scenariosOpNav/CNN_ImageGen/scenario_CNNImages.py
@@ -29,10 +29,11 @@ import os
 import subprocess
 import sys
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -133,12 +134,12 @@ class scenario_OpNav(BSKSim):
     def pull_outputs(self, showPlots):
         ## Spacecraft true states
         scStates = self.msgRecList[self.retainedMessageName1]
-        position_N = unitTestSupport.addTimeColumn(scStates.times(), scStates.r_BN_N)
-        sigma_BN = unitTestSupport.addTimeColumn(scStates.times(), scStates.sigma_BN)
+        position_N = simHelpers.addTimeColumn(scStates.times(), scStates.r_BN_N)
+        sigma_BN = simHelpers.addTimeColumn(scStates.times(), scStates.sigma_BN)
 
         ## Image processing
         circleStates = self.scRecmsgRecList[self.retainedMessageName2]
-        validCircle = unitTestSupport.addTimeColumn(
+        validCircle = simHelpers.addTimeColumn(
             circleStates.times(), circleStates.valid
         )
 

--- a/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_LimbAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_LimbAttOD.py
@@ -29,10 +29,11 @@ import os
 import subprocess
 import sys
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -150,33 +151,33 @@ class scenario_OpNav(BSKSim):
         # Dynamics process outputs: pull log messages below if any
         ## Spacecraft true states
         scRec = self.msgRecList[self.retainedMessageNameSc]
-        position_N = unitTestSupport.addTimeColumn(scRec.times(), scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(scRec.times(), scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(scRec.times(), scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(scRec.times(), scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(scRec.times(), scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(scRec.times(), scRec.sigma_BN)
 
         ## Image processing
         limbRec = self.msgRecList[self.retainedMessageNameLimb]
-        limb = unitTestSupport.addTimeColumn(limbRec.times(), limbRec.limbPoints)
-        numLimbPoints = unitTestSupport.addTimeColumn(
+        limb = simHelpers.addTimeColumn(limbRec.times(), limbRec.limbPoints)
+        numLimbPoints = simHelpers.addTimeColumn(
             limbRec.times(), limbRec.numLimbPoints
         )
-        validLimb = unitTestSupport.addTimeColumn(limbRec.times(), limbRec.valid)
+        validLimb = simHelpers.addTimeColumn(limbRec.times(), limbRec.valid)
 
         ## OpNav Out
         opNavRec = self.msgRecList[self.retainedMessageNameOpNav]
-        measPos = unitTestSupport.addTimeColumn(opNavRec.times(), opNavRec.r_BN_N)
-        r_C = unitTestSupport.addTimeColumn(opNavRec.times(), opNavRec.r_BN_C)
-        measCovar = unitTestSupport.addTimeColumn(opNavRec.times(), opNavRec.covar_N)
-        covar_C = unitTestSupport.addTimeColumn(opNavRec.times(), opNavRec.covar_C)
+        measPos = simHelpers.addTimeColumn(opNavRec.times(), opNavRec.r_BN_N)
+        r_C = simHelpers.addTimeColumn(opNavRec.times(), opNavRec.r_BN_C)
+        measCovar = simHelpers.addTimeColumn(opNavRec.times(), opNavRec.covar_N)
+        covar_C = simHelpers.addTimeColumn(opNavRec.times(), opNavRec.covar_C)
 
         NUM_STATES = 6
         ## Navigation results
         filtRec = self.msgRecList[self.retainedMessageNameFilt]
-        navState = unitTestSupport.addTimeColumn(filtRec.times(), filtRec.state)
-        navCovar = unitTestSupport.addTimeColumn(filtRec.times(), filtRec.covar)
-        navPostFits = unitTestSupport.addTimeColumn(filtRec.times(), filtRec.postFitRes)
+        navState = simHelpers.addTimeColumn(filtRec.times(), filtRec.state)
+        navCovar = simHelpers.addTimeColumn(filtRec.times(), filtRec.covar)
+        navPostFits = simHelpers.addTimeColumn(filtRec.times(), filtRec.postFitRes)
 
         sigma_CB = self.get_DynModel().cameraMRP_CB
         sizeMM = self.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_OpNavAttODMC.py
+++ b/examples/OpNavScenarios/scenariosOpNav/OpNavMC/scenario_OpNavAttODMC.py
@@ -30,7 +30,10 @@ import subprocess
 import sys
 
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import (
+    orbitalMotion,
+    macros,
+)
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_CNNAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_CNNAttOD.py
@@ -35,9 +35,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -130,32 +131,32 @@ class scenario_OpNav(BSKScenario):
         # Dynamics process outputs: pull log messages below if any
 
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Image processing
-        circleCenters = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
-        circleRadii = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
-        validCircle = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
+        circleCenters = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
+        circleRadii = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
+        validCircle = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
         if self.filterUse == "bias":
             NUM_STATES = 9
             ## Navigation results
-            navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-            navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-            navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+            navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+            navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+            navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
         if self.filterUse == "relOD":
             NUM_STATES = 6
             ## Navigation results
-            navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-            navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-            navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
-            measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-            r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-            measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-            covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+            navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+            navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+            navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+            measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+            r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+            measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+            covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttOD.py
@@ -57,9 +57,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -157,32 +158,32 @@ class scenario_OpNav(BSKScenario):
 
     def pull_outputs(self, showPlots):
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Image processing
-        circleCenters = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
-        circleRadii = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
-        validCircle = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
+        circleCenters = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
+        circleRadii = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
+        validCircle = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
         if self.filterUse == "bias":
             NUM_STATES = 9
             ## Navigation results
-            navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-            navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-            navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+            navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+            navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+            navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
         if self.filterUse == "relOD":
             NUM_STATES = 6
             ## Navigation results
-            navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-            navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-            navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
-            measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-            r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-            measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-            covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+            navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+            navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+            navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+            measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+            r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+            measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+            covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttODLimb.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavAttODLimb.py
@@ -40,9 +40,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -135,28 +136,28 @@ class scenario_OpNav(BSKScenario):
     def pull_outputs(self, showPlots):
         # Dynamics process outputs: pull log messages below if any
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Image processing
-        limb = unitTestSupport.addTimeColumn(self.limbRec.times(), self.limbRec.limbPoints)
-        numLimbPoints = unitTestSupport.addTimeColumn(self.limbRec.times(), self.limbRec.numLimbPoints)
-        validLimb = unitTestSupport.addTimeColumn(self.limbRec.times(), self.limbRec.valid)
+        limb = simHelpers.addTimeColumn(self.limbRec.times(), self.limbRec.limbPoints)
+        numLimbPoints = simHelpers.addTimeColumn(self.limbRec.times(), self.limbRec.numLimbPoints)
+        validLimb = simHelpers.addTimeColumn(self.limbRec.times(), self.limbRec.valid)
 
         ## OpNav Out
-        measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-        r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-        measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-        covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+        measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+        r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+        measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+        covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         NUM_STATES = 6
         ## Navigation results
-        navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-        navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-        navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+        navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+        navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+        navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavHeading.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavHeading.py
@@ -37,9 +37,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -156,37 +157,37 @@ class scenario_OpNav(BSKScenario):
         # Dynamics process outputs: pull log messages below if any
 
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
-        Outomega_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.omega_BN_B)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        Outomega_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.omega_BN_B)
 
         ## Image processing
-        circleCenters = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
-        circleRadii = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
-        validCircle = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
+        circleCenters = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
+        circleRadii = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
+        validCircle = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
 
-        frame = unitTestSupport.addTimeColumn(self.headingBVecLog.times(), self.headingBVecLog.bVec_B)
+        frame = simHelpers.addTimeColumn(self.headingBVecLog.times(), self.headingBVecLog.bVec_B)
 
         numRW = 4
         dataRW = []
         for i in range(numRW):
-            dataRW.append(unitTestSupport.addTimeColumn(self.rwMotorRec.times(), self.rwLogs[i].u_current))
+            dataRW.append(simHelpers.addTimeColumn(self.rwMotorRec.times(), self.rwLogs[i].u_current))
 
-        measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-        r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-        measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-        covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
-        covar_B = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_B)
+        measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+        r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+        measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+        covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+        covar_B = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_B)
 
         FilterType = "Switch-SRuKF"
         numStates = 5
         # Get the filter outputs through the messages
-        stateLog = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-        r_BN_C = unitTestSupport.addTimeColumn(self.opNavFiltRec.times(), self.opNavFiltRec.r_BN_C)
-        postFitLog = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
-        covarLog = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+        stateLog = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+        r_BN_C = simHelpers.addTimeColumn(self.opNavFiltRec.times(), self.opNavFiltRec.r_BN_C)
+        postFitLog = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+        covarLog = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
         stateLog[0, 3] = 1.0  # adjust first measurement to be non-zero
         for i in range(len(stateLog[:, 0])):
             stateLog[i, 1:4] = stateLog[i, 1:4] / np.linalg.norm(stateLog[i, 1:4])

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavOD.py
@@ -31,9 +31,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -122,32 +123,32 @@ class scenario_OpNav(BSKScenario):
     def pull_outputs(self, showPlots):
         # Dynamics process outputs: pull log messages below if any
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Image processing
-        circleCenters = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
-        circleRadii = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
-        validCircle = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
+        circleCenters = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
+        circleRadii = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
+        validCircle = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.valid)
         if self.filterUse == "bias":
             NUM_STATES = 9
             ## Navigation results
-            navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-            navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-            navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+            navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+            navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+            navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
         if self.filterUse == "relOD":
             NUM_STATES = 6
             ## Navigation results
-            navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-            navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-            navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
-            measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-            r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-            measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-            covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+            navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+            navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+            navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+            measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+            r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+            measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+            covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavODLimb.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavODLimb.py
@@ -31,9 +31,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -117,28 +118,28 @@ class scenario_OpNav(BSKScenario):
         # Dynamics process outputs: pull log messages below if any
 
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Image processing
-        limb = unitTestSupport.addTimeColumn(self.limbRec.times(), self.limbRec.limbPoints)
-        numLimbPoints = unitTestSupport.addTimeColumn(self.limbRec.times(), self.limbRec.numLimbPoints)
-        validLimb = unitTestSupport.addTimeColumn(self.limbRec.times(), self.limbRec.valid)
+        limb = simHelpers.addTimeColumn(self.limbRec.times(), self.limbRec.limbPoints)
+        numLimbPoints = simHelpers.addTimeColumn(self.limbRec.times(), self.limbRec.numLimbPoints)
+        validLimb = simHelpers.addTimeColumn(self.limbRec.times(), self.limbRec.valid)
 
         ## OpNav Out
-        measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-        r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-        measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-        covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+        measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+        r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+        measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+        covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         NUM_STATES = 6
         ## Navigation results
-        navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-        navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
-        navPostFits = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
+        navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+        navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+        navPostFits = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.postFitRes)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPoint.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPoint.py
@@ -31,9 +31,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -121,25 +122,25 @@ class scenario_OpNav(BSKScenario):
     def pull_outputs(self, showPlots):
 
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Image processing
-        circleCenters = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
-        circleRadii = unitTestSupport.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
+        circleCenters = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesCenters)
+        circleRadii = simHelpers.addTimeColumn(self.circlesRec.times(), self.circlesRec.circlesRadii)
 
         numRW = 4
-        dataUsReq = unitTestSupport.addTimeColumn(self.rwMotorRec.times(), self.rwMotorRec.motorTorque)
+        dataUsReq = simHelpers.addTimeColumn(self.rwMotorRec.times(), self.rwMotorRec.motorTorque)
         dataRW = []
         for i in range(numRW):
-            dataRW.append(unitTestSupport.addTimeColumn(self.rwMotorRec.times(), self.rwLogs[i].u_current))
+            dataRW.append(simHelpers.addTimeColumn(self.rwMotorRec.times(), self.rwLogs[i].u_current))
 
-        measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-        r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-        measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-        covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+        measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+        r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+        measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+        covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPointLimb.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_OpNavPointLimb.py
@@ -33,7 +33,8 @@ import sys
 import time
 
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -111,14 +112,14 @@ class scenario_OpNav(BSKScenario):
 
     def pull_outputs(self, showPlots):
 
-        sigma_BR = unitTestSupport.addTimeColumn(self.attGuidRec.times(), self.attGuidRec.sigma_BR)
-        omega_BR_B = unitTestSupport.addTimeColumn(self.attGuidRec.times(), self.attGuidRec.omega_BR_B)
+        sigma_BR = simHelpers.addTimeColumn(self.attGuidRec.times(), self.attGuidRec.sigma_BR)
+        omega_BR_B = simHelpers.addTimeColumn(self.attGuidRec.times(), self.attGuidRec.omega_BR_B)
 
         numRW = 4
-        dataUsReq = unitTestSupport.addTimeColumn(self.rwMotorRec.times(), self.rwMotorRec.motorTorque)
+        dataUsReq = simHelpers.addTimeColumn(self.rwMotorRec.times(), self.rwMotorRec.motorTorque)
         dataRW = []
         for i in range(numRW):
-            dataRW.append(unitTestSupport.addTimeColumn(self.rwMotorRec.times(), self.rwLogs[i].u_current))
+            dataRW.append(simHelpers.addTimeColumn(self.rwMotorRec.times(), self.rwLogs[i].u_current))
 
         # Plot results
         BSK_plt.clear_all_plots()

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_faultDetOpNav.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_faultDetOpNav.py
@@ -37,9 +37,10 @@ import os
 import sys
 import time
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rbk
 # Import utilities
-from Basilisk.utilities import orbitalMotion, macros, unitTestSupport
+from Basilisk.utilities import orbitalMotion, macros
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -142,26 +143,26 @@ class scenario_OpNav(BSKScenario):
         NUM_STATES = 6
 
         ## Spacecraft true states
-        position_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
-        velocity_N = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
+        position_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.r_BN_N)
+        velocity_N = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.v_BN_N)
 
         ## Attitude
-        sigma_BN = unitTestSupport.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
+        sigma_BN = simHelpers.addTimeColumn(self.scRec.times(), self.scRec.sigma_BN)
 
         ## Navigation results
-        navState = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.state)
-        navCovar = unitTestSupport.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
+        navState = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.state)
+        navCovar = simHelpers.addTimeColumn(self.filtRec.times(), self.filtRec.covar)
 
-        validLimb = unitTestSupport.addTimeColumn(self.opNavPrimRec.times(), self.opNavPrimRec.valid)
-        validHough = unitTestSupport.addTimeColumn(self.opNavSecRec.times(), self.opNavSecRec.valid)
+        validLimb = simHelpers.addTimeColumn(self.opNavPrimRec.times(), self.opNavPrimRec.valid)
+        validHough = simHelpers.addTimeColumn(self.opNavSecRec.times(), self.opNavSecRec.valid)
 
         ## Fault Detection
-        measPos = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
-        valid = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.valid)
-        faults = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.faultDetected)
-        r_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
-        measCovar = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
-        covar_C = unitTestSupport.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
+        measPos = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_N)
+        valid = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.valid)
+        faults = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.faultDetected)
+        r_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.r_BN_C)
+        measCovar = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_N)
+        covar_C = simHelpers.addTimeColumn(self.opNavRec.times(), self.opNavRec.covar_C)
 
         sigma_CB = self.masterSim.get_DynModel().cameraMRP_CB
         sizeMM = self.masterSim.get_DynModel().cameraSize

--- a/examples/SunLineKF_test_utilities.py
+++ b/examples/SunLineKF_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -185,7 +185,7 @@ def StateErrorCovarPlot(x, Pflat, FilterType, show_plots, saveFigures):
         plt.grid()
 
     if saveFigures:
-        unitTestSupport.saveScenarioFigure('scenario_Filters_StatesPlot'+FilterType,  plt,  path)
+        simHelpers.saveScenarioFigure('scenario_Filters_StatesPlot'+FilterType,  plt,  path)
     if show_plots:
         plt.show()
     plt.close('all')
@@ -387,7 +387,7 @@ def StatesPlotCompare(x, x2, Pflat, Pflat2, FilterType, show_plots, saveFigures)
         plt.grid()
 
     if saveFigures:
-        unitTestSupport.saveScenarioFigure('scenario_Filters_StatesCompare'+FilterType, plt, path)
+        simHelpers.saveScenarioFigure('scenario_Filters_StatesCompare'+FilterType, plt, path)
 
     if show_plots:
         plt.show()
@@ -401,7 +401,7 @@ def numMeasurements(numObs, FilterType, show_plots, saveFigures):
     plt.title('Number of Activated CSS')
 
     if saveFigures:
-        unitTestSupport.saveScenarioFigure('scenario_Filters_Obs'+ FilterType, plt,  path)
+        simHelpers.saveScenarioFigure('scenario_Filters_Obs'+ FilterType, plt,  path)
 
     if show_plots:
         plt.show()
@@ -461,7 +461,7 @@ def PostFitResiduals(Res, noise, FilterType, show_plots, saveFigures):
     plt.title('Fourth CSS')
 
     if saveFigures:
-        unitTestSupport.saveScenarioFigure('scenario_Filters_PostFit'+ FilterType, plt,  path)
+        simHelpers.saveScenarioFigure('scenario_Filters_PostFit'+ FilterType, plt,  path)
 
     if show_plots:
         plt.show()
@@ -619,7 +619,7 @@ def StatesVsExpected(stateLog, Pflat, expectedStateArray, FilterType, show_plots
 
 
     if saveFigures:
-        unitTestSupport.saveScenarioFigure('scenario_Filters_StatesExpected' + FilterType , plt, path)
+        simHelpers.saveScenarioFigure('scenario_Filters_StatesExpected' + FilterType , plt, path)
 
     if show_plots:
         plt.show()
@@ -698,7 +698,7 @@ def StatesVsTargets(target1, target2, stateLog, FilterType, show_plots, saveFigu
         plt.grid()
 
     if saveFigures:
-        unitTestSupport.saveScenarioFigure('scenario_Filters_StatesTarget' + FilterType,  plt,  path)
+        simHelpers.saveScenarioFigure('scenario_Filters_StatesTarget' + FilterType,  plt,  path)
 
     if show_plots:
         plt.show()

--- a/examples/mujoco/scenarioAttitudeFeedbackRWMuJoCo.py
+++ b/examples/mujoco/scenarioAttitudeFeedbackRWMuJoCo.py
@@ -79,7 +79,14 @@ from Basilisk.simulation import pointMassGravityModel
 from Basilisk.simulation import saturationSingleActuator
 from Basilisk.simulation import scalarJointStatesToRWSpeed
 from Basilisk.simulation import simpleNav
-from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport, vizSupport
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -88,13 +95,13 @@ def plotAttitudeAndRateErrors(timeMin: np.ndarray, sigmaBR: np.ndarray, omegaBRB
     fig, (ax1, ax2) = plt.subplots(1, 2, sharex=True, num=1, clear=True)
 
     for i in range(3):
-        ax1.plot(timeMin, sigmaBR[:, i], color=unitTestSupport.getLineColor(i, 3), label=rf"$\sigma_{i}$")
+        ax1.plot(timeMin, sigmaBR[:, i], color=simHelpers.getLineColor(i, 3), label=rf"$\sigma_{i}$")
     ax1.set_xlabel("Time [min]")
     ax1.set_ylabel(r"Attitude Error $[\mathbf{\sigma}]$")
     ax1.legend(loc="lower right")
 
     for i in range(3):
-        ax2.plot(timeMin, omegaBRB[:, i], color=unitTestSupport.getLineColor(i, 3), label=rf"$\omega_{{BR,{i}}}$")
+        ax2.plot(timeMin, omegaBRB[:, i], color=simHelpers.getLineColor(i, 3), label=rf"$\omega_{{BR,{i}}}$")
     ax2.set_xlabel("Time [min]")
     ax2.set_ylabel("Rate Tracking Error [rad/s]")
     ax2.legend(loc="lower right")
@@ -109,13 +116,13 @@ def plotCmdTorquesAndRwSpeeds(timeMin: np.ndarray, motorTorque: np.ndarray, rwOm
     fig, (ax1, ax2) = plt.subplots(1, 2, sharex=True, num=2, clear=True)
 
     for i in range(numRw):
-        ax1.plot(timeMin, motorTorque[:, i], color=unitTestSupport.getLineColor(i, 3), label=rf"$\hat u_{{s,{i}}}$")
+        ax1.plot(timeMin, motorTorque[:, i], color=simHelpers.getLineColor(i, 3), label=rf"$\hat u_{{s,{i}}}$")
     ax1.set_xlabel("Time [min]")
     ax1.set_ylabel("Commanded RW Motor Torque [Nm]")
     ax1.legend(loc="lower right")
 
     for i in range(numRw):
-        ax2.plot(timeMin, rwOmega[:, i] / macros.RPM, color=unitTestSupport.getLineColor(i, 3), label=rf"$\Omega_{i}$")
+        ax2.plot(timeMin, rwOmega[:, i] / macros.RPM, color=simHelpers.getLineColor(i, 3), label=rf"$\Omega_{i}$")
     ax2.set_xlabel("Time [min]")
     ax2.set_ylabel("RW Speed [RPM]")
     ax2.legend(loc="lower right")
@@ -357,7 +364,7 @@ def run(showPlots: bool = False):
     # 9) Data logging setup
     # -------------------------------------------------------------------------
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, timeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, timeStep, numDataPoints)
 
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
 

--- a/examples/mujoco/scenarioThrArmControl.py
+++ b/examples/mujoco/scenarioThrArmControl.py
@@ -109,7 +109,11 @@ import sys
 import argparse
 import matplotlib.pyplot as plt
 
-from Basilisk.utilities import macros as mc, unitTestSupport, vizSupport
+from Basilisk.utilities import (
+    macros as mc,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -166,9 +170,9 @@ class scenarioThrArmControl(BSKSim, BSKScenario):
         r_CN_N = self.posRec.r_CN_N
         sigma_BN = self.attRec.sigma_BN
 
-        color_x = unitTestSupport.getLineColor(0, 3)
-        color_y = unitTestSupport.getLineColor(1, 3)
-        color_z = unitTestSupport.getLineColor(2, 3)
+        color_x = simHelpers.getLineColor(0, 3)
+        color_y = simHelpers.getLineColor(1, 3)
+        color_z = simHelpers.getLineColor(2, 3)
 
         figureList = {}
 

--- a/examples/scenarioAerocapture.py
+++ b/examples/scenarioAerocapture.py
@@ -97,8 +97,8 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.readAtmTable import readAtmTable
 from Basilisk.utilities.supportDataTools.dataFetcher import (
     get_path,
@@ -349,7 +349,7 @@ def run(show_plots, planetCase, useWind=False):
         plt.plot(
             dataLog.times() * macros.NANO2MIN,
             posData[:, idx] / 1000.0,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label="$r_{BN," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")

--- a/examples/scenarioAlbedo.py
+++ b/examples/scenarioAlbedo.py
@@ -152,12 +152,10 @@ from Basilisk.simulation import eclipse
 from Basilisk.simulation import spacecraft
 
 # import general simulation support files
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros, simIncludeGravBody
 from Basilisk.utilities import orbitalMotion as om
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 from Basilisk.utilities.supportDataTools.dataFetcher import DataFile, get_path
 
 bskPath = __path__[0]
@@ -241,7 +239,7 @@ def run(
         [0.0],
         [0.0],
     ]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     if multiplePlanet:
         # Set initial spacecraft states
         scObject.hub.r_CN_NInit = [[0.0], [rLEO], [0.0]]  # m - r_CN_N
@@ -389,7 +387,7 @@ def run(
         scSim.ConfigureStopTime(T1)
         scSim.ExecuteSimulation()
         # get the current spacecraft states
-        vVt = unitTestSupport.EigenVector3d2np(velRef.getState())
+        vVt = simHelpers.EigenVector3d2np(velRef.getState())
         T2 = macros.sec2nano(1000.0)
         # Set second spacecraft states for decrease in altitude
         vVt = vVt + [0.0, 375300, 0.0]  # m - v_CN_N
@@ -441,7 +439,7 @@ def run(
                 dataAlb[:, idx],
                 linewidth=2,
                 alpha=0.7,
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 label="Albedo$_{" + str(idx) + "}$",
             )
             if not multiplePlanet:
@@ -450,7 +448,7 @@ def run(
                     dataCSS[:, idx],
                     "--",
                     linewidth=1.5,
-                    color=unitTestSupport.getLineColor(idx, 3),
+                    color=simHelpers.getLineColor(idx, 3),
                     label="CSS$_{" + str(idx) + "}$",
                 )
     else:
@@ -459,7 +457,7 @@ def run(
             dataAlb,
             linewidth=2,
             alpha=0.7,
-            color=unitTestSupport.getLineColor(0, 2),
+            color=simHelpers.getLineColor(0, 2),
             label="Alb$_{1}$",
         )
         if not multiplePlanet:
@@ -468,7 +466,7 @@ def run(
                 dataCSS,
                 "--",
                 linewidth=1.5,
-                color=unitTestSupport.getLineColor(1, 2),
+                color=simHelpers.getLineColor(1, 2),
                 label="CSS$_{1}$",
             )
     if multiplePlanet:

--- a/examples/scenarioAsteroidArrival.py
+++ b/examples/scenarioAsteroidArrival.py
@@ -194,7 +194,14 @@ bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 
-from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody, vizSupport, unitTestSupport, orbitalMotion)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    simIncludeGravBody,
+    vizSupport,
+    orbitalMotion,
+)
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import spacecraft, extForceTorque, simpleNav, ephemerisConverter, planetEphemeris
 from Basilisk.fswAlgorithms import mrpFeedback, attTrackingError, velocityPoint, locationPointing
 from Basilisk.architecture import messaging, astroConstants
@@ -328,7 +335,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Define the initial spacecraft orbit about the asteroid
     oe = orbitalMotion.ClassicElements()

--- a/examples/scenarioAttGuideHyperbolic.py
+++ b/examples/scenarioAttGuideHyperbolic.py
@@ -126,8 +126,14 @@ from Basilisk import __path__
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import mrpFeedback, attTrackingError, velocityPoint
 from Basilisk.simulation import extForceTorque, simpleNav, spacecraft
-from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -140,7 +146,7 @@ def plot_track_error_norm(timeLineSet, dataSigmaBR):
     vectorData = dataSigmaBR
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Attitude Error Norm $|\sigma_{B/R}|$')
@@ -151,7 +157,7 @@ def plot_control_torque(timeLineSet, dataLr):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeLineSet, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -162,7 +168,7 @@ def plot_rate_error(timeLineSet, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeLineSet, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -248,7 +254,7 @@ def run(show_plots, useAltBodyFrame):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -344,7 +350,7 @@ def run(show_plots, useAltBodyFrame):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)

--- a/examples/scenarioAttLocPoint.py
+++ b/examples/scenarioAttLocPoint.py
@@ -81,11 +81,11 @@ from Basilisk.simulation import simpleNav
 # import simulation related support
 from Basilisk.simulation import spacecraft
 # import general simulation support files
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 from Basilisk.architecture import astroConstants
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
@@ -103,7 +103,7 @@ def plot_attitude_error(timeLineSet, dataSigmaBR):
     vectorData = dataSigmaBR
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Attitude Error Norm $|\sigma_{B/R}|$')
@@ -114,7 +114,7 @@ def plot_control_torque(timeLineSet, dataLr):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeLineSet, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -126,7 +126,7 @@ def plot_rate_error(timeLineSet, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeLineSet, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -175,7 +175,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -269,7 +269,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrLog = locPoint.attGuidOutMsg.recorder(samplingTime)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)
@@ -296,7 +296,7 @@ def run(show_plots):
                                                   )
         vizSupport.addLocation(viz, stationName="Boulder Station"
                                , parentBodyName=earth.displayName
-                               , r_GP_P=unitTestSupport.EigenVector3d2list(groundStation.r_LP_P_Init)
+                               , r_GP_P=simHelpers.EigenVector3d2list(groundStation.r_LP_P_Init)
                                , fieldOfView=np.radians(160.)
                                , color='pink'
                                , range=2000.0*1000  # meters

--- a/examples/scenarioAttitudeConstrainedManeuver.py
+++ b/examples/scenarioAttitudeConstrainedManeuver.py
@@ -100,9 +100,15 @@ from Basilisk import __path__
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError, constrainedAttitudeManeuver, rwMotorTorque)
 from Basilisk.simulation import (reactionWheelStateEffector, simpleNav, spacecraft, boreAngCalc)
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -194,7 +200,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
          0.,        0.,         0.1256 / 3]
     scObject.hub.mHub = 4.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     #
     # add RW devices
@@ -308,7 +314,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 500
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     sNavRec = sNavObject.attOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, sNavRec)
     CAMRec = CAM.attRefOutMsg.recorder(samplingTime)
@@ -466,7 +472,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -478,7 +484,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -490,10 +496,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -504,7 +510,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -515,7 +521,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -531,7 +537,7 @@ def plot_st_miss_angle(timeData, dataMissAngle, Fov):
     data = dataMissAngle*macros.R2D
     for idx in range(1):
         plt.plot(timeData, data,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\alpha $')
     plt.fill_between(timeData, 0, 1, where=dataFov >= data, facecolor='red',
                   alpha = 0.4, interpolate=True, transform = trans)
@@ -551,7 +557,7 @@ def plot_ss_miss_angle(timeData, dataMissAngle, Fov):
         data.append(d*macros.R2D)
     for idx in range(len(data)):
         plt.plot(timeData, data[idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\beta_{' + str(idx+1) + '}$')
     dataMinAngle = 180*np.ones(len(timeData))
     for i in range(len(timeData)):

--- a/examples/scenarioAttitudeConstraintViolation.py
+++ b/examples/scenarioAttitudeConstraintViolation.py
@@ -144,9 +144,15 @@ from Basilisk import __path__
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError, inertial3D, rwMotorTorque)
 from Basilisk.simulation import (reactionWheelStateEffector, simpleNav, spacecraft, boreAngCalc)
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -243,7 +249,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
          0.,        0.,         0.1256 / 3]
     scObject.hub.mHub = 4.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     #
     # add RW devices
@@ -350,7 +356,7 @@ def run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCas
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 200
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataRec)
     rwMotorLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
@@ -504,7 +510,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -516,7 +522,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -528,10 +534,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -542,7 +548,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -553,7 +559,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -569,7 +575,7 @@ def plot_st_miss_angle(timeData, dataMissAngle, Fov):
     data = dataMissAngle*macros.R2D
     for idx in range(1):
         plt.plot(timeData, data,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\alpha $')
     plt.fill_between(timeData, 0, 1, where=dataFov >= data, facecolor='red',
                   alpha = 0.4, interpolate=True, transform = trans)
@@ -589,7 +595,7 @@ def plot_ss_miss_angle(timeData, dataMissAngle, Fov):
         data.append(d*macros.R2D)
     for idx in range(len(data)):
         plt.plot(timeData, data[idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\beta_{' + str(idx+1) + '}$')
     dataMinAngle = 180*np.ones(len(timeData))
     for i in range(len(timeData)):

--- a/examples/scenarioAttitudeFeedback.py
+++ b/examples/scenarioAttitudeFeedback.py
@@ -165,7 +165,6 @@ np.set_printoptions(precision=16)
 
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib.pyplot as plt
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
@@ -191,6 +190,7 @@ from Basilisk.utilities import vizSupport
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -240,7 +240,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -344,7 +344,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     # Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     snLog = scObject.scStateOutMsg.recorder(samplingTime)
     # instead of recording the contents of a C++ output message, you can also recording
     # the incoming contents of a C++ input message.  However, note that you must setup the
@@ -402,7 +402,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attErrorLog.sigma_BR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -414,7 +414,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, mrpLog.torqueRequestBody[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -425,7 +425,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attErrorLog.omega_BR_B[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -434,7 +434,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
     plt.figure(4)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, snLog.r_BN_N[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -460,7 +460,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg):
         includeUnlinked=False,
     )
     if "pytest" in sys.modules:
-        unitTestSupport.saveScenarioGraphvizFigure(
+        simHelpers.saveScenarioGraphvizFigure(
             pltName,
             scSim,
             os.path.dirname(os.path.abspath(__file__)),

--- a/examples/scenarioAttitudeFeedback2T.py
+++ b/examples/scenarioAttitudeFeedback2T.py
@@ -141,9 +141,9 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -197,7 +197,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(dynTaskName, scObject)
@@ -263,10 +263,10 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     #
     #   Add logging object to a task group, this controls the logging rate
     numDataPoints = 100
-    dataLog = scObject.scStateOutMsg.recorder(unitTestSupport.samplingTime(simulationTime, simTimeStep, numDataPoints))
-    attErrorLog = attError.attGuidOutMsg.recorder(unitTestSupport.samplingTime(simulationTime,
+    dataLog = scObject.scStateOutMsg.recorder(simHelpers.samplingTime(simulationTime, simTimeStep, numDataPoints))
+    attErrorLog = attError.attGuidOutMsg.recorder(simHelpers.samplingTime(simulationTime,
                                                                                      fswTimeStep, numDataPoints))
-    mrpLog = mrpControl.cmdTorqueOutMsg.recorder(unitTestSupport.samplingTime(simulationTime,
+    mrpLog = mrpControl.cmdTorqueOutMsg.recorder(simHelpers.samplingTime(simulationTime,
                                                                                     fswTimeStep, numDataPoints))
 
     scSim.AddModelToTask(dynTaskName, dataLog)
@@ -346,7 +346,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -358,7 +358,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -369,7 +369,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -378,7 +378,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     plt.figure(4)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataPos[:, idx] / 1000,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -387,7 +387,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain):
     plt.figure(5)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudeFeedback2T_TH.py
+++ b/examples/scenarioAttitudeFeedback2T_TH.py
@@ -231,9 +231,9 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeThruster
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -244,7 +244,7 @@ def plot_attitude_error(timeDataFSW, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeDataFSW, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -255,7 +255,7 @@ def plot_rate_error(timeDataFSW, dataOmegaBR):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeDataFSW, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -266,7 +266,7 @@ def plot_requested_torque(timeDataFSW, dataLr):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeDataFSW, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$L_{r,' + str(idx) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -277,7 +277,7 @@ def plot_thrForce(timeDataFSW, dataMap, numTh):
     plt.figure(4)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataMap[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$thrForce_{' + str(idx) + r'}$'
                  )
     plt.legend(loc='lower right')
@@ -289,7 +289,7 @@ def plot_OnTimeRequest(timeDataFSW, dataSchm, numTh):
     plt.figure(5)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataSchm[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$OnTimeRequest_{' + str(idx) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -344,7 +344,7 @@ def run(show_plots, useDVThrusters):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(dynTaskName, scObject)
@@ -581,7 +581,7 @@ def run(show_plots, useDVThrusters):
     #
 
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, fswTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, fswTimeStep, numDataPoints)
     mrpTorqueLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     snTransLog = sNavObject.transOutMsg.recorder(samplingTime)

--- a/examples/scenarioAttitudeFeedback2T_stateEffTH.py
+++ b/examples/scenarioAttitudeFeedback2T_stateEffTH.py
@@ -117,9 +117,9 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeThruster
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -131,7 +131,7 @@ def plot_attitude_error(timeDataFSW, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeDataFSW, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + r'$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -143,7 +143,7 @@ def plot_rate_error(timeDataFSW, dataOmegaBR):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeDataFSW, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -155,7 +155,7 @@ def plot_requested_torque(timeDataFSW, dataLr):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeDataFSW, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -167,7 +167,7 @@ def plot_thrForce(timeDataFSW, dataMap, numTh):
     plt.figure(4)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataMap[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$thrForce_{' + str(idx) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -179,7 +179,7 @@ def plot_OnTimeRequest(timeDataFSW, dataSchm, numTh):
     plt.figure(5)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataSchm[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$OnTimeRequest_{' + str(idx) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -191,7 +191,7 @@ def plot_trueThrForce(timeDataFSW, dataMap, numTh):
     plt.figure(6)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataMap[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$thrForce_{' + str(idx) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -246,7 +246,7 @@ def run(show_plots, useDVThrusters):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(dynTaskName, scObject)
@@ -486,7 +486,7 @@ def run(show_plots, useDVThrusters):
     #
 
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, fswTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, fswTimeStep, numDataPoints)
     mrpTorqueLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     snTransLog = sNavObject.transOutMsg.recorder(samplingTime)

--- a/examples/scenarioAttitudeFeedbackNoEarth.py
+++ b/examples/scenarioAttitudeFeedbackNoEarth.py
@@ -124,9 +124,9 @@ from Basilisk.simulation import spacecraft
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -177,7 +177,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -233,7 +233,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, attErrorLog)
@@ -296,7 +296,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -308,7 +308,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -319,7 +319,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudeFeedbackNumba.py
+++ b/examples/scenarioAttitudeFeedbackNumba.py
@@ -64,8 +64,14 @@ from Basilisk import __path__
 from Basilisk.architecture import messaging
 from Basilisk.architecture.numbaModel import NumbaModel
 from Basilisk.simulation import extForceTorque, spacecraft
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                 simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.RigidBodyKinematicsNumba import MRP2C, addMRP, subMRP
 
 bskPath = __path__[0]
@@ -351,7 +357,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
          0.,  0.,  600.]
     scObject.hub.mHub        = 750.0                    # [kg]
     scObject.hub.r_BcB_B     = [[0.0], [0.0], [0.0]]   # [m]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scSim.AddModelToTask(simTaskName, scObject)
 
     gravFactory = simIncludeGravBody.gravBodyFactory()
@@ -402,7 +408,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     # Logging
     # -------------------------------------------------------------------------
     numDataPoints = 50
-    samplingTime  = unitTestSupport.samplingTime(simulationTime, simulationTimeStep,
+    samplingTime  = simHelpers.samplingTime(simulationTime, simulationTimeStep,
                                                   numDataPoints)
     attGuidLog = attError.attGuidOutMsg.recorder(samplingTime)
     torqueLog  = mrpCtrl.cmdTorqueOutMsg.recorder(samplingTime)
@@ -464,7 +470,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -476,7 +482,7 @@ def run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudeFeedbackRW.py
+++ b/examples/scenarioAttitudeFeedbackRW.py
@@ -293,9 +293,16 @@ from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError,
                                     inertial3D, rwMotorTorque, rwMotorVoltage)
 from Basilisk.simulation import reactionWheelStateEffector, motorVoltageInterface, simpleNav, spacecraft
-from Basilisk.utilities import (SimulationBaseClass, fswSetupRW, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    fswSetupRW,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -307,7 +314,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -319,7 +326,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -331,10 +338,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -345,7 +352,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -356,7 +363,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -368,7 +375,7 @@ def plot_rw_voltages(timeData, dataVolt, numRW):
     plt.figure(5)
     for idx in range(numRW):
         plt.plot(timeData, dataVolt[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$V_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -417,7 +424,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, 1)
@@ -536,7 +543,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwMotorLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     snTransLog = sNavObject.transOutMsg.recorder(samplingTime)
@@ -578,7 +585,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
     # to show both options.
     fswSetupRW.clearSetup()
     for key, rw in rwFactory.rwList.items():
-        fswSetupRW.create(unitTestSupport.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
+        fswSetupRW.create(simHelpers.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
     fswRwParamMsg1 = fswSetupRW.writeConfigMessage()
 
     # Second case: If the exact same RW configuration states are to be used by the simulation and fsw, then the
@@ -701,7 +708,7 @@ def run(show_plots, useJitterSimple, useRWVoltageIO):
     )
 
     if "pytest" in sys.modules:
-        unitTestSupport.saveScenarioGraphvizFigure(
+        simHelpers.saveScenarioGraphvizFigure(
             pltName,
             scSim,
             os.path.dirname(os.path.abspath(__file__)),

--- a/examples/scenarioAttitudeFeedbackRWPower.py
+++ b/examples/scenarioAttitudeFeedbackRWPower.py
@@ -93,9 +93,15 @@ from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError,
 from Basilisk.simulation import ReactionWheelPower
 from Basilisk.simulation import reactionWheelStateEffector, simpleNav, spacecraft
 from Basilisk.simulation import simpleBattery
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -107,7 +113,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -119,10 +125,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -133,7 +139,7 @@ def plot_rw_power(timeData, dataRwPower, numRW):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataRwPower[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$p_{rw,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -182,7 +188,7 @@ def run(show_plots, useRwPowerGeneration):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, 1)
@@ -315,7 +321,7 @@ def run(show_plots, useRwPowerGeneration):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwCmdLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, rwCmdLog)

--- a/examples/scenarioAttitudeGG.py
+++ b/examples/scenarioAttitudeGG.py
@@ -89,9 +89,9 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -138,7 +138,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -223,7 +223,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     ggLog = ggEff.gravityGradientOutMsg.recorder(samplingTime)
@@ -291,7 +291,7 @@ def run(show_plots):
     vectorData = dataSigmaBR
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Attitude Error Norm $|\sigma_{B/R}|$')
@@ -307,7 +307,7 @@ def run(show_plots):
     vectorData = dataLr
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Control Torque $L_r$ [Nm]')
@@ -318,7 +318,7 @@ def run(show_plots):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeLineSet, ggData[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$r_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudeGuidance.py
+++ b/examples/scenarioAttitudeGuidance.py
@@ -152,9 +152,9 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -169,7 +169,7 @@ def plot_attitude_error(timeLineSet, dataSigmaBR):
     vectorData = dataSigmaBR
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Attitude Error Norm $|\sigma_{B/R}|$')
@@ -180,7 +180,7 @@ def plot_control_torque(timeLineSet, dataLr):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeLineSet, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -191,7 +191,7 @@ def plot_rate_error(timeLineSet, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeLineSet, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -217,7 +217,7 @@ def plot_orientation(timeLineSet, dataPos, dataVel, dataSigmaBN):
                     , r'$\hat\imath_h\cdot \hat b_3$')
     for idx in range(3):
         plt.plot(timeLineSet, data[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=labelStrings[idx])
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -266,7 +266,7 @@ def run(show_plots, useAltBodyFrame):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -358,7 +358,7 @@ def run(show_plots, useAltBodyFrame):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)

--- a/examples/scenarioAttitudePointing.py
+++ b/examples/scenarioAttitudePointing.py
@@ -102,9 +102,9 @@ from Basilisk.simulation import spacecraft
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -157,7 +157,7 @@ def run(show_plots, useLargeTumble):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]  # sigma_BN_B
     if useLargeTumble:
         scObject.hub.omega_BN_BInit = [[0.8], [-0.6], [0.5]]  # rad/s - omega_BN_B
@@ -208,7 +208,7 @@ def run(show_plots, useLargeTumble):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 50
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, attErrorLog)
@@ -265,7 +265,7 @@ def run(show_plots, useLargeTumble):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -277,7 +277,7 @@ def run(show_plots, useLargeTumble):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -288,7 +288,7 @@ def run(show_plots, useLargeTumble):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudePointingNumba.py
+++ b/examples/scenarioAttitudePointingNumba.py
@@ -90,8 +90,8 @@ from Basilisk.simulation import simpleNav
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -126,7 +126,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0                   # [kg]
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]   # [MRP]
     scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]  # [rad/s]
     scSim.AddModelToTask(simTaskName, scObject)
@@ -158,7 +158,7 @@ def run(show_plots):
     scSim.AddModelToTask(simTaskName, numMRPPD)
 
     numDataPoints = 50
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     mrpLog = numMRPPD.cmdTorqueOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, attErrorLog)
@@ -191,7 +191,7 @@ def run(show_plots):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -203,7 +203,7 @@ def run(show_plots):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -214,7 +214,7 @@ def run(show_plots):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudePointingPy.py
+++ b/examples/scenarioAttitudePointingPy.py
@@ -96,9 +96,9 @@ from Basilisk.simulation import spacecraft
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import sysModel
 
 bskPath = __path__[0]
@@ -151,7 +151,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]  # sigma_BN_B
     scObject.hub.omega_BN_BInit = [[0.001], [-0.01], [0.03]]  # rad/s - omega_BN_B
 
@@ -197,7 +197,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 50
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     mrpLog = pyMRPPD.cmdTorqueOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, attErrorLog)
@@ -244,7 +244,7 @@ def run(show_plots):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -256,7 +256,7 @@ def run(show_plots):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -267,7 +267,7 @@ def run(show_plots):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudePrescribed.py
+++ b/examples/scenarioAttitudePrescribed.py
@@ -99,9 +99,9 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 # import message declarations
 bskPath = __path__[0]
@@ -150,7 +150,7 @@ def run(show_plots, useAltBodyFrame):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -217,7 +217,7 @@ def run(show_plots, useAltBodyFrame):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, snAttLog)
 
@@ -253,7 +253,7 @@ def run(show_plots, useAltBodyFrame):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeLineSet, dataSigmaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioAttitudeSteering.py
+++ b/examples/scenarioAttitudeSteering.py
@@ -154,6 +154,7 @@ from Basilisk.simulation import reactionWheelStateEffector
 from Basilisk.simulation import simpleNav
 # import simulation related support
 from Basilisk.simulation import spacecraft
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import RigidBodyKinematics as rb
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
@@ -162,7 +163,6 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion as om
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeRW
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
 
@@ -175,7 +175,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.semilogy(timeData, np.abs(dataSigmaBR[:, idx]),
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$|\sigma_' + str(idx) + '|$')
     plt.legend(loc='upper right')
     plt.xlabel('Time [min]')
@@ -187,7 +187,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -198,7 +198,7 @@ def plot_rw_motor_torque(timeData, dataRW, numRW):
     plt.figure(2)
     for idx in range(3):
         plt.semilogy(timeData, np.abs(dataRW[idx]),
-                     color=unitTestSupport.getLineColor(idx, numRW),
+                     color=simHelpers.getLineColor(idx, numRW),
                      label='$|u_{s,' + str(idx) + '}|$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -209,12 +209,12 @@ def plot_rate_error(timeData, dataOmegaBR, dataOmegaBRAst):
     plt.figure(3)
     for idx in range(3):
         plt.semilogy(timeData, np.abs(dataOmegaBR[:, idx]) / macros.D2R,
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$|\omega_{BR,' + str(idx) + '}|$')
     for idx in range(3):
         plt.semilogy(timeData, np.abs(dataOmegaBRAst[:, idx]) / macros.D2R,
                      '--',
-                     color=unitTestSupport.getLineColor(idx, 3)
+                     color=simHelpers.getLineColor(idx, 3)
                      )
     plt.legend(loc='upper right')
     plt.xlabel('Time [min]')
@@ -226,7 +226,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='upper right')
     plt.xlabel('Time [min]')
@@ -298,7 +298,7 @@ def run(show_plots, simCase):
          0., 0., 200.]
     scObject.hub.mHub = 750.0                   # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]] # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # clear prior gravitational body and SPICE setup definitions
     gravFactory = simIncludeGravBody.gravBodyFactory()
@@ -424,7 +424,7 @@ def run(show_plots, simCase):
     # use the same RW states in the FSW algorithm as in the simulation
     fswSetupRW.clearSetup()
     for key, rw in rwFactory.rwList.items():
-        fswSetupRW.create(unitTestSupport.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
+        fswSetupRW.create(simHelpers.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
     fswRwParamMsg = fswSetupRW.writeConfigMessage()
 
     # setup message connections
@@ -446,7 +446,7 @@ def run(show_plots, simCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 200
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwMotorLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     snTransLog = sNavObject.transOutMsg.recorder(samplingTime)

--- a/examples/scenarioBasicOrbit.py
+++ b/examples/scenarioBasicOrbit.py
@@ -227,9 +227,9 @@ from Basilisk.utilities import (
     macros,
     orbitalMotion,
     simIncludeGravBody,
-    unitTestSupport,
     vizSupport,
 )
+from Basilisk.utilities import simHelpers
 # import the pooch python package data fetching tools
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -399,7 +399,7 @@ def run(show_plots, orbitCase, useSphericalHarmonics, planetCase):
     # The recorder can be put onto a separate task with its own update rate.  However, this can be
     # trickier to do as the recording timing must be carefully balanced with the module msg writing
     # to avoid recording an older message.
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
     # create a logging task object of the spacecraft output message at the desired down sampling ratio
@@ -518,7 +518,7 @@ def plotOrbits(
         plt.plot(
             timeAxis * macros.NANO2SEC / P,
             posData[:, idx] / 1000.0,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label="$r_{BN," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")
@@ -590,7 +590,7 @@ def plotOrbits(
             plt.plot(
                 timeAxis * macros.NANO2SEC / P,
                 Deltar[:, idx],
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 label=r"$\Delta r_{BN," + str(idx) + "}$",
             )
         plt.legend(loc="lower right")

--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -97,10 +97,10 @@ from Basilisk.utilities import (
     macros,
     orbitalMotion,
     simIncludeGravBody,
-    unitTestSupport,
     vizSupport,
     simIncludeThruster,
 )
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import simSynch
 from Basilisk.architecture import messaging
 from Basilisk.simulation import thrusterDynamicEffector
@@ -169,7 +169,7 @@ def run(
     scObject.ModelTag = "bskSat"
     I = [60.0, 0.0, 0.0, 0.0, 30.0, 0.0, 0.0, 0.0, 40.0]
     scObject.hub.mHub = 50.0  # kg - spacecraft mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -259,7 +259,7 @@ def run(
         numDataPoints = 400
     else:
         numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
@@ -449,7 +449,7 @@ Press 'p' to pause the simulation, 'z' to stop the simulation, 'q' to stop the s
         plt.plot(
             dataLog.times() * macros.NANO2SEC / P,
             posData[:, idx] / 1000.0,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label="$r_{BN," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")

--- a/examples/scenarioCSS.py
+++ b/examples/scenarioCSS.py
@@ -175,8 +175,8 @@ from Basilisk.simulation import spacecraft
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion as om
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 
@@ -226,7 +226,7 @@ def run(show_plots, useCSSConstellation, usePlatform, useEclipse, useKelly):
          0., 0., 600.]
     scObject.hub.mHub = 750.0                     # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     #
     # set initial spacecraft states
@@ -379,18 +379,18 @@ def run(show_plots, useCSSConstellation, usePlatform, useEclipse, useKelly):
     if useCSSConstellation:
         for idx in range(len(cssList)):
             plt.plot(cssConstLog.times()*macros.NANO2SEC, dataCSSArray[:, idx],
-                         color=unitTestSupport.getLineColor(idx,3),
+                         color=simHelpers.getLineColor(idx,3),
                          label='CSS$_{'+str(idx)+'}$')
     else:
         timeAxis = css1Log.times()
         plt.plot(timeAxis * macros.NANO2SEC, dataCSS1,
-                 color=unitTestSupport.getLineColor(0, 3),
+                 color=simHelpers.getLineColor(0, 3),
                  label='CSS$_{1}$')
         plt.plot(timeAxis * macros.NANO2SEC, dataCSS2,
-                 color=unitTestSupport.getLineColor(1, 3),
+                 color=simHelpers.getLineColor(1, 3),
                  label='CSS$_{2}$')
         plt.plot(timeAxis * macros.NANO2SEC, dataCSS3,
-                 color=unitTestSupport.getLineColor(2, 3),
+                 color=simHelpers.getLineColor(2, 3),
                  label='CSS$_{3}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [sec]')

--- a/examples/scenarioCSSFilters.py
+++ b/examples/scenarioCSSFilters.py
@@ -265,10 +265,14 @@ import numpy as np
 from Basilisk import __path__
 bskPath = __path__[0]
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 import matplotlib.pyplot as plt
 from Basilisk.utilities import orbitalMotion as om
 from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import simHelpers
 
 from Basilisk.simulation import spacecraft, coarseSunSensor
 from Basilisk.fswAlgorithms import sunlineUKF, sunlineEKF, okeefeEKF, sunlineSEKF, sunlineSuKF
@@ -419,7 +423,7 @@ def run(saveFigures, show_plots, FilterType, simTime):
          0., 0., 600.]
     scObject.hub.mHub = 750.0                   # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]] # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     #
     # set initial spacecraft states

--- a/examples/scenarioCentralBody.py
+++ b/examples/scenarioCentralBody.py
@@ -87,14 +87,19 @@ bskPath = __path__[0]
 from Basilisk.simulation import spacecraft
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.utilities import planetStates
 from numpy import array
 from numpy.linalg import norm
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -212,7 +217,7 @@ def run(show_plots, useCentral):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     plLog = spiceObject.planetStateOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
@@ -273,7 +278,7 @@ def run(show_plots, useCentral):
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(3):
         plt.plot(dataLog.times() * macros.NANO2SEC / P, posData[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')

--- a/examples/scenarioConstrainedDynamicsComponentAnalysis.py
+++ b/examples/scenarioConstrainedDynamicsComponentAnalysis.py
@@ -95,8 +95,13 @@ much smaller than the initial excitation introduced in the servicer's slosh part
 #
 
 # Basilisk imports
-from Basilisk.utilities import (SimulationBaseClass, macros, RigidBodyKinematics, vizSupport,
-                                pythonVariableLogger, unitTestSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    RigidBodyKinematics,
+    vizSupport,
+    pythonVariableLogger,
+)
 from Basilisk.simulation import (spacecraft, constraintDynamicEffector, svIntegrators,
                                  linearSpringMassDamper, hingedRigidBodyStateEffector, fuelTank)
 # plotting imports
@@ -104,6 +109,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 import os
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -171,9 +177,9 @@ def plot_direction_violations(timeData, psi_B1):
     plt.figure(1)
     for i in range(3):
         plt.semilogy(timeData, np.abs(psi_B1[:, i]), alpha=0.8,
-                     color=unitTestSupport.getLineColor(i, 4))
+                     color=simHelpers.getLineColor(i, 4))
     plt.semilogy(timeData, np.linalg.norm(psi_B1, axis=1),
-                 color=unitTestSupport.getLineColor(3, 4))
+                 color=simHelpers.getLineColor(3, 4))
     plt.legend([r'$\psi_1$', r'$\psi_2$', r'$\psi_3$', r'$|\mathbf{\psi}|$'], loc='best')
     plt.xlabel('Time [sec]')
     plt.ylabel('Direction Constraint \nViolation ' r'$\psi$ [m]')
@@ -185,10 +191,10 @@ def plot_attitude_violations(timeData, sigma_B2B1):
     for i in range(3):
         plt.semilogy(timeData,
                      np.abs(4 * np.arctan(sigma_B2B1[:, i]) * macros.R2D), alpha=0.8,
-                     color=unitTestSupport.getLineColor(i, 4))
+                     color=simHelpers.getLineColor(i, 4))
     plt.semilogy(timeData,
                  np.linalg.norm(4 * np.arctan(sigma_B2B1) * macros.R2D, axis=1),
-                 color=unitTestSupport.getLineColor(3, 4))
+                 color=simHelpers.getLineColor(3, 4))
     plt.legend([r'$\phi_1$', r'$\phi_2$', r'$\phi_3$', r'$|\mathbf{\phi}|$'], loc='best')
     plt.xlabel('Time [sec]')
     plt.ylabel('Attitude Constraint \nViolation ' r'$\phi$ [deg]')
@@ -198,9 +204,9 @@ def plot_attitude_violations(timeData, sigma_B2B1):
 def plot_panel_angle_error(timeData, sp1ThetaLog, sp2ThetaLog, sp3ThetaLog, sp4ThetaLog):
     plt.figure(3)
     plt.plot(timeData, (sp1ThetaLog - sp3ThetaLog) * macros.R2D,
-             color=unitTestSupport.getLineColor(0, 2), label=r'$\Delta\theta_1$')
+             color=simHelpers.getLineColor(0, 2), label=r'$\Delta\theta_1$')
     plt.plot(timeData, (sp2ThetaLog - sp4ThetaLog) * macros.R2D,
-             color=unitTestSupport.getLineColor(1, 2), label=r'$\Delta\theta_2$')
+             color=simHelpers.getLineColor(1, 2), label=r'$\Delta\theta_2$')
     plt.legend(loc='best')
     plt.xlabel('Time [sec]')
     plt.ylabel('Panel Angle Error [deg]')
@@ -210,7 +216,7 @@ def plot_slosh_displacement_error(timeData, rhoLog, rhoTLog):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, rhoLog[idx] - rhoTLog[idx],
-                 color=unitTestSupport.getLineColor(idx, 3), label=r'$\Delta\rho_' + str(idx + 1) + '$')
+                 color=simHelpers.getLineColor(idx, 3), label=r'$\Delta\rho_' + str(idx + 1) + '$')
     plt.legend(loc='best')
     plt.xlabel('Time [sec]')
     plt.ylabel('Mass Displacement Error [m]')

--- a/examples/scenarioConstrainedDynamicsFrequencyAnalysis.py
+++ b/examples/scenarioConstrainedDynamicsFrequencyAnalysis.py
@@ -66,7 +66,12 @@ the fictitious frequency does not appear in the truth model.
 #
 
 # Basilisk imports
-from Basilisk.utilities import (SimulationBaseClass, macros, RigidBodyKinematics, vizSupport, unitTestSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    RigidBodyKinematics,
+    vizSupport,
+)
 from Basilisk.simulation import (spacecraft, constraintDynamicEffector, svIntegrators, hingedRigidBodyStateEffector)
 # plotting imports
 import matplotlib.pyplot as plt
@@ -75,6 +80,7 @@ import numpy as np
 import time
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 import os
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -120,7 +126,7 @@ def plot_panel_angles_error(timeData, sp1ThetaLog, sp3ThetaLog, gain_list):
     plt.figure(1)
     for idx, gain in enumerate(gain_list):
         plt.semilogy(timeData[idx], abs((sp1ThetaLog[idx] - sp3ThetaLog[idx])) * macros.R2D,
-                     color=unitTestSupport.getLineColor(idx, len(gain_list)), label=r'$\alpha=$' f'{gain:.0e}')
+                     color=simHelpers.getLineColor(idx, len(gain_list)), label=r'$\alpha=$' f'{gain:.0e}')
     plt.legend(loc='best')
     plt.xlabel('Time [sec]')
     plt.ylabel('Angle Error ' r'$\Delta \theta$ [deg]')
@@ -145,7 +151,7 @@ def plot_fft_panels(sampling_rate, sigma_B2B1_list, gain_list):
 
     plt.figure(2)
     for idx, gain in enumerate(gain_list):
-        plt.loglog(f, X[idx], label=r'$\alpha=$' f'{gain:.0e}', color=unitTestSupport.getLineColor(idx, len(gain_list)))
+        plt.loglog(f, X[idx], label=r'$\alpha=$' f'{gain:.0e}', color=simHelpers.getLineColor(idx, len(gain_list)))
         print(f'Frequency of highest amplitude for gain={gain} is {np.unravel_index(X[idx].argmax(), N // 2)[0] / T} Hz.')
     plt.legend(loc='best')
     plt.xlabel('Freq [Hz]')

--- a/examples/scenarioCustomGravBody.py
+++ b/examples/scenarioCustomGravBody.py
@@ -86,7 +86,7 @@ from Basilisk.simulation import planetEphemeris
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody, vizSupport)
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 # The path to the location of Basilisk
@@ -194,7 +194,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     scRec = scObject.scStateOutMsg.recorder(samplingTime)
     astRec = gravBodyEphem.planetOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, scRec)
@@ -240,7 +240,7 @@ def run(show_plots):
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(3):
         plt.plot(timeAxis, posData[:, idx] ,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BI,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [h]')

--- a/examples/scenarioDataToViz.py
+++ b/examples/scenarioDataToViz.py
@@ -75,7 +75,7 @@ import numpy as np
 from Basilisk.simulation import dataFileToViz
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody, vizSupport)
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
@@ -155,7 +155,7 @@ def run(show_plots, attType):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = []
     for scCounter in range(2):
         dataLog.append(dataModule.scStateOutMsgs[scCounter].recorder(samplingTime))
@@ -223,12 +223,12 @@ def run(show_plots, attType):
     for idx in sigmaB1N:
         sNorm = np.linalg.norm(idx)
         s1Data.append(sNorm)
-    plt.plot(timeData, s1Data, color=unitTestSupport.getLineColor(1, 3), label=r'$|\sigma_{B1/N}|$')
+    plt.plot(timeData, s1Data, color=simHelpers.getLineColor(1, 3), label=r'$|\sigma_{B1/N}|$')
     s2Data = []
     for idx in sigmaB2N:
         sNorm = np.linalg.norm(idx)
         s2Data.append(sNorm)
-    plt.plot(timeData, s2Data, color=unitTestSupport.getLineColor(2, 3), label=r'$|\sigma_{B2/N}|$')
+    plt.plot(timeData, s2Data, color=simHelpers.getLineColor(2, 3), label=r'$|\sigma_{B2/N}|$')
     plt.xlabel('Time [h]')
     plt.ylabel(r'MRP Norm')
     plt.legend(loc='lower right')
@@ -242,7 +242,7 @@ def run(show_plots, attType):
     rhoData = np.array(rhoData)
     for idx in range(3):
         plt.plot(timeData, rhoData[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\rho_{' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [h]')

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -72,9 +72,13 @@ import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import etSphericalControl
 from Basilisk.simulation import simpleNav, spacecraft, extForceTorque, msmForceTorque
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
 
 try:
     from Basilisk.simulation import vizInterface
@@ -85,6 +89,7 @@ except ImportError:
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -174,9 +179,9 @@ def run(show_plots):
 
     # add spacecraft to state
     MSMmodule.addSpacecraftToModel(scObjectServicer.scStateOutMsg, messaging.DoubleVector(rListServicer),
-                                   unitTestSupport.npList2EigenXdVector(spPosListServicer))
+                                   simHelpers.npList2EigenXdVector(spPosListServicer))
     MSMmodule.addSpacecraftToModel(scObjectDebris.scStateOutMsg, messaging.DoubleVector(rListDebris),
-                                   unitTestSupport.npList2EigenXdVector(spPosListDebris))
+                                   simHelpers.npList2EigenXdVector(spPosListDebris))
 
     # subscribe input messages to module
     MSMmodule.voltInMsgs[0].subscribeTo(voltServicerInMsg)

--- a/examples/scenarioDeployingPanel.py
+++ b/examples/scenarioDeployingPanel.py
@@ -30,7 +30,7 @@ The script is found in the folder ``basilisk/examples`` and executed by using::
 
     python3 scenarioDeployingPanel.py
 
-The simulation includes two deploying panels that start undeployed. The first panel deploys fully, 
+The simulation includes two deploying panels that start undeployed. The first panel deploys fully,
 but the second panel deploys off-nominally (to 80%), leading to a reduced power output.
 
 
@@ -90,8 +90,14 @@ bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 from Basilisk.simulation import spacecraft
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import hingedRigidBodyStateEffector, simpleSolarPanel
 from Basilisk.simulation import hingedBodyLinearProfiler, hingedRigidBodyMotor
 import math
@@ -163,9 +169,9 @@ def run(show_plots):
     panel1.ModelTag = "panel1"
     panel1.mass = 100.0
     panel1.IPntS_S = [[100.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]
-    panel1.d = 1.5  
+    panel1.d = 1.5
     panel1.k = 200.
-    panel1.c = 20.  
+    panel1.c = 20.
     panel1.r_HB_B = [[-.5], [0.0], [-1.0]]
     panel1.dcm_HB = [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]]
     panel1.thetaInit = -np.pi
@@ -175,9 +181,9 @@ def run(show_plots):
     panel2.ModelTag = "panel2"
     panel2.mass = 100.0
     panel2.IPntS_S = [[100.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]
-    panel2.d = 1.5  
+    panel2.d = 1.5
     panel2.k = 200.
-    panel2.c = 20.  
+    panel2.c = 20.
     panel2.r_HB_B = [[.5], [0.0], [-1.0]]
     panel2.dcm_HB = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     panel2.thetaInit = -np.pi
@@ -228,7 +234,7 @@ def run(show_plots):
 
     solarPanel1 = simpleSolarPanel.SimpleSolarPanel()
     solarPanel1.ModelTag = "pwr1"
-    solarPanel1.nHat_B = [0, 0, 1]  
+    solarPanel1.nHat_B = [0, 0, 1]
     solarPanel1.panelArea = 2.0  # m^2
     solarPanel1.panelEfficiency = 0.9  # 90% efficiency in power generation
     solarPanel1.stateInMsg.subscribeTo(panel1.hingedRigidBodyConfigLogOutMsg)
@@ -236,7 +242,7 @@ def run(show_plots):
 
     solarPanel2 = simpleSolarPanel.SimpleSolarPanel()
     solarPanel2.ModelTag = "pwr2"
-    solarPanel2.nHat_B = [0, 0, 1] 
+    solarPanel2.nHat_B = [0, 0, 1]
     solarPanel2.panelArea = 2.0  # m^2
     solarPanel2.panelEfficiency = 0.9  # 90% efficiency in power generation
     solarPanel2.stateInMsg.subscribeTo(panel2.hingedRigidBodyConfigLogOutMsg)
@@ -259,7 +265,7 @@ def run(show_plots):
 
     # Setup data logging before the simulation is initialized
     numDataPoints = 1000
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     p1Log = panel1.hingedRigidBodyOutMsg.recorder(samplingTime)
     prof1Log = profiler1.hingedRigidBodyReferenceOutMsg.recorder(samplingTime)
@@ -316,9 +322,9 @@ def run(show_plots):
 
     np.set_printoptions(precision=16)
 
-    figureList = plotOrbits(dataLog.times(), dataSigmaBN, dataOmegaBN_B, 
+    figureList = plotOrbits(dataLog.times(), dataSigmaBN, dataOmegaBN_B,
                             panel1thetaLog, panel1thetaDotLog,
-                            panel2thetaLog, panel2thetaDotLog, 
+                            panel2thetaLog, panel2thetaDotLog,
                             pwrLog1, pwrLog2)
 
     if show_plots:
@@ -345,7 +351,7 @@ def plotOrbits(timeAxis, dataSigmaBN, dataOmegaBN,
     timeData = timeAxis * macros.NANO2SEC
     for idx in range(3):
         plt.plot(timeData, dataSigmaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [s]')
@@ -362,7 +368,7 @@ def plotOrbits(timeAxis, dataSigmaBN, dataOmegaBN,
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(3):
         plt.plot(timeData, dataOmegaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [s]')

--- a/examples/scenarioDragDeorbit.py
+++ b/examples/scenarioDragDeorbit.py
@@ -174,9 +174,9 @@ from Basilisk.utilities import (
     orbitalMotion,
     simIncludeGravBody,
     simSetPlanetEnvironment,
-    unitTestSupport,
     vizSupport,
 )
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -305,7 +305,7 @@ def run(show_plots, initialAlt=250, deorbitAlt=100, model="exponential", useWind
     P = 2. * np.pi / n
     simulationTime = macros.sec2nano(100 * P)
     numDataPoints = 10000
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
 
     # Setup data logging before the simulation is initialized
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)

--- a/examples/scenarioDragRendezvous.py
+++ b/examples/scenarioDragRendezvous.py
@@ -92,8 +92,8 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import astroConstants
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -235,7 +235,7 @@ def setup_spacecraft_plant(rN, vN, modelName):
     scObject.hub.mHub = 6.0
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
     I = [10.0, 0.0, 0.0, 0.0, 9.0, 0.0, 0.0, 0.0, 8.0]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scObject.hub.r_CN_NInit = rN
     scObject.hub.v_CN_NInit = vN
 

--- a/examples/scenarioExtendingBoom.py
+++ b/examples/scenarioExtendingBoom.py
@@ -66,9 +66,13 @@ import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.utilities import SimulationBaseClass, vizSupport, simIncludeGravBody
 from Basilisk.simulation import spacecraft, linearTranslationNDOFStateEffector, prescribedLinearTranslation
-from Basilisk.utilities import macros, orbitalMotion, unitTestSupport
+from Basilisk.utilities import (
+    macros,
+    orbitalMotion,
+)
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -368,7 +372,7 @@ def plotSCStates(timeData, attLog, omegaLog, figureList):
     ax = plt.axes()
     for idx in range(3):
         plt.plot(timeData, attLog[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(fontsize='14')
     # plt.title('Attitude', fontsize='22')
@@ -384,10 +388,10 @@ def plotSCStates(timeData, attLog, omegaLog, figureList):
     ax = plt.axes()
     for idx in range(3):
         plt.plot(timeData, omegaLog[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 4),
+                 color=simHelpers.getLineColor(idx, 4),
                  label=r'$\omega_' + str(idx) + '$')
     plt.plot(timeData, np.linalg.norm(omegaLog, axis=1),
-             color=unitTestSupport.getLineColor(3, 4),
+             color=simHelpers.getLineColor(3, 4),
              label=r'$|\mathbf{\omega}|$',
              linestyle='dashed')
     plt.legend(fontsize='14')

--- a/examples/scenarioFlexiblePanel.py
+++ b/examples/scenarioFlexiblePanel.py
@@ -82,7 +82,6 @@ from Basilisk.utilities import (
     simIncludeGravBody,
     macros,
     orbitalMotion,
-    unitTestSupport,
     RigidBodyKinematics as rbk,
 )
 from Basilisk.simulation import (
@@ -96,6 +95,7 @@ from Basilisk.fswAlgorithms import mrpFeedback, inertial3D, attTrackingError
 from Basilisk.architecture import messaging
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -585,7 +585,7 @@ def plotting(show_plots, thetaData, attErrorLog, scGeometry):
         plt.plot(
             timeSecFSW,
             attErrorLog.sigma_BR[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\sigma_" + str(idx) + "$",
         )
     plt.legend(fontsize="14")
@@ -605,7 +605,7 @@ def plotting(show_plots, thetaData, attErrorLog, scGeometry):
         plt.plot(
             timeSecFSW,
             attErrorLog.omega_BR_B[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\omega_" + str(idx) + "$",
         )
     plt.legend(fontsize="14")

--- a/examples/scenarioFlybySpice.py
+++ b/examples/scenarioFlybySpice.py
@@ -248,9 +248,14 @@ bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 from Basilisk.simulation import spacecraft, gravityEffector, extForceTorque, simpleNav, ephemerisConverter
-from Basilisk.utilities import SimulationBaseClass, macros, simIncludeGravBody, unitTestSupport
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    simIncludeGravBody,
+)
 from Basilisk.architecture import messaging
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 # import general simulation support files
 try:
@@ -359,7 +364,7 @@ def run(planetCase):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # To set the spacecraft initial conditions, the following initial position and velocity variables are set:
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]  # sigma_BN_B

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -110,9 +110,14 @@ from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError,
                                     rwMotorTorque, hillPoint)
 from Basilisk.simulation import reactionWheelStateEffector, simpleNav, spacecraft, svIntegrators
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
 
 try:
     from Basilisk.simulation import vizInterface
@@ -122,6 +127,7 @@ except ImportError:
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -132,7 +138,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -145,7 +151,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -158,10 +164,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -173,7 +179,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -185,7 +191,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -233,7 +239,7 @@ def run(show_plots):
          0., 800., 0.,
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # create the debris object states
     scObject2 = spacecraft.Spacecraft()
@@ -242,7 +248,7 @@ def run(show_plots):
           0., 650., 0.,
           0., 0, 450.]
     scObject2.hub.mHub = 350.0  # kg
-    scObject2.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I2)
+    scObject2.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I2)
     # this next step is not required, just a demonstration how we can ensure that
     # the Servicer and Debris differential equations are integrated simultaneously
     scObject.syncDynamicsIntegration(scObject2)
@@ -261,7 +267,7 @@ def run(show_plots):
           0., 650., 0.,
           0., 0, 450.]
     scObject3.hub.mHub = 350.0  # kg
-    scObject3.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I3)
+    scObject3.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I3)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -385,7 +391,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwCmdLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     sNavLog = sNavObject.transOutMsg.recorder(samplingTime)
@@ -516,7 +522,7 @@ def run(show_plots):
     plt.figure(5)
     for idx in range(numRW2):
         plt.plot(timeData, omegaRW2[idx]*60/(2*3.14159),
-                 color=unitTestSupport.getLineColor(idx, numRW2),
+                 color=simHelpers.getLineColor(idx, numRW2),
                  label=r'$\Omega_{s,' + str(idx) + '}$')
     plt.xlabel('Time [min]')
     plt.ylabel('RW2 Omega (rpm)')

--- a/examples/scenarioFormationMeanOEFeedback.py
+++ b/examples/scenarioFormationMeanOEFeedback.py
@@ -79,8 +79,8 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import astroConstants
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -116,10 +116,10 @@ def run(show_plots, useClassicElem, numOrbits):
     I = [900.0, 0.0, 0.0, 0.0, 800.0, 0.0, 0.0, 0.0, 600.0]
     scObject.hub.mHub = 500.0
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scObject2.hub.mHub = 500.0
     scObject2.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject2.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject2.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     scSim.AddModelToTask(dynTaskName, scObject, 2)
     scSim.AddModelToTask(dynTaskName, scObject2, 2)
@@ -242,7 +242,7 @@ def run(show_plots, useClassicElem, numOrbits):
     simulationTime = orbit_period * numOrbits
     simulationTime = macros.sec2nano(simulationTime)
     numDataPoints = 1000
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, dynTimeStep, numDataPoints
     )
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)

--- a/examples/scenarioFormationReconfig.py
+++ b/examples/scenarioFormationReconfig.py
@@ -91,8 +91,8 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeThruster
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -127,10 +127,10 @@ def run(show_plots, useRefAttitude):
          0., 0., 600.]
     scObject.hub.mHub = 500.0
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scObject2.hub.mHub = 500.0
     scObject2.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject2.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject2.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     scSim.AddModelToTask(dynTaskName, scObject, 2)
     scSim.AddModelToTask(dynTaskName, scObject2, 2)
@@ -266,7 +266,7 @@ def run(show_plots, useRefAttitude):
     simulationTime = orbit_period*1.1
     simulationTime = macros.sec2nano(simulationTime)
     numDataPoints = 1000
-    samplingTime = unitTestSupport.samplingTime(simulationTime, dynTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, dynTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     dataLog2 = scObject2.scStateOutMsg.recorder(samplingTime)
     attRefLog = spacecraftReconfigModule.attRefOutMsg.recorder(samplingTime)

--- a/examples/scenarioFuelSlosh.py
+++ b/examples/scenarioFuelSlosh.py
@@ -183,8 +183,8 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import pythonVariableLogger
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -316,7 +316,7 @@ def run(show_plots, damping_parameter, timeStep):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 

--- a/examples/scenarioGroundDownlink.py
+++ b/examples/scenarioGroundDownlink.py
@@ -76,7 +76,7 @@ from Basilisk.simulation import (
 )
 from Basilisk.simulation import groundLocation
 from Basilisk.utilities import vizSupport
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import macros
@@ -239,7 +239,7 @@ def run(show_plots):
             viz,
             stationName="Boulder Station",
             parentBodyName=planet.displayName,
-            r_GP_P=unitTestSupport.EigenVector3d2list(groundStation.r_LP_P_Init),
+            r_GP_P=simHelpers.EigenVector3d2list(groundStation.r_LP_P_Init),
             fieldOfView=np.radians(160.0),
             color="pink",
             range=1000.0 * 1000,  # meters

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -96,14 +96,12 @@ from Basilisk.simulation import spaceToGroundTransmitter
 from Basilisk.simulation import spacecraft
 
 # import general simulation support files
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.architecture import astroConstants
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
@@ -133,7 +131,7 @@ def plot_attitude_error(timeLineSet, dataSigmaBR):
     plt.plot(
         timeLineSet,
         sNorm,
-        color=unitTestSupport.getLineColor(1, 3),
+        color=simHelpers.getLineColor(1, 3),
     )
     plt.xlabel("Time [min]")
     plt.ylabel(r"Attitude Error Norm $|\sigma_{B/R}|$")
@@ -218,7 +216,7 @@ def run(show_plots):
         [0.0],
         [0.0],
     ]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, ModelPriority=100)
@@ -445,7 +443,7 @@ def run(show_plots):
             viz,
             stationName="Boulder Target",
             parentBodyName=earth.displayName,
-            r_GP_P=unitTestSupport.EigenVector3d2list(imagingTarget.r_LP_P_Init),
+            r_GP_P=simHelpers.EigenVector3d2list(imagingTarget.r_LP_P_Init),
             fieldOfView=np.radians(160.0),
             color="pink",
             range=2000.0 * 1000,  # meters
@@ -470,7 +468,7 @@ def run(show_plots):
             viz,
             stationName="Singapore Station",
             parentBodyName=earth.displayName,
-            r_GP_P=unitTestSupport.EigenVector3d2list(singaporeStation.r_LP_P_Init),
+            r_GP_P=simHelpers.EigenVector3d2list(singaporeStation.r_LP_P_Init),
             fieldOfView=np.radians(160.0),
             color="green",
             range=2000.0 * 1000,  # meters

--- a/examples/scenarioGroundMapping.py
+++ b/examples/scenarioGroundMapping.py
@@ -90,9 +90,6 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import planetStates
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 from Basilisk.architecture import astroConstants
 
 # attempt to import vizard
@@ -107,6 +104,7 @@ except ImportError:
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -123,7 +121,7 @@ def plot_attitude_error(timeLineSet, dataSigmaBR):
     plt.plot(
         timeLineSet,
         sNorm,
-        color=unitTestSupport.getLineColor(1, 3),
+        color=simHelpers.getLineColor(1, 3),
     )
     plt.xlabel("Time [min]")
     plt.ylabel(r"Attitude Error Norm $|\sigma_{B/R}|$")
@@ -221,7 +219,7 @@ def run(show_plots, useCentral):
         [0.0],
         [0.0],
     ]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)

--- a/examples/scenarioGroundTracks.py
+++ b/examples/scenarioGroundTracks.py
@@ -76,8 +76,14 @@ fileName = os.path.basename(os.path.splitext(__file__)[0])
 from Basilisk.simulation import spacecraft
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 # always import the Basilisk messaging support
 
@@ -197,7 +203,7 @@ def run(show_plots):
     simulationTime = macros.sec2nano(2 * P)
 
     numDataPoints = 300
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataList = []
     for sc in scList:
         dataRec = sc.scStateOutMsg.recorder(samplingTime)

--- a/examples/scenarioHaloOrbit.py
+++ b/examples/scenarioHaloOrbit.py
@@ -76,9 +76,9 @@ from Basilisk.utilities import (
     macros,
     orbitalMotion,
     simIncludeGravBody,
-    unitTestSupport,
     vizSupport,
 )
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.pyswice_spk_utilities import spkRead
 from Basilisk.utilities.supportDataTools.dataFetcher import (
     get_path,
@@ -192,7 +192,7 @@ def run(showPlots=True):
 
     # Setup data logging
     numDataPoints = 1000
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
 

--- a/examples/scenarioHelioTransSpice.py
+++ b/examples/scenarioHelioTransSpice.py
@@ -82,8 +82,8 @@ from Basilisk.simulation import spacecraft
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -150,7 +150,7 @@ def run():
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # To set the spacecraft initial conditions, the following initial position and velocity variables are set:
     scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]  # sigma_BN_B

--- a/examples/scenarioHingedRigidBody.py
+++ b/examples/scenarioHingedRigidBody.py
@@ -160,9 +160,9 @@ from Basilisk.utilities import SimulationBaseClass  # The class which contains t
 from Basilisk.utilities import macros  # Some unit conversions
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -286,7 +286,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     pl1Log = scSim.panel1.hingedRigidBodyOutMsg.recorder(samplingTime)
     pl2Log = scSim.panel2.hingedRigidBodyOutMsg.recorder(samplingTime)
@@ -342,7 +342,7 @@ def run(show_plots):
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, posData[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [h]')

--- a/examples/scenarioHohmann.py
+++ b/examples/scenarioHohmann.py
@@ -113,9 +113,9 @@ from Basilisk.utilities import (
     orbitalMotion,
     simIncludeGravBody,
     simIncludeRW,
-    unitTestSupport,
     vizSupport,
 )
+from Basilisk.utilities import simHelpers
 from mpl_toolkits import mplot3d as plt3
 
 bskPath = __path__[0]
@@ -154,7 +154,7 @@ def plotAttitudeError(timeAxis, attErrorData):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attErrorData[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='best')
     plt.xlabel('Time [min]')
@@ -165,7 +165,7 @@ def plotAttitude(timeAxis, attData):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attData[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='best')
     plt.xlabel('Time [min]')
@@ -176,7 +176,7 @@ def plotReferenceAttitude(timeAxis, attRefData):
     plt.figure(4)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attRefData[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='best')
     plt.xlabel('Time [min]')
@@ -218,7 +218,7 @@ def run(show_plots, rFirst, rSecond):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, None, 1)

--- a/examples/scenarioImpact.py
+++ b/examples/scenarioImpact.py
@@ -63,9 +63,10 @@ import matplotlib.pyplot as plt
 
 from Basilisk.utilities import SimulationBaseClass, vizSupport, simIncludeGravBody, orbitalMotion
 from Basilisk.simulation import spacecraft, spinningBodyTwoDOFStateEffector, spinningBodyNDOFStateEffector, extForceTorque
-from Basilisk.utilities import macros, unitTestSupport
+from Basilisk.utilities import macros
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -300,7 +301,7 @@ def run(show_plots):
     plt.clf()
     for idx in range(3):
         plt.plot(theta1Data.times() * macros.NANO2SEC, omega_BN_B[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BN,' + str(idx) + '}$')
     plt.xlabel('time [s]')
     plt.ylabel(r'Angular Velocity [rad/s]')

--- a/examples/scenarioInertialSpiral.py
+++ b/examples/scenarioInertialSpiral.py
@@ -85,7 +85,6 @@ np.set_printoptions(precision=16)
 
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib.pyplot as plt
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
@@ -109,6 +108,7 @@ from Basilisk.architecture import messaging
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -145,7 +145,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -234,7 +234,7 @@ def run(show_plots):
     # Set up data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)
     snLog = sNavObject.scStateInMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
@@ -292,7 +292,7 @@ def run(show_plots):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attErrorLog.sigma_BR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -304,7 +304,7 @@ def run(show_plots):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, mrpLog.torqueRequestBody[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='upper right')
     plt.xlabel('Time [min]')
@@ -315,7 +315,7 @@ def run(show_plots):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2MIN, attErrorLog.omega_BR_B[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -325,9 +325,9 @@ def run(show_plots):
 
     plt.figure(4)
     plt.plot(timeLineSet, dataEulerAnglesYaw,
-                 color=unitTestSupport.getLineColor(0, 3),label=r'Yaw')
+                 color=simHelpers.getLineColor(0, 3),label=r'Yaw')
     plt.plot(timeLineSet, dataEulerAnglesPitch,
-                 color=unitTestSupport.getLineColor(1, 3),label=r'Pitch')
+                 color=simHelpers.getLineColor(1, 3),label=r'Pitch')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
     plt.ylabel('Euler Angles [rad]')

--- a/examples/scenarioIntegrators.py
+++ b/examples/scenarioIntegrators.py
@@ -152,12 +152,10 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -287,7 +285,7 @@ def run(show_plots, integratorCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
@@ -348,7 +346,7 @@ def run(show_plots, integratorCase):
     plt.plot(
         rData * np.cos(fData) / 1000,
         rData * np.sin(fData) / 1000
-        # , color=unitTestSupport.getLineColor(labelStrings.index(integratorCase), len(labelStrings))
+        # , color=simHelpers.getLineColor(labelStrings.index(integratorCase), len(labelStrings))
         ,
         label=integratorCase,
         linewidth=3.0,

--- a/examples/scenarioIntegratorsComparison.py
+++ b/examples/scenarioIntegratorsComparison.py
@@ -26,12 +26,12 @@ The script is found in the folder ``basilisk/examples`` and executed by using::
 
       python3 scenarioIntegratorsComparison.py
 
-For information on how to setup different integrators, see :ref:`scenarioIntegrators` and :ref:`scenarioVariableTimeStepIntegrators`. 
+For information on how to setup different integrators, see :ref:`scenarioIntegrators` and :ref:`scenarioVariableTimeStepIntegrators`.
 
 Currently, Basilisk only supports explicit Runge-Kutta integrators,
 both of the regular and adaptive variations. Non-adaptive Runge-Kutta
 integrators can be controlled solely by the step size: larger step
-sizes means that faster computation, but less accurate results. 
+sizes means that faster computation, but less accurate results.
 
 In contrast, adaptive Runge-Kutta methods are affected both by the step
 size and absolute and relative tolerance. These integrators will try
@@ -39,10 +39,10 @@ to use the user-given step size, but if the error grows too large, a
 smaller time step is used internally for greater accuracy.
 
 When using an adaptive integrator, the Basilisk dynamics task time step
-can be increased without risk of increasing the integration error. However, 
+can be increased without risk of increasing the integration error. However,
 this also means that other modules in the task are updated less often,
 which might be undesirable. Additionally, spacecraft state messages will
-also be updated less frequently. 
+also be updated less frequently.
 
 Finally, each integrator is associated with an order. Greater
 order integrators are more accurate, but more computationally
@@ -54,11 +54,11 @@ Five integrators are compared in this section, two of them adaptive.
 These are the Euler method (order 1), Heun's method (order 2),
 the Runge-Kutta 4 (order 4), the Runge-Kutta-Fehlberg 4(5) (adaptive
 with order 5), and the Runge-Kutta-Fehlberg 7(8) (adaptive with order 8).
-The adaptive integrators are used with two different absolute 
+The adaptive integrators are used with two different absolute
 tolerances: 0.1 and 10.
 
 Each integrator is used to propagate a two-body orbit around the
-Earth. The final position of each propagation is compared to 
+Earth. The final position of each propagation is compared to
 the analytical solution, and a final position error is obtained.
 Moreover, the time that it takes to propagate each orbit is recorded.
 
@@ -93,12 +93,12 @@ similarly to fixed-step RK methods. The main difference occurs
 for the larger time steps in which time adaption takes place.
 Here, a tighter tolerance would translate into higher computational
 costs. However, this is hard to see in the plot given the inherent
-noisiness of performance measuring. 
+noisiness of performance measuring.
 
-Fixed-timestep integrators are helpful when you want your simulation runtime 
-to be consistent as you vary simulation parameters. Since there is no adaptation, 
-runtime will be similar even if the parameters change the stiffness of the system's 
-dynamic equations. Of course, this comes at the cost of accuracy, but can it be 
+Fixed-timestep integrators are helpful when you want your simulation runtime
+to be consistent as you vary simulation parameters. Since there is no adaptation,
+runtime will be similar even if the parameters change the stiffness of the system's
+dynamic equations. Of course, this comes at the cost of accuracy, but can it be
 very useful for hardware-in-the-loop simulations.
 
 One should note that adaptive RK methods are inherently slower than
@@ -133,7 +133,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # The following code may not be very interesting to learn how to
 # set up different integrators. To learn this, refer to the other
@@ -192,7 +192,7 @@ def run(show_plots=True):
         ax.loglog(
             time_steps_to_test,
             errors[integrator],
-            color=unitTestSupport.getLineColor(INTEGRATORS[integrator].color, 5),
+            color=simHelpers.getLineColor(INTEGRATORS[integrator].color, 5),
             linestyle=INTEGRATORS[integrator].linestyle,
             label=INTEGRATORS[integrator].label,
         )
@@ -205,7 +205,7 @@ def run(show_plots=True):
         ax.loglog(
             time_steps_to_test,
             times[integrator],
-            color=unitTestSupport.getLineColor(INTEGRATORS[integrator].color, 5),
+            color=simHelpers.getLineColor(INTEGRATORS[integrator].color, 5),
             linestyle=INTEGRATORS[integrator].linestyle,
             label=INTEGRATORS[integrator].label,
         )

--- a/examples/scenarioJupiterArrival.py
+++ b/examples/scenarioJupiterArrival.py
@@ -91,8 +91,14 @@ bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 from Basilisk.simulation import spacecraft, gravityEffector
-from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 def run(show_plots):
     """
@@ -192,7 +198,7 @@ def run(show_plots):
 
     # Setup data logging before the simulation is initialized
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataRec)
 
@@ -257,7 +263,7 @@ def plotOrbits(timeAxis, posData, jupiter, a_park, e_park):
 
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2SEC, posData[:,idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')

--- a/examples/scenarioLagrangePointOrbit.py
+++ b/examples/scenarioLagrangePointOrbit.py
@@ -141,9 +141,9 @@ from Basilisk.utilities import (
     macros,
     orbitalMotion,
     simIncludeGravBody,
-    unitTestSupport,
     vizSupport,
 )
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.pyswice_spk_utilities import spkRead
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -257,7 +257,7 @@ def run(lagrangePoint, nOrbits, timestep, showPlots=True):
 
     # Setup data logging
     numDataPoints = 1000
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
 

--- a/examples/scenarioLambertSolver.py
+++ b/examples/scenarioLambertSolver.py
@@ -108,7 +108,7 @@ from Basilisk.simulation import simpleNav
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody, vizSupport)
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 try:
     from Basilisk.simulation import vizInterface
@@ -298,12 +298,12 @@ def run(show_plots):
 
     # Next, the state manager objects are called to retrieve the latest inertial position and
     # velocity vector components:
-    vm_N = unitTestSupport.EigenVector3d2np(velRef.getState())
+    vm_N = simHelpers.EigenVector3d2np(velRef.getState())
 
     dv_N = dvCmd_recorder.dvInrtlCmd[-1, :]
 
     # After reading the Delta-V command, the state managers velocity is updated through
-    velRef.setState(unitTestSupport.np2EigenVectorXd(vm_N + dv_N))
+    velRef.setState(simHelpers.np2EigenVectorXd(vm_N + dv_N))
     # disable flight software after maneuver
     fswProcess.disableAllTasks()
 

--- a/examples/scenarioMagneticFieldCenteredDipole.py
+++ b/examples/scenarioMagneticFieldCenteredDipole.py
@@ -161,12 +161,17 @@ from Basilisk.simulation import spacecraft
 from Basilisk.simulation import magneticFieldCenteredDipole
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.utilities import simSetPlanetEnvironment
 
 #attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 
@@ -296,7 +301,7 @@ def run(show_plots, orbitCase, planetCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     magLog = magModule.envOutMsgs[0].recorder(samplingTime)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, magLog)
@@ -342,7 +347,7 @@ def run(show_plots, orbitCase, planetCase):
     timeAxis = dataLog.times() * macros.NANO2SEC
     for idx in range(3):
         plt.plot(timeAxis / P, posData[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')
@@ -358,7 +363,7 @@ def run(show_plots, orbitCase, planetCase):
     ax.get_yaxis().set_major_formatter(plt.FuncFormatter(lambda x, loc: "{:,}".format(int(x))))
     for idx in range(3):
         plt.plot(timeAxis / P, magData[:, idx] *1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$B\_N_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')
@@ -366,7 +371,7 @@ def run(show_plots, orbitCase, planetCase):
     if planetCase == 'Earth' and orbitCase == 'elliptical':
         for idx in range(3):
             plt.plot(timeAxis / P, magData2[:, idx] * 1e9, '--',
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$B\_N_{' + str(idx) + '}$')
     pltName = fileName + "2" + orbitCase + planetCase
     figureList[pltName] = plt.figure(2)

--- a/examples/scenarioMagneticFieldWMM.py
+++ b/examples/scenarioMagneticFieldWMM.py
@@ -142,12 +142,12 @@ from Basilisk.simulation import magneticFieldWMM
 
 # general support file with common unit test functions
 # import general simulation support files
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import (
     SimulationBaseClass,
     macros,
     orbitalMotion,
     simIncludeGravBody,
-    unitTestSupport,
 )
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -214,7 +214,7 @@ def run(show_plots, orbitCase):
         magModule.envMaxReach = 20000 * 1000.0
 
     # set epoch date/time message
-    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(
+    epochMsg = simHelpers.timeStringToGregorianUTCMsg(
         "2019 June 27, 10:23:0.0 (UTC)"
     )
 
@@ -269,7 +269,7 @@ def run(show_plots, orbitCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
@@ -357,7 +357,7 @@ def run(show_plots, orbitCase):
         plt.plot(
             timeAxis / P,
             magData[:, idx] * 1e9,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$B\_N_{" + str(idx) + "}$",
         )
     plt.legend(loc="lower right")

--- a/examples/scenarioMomentumDumping.py
+++ b/examples/scenarioMomentumDumping.py
@@ -90,9 +90,16 @@ from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError, inertial3D, rwMotorTorque,
                                     thrMomentumManagement, thrForceMapping, thrMomentumDumping)
 from Basilisk.simulation import (reactionWheelStateEffector, thrusterDynamicEffector, simpleNav, spacecraft)
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, simIncludeThruster, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    simIncludeThruster,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -181,7 +188,7 @@ def run(show_plots):
          0.,    0.,    1800]
     scObject.hub.mHub = 2500  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [1.28]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     #
     # add RW devices
@@ -372,7 +379,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 5000
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStepDyn, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStepDyn, numDataPoints)
     sNavRec = sNavObject.attOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(dynTask, sNavRec)
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
@@ -490,7 +497,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + r'$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -501,7 +508,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx+1) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -519,7 +526,7 @@ def plot_rw_momenta(timeData, dataOmegaRw, RW, numRW):
     plt.figure(3)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRw[:, idx] * RW[idx].Js,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$H_{' + str(idx+1) + r'}$')
     plt.plot(timeData, totMomentumNorm, '--',
              label=r'$\|H\|$')
@@ -532,7 +539,7 @@ def plot_DH(timeData, dataDH):
     plt.figure(4)
     for idx in range(3):
         plt.plot(timeData, dataDH[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\Delta H_{' + str(idx+1) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -543,7 +550,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(5)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx+1) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -554,7 +561,7 @@ def plot_thrImpulse(timeDataFSW, dataMap, numTh):
     plt.figure(5)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataMap[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$thrImpulse_{' + str(idx+1) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -565,7 +572,7 @@ def plot_OnTimeRequest(timeData, dataOnTime, numTh):
     plt.figure(6)
     for idx in range(numTh):
         plt.plot(timeData, dataOnTime[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$OnTimeRequest_{' + str(idx+1) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -576,7 +583,7 @@ def plot_thrForce(timeDataFSW, dataThr, numTh):
     plt.figure(7)
     for idx in range(numTh):
         plt.plot(timeDataFSW, dataThr[idx],
-                 color=unitTestSupport.getLineColor(idx, numTh),
+                 color=simHelpers.getLineColor(idx, numTh),
                  label=r'$thrForce_{' + str(idx+1) + r'}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioMonteCarloAttRW.py
+++ b/examples/scenarioMonteCarloAttRW.py
@@ -197,7 +197,7 @@ bskPath = __path__[0]
 
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 
@@ -505,7 +505,7 @@ def createScenarioAttitudeFeedbackRW():
          0., 0., 600.]
     scSim.scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scSim.scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scSim.scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scSim.scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scSim.hubref = scSim.scObject.hub
 
     # add spacecraft object to the simulation process
@@ -588,7 +588,7 @@ def createScenarioAttitudeFeedbackRW():
     # use the same RW states in the FSW algorithm as in the simulation
     fswSetupRW.clearSetup()
     for key, rw in scSim.rwFactory.rwList.items():
-        fswSetupRW.create(unitTestSupport.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
+        fswSetupRW.create(simHelpers.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
     scSim.fswRwConfMsg = fswSetupRW.writeConfigMessage()
 
     # setup inertial3D guidance module
@@ -782,7 +782,7 @@ def plotSimAndSave(data, retentionPolicy):
     figureList = plotSim(data, retentionPolicy)
     for pltName, plt in list(figureList.items()):
         # plt.subplots_adjust(top = 0.6, bottom = 0.4)
-        unitTestSupport.saveScenarioFigure(
+        simHelpers.saveScenarioFigure(
             fileNameString + "_" + pltName
             , plt, path + "/dataForExamples")
 

--- a/examples/scenarioMtbMomentumManagement.py
+++ b/examples/scenarioMtbMomentumManagement.py
@@ -90,9 +90,15 @@ from Basilisk.simulation import (reactionWheelStateEffector,
                                  simpleNav,
                                  magneticFieldWMM, magnetometer, MtbEffector,
                                  spacecraft)
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 bskPath = __path__[0]
@@ -106,7 +112,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -119,7 +125,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -132,10 +138,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(numRW):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -147,7 +153,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -159,7 +165,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -171,7 +177,7 @@ def plot_magnetic_field(timeData, dataMagField):
     plt.figure(5)
     for idx in range(3):
         plt.plot(timeData, dataMagField[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$B\_N_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -183,7 +189,7 @@ def plot_data_tam(timeData, dataTam):
     plt.figure(6)
     for idx in range(3):
         plt.plot(timeData, dataTam[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM\_S_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -195,7 +201,7 @@ def plot_data_tam_comm(timeData, dataTamComm):
     plt.figure(7)
     for idx in range(3):
         plt.plot(timeData, dataTamComm[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM\_B_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -207,7 +213,7 @@ def plot_data_mtb_momentum_management(timeData, dataMtbMomentumManegement, numMT
     plt.figure(8)
     for idx in range(numMTB):
         plt.plot(timeData, dataMtbMomentumManegement[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numMTB),
+                 color=simHelpers.getLineColor(idx, numMTB),
                  label=r'$MTB\_T_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -220,7 +226,7 @@ def plot_data_rw_motor_torque_desired(dataUsReq, tauRequested_W, numRW):
     plt.figure(9)
     for idx in range(numRW):
         plt.plot(tauRequested_W[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -270,7 +276,7 @@ def run(show_plots):
          0., 0., 0.1256 / 3]
     scObject.hub.mHub = 10.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, 1)
@@ -343,7 +349,7 @@ def run(show_plots):
     magModule.ModelTag = "WMM"
     wmm_path = get_path(DataFile.MagneticFieldData.WMM)
     magModule.configureWMMFile(str(wmm_path))
-    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
+    epochMsg = simHelpers.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
     magModule.epochInMsg.subscribeTo(epochMsg)
     magModule.addSpacecraftToModel(scObject.scStateOutMsg)  # this command can be repeated if multiple
     scSim.AddModelToTask(simTaskName, magModule)
@@ -431,7 +437,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 200
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwMotorLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     magLog = magModule.envOutMsgs[0].recorder(samplingTime)

--- a/examples/scenarioMtbMomentumManagementSimple.py
+++ b/examples/scenarioMtbMomentumManagementSimple.py
@@ -100,9 +100,15 @@ from Basilisk.simulation import (reactionWheelStateEffector,
                                  simpleNav,
                                  magneticFieldWMM, magnetometer, MtbEffector,
                                  spacecraft)
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 bskPath = __path__[0]
@@ -115,7 +121,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -128,7 +134,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -141,10 +147,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(numRW):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -156,7 +162,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -168,7 +174,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -180,7 +186,7 @@ def plot_magnetic_field(timeData, dataMagField):
     plt.figure(5)
     for idx in range(3):
         plt.plot(timeData, dataMagField[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$B\_N_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -192,7 +198,7 @@ def plot_data_tam(timeData, dataTam):
     plt.figure(6)
     for idx in range(3):
         plt.plot(timeData, dataTam[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM\_S_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -204,7 +210,7 @@ def plot_data_tam_comm(timeData, dataTamComm):
     plt.figure(7)
     for idx in range(3):
         plt.plot(timeData, dataTamComm[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM\_B_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -216,7 +222,7 @@ def plot_data_mtb_momentum_management(timeData, dataMtbMomentumManegement, numMT
     plt.figure(8)
     for idx in range(numMTB):
         plt.plot(timeData, dataMtbMomentumManegement[:, idx],
-                 color=unitTestSupport.getLineColor(idx, numMTB),
+                 color=simHelpers.getLineColor(idx, numMTB),
                  label=r'$MTB\_T_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -229,7 +235,7 @@ def plot_data_rw_motor_torque_desired(dataUsReq, tauRequested_W, numRW):
     plt.figure(9)
     for idx in range(numRW):
         plt.plot(tauRequested_W[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -277,7 +283,7 @@ def run(show_plots):
          0., 0., 0.1256 / 3]
     scObject.hub.mHub = 10.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, 1)
@@ -350,7 +356,7 @@ def run(show_plots):
     magModule.ModelTag = "WMM"
     wmm_path = get_path(DataFile.MagneticFieldData.WMM)
     magModule.configureWMMFile(str(wmm_path))
-    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
+    epochMsg = simHelpers.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
     magModule.epochInMsg.subscribeTo(epochMsg)
     magModule.addSpacecraftToModel(scObject.scStateOutMsg)  # this command can be repeated if multiple
     scSim.AddModelToTask(simTaskName, magModule)
@@ -483,7 +489,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 200
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwMotorLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrorLog = attError.attGuidOutMsg.recorder(samplingTime)
     magLog = magModule.envOutMsgs[0].recorder(samplingTime)

--- a/examples/scenarioOrbitManeuver.py
+++ b/examples/scenarioOrbitManeuver.py
@@ -102,11 +102,11 @@ import numpy as np
 # Used to get the location of supporting data.
 from Basilisk import __path__
 from Basilisk.simulation import spacecraft
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
 
@@ -200,7 +200,7 @@ def run(show_plots, maneuverCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataRec)
 
@@ -237,8 +237,8 @@ def run(show_plots, maneuverCase):
 
     # Next, the state manager objects are called to retrieve the latest inertial position and
     # velocity vector components:
-    rVt = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vVt = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rVt = simHelpers.EigenVector3d2np(posRef.getState())
+    vVt = simHelpers.EigenVector3d2np(velRef.getState())
 
     # compute maneuver Delta_v's
     if maneuverCase == 1:
@@ -274,8 +274,8 @@ def run(show_plots, maneuverCase):
     # This process is then repeated for the second maneuver.
 
     # get the current spacecraft states
-    rVt = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vVt = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rVt = simHelpers.EigenVector3d2np(posRef.getState())
+    vVt = simHelpers.EigenVector3d2np(velRef.getState())
     # compute maneuver Delta_v's
     if maneuverCase == 1:
         # inclination change
@@ -324,7 +324,7 @@ def run(show_plots, maneuverCase):
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(3):
         plt.plot(dataRec.times() * macros.NANO2HOUR, posData[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [h]')

--- a/examples/scenarioOrbitManeuverTH.py
+++ b/examples/scenarioOrbitManeuverTH.py
@@ -98,12 +98,12 @@ from Basilisk.simulation import spacecraft
 from Basilisk.simulation import svIntegrators
 from Basilisk.simulation import thrusterStateEffector
 # import general simulation support files
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeThruster
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
 
@@ -147,7 +147,7 @@ def run(show_plots):
          0., 800., 0.,
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)
@@ -268,7 +268,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)
@@ -328,8 +328,8 @@ def run(show_plots):
 
     # Next, the state manager objects are called to retrieve the latest inertial position and
     # velocity vector components:
-    rVt = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vVt = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rVt = simHelpers.EigenVector3d2np(posRef.getState())
+    vVt = simHelpers.EigenVector3d2np(velRef.getState())
 
     # Hohmann Transfer to GEO
     v0 = np.linalg.norm(vVt)
@@ -353,8 +353,8 @@ def run(show_plots):
     scSim.ExecuteSimulation()
 
     # get the current spacecraft states
-    rVt = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vVt = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rVt = simHelpers.EigenVector3d2np(posRef.getState())
+    vVt = simHelpers.EigenVector3d2np(velRef.getState())
 
     # Find the time from current orbital position to apogee
     oe1 = orbitalMotion.rv2elem(mu, rVt, vVt)
@@ -369,8 +369,8 @@ def run(show_plots):
     scSim.ExecuteSimulation()
 
     # get the current spacecraft states
-    rVt = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vVt = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rVt = simHelpers.EigenVector3d2np(posRef.getState())
+    vVt = simHelpers.EigenVector3d2np(velRef.getState())
 
     # Compute second Delta-v maneuver
     v1 = np.linalg.norm(vVt)
@@ -413,7 +413,7 @@ def run(show_plots):
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(3):
         plt.plot(dataRec.times() * macros.NANO2HOUR, posData[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [h]')

--- a/examples/scenarioOrbitMultiBody.py
+++ b/examples/scenarioOrbitMultiBody.py
@@ -121,13 +121,11 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 from Basilisk.architecture import astroConstants
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.pyswice_spk_utilities import spkRead
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -290,7 +288,7 @@ def run(show_plots, scCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 50
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
@@ -347,7 +345,7 @@ def run(show_plots, scCase):
         plt.plot(
             timeAxis * timeScale,
             posData[:, idx] / axesScale,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label="$r_{BN," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")
@@ -451,7 +449,7 @@ def run(show_plots, scCase):
         plt.plot(
             dataRec.times() * macros.NANO2MIN,
             np.array(posError)[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\Delta r_{" + str(idx) + "}$",
         )
     plt.legend(loc="lower right")
@@ -472,7 +470,7 @@ def run(show_plots, scCase):
     )
 
     if "pytest" in sys.modules:
-        unitTestSupport.saveScenarioGraphvizFigure(
+        simHelpers.saveScenarioGraphvizFigure(
             pltName,
             scSim,
             os.path.dirname(os.path.abspath(__file__)),

--- a/examples/scenarioPatchedConics.py
+++ b/examples/scenarioPatchedConics.py
@@ -104,7 +104,13 @@ from Basilisk import __path__
 
 bskPath = __path__[0]
 from Basilisk.simulation import spacecraft, gravityEffector
-from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.architecture import messaging
 from Basilisk.utilities import vizSupport
 
@@ -228,7 +234,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 
@@ -252,8 +258,8 @@ def run(show_plots):
     posRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubPosition)
     velRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubVelocity)
 
-    rN = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vN = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rN = simHelpers.EigenVector3d2np(posRef.getState())
+    vN = simHelpers.EigenVector3d2np(velRef.getState())
 
     v_S_E = vN - vel_N_Earth  # vel of s/c (S) wrt Earth (E)
 
@@ -298,8 +304,8 @@ def run(show_plots):
     # manipulated and fed back to the simulation by:
     posRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubPosition)
     velRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubVelocity)
-    rN = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vN = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rN = simHelpers.EigenVector3d2np(posRef.getState())
+    vN = simHelpers.EigenVector3d2np(velRef.getState())
 
     pos_N_Earth = [0.0, -149598023 * 1000, 0.0]
     depVel_N_Earth = [29.7859 * 1000, 0, 0]
@@ -369,8 +375,8 @@ def run(show_plots):
 
     posRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubPosition)
     velRef = scObject.dynManager.getStateObject(scObject.hub.nameOfHubVelocity)
-    rN = unitTestSupport.EigenVector3d2np(posRef.getState())
-    vN = unitTestSupport.EigenVector3d2np(velRef.getState())
+    rN = simHelpers.EigenVector3d2np(posRef.getState())
+    vN = simHelpers.EigenVector3d2np(velRef.getState())
 
     pos_N_Jup = [0.0, rJupiter, 0.0]
     vel_N_Jup = [-13.0697 * 1000, 0.0, 0.0]

--- a/examples/scenarioPrescribedMotionWithRotationBranching.py
+++ b/examples/scenarioPrescribedMotionWithRotationBranching.py
@@ -84,7 +84,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import prescribedMotionStateEffector, spacecraft, spinningBodyOneDOFStateEffector
 from Basilisk.simulation import prescribedLinearTranslation
 from Basilisk.simulation import prescribedRotation1DOF

--- a/examples/scenarioPrescribedMotionWithTranslationBranching.py
+++ b/examples/scenarioPrescribedMotionWithTranslationBranching.py
@@ -91,7 +91,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import prescribedMotionStateEffector, spacecraft, linearTranslationOneDOFStateEffector
 from Basilisk.simulation import prescribedLinearTranslation
 from Basilisk.simulation import prescribedRotation1DOF

--- a/examples/scenarioPrescribedScrewMotion.py
+++ b/examples/scenarioPrescribedScrewMotion.py
@@ -73,7 +73,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import os
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import prescribedMotionStateEffector, spacecraft
 from Basilisk.simulation import prescribedRotation1DOF
 from Basilisk.architecture import messaging

--- a/examples/scenarioQuadMaps.py
+++ b/examples/scenarioQuadMaps.py
@@ -98,8 +98,14 @@ from Basilisk.simulation import spacecraft
 
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -175,7 +181,7 @@ def run(show_plots):
 
     # Set up data logging before the simulation is initialized
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     # create a logging task object of the spacecraft output message at the desired down sampling ratio
     dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataRec)

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -92,9 +92,15 @@ from Basilisk.fswAlgorithms import locationPointing
 from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError,
                                     rwMotorTorque, hillPoint)
 from Basilisk.simulation import reactionWheelStateEffector, simpleNav, spacecraft, ephemerisConverter
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
 
 try:
     from Basilisk.simulation import vizInterface
@@ -114,7 +120,7 @@ def plot_attitude_error(timeData, dataSigmaBR):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -127,7 +133,7 @@ def plot_rw_cmd_torque(timeData, dataUsReq, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -140,10 +146,10 @@ def plot_rw_motor_torque(timeData, dataUsReq, dataRW, numRW):
     for idx in range(3):
         plt.plot(timeData, dataUsReq[:, idx],
                  '--',
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\hat u_{s,' + str(idx) + '}$')
         plt.plot(timeData, dataRW[idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$u_{s,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -155,7 +161,7 @@ def plot_rate_error(timeData, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeData, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -167,7 +173,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW):
     plt.figure(4)
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -215,7 +221,7 @@ def run(show_plots):
          0., 800., 0.,
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # create the debris object states
     scObject2 = spacecraft.Spacecraft()
@@ -224,7 +230,7 @@ def run(show_plots):
           0., 650., 0.,
           0., 0, 450.]
     scObject2.hub.mHub = 350.0  # kg
-    scObject2.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I2)
+    scObject2.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I2)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, 1)
@@ -380,7 +386,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     rwCmdLog = rwMotorTorqueObj.rwMotorTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     sNavLog = sNavObject.transOutMsg.recorder(samplingTime)
@@ -478,10 +484,10 @@ def run(show_plots):
         scSim.ExecuteSimulation()
 
     def relOrbDrift():
-        rd = unitTestSupport.EigenVector3d2np(servicerPos.getState())
-        vd = unitTestSupport.EigenVector3d2np(servicerVel.getState())
-        rc = unitTestSupport.EigenVector3d2np(debrisPos.getState())
-        vc = unitTestSupport.EigenVector3d2np(debrisVel.getState())
+        rd = simHelpers.EigenVector3d2np(servicerPos.getState())
+        vd = simHelpers.EigenVector3d2np(servicerVel.getState())
+        rc = simHelpers.EigenVector3d2np(debrisPos.getState())
+        vc = simHelpers.EigenVector3d2np(debrisVel.getState())
         rho_H, rho_Prime_H = orbitalMotion.rv2hill(rc, vc, rd, vd)
         xOff = rho_H[0]
         rho_Prime_H[0] = 0.0
@@ -490,10 +496,10 @@ def run(show_plots):
         servicerVel.setState(vd)
 
     def relativeEllipse(A0, xOff, B0=-1):
-        rd = unitTestSupport.EigenVector3d2np(servicerPos.getState())
-        vd = unitTestSupport.EigenVector3d2np(servicerVel.getState())
-        rc = unitTestSupport.EigenVector3d2np(debrisPos.getState())
-        vc = unitTestSupport.EigenVector3d2np(debrisVel.getState())
+        rd = simHelpers.EigenVector3d2np(servicerPos.getState())
+        vd = simHelpers.EigenVector3d2np(servicerVel.getState())
+        rc = simHelpers.EigenVector3d2np(debrisPos.getState())
+        vc = simHelpers.EigenVector3d2np(debrisVel.getState())
         rho_H, rho_Prime_H = orbitalMotion.rv2hill(rc, vc, rd, vd)
         alpha = np.arccos((rho_H[0] - xOff)/A0)
         if B0 > 0.01:

--- a/examples/scenarioRoboticArm.py
+++ b/examples/scenarioRoboticArm.py
@@ -76,7 +76,6 @@ from Basilisk.utilities import (
     simIncludeGravBody,
     macros,
     orbitalMotion,
-    unitTestSupport,
 )
 from Basilisk.simulation import (
     spacecraft,
@@ -86,6 +85,7 @@ from Basilisk.simulation import (
 from Basilisk.architecture import messaging
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -515,7 +515,7 @@ def plotting(show_plots, scLog, thetaLog):
         plt.plot(
             dynTimeMin,
             sigma_BN[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\sigma_" + str(idx) + "$",
         )
     plt.legend(fontsize="14")
@@ -535,7 +535,7 @@ def plotting(show_plots, scLog, thetaLog):
         plt.plot(
             dynTimeMin,
             omega_BN[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\omega_" + str(idx) + "$",
         )
     plt.legend(fontsize="14")

--- a/examples/scenarioRotatingPanel.py
+++ b/examples/scenarioRotatingPanel.py
@@ -102,10 +102,16 @@ fileName = os.path.basename(os.path.splitext(__file__)[0])
 from Basilisk.simulation import spacecraft
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
 from Basilisk.simulation import hingedRigidBodyStateEffector
 from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 from Basilisk.simulation import simpleSolarPanel
 from Basilisk.simulation import coarseSunSensor
@@ -237,7 +243,7 @@ def run(show_plots):
 
     # Setup data logging before the simulation is initialized
     numDataPoints = 200
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     pl1Log = panel1.hingedRigidBodyOutMsg.recorder(samplingTime)
     spLog = solarPanel.nodePowerOutMsg.recorder(samplingTime)
@@ -291,7 +297,7 @@ def plotOrbits(timeAxis, dataSigmaBN, panel1thetaLog, solarPowerLog, css1Log, cs
     timeData = timeAxis * macros.NANO2MIN
     for idx in range(3):
         plt.plot(timeData, dataSigmaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/examples/scenarioSatelliteConstellation.py
+++ b/examples/scenarioSatelliteConstellation.py
@@ -21,7 +21,7 @@ r"""
 Overview
 --------
 
-This scenario demonstrates how to set up a Walker-Delta constellation of satellites. Note that this scenario 
+This scenario demonstrates how to set up a Walker-Delta constellation of satellites. Note that this scenario
 uses the stand-alone Basilisk architecture rather than using the ''examples/FormationBskSim`` or ``examples/MultiSatBskSim``
 architectures for simultaneously simulating multiple spacecraft.
 
@@ -29,8 +29,8 @@ The script is found in the folder ``basilisk/examples`` and executed by using::
 
     python3 scenarioSatelliteConstellation.py
 
-When designing a satellite constellation, symmetry provides repeatable performance and makes design and operations simpler. One 
-such symmetric constellation design methodology is the Walker constellation which consists of circular orbits in evenly spaced 
+When designing a satellite constellation, symmetry provides repeatable performance and makes design and operations simpler. One
+such symmetric constellation design methodology is the Walker constellation which consists of circular orbits in evenly spaced
 planes at a chosen inclination. Walker constellation layouts are fully specified by four parameters written as "i:T/P/F" where:
 
     * i = inclination angle
@@ -38,7 +38,7 @@ planes at a chosen inclination. Walker constellation layouts are fully specified
     * P = numer of orbit planes evenly spaced in node angle
     * F = relative spacing between satellites in adjacent orbit planes
 
-In order to simulate the constellation a semi-major axis 'a' is also specified as an input. The total number of satellites T must 
+In order to simulate the constellation a semi-major axis 'a' is also specified as an input. The total number of satellites T must
 be specified as an integer multiple of the number of planes P. The relative spacing F must be an integer between 0 and (P-1).
 
 Illustration of Simulation Results
@@ -53,7 +53,7 @@ The default scenario is modelled after the Galileo constellation with Walker num
 .. image:: /_images/Scenarios/scenarioSatelliteConstellation.svg
    :align: center
 
-Each line color corresponds to a different orbital plane, in this case 3 planes. Green circles mark the start of each of the 24 
+Each line color corresponds to a different orbital plane, in this case 3 planes. Green circles mark the start of each of the 24
 individual satellite's ground tracks and a red circle marks their end.
 
 Simulation Visualization In Vizard
@@ -75,7 +75,7 @@ is created through the ``vizInterface``::
 #
 # Basilisk Scenario Script and Integrated Test
 #
-# Purpose:  Demonstrates how to use the stand alone Basilisk architecture to automate 
+# Purpose:  Demonstrates how to use the stand alone Basilisk architecture to automate
 #           the setup of a Walker constellation.
 # Author:   Andrew Morell
 # Creation Date:  Dec. 13, 2023
@@ -91,8 +91,14 @@ bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
 from Basilisk.simulation import (spacecraft, ephemerisConverter)
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
+from Basilisk.utilities import simHelpers
 from Basilisk.fswAlgorithms import locationPointing
 from Basilisk.simulation import (simpleNav, planetEphemeris)
 
@@ -156,10 +162,10 @@ def run(show_plots, a, i, T, P, F):
     n = np.sqrt(mu / a / a / a)
     Pr = 2. * np.pi / n
     simulationTime = macros.sec2nano(1.5 * Pr)
-    
+
     # create a logging task object of the spacecraft output message at the desired down sampling ratio
     numDataPoints = 500
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
 
     if (np.mod(T,1) !=0 or np.mod(P,1) !=0 or np.mod(F,1) != 0 or T < 1 or P < 1 or F < 1):
         raise Exception('number of satellites T, number of planes P, and relative spaceing F must be positive integer numbers')
@@ -201,7 +207,7 @@ def run(show_plots, a, i, T, P, F):
 
         # set the spacecraft mass and inertia
         scList[i].hub.mHub = 750.0  # kg - spacecraft mass
-        scList[i].hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+        scList[i].hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
         # set up prescribed attitude guidance
         navList.append(simpleNav.SimpleNav())
@@ -248,7 +254,7 @@ def run(show_plots, a, i, T, P, F):
     for n in range(T):
         # calculate latitude and longitude
         [lon, lat] = rv2latlon(dataRec[n])
-        color = unitTestSupport.getLineColor(int(np.floor(n/S)), 3)
+        color = simHelpers.getLineColor(int(np.floor(n/S)), 3)
         plt.scatter(lat, lon, s=5, c=[color])
         plt.scatter(lat[0], lon[0], s=20, c='#00A300')
         plt.scatter(lat[-1], lon[-1], s=20, c='#A30000')

--- a/examples/scenarioSensorThermal.py
+++ b/examples/scenarioSensorThermal.py
@@ -63,9 +63,6 @@ import numpy as np
 
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 import matplotlib.pyplot as plt
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
@@ -91,6 +88,7 @@ from Basilisk.utilities import vizSupport
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -134,7 +132,7 @@ def run(show_plots):
         [0.0],
         [0.0],
     ]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)

--- a/examples/scenarioSepMomentumManagement.py
+++ b/examples/scenarioSepMomentumManagement.py
@@ -109,8 +109,16 @@ from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError, oneAxisSolarA
 from Basilisk.simulation import (reactionWheelStateEffector, simpleNav, simpleMassProps, spacecraft,
                                  spinningBodyOneDOFStateEffector, spinningBodyTwoDOFStateEffector,
                                  thrusterStateEffector, facetSRPDynamicEffector, boreAngCalc)
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, simIncludeRW,
-                                unitTestSupport, vizSupport, RigidBodyKinematics as rbk)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+    RigidBodyKinematics as rbk,
+)
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -213,7 +221,7 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
             -12,   43,  4810]
     scObject.hub.mHub = 2500  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.008], [-0.010], [1.214]]  # [m] - position vector of hub CM relative to the body-fixed point B
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     #
     # add RW devices
@@ -698,7 +706,7 @@ def run(swirlTorque, thrMomManagement, saMomManagement, cmEstimation, showPlots)
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = simulationTime / simulationTimeStepFsw
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStepFsw, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStepFsw, numDataPoints)
 
     vehConfigLog = simpleMassPropsObject.vehicleConfigOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(dynTask, vehConfigLog)
@@ -875,11 +883,11 @@ def plot_attitude(timeData, dataSigmaBN, dataSigmaRN, figID=None):
     plt.figure(figID, figsize=(5, 2.75))
     for idx in range(3):
         plt.plot(timeData, dataSigmaBN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_{BN,' + str(idx + 1) + '}$')
     for idx in range(3):
         plt.plot(timeData, dataSigmaRN[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3), linestyle='dashed',
+                 color=simHelpers.getLineColor(idx, 3), linestyle='dashed',
                  label=r'$\sigma_{RN,' + str(idx + 1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [hours]')
@@ -890,7 +898,7 @@ def plot_attitude_error(timeData, dataSigmaBR, figID=None):
     plt.figure(figID, figsize=(5, 2.75))
     for idx in range(3):
         plt.plot(timeData, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx + 1) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [hours]')
@@ -901,7 +909,7 @@ def plot_rw_speeds(timeData, dataOmegaRW, numRW, figID=None):
     plt.figure(figID, figsize=(5, 2.75))
     for idx in range(numRW):
         plt.plot(timeData, dataOmegaRW[:, idx] / macros.RPM,
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label=r'$\Omega_{' + str(idx + 1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [hours]')
@@ -957,7 +965,7 @@ def plot_external_torque(timeData, dataTorque, yString=None, figID=None):
     plt.figure(figID, figsize=(5, 2.75))
     for idx in range(3):
         plt.plot(timeData, dataTorque[:, idx] * 1000,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'${}^BL_' + str(idx+1) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [hours]')

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -84,7 +84,7 @@ from Basilisk.simulation import spacecraft
 from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody, vizSupport)
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeRW
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 try:
     from Basilisk.simulation import vizInterface
@@ -308,7 +308,7 @@ def run(show_plots):
 
     mass = 330.  # kg
     scObject.hub.mHub = mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Set the truth ICs for the spacecraft attitude and rate
     scObject.hub.sigma_BNInit = np.array([0.1, 0.0, 0.0])  # rad
@@ -446,7 +446,7 @@ def run(show_plots):
     waypointFeedback.navTransInMsg.subscribeTo(simpleNavMeas.transOutMsg)
     waypointFeedback.A_sc = 1.  # Surface area of the spacecraft, m^2
     waypointFeedback.M_sc = mass  # Mass of the spacecraft, kg
-    waypointFeedback.IHubPntC_B = unitTestSupport.np2EigenMatrix3d(I)  # sc inertia
+    waypointFeedback.IHubPntC_B = simHelpers.np2EigenMatrix3d(I)  # sc inertia
     waypointFeedback.mu_ast = mu  # Gravitational constant of the asteroid
     waypointFeedback.x1_ref = [-2000., 0., 0.]
     waypointFeedback.x2_ref = [0.0, 0.0, 0.0]
@@ -505,8 +505,8 @@ def run(show_plots):
 
     simulationTime_1 = macros.sec2nano(15000.0)
 
-    waypointFeedback.K1 = unitTestSupport.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
-    waypointFeedback.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
+    waypointFeedback.K1 = simHelpers.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
+    waypointFeedback.K2 = simHelpers.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # configure a simulation stop time and execute the simulation run
     scSim.ConfigureStopTime(simulationTime_1)

--- a/examples/scenarioSmallBodyLandmarks.py
+++ b/examples/scenarioSmallBodyLandmarks.py
@@ -141,13 +141,11 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import RigidBodyKinematics
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -304,7 +302,7 @@ def plot_orientation(t, dcm_HP, dcm_CP):
         plt.plot(
             t / 3600,
             data[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=labelStrings[idx],
         )
     ax.set_xlim([t[0] / 3600, t[-1] / 3600])
@@ -389,7 +387,7 @@ def run(show_plots, useBatch):
     I = [900.0, 0.0, 0.0, 0.0, 800.0, 0.0, 0.0, 0.0, 600.0]
     scObject.hub.mHub = 750.0
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Set spacecraft initial condition
     oe = orbitalMotion.ClassicElements()

--- a/examples/scenarioSmallBodyNav.py
+++ b/examples/scenarioSmallBodyNav.py
@@ -105,7 +105,7 @@ from Basilisk.simulation import spacecraft
 from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody, vizSupport)
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeRW
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 # The path to the location of Basilisk
@@ -516,7 +516,7 @@ def run(show_plots):
 
     mass = 330.  # kg
     scObject.hub.mHub = mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # Set the truth ICs for the spacecraft attitude and rate
     scObject.hub.sigma_BNInit = np.array([0.1, 0.0, 0.0])  # rad
@@ -658,7 +658,7 @@ def run(show_plots):
     waypointFeedback.navAttInMsg.subscribeTo(simpleNavMeas2.attOutMsg)
     waypointFeedback.A_sc = 1.  # Surface area of the spacecraft, m^2
     waypointFeedback.M_sc = mass  # Mass of the spacecraft, kg
-    waypointFeedback.IHubPntC_B = unitTestSupport.np2EigenMatrix3d(I)  # sc inertia
+    waypointFeedback.IHubPntC_B = simHelpers.np2EigenMatrix3d(I)  # sc inertia
     waypointFeedback.mu_ast = mu  # Gravitational constant of the asteroid
     waypointFeedback.x1_ref = [-2000., 0., 0.]
     waypointFeedback.x2_ref = [0.0, 0.0, 0.0]
@@ -716,8 +716,8 @@ def run(show_plots):
     waypointFeedback.navTransInMsg.subscribeTo(smallBodyNav.navTransOutMsg)
 
     # Set the waypoint feedback gains
-    waypointFeedback.K1 = unitTestSupport.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
-    waypointFeedback.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
+    waypointFeedback.K1 = simHelpers.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
+    waypointFeedback.K2 = simHelpers.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Add all models to the task
     scSim.AddModelToTask(simTaskName, scObject, 100)

--- a/examples/scenarioSmallBodyNavUKF.py
+++ b/examples/scenarioSmallBodyNavUKF.py
@@ -95,7 +95,6 @@ from Basilisk.simulation import spacecraft
 from Basilisk.utilities import RigidBodyKinematics
 from Basilisk.utilities import SimulationBaseClass, macros, simIncludeGravBody
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 # The path to the location of Basilisk

--- a/examples/scenarioSpacecraftLocation.py
+++ b/examples/scenarioSpacecraftLocation.py
@@ -53,14 +53,19 @@ from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError, hillPoint)
 from Basilisk.simulation import extForceTorque
 from Basilisk.simulation import simpleNav, spacecraft
 from Basilisk.simulation import spacecraftLocation
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                unitTestSupport, vizSupport)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+)
 
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -104,7 +109,7 @@ def run(show_plots):
          0., 800., 0.,
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # create the debris object states
     scObject2 = spacecraft.Spacecraft()
@@ -113,7 +118,7 @@ def run(show_plots):
           0., 650., 0.,
           0., 0, 450.]
     scObject2.hub.mHub = 350.0  # kg
-    scObject2.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I2)
+    scObject2.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I2)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject)

--- a/examples/scenarioSpiceSpacecraft.py
+++ b/examples/scenarioSpiceSpacecraft.py
@@ -81,9 +81,6 @@ np.set_printoptions(precision=16)
 
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import (
-    unitTestSupport,
-)  # general support file with common unit test functions
 import matplotlib.pyplot as plt
 from Basilisk.utilities import macros
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
@@ -109,6 +106,7 @@ from Basilisk.utilities import vizSupport
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -152,7 +150,7 @@ def run(show_plots):
     # define the simulation inertia
     I = [900.0, 0.0, 0.0, 0.0, 800.0, 0.0, 0.0, 0.0, 600.0]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
 
@@ -241,7 +239,7 @@ def run(show_plots):
     # Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(
+    samplingTime = simHelpers.samplingTime(
         simulationTime, simulationTimeStep, numDataPoints
     )
     snLog = sNavObject.scStateInMsg.recorder(samplingTime)
@@ -290,7 +288,7 @@ def run(show_plots):
         plt.plot(
             timeAxis * macros.NANO2MIN,
             attErrorLog.sigma_BR[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\sigma_" + str(idx) + "$",
         )
     plt.legend(loc="lower right")
@@ -305,7 +303,7 @@ def run(show_plots):
         plt.plot(
             timeAxis * macros.NANO2MIN,
             mrpLog.torqueRequestBody[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label="$L_{r," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")
@@ -318,7 +316,7 @@ def run(show_plots):
         plt.plot(
             timeAxis * macros.NANO2MIN,
             attErrorLog.omega_BR_B[:, idx],
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label=r"$\omega_{BR," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")
@@ -330,7 +328,7 @@ def run(show_plots):
         plt.plot(
             timeAxis * macros.NANO2MIN,
             snLog.r_BN_N[:, idx] / 1000.0,
-            color=unitTestSupport.getLineColor(idx, 3),
+            color=simHelpers.getLineColor(idx, 3),
             label="$r_{BN," + str(idx) + "}$",
         )
     plt.legend(loc="lower right")

--- a/examples/scenarioSpinningBodiesTwoDOF.py
+++ b/examples/scenarioSpinningBodiesTwoDOF.py
@@ -100,9 +100,13 @@ import numpy as np
 
 from Basilisk.utilities import SimulationBaseClass, vizSupport, simIncludeGravBody
 from Basilisk.simulation import spacecraft, spinningBodyTwoDOFStateEffector
-from Basilisk.utilities import macros, orbitalMotion, unitTestSupport
+from Basilisk.utilities import (
+    macros,
+    orbitalMotion,
+)
 
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
 
@@ -330,7 +334,7 @@ def run(show_plots, numberPanels):
     plt.clf()
     for idx in range(3):
         plt.plot(theta1Data.times() * macros.NANO2SEC, v_BN_N[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$v_{BN,' + str(idx) + '}$')
     plt.legend()
     plt.xlabel('time [s]')
@@ -342,7 +346,7 @@ def run(show_plots, numberPanels):
     plt.clf()
     for idx in range(3):
         plt.plot(theta1Data.times() * macros.NANO2SEC, omega_BN_B[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BN,' + str(idx) + '}$')
     plt.legend()
     plt.xlabel('time [s]')

--- a/examples/scenarioStripImaging.py
+++ b/examples/scenarioStripImaging.py
@@ -113,7 +113,7 @@ from Basilisk.utilities import fswSetupRW
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeRW
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
@@ -437,7 +437,7 @@ def run(show_plots=True):
          0., 0., 100.]
     scObject.hub.mHub = 330.0
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # ------------------------------------------------------------------
     # Gravity
@@ -561,7 +561,7 @@ def run(show_plots=True):
 
     fswSetupRW.clearSetup()
     for key, rw in rwFactory.rwList.items():
-        fswSetupRW.create(unitTestSupport.EigenVector3d2np(rw.gsHat_B),
+        fswSetupRW.create(simHelpers.EigenVector3d2np(rw.gsHat_B),
                           rw.Js, 0.2)
     fswRwParamMsg = fswSetupRW.writeConfigMessage()
     fswSetupRW.clearSetup()  # release SWIG-owned objects before shutdown
@@ -664,9 +664,9 @@ def run(show_plots=True):
             tile_id = id_base
             img_start_ns, img_end_ns = strip_phase_ns[si]
             while t_tile < (img_end_ns - img_start_ns + pre_imaging_ns):
-                r_s = unitTestSupport.EigenVector3d2list(
+                r_s = simHelpers.EigenVector3d2list(
                     get_target_position(t_tile, r_start_ext, r_end, speed=3e-6))
-                r_e = unitTestSupport.EigenVector3d2list(
+                r_e = simHelpers.EigenVector3d2list(
                     get_target_position(t_tile + dt_viz, r_start_ext, r_end, speed=3e-6))
                 verts = compute_strip_vertices(r_s, r_e, width=200e3)
                 # Default grey – will be updated green/red during simulation
@@ -686,9 +686,9 @@ def run(show_plots=True):
         r_e0 = lat_lon_to_surface(
             strip_configs[0]["end"][0], strip_configs[0]["end"][1], astroConstants.REQ_EARTH * 1e3)
         r_s0_ext = compute_extended_start(r_s0, r_e0, pre_imaging_ns, speed=3e-6)
-        r_init = unitTestSupport.EigenVector3d2list(
+        r_init = simHelpers.EigenVector3d2list(
             get_target_position(0, r_s0_ext, r_e0, speed=3e-6))
-        r_init_next = unitTestSupport.EigenVector3d2list(
+        r_init_next = simHelpers.EigenVector3d2list(
             get_target_position(dt_viz, r_s0_ext, r_e0, speed=3e-6))
         r_left_init, r_right_init = compute_scan_line_extremities(
             r_init, r_init_next, width=200e3)
@@ -764,9 +764,9 @@ def run(show_plots=True):
             if viz is not None:
                 # Time within the strip's own timeline
                 elapsed = t_cur - img_start_ns + pre_imaging_ns
-                r_s = unitTestSupport.EigenVector3d2list(
+                r_s = simHelpers.EigenVector3d2list(
                     get_target_position(elapsed, r_start_ext, r_end, speed=3e-6))
-                r_e = unitTestSupport.EigenVector3d2list(
+                r_e = simHelpers.EigenVector3d2list(
                     get_target_position(elapsed + dt_step, r_start_ext, r_end, speed=3e-6))
                 verts = compute_strip_vertices(r_s, r_e, width=200e3)
 

--- a/examples/scenarioSweepingSpacecraft.py
+++ b/examples/scenarioSweepingSpacecraft.py
@@ -120,9 +120,9 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -138,7 +138,7 @@ def plot_attitude_error(timeLineSet, dataSigmaBR):
     vectorData = dataSigmaBR
     sNorm = np.array([np.linalg.norm(v) for v in vectorData])
     plt.plot(timeLineSet, sNorm,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              )
     plt.xlabel('Time [min]')
     plt.ylabel(r'Attitude Error Norm $|\sigma_{B/R}|$')
@@ -149,7 +149,7 @@ def plot_control_torque(timeLineSet, dataLr):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeLineSet, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -160,7 +160,7 @@ def plot_rate_error(timeLineSet, dataOmegaBR):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeLineSet, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -186,7 +186,7 @@ def plot_orientation(timeLineSet, dataPos, dataVel, dataSigmaBN):
                     , r'$\hat\imath_h\cdot \hat b_3$')
     for idx in range(3):
         plt.plot(timeLineSet, data[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=labelStrings[idx])
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -234,7 +234,7 @@ def run (show_plots, useAltBodyFrame, angle_rate_command, time_command):
          0., 0., 600.]  # Inertia of the spacecraft
     scObject.hub.mHub = 750.0  # kg - Mass of the spacecraft
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     scSim.AddModelToTask(simTaskName, scObject)
 
     # Setup earth gravity body
@@ -304,7 +304,7 @@ def run (show_plots, useAltBodyFrame, angle_rate_command, time_command):
     #
 
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mrpLog = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrLog = attError.attGuidOutMsg.recorder(samplingTime)
     snAttLog = sNavObject.attOutMsg.recorder(samplingTime)

--- a/examples/scenarioTAM.py
+++ b/examples/scenarioTAM.py
@@ -119,8 +119,13 @@ from Basilisk.simulation import magnetometer
 
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.utilities import simSetPlanetEnvironment
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -197,7 +202,7 @@ def run(show_plots, orbitCase, planetCase, useBias, useBounds):
         wmm_path = get_path(DataFile.MagneticFieldData.WMM)
         magModule.configureWMMFile(str(wmm_path))
         # set epoch date/time message
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
         magModule.epochInMsg.subscribeTo(epochMsg)
         if orbitCase == 'elliptical':
             magModule.envMinReach = 10000 * 1000.
@@ -263,7 +268,7 @@ def run(show_plots, orbitCase, planetCase, useBias, useBounds):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     magLog = magModule.envOutMsgs[0].recorder(samplingTime)
     tamLog = TAM.tamDataOutMsg.recorder(samplingTime)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
@@ -330,7 +335,7 @@ def run(show_plots, orbitCase, planetCase, useBias, useBounds):
     ax.get_yaxis().set_major_formatter(plt.FuncFormatter(lambda x, loc: "{:,}".format(int(x))))
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2SEC / P, tamData[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')

--- a/examples/scenarioTAMcomparison.py
+++ b/examples/scenarioTAMcomparison.py
@@ -130,8 +130,13 @@ from Basilisk.simulation import magnetometer
 
 # general support file with common unit test functions
 # import general simulation support files
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
-                                simIncludeGravBody, unitTestSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+)
 from Basilisk.utilities import simSetPlanetEnvironment
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -224,7 +229,7 @@ def run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2):
     magModule3.configureWMMFile(str(wmm_path))
 
     # set epoch date/time message
-    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
+    epochMsg = simHelpers.timeStringToGregorianUTCMsg('2019 June 27, 10:23:0.0 (UTC)')
     magModule3.epochInMsg.subscribeTo(epochMsg)
     # set the minReach and maxReach values if on an elliptic orbit
     if orbitCase == 'elliptical':
@@ -331,7 +336,7 @@ def run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     mag1Log = magModule1.envOutMsgs[0].recorder(samplingTime)
     mag3Log = magModule3.envOutMsgs[0].recorder(samplingTime)
     tam1Log = TAM1.tamDataOutMsg.recorder(samplingTime)
@@ -415,7 +420,7 @@ def run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2):
     ax.get_yaxis().set_major_formatter(plt.FuncFormatter(lambda x, loc: "{:,}".format(int(x))))
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2SEC / P, tam1Data[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')
@@ -424,7 +429,7 @@ def run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2):
     if orbitCase == 'elliptical':
         for idx in range(3):
             plt.plot(timeAxis * macros.NANO2SEC / P, tam3Data[:, idx] * 1e9, '--',
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$TAM_{' + str(idx) + '}$')
     pltName = fileName + "2" + orbitCase + useBias1_str + useBounds1_str + useBias2_str + useBounds2_str
     figureList[pltName] = plt.figure(2)
@@ -437,7 +442,7 @@ def run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2):
     ax.get_yaxis().set_major_formatter(plt.FuncFormatter(lambda x, loc: "{:,}".format(int(x))))
     for idx in range(3):
         plt.plot(timeAxis * macros.NANO2SEC / P, tam2Data[:, idx] * 1e9,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$TAM_{' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [orbits]')

--- a/examples/scenarioTempMeasurementAttitude.py
+++ b/examples/scenarioTempMeasurementAttitude.py
@@ -71,9 +71,16 @@ from Basilisk.fswAlgorithms import (mrpFeedback, attTrackingError,
                                     inertial3D, rwMotorTorque)
 from Basilisk.simulation import (reactionWheelStateEffector, simpleNav,
                                  spacecraft, motorThermal, tempMeasurement)
-from Basilisk.utilities import (SimulationBaseClass, fswSetupRW, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                simIncludeRW, unitTestSupport, vizSupport)
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    fswSetupRW,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    simIncludeRW,
+    vizSupport,
+)
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -85,7 +92,7 @@ def plot_rw_temperature(timeData, dataTemp, numRW, id=None):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataTemp[:,idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$T_{rw,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -97,7 +104,7 @@ def plot_rw_temp_measurement(timeData, dataTemp, numRW, id=None):
     plt.figure(id)
     for idx in range(numRW):
         plt.plot(timeData, dataTemp[:,idx],
-                 color=unitTestSupport.getLineColor(idx, numRW),
+                 color=simHelpers.getLineColor(idx, numRW),
                  label='$T_{rw,' + str(idx+1) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -144,7 +151,7 @@ def run(show_plots):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     # add spacecraft object to the simulation process
     scSim.AddModelToTask(simTaskName, scObject, 1)
@@ -271,7 +278,7 @@ def run(show_plots):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
 
     # A message is created that stores an array of the true temperature and temperature measurement.
     # This is logged here to be plotted later on.
@@ -296,7 +303,7 @@ def run(show_plots):
     # set up the FSW RW configuration message.
     fswSetupRW.clearSetup()
     for key, rw in rwFactory.rwList.items():
-        fswSetupRW.create(unitTestSupport.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
+        fswSetupRW.create(simHelpers.EigenVector3d2np(rw.gsHat_B), rw.Js, 0.2)
     fswRwParamMsg = fswSetupRW.writeConfigMessage()
 
     #

--- a/examples/scenarioTwoChargedSC.py
+++ b/examples/scenarioTwoChargedSC.py
@@ -72,13 +72,20 @@ import matplotlib.pyplot as plt
 import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.simulation import spacecraft, extForceTorque, msmForceTorque
-from Basilisk.utilities import (SimulationBaseClass, macros,
-                                orbitalMotion, simIncludeGravBody,
-                                unitTestSupport, RigidBodyKinematics, vizSupport, SpherePlot)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    RigidBodyKinematics,
+    vizSupport,
+    SpherePlot,
+)
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -184,9 +191,9 @@ def run(show_plots):
 
     # add spacecraft to state
     MSMmodule.addSpacecraftToModel(scObjectLeader.scStateOutMsg, messaging.DoubleVector(rListLeader),
-                                   unitTestSupport.npList2EigenXdVector(spPosListLeader_H))
+                                   simHelpers.npList2EigenXdVector(spPosListLeader_H))
     MSMmodule.addSpacecraftToModel(scObjectFollower.scStateOutMsg, messaging.DoubleVector(rListFollower),
-                                   unitTestSupport.npList2EigenXdVector(spPosListFollower_H))
+                                   simHelpers.npList2EigenXdVector(spPosListFollower_H))
 
     # subscribe input messages to module
     MSMmodule.voltInMsgs[0].subscribeTo(voltLeaderInMsg)
@@ -264,8 +271,8 @@ def run(show_plots):
     scSim.ExecuteSimulation()
 
     # Retrieve the charge data of the spheres
-    LeaderSpCharges = unitTestSupport.columnToRowList(MSMmodule.chargeMsmOutMsgs[0].read().q)
-    FollowerSpCharges = unitTestSupport.columnToRowList(MSMmodule.chargeMsmOutMsgs[1].read().q)
+    LeaderSpCharges = simHelpers.columnToRowList(MSMmodule.chargeMsmOutMsgs[0].read().q)
+    FollowerSpCharges = simHelpers.columnToRowList(MSMmodule.chargeMsmOutMsgs[1].read().q)
 
     # retrieve the logged data from the recorders
     posDataL_N = dataRecL.r_BN_N

--- a/examples/scenarioVariableTimeStepIntegrators.py
+++ b/examples/scenarioVariableTimeStepIntegrators.py
@@ -82,9 +82,9 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -194,7 +194,7 @@ def run(show_plots, integratorCase, relTol, absTol):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 
@@ -248,7 +248,7 @@ def run(show_plots, integratorCase, relTol, absTol):
         rData.append(oeData.rmag/earth.radEquator)
         fData.append(oeData.f + oeData.omega - oe.omega)
     plt.plot(rData * np.cos(fData), rData * np.sin(fData)
-             , color=unitTestSupport.getLineColor(labelStrings.index(integratorCase), len(labelStrings))
+             , color=simHelpers.getLineColor(labelStrings.index(integratorCase), len(labelStrings))
              , label=integratorCase
              , linewidth=3.0
              )

--- a/examples/scenarioVizPoint.py
+++ b/examples/scenarioVizPoint.py
@@ -105,7 +105,6 @@ fileNamePath = os.path.abspath(__file__)
 
 # import general simulation support files
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib.pyplot as plt
 from Basilisk.utilities import macros, orbitalMotion
 from Basilisk.utilities import RigidBodyKinematics as rbk
@@ -126,6 +125,7 @@ from Basilisk.architecture import messaging
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
+from Basilisk.utilities import simHelpers
 
 
 def run(show_plots, missionType, saveVizardFile):
@@ -220,7 +220,7 @@ def run(show_plots, missionType, saveVizardFile):
          0., 0., 600.]
     scObject.hub.mHub = 750.0  # kg - spacecraft mass
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
     # attach gravity model to spacecraft
     gravFactory.addBodiesTo(scObject)
 
@@ -305,7 +305,7 @@ def run(show_plots, missionType, saveVizardFile):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     cmdRec = mrpControl.cmdTorqueOutMsg.recorder(samplingTime)
     attErrRec = attError.attGuidOutMsg.recorder(samplingTime)
     dataLog = sNavObject.transOutMsg.recorder(samplingTime)
@@ -371,7 +371,7 @@ def run(show_plots, missionType, saveVizardFile):
     plt.figure(1)
     for idx in range(3):
         plt.plot(timeAxis, dataSigmaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\sigma_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -383,7 +383,7 @@ def run(show_plots, missionType, saveVizardFile):
     plt.figure(2)
     for idx in range(3):
         plt.plot(timeAxis, dataLr[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$L_{r,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')
@@ -394,7 +394,7 @@ def run(show_plots, missionType, saveVizardFile):
     plt.figure(3)
     for idx in range(3):
         plt.plot(timeAxis, dataOmegaBR[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$\omega_{BR,' + str(idx) + '}$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/src/architecture/utilitiesSelfCheck/_UnitTest/test_avsLibrarySelfCheck.py
+++ b/src/architecture/utilitiesSelfCheck/_UnitTest/test_avsLibrarySelfCheck.py
@@ -26,7 +26,7 @@ import os
 
 import pytest
 from Basilisk.architecture import avsLibrarySelfCheck
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 @pytest.mark.parametrize("testName",
@@ -87,11 +87,11 @@ def unitAVSLibrarySelfCheck(testName):
     path = os.path.dirname(os.path.abspath(__file__))
 
     snippetMsgName = fileName + 'Msg-' + testName
-    unitTestSupport.writeTeXSnippet(snippetMsgName, snippetContent, path + "/../_Documentation/")
+    simHelpers.writeTeXSnippet(snippetMsgName, snippetContent, path + "/../_Documentation/")
 
     snippetPassFailName = fileName + 'TestMsg-' + testName
     snippetContent = r'\textcolor{' + colorText + '}{' + passFailText + '}'
-    unitTestSupport.writeTeXSnippet(snippetPassFailName, snippetContent, path + "/../_Documentation/")
+    simHelpers.writeTeXSnippet(snippetPassFailName, snippetContent, path + "/../_Documentation/")
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/fswAlgorithms/attControl/thrMomentumManagement/_UnitTest/test_thrMomentumManagement.py
+++ b/src/fswAlgorithms/attControl/thrMomentumManagement/_UnitTest/test_thrMomentumManagement.py
@@ -43,6 +43,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import thrMomentumManagement            # import the module that is to be tested
 from Basilisk.utilities import macros
 from Basilisk.utilities import fswSetupRW
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -144,7 +145,7 @@ def thrMomentumManagementTestFunction(show_plots, hsMinCheck):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
     testFailCount, testMessages = unitTestSupport.compareArray(trueVector, dataLog.torqueRequestBody, accuracy,
                                                                "torqueRequestBody", testFailCount, testMessages)
 
@@ -157,7 +158,7 @@ def thrMomentumManagementTestFunction(show_plots, hsMinCheck):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+    simHelpers.writeTeXSnippet(snippetName, passedText, path)
 
 
     # each test method requires a single assert method to be called

--- a/src/fswAlgorithms/attDetermination/CSSEst/_UnitTest/test_cssWlsEstUnitTest.py
+++ b/src/fswAlgorithms/attDetermination/CSSEst/_UnitTest/test_cssWlsEstUnitTest.py
@@ -33,6 +33,7 @@ import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import cssWlsEst
 # Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
@@ -260,7 +261,7 @@ def cssWlsEstTestFunction(show_plots):
         # Pull logged data out into workspace for analysis
         sHatEst = navData.vehSunPntBdy
 
-        numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss) 
+        numActive = simHelpers.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
         sHatEstUse = sHatEst[logLengthPrev:, :]  # Only data for this subtest
         numActiveUse = numActive[logLengthPrev + 1:, :]  # Only data for this subtest
 
@@ -297,7 +298,7 @@ def cssWlsEstTestFunction(show_plots):
     unitTestSim.ExecuteSimulation()
     stepCount += 1
     sHatEst = navData.vehSunPntBdy
-    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
+    numActive = simHelpers.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
     sHatEstUse = sHatEst[logLengthPrev:, :]
     numActiveUse = numActive[logLengthPrev + 1:, :]
     logLengthPrev = sHatEst.shape[0]
@@ -321,7 +322,7 @@ def cssWlsEstTestFunction(show_plots):
     unitTestSim.ConfigureStopTime(int((stepCount + 1) * 1E9))
     unitTestSim.ExecuteSimulation()
     stepCount += 1
-    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
+    numActive = simHelpers.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
     numActiveUse = numActive[logLengthPrev + 1:, :]
     sHatEst = navData.vehSunPntBdy
     sHatEstUse = sHatEst[logLengthPrev + 1:, :]
@@ -342,7 +343,7 @@ def cssWlsEstTestFunction(show_plots):
 
     unitTestSim.ConfigureStopTime(int((stepCount + 1) * 1E9))
     unitTestSim.ExecuteSimulation()
-    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
+    numActive = simHelpers.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
     numActiveUse = numActive[logLengthPrev:, :]
     logLengthPrev = numActive.shape[0]
     testFailCount += checkNumActiveAccuracy(cssDataMsg, numActiveUse,
@@ -351,7 +352,7 @@ def cssWlsEstTestFunction(show_plots):
     # Format data for plotting
     truthData = numpy.array(truthData)
     sHatEst = navData.vehSunPntBdy
-    numActive = unitTestSupport.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
+    numActive = simHelpers.addTimeColumn(numActiveData.times(), numActiveData.numActiveCss)
 
 
     #
@@ -525,7 +526,7 @@ def cssRateTestFunction(show_plots):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/fswAlgorithms/attDetermination/InertialUKF/_UnitTest/test_inertialKF.py
+++ b/src/fswAlgorithms/attDetermination/InertialUKF/_UnitTest/test_inertialKF.py
@@ -23,9 +23,9 @@ import matplotlib.pyplot as plt
 import numpy
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import inertialUKF  # import the module that is to be tested
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -194,18 +194,18 @@ def filterMethods():
     unitTestSim.ConfigureStopTime(1E9)
     unitTestSim.ExecuteSimulation()
 
-    stOrdered = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.stSensorOrder)
+    stOrdered = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.stSensorOrder)
     if numpy.linalg.norm(numpy.array(stOrdered[0]) - numpy.array([0., 2, 1, 0, 0])) > accuracy:
         testFailCount += 1
         testMessages.append("ST order test failed")
 
-    unitTestSupport.writeTeXSnippet("toleranceValue00", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue00", str(accuracy), path)
     if testFailCount == 0:
         print('Passed: test_FilterMethods')
-        unitTestSupport.writeTeXSnippet("passFail00", textSnippetPassed, path)
+        simHelpers.writeTeXSnippet("passFail00", textSnippetPassed, path)
     else:
         print('Failed: test_FilterMethods')
-        unitTestSupport.writeTeXSnippet("passFail00", textSnippetFailed, path)
+        simHelpers.writeTeXSnippet("passFail00", textSnippetFailed, path)
 
     return [testFailCount, ''.join(testMessages)]
 
@@ -288,24 +288,24 @@ def stateUpdateInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i+1)*0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
+    covarLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     accuracy = 1.0E-5
-    unitTestSupport.writeTeXSnippet("toleranceValue11", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue11", str(accuracy), path)
     for i in range(3):
         if(covarLog[-1, i*6+1+i] > covarLog[0, i*6+1+i]):
             testFailCount += 1
             testMessages.append("Covariance update failure")
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetPassed, path)
         if(abs(stateLog[-1, i+1] - stMessage1.MRP_BdyInrtl[i]) > accuracy):
             print(abs(stateLog[-1, i+1] - stMessage1.MRP_BdyInrtl[i]))
             testFailCount += 1
             testMessages.append("State update failure")
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetPassed, path)
 
     stMessage1.MRP_BdyInrtl = [1.2, 0.0, 0.0]
     stMessage2.MRP_BdyInrtl = [1.2, 0.0, 0.0]
@@ -320,29 +320,29 @@ def stateUpdateInertialAttitude(show_plots):
         unitTestSim.ExecuteSimulation()
 
 
-    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
+    covarLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     for i in range(3):
         if(covarLog[-1, i*6+1+i] > covarLog[0, i*6+1+i]):
             testFailCount += 1
             testMessages.append("Covariance update large failure")
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetPassed, path)
     plt.figure()
     for i in range(module.numStates):
         plt.plot(stateLog[:,0]*1.0E-9, stateLog[:,i+1], label='State_' +str(i))
         plt.legend()
         plt.ylim([-1, 1])
 
-    unitTestSupport.writeFigureLaTeX('Test11', 'Test 1 State convergence', plt, 'width=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('Test11', 'Test 1 State convergence', plt, 'width=0.9\\textwidth, keepaspectratio', path)
     plt.figure()
     for i in range(module.numStates):
         plt.plot(covarLog[:,0]*1.0E-9, covarLog[:,i*module.numStates+i+1], label='Covar_' +str(i))
         plt.legend()
         plt.ylim([0, 2.E-7])
 
-    unitTestSupport.writeFigureLaTeX('Test12', 'Test 1 Covariance convergence', plt, 'width=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('Test12', 'Test 1 Covariance convergence', plt, 'width=0.9\\textwidth, keepaspectratio', path)
     if(show_plots):
         plt.show()
         plt.close('all')
@@ -420,18 +420,18 @@ def statePropInertialAttitude(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(8000.0))
     unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
+    covarLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
 
     accuracy = 1.0E-10
-    unitTestSupport.writeTeXSnippet("toleranceValue22", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue22", str(accuracy), path)
     for i in range(6):
         if(abs(stateLog[-1, i+1] - stateLog[0, i+1]) > accuracy):
             testFailCount += 1
             testMessages.append("State propagation failure")
-            unitTestSupport.writeTeXSnippet('passFail22', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail22', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail22', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail22', textSnippetPassed, path)
 
     for i in range(6):
        if(covarLog[-1, i*6+i+1] <= covarLog[0, i*6+i+1]):
@@ -540,12 +540,12 @@ def stateUpdateRWInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + 1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
+    covarLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     print(inertialUKFLog.covar, covarLog)
 
     accuracy = 1.0E-5
-    unitTestSupport.writeTeXSnippet("toleranceValue33", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue33", str(accuracy), path)
     for i in range(3):
         if (covarLog[-1, i * 6 + 1 + i] > covarLog[0, i * 6 + 1 + i]):
             testFailCount += 1
@@ -554,9 +554,9 @@ def stateUpdateRWInertialAttitude(show_plots):
             print(abs(stateLog[-1, i + 1] - stMessage1.MRP_BdyInrtl[i]))
             testFailCount += 1
             testMessages.append("State update with RW failure")
-            unitTestSupport.writeTeXSnippet('passFail33', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail33', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail33', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail33', textSnippetPassed, path)
 
     stMessage1.MRP_BdyInrtl = [1.2, 0.0, 0.0]
     stMessage2.MRP_BdyInrtl = [1.2, 0.0, 0.0]
@@ -571,29 +571,29 @@ def stateUpdateRWInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + 20000 + 1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
+    covarLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    stateLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.state)
     for i in range(3):
         if (covarLog[-1, i * 6 + 1 + i] > covarLog[0, i * 6 + 1 + i]):
             testFailCount += 1
             testMessages.append("Covariance update large failure")
-            unitTestSupport.writeTeXSnippet('passFail33', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail33', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail33', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail33', textSnippetPassed, path)
     plt.figure()
     for i in range(module.numStates):
         plt.plot(stateLog[:, 0] * 1.0E-9, stateLog[:, i + 1], label='State_' +str(i))
         plt.legend()
         plt.ylim([-1, 1])
 
-    unitTestSupport.writeFigureLaTeX('Test31', 'Test 3 State convergence', plt, 'width=0.7\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('Test31', 'Test 3 State convergence', plt, 'width=0.7\\textwidth, keepaspectratio', path)
     plt.figure()
     for i in range(module.numStates):
         plt.plot(covarLog[:, 0] * 1.0E-9, covarLog[:, i * module.numStates + i + 1], label='Covar_' +str(i))
         plt.legend()
         plt.ylim([0., 2E-7])
 
-    unitTestSupport.writeFigureLaTeX('Test32', 'Test 3 Covariance convergence', plt, 'width=0.7\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('Test32', 'Test 3 Covariance convergence', plt, 'width=0.7\\textwidth, keepaspectratio', path)
     if (show_plots):
         plt.show()
         plt.close('all')
@@ -708,19 +708,19 @@ def statePropRateInertialAttitude(show_plots):
         unitTestSim.ConfigureStopTime(macros.sec2nano((i+1)*0.5))
         unitTestSim.ExecuteSimulation()
 
-    covarLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
-    sigmaLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.sigma_BNOut)
-    omegaLog = unitTestSupport.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.omega_BN_BOut)
+    covarLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.covar)
+    sigmaLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.sigma_BNOut)
+    omegaLog = simHelpers.addTimeColumn(inertialUKFLog.times(), inertialUKFLog.omega_BN_BOut)
     accuracy = 1.0E-3
-    unitTestSupport.writeTeXSnippet("toleranceValue44", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue44", str(accuracy), path)
     for i in range(3):
         if(abs(omegaLog[-1, i+1] - stateInit[i+3]) > accuracy):
             print(abs(omegaLog[-1, i+1] - stateInit[i+3]))
             testFailCount += 1
             testMessages.append("State omega propagation failure")
-            unitTestSupport.writeTeXSnippet('passFail44', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail44', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail44', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail44', textSnippetPassed, path)
 
     for i in range(6):
        if(covarLog[-1, i*6+i+1] <= covarLog[0, i*6+i+1]):

--- a/src/fswAlgorithms/attDetermination/headingSuKF/_UnitTest/headingSuKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/headingSuKF/_UnitTest/headingSuKF_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -81,7 +81,7 @@ def StateCovarPlot(time, x, Pflat, string, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot' + string, 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot' + string, 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -132,7 +132,7 @@ def PostFitResiduals(time, Res, noise, string, show_plots):
 
 
 
-    unitTestSupport.writeFigureLaTeX('PostFit' +string , 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit' +string , 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/SunLineOEKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/SunLineOEKF_test_utilities.py
@@ -20,7 +20,7 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -59,7 +59,7 @@ def StatesPlot(time, x, Pflat, show_plots):
 
 
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close('all')
@@ -110,7 +110,7 @@ def StatesPlotCompare(x, x2, Pflat, Pflat2, show_plots):
 
 
 
-    unitTestSupport.writeFigureLaTeX('StatesCompare', 'State error and covariance vs expected Values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesCompare', 'State error and covariance vs expected Values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -196,7 +196,7 @@ def PostFitResiduals(time, Res, noise, show_plots):
     plt.title('Eight CSS')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('PostFit', 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit', 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -223,7 +223,7 @@ def StatesVsExpected(stateLog, expectedStateArray, show_plots):
     plt.title('Second LOS component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesExpected', 'States vs true states in static case', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesExpected', 'States vs true states in static case', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -260,7 +260,7 @@ def StatesVsTargets(time, target1, target2, stateLog, show_plots):
 
 
 
-    unitTestSupport.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -290,7 +290,7 @@ def OmegaVsExpected(omegaExp, omegaSim, show_plots):
 
 
 
-    unitTestSupport.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/test_okeefeEKF.py
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/test_okeefeEKF.py
@@ -30,9 +30,9 @@ sys.path.append(splitPath[0] + '/PythonModules')
 
 import SunLineOEKF_test_utilities as FilterPlots
 from Basilisk.fswAlgorithms import okeefeEKF
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 from Basilisk.architecture import messaging
 
 
@@ -467,7 +467,7 @@ def StatePropStatic():
     unitTestSim.ConfigureStopTime(macros.sec2nano(8000.0))
     unitTestSim.ExecuteSimulation()
 
-    stateLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.state)
+    stateLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.state)
 
     for i in range(NUMSTATES):
         if (abs(stateLog[-1, i + 1] - stateLog[0, i + 1]) > 1.0E-10):
@@ -538,11 +538,11 @@ def StatePropVariable(show_plots):
     unitTestSim.ExecuteSimulation()
 
 
-    covarLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.state)
-    stateErrorLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.x)
-    stmLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.stateTransition)
-    omegaLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.omega)
+    covarLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.covar)
+    stateLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.state)
+    stateErrorLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.x)
+    stmLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.stateTransition)
+    omegaLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.omega)
 
     dt = 0.5
     expectedOmega = np.zeros([2001, (NUMSTATES + 1)])
@@ -767,7 +767,7 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + SimHalfLength+1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    stateErrorLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.x)
+    stateErrorLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.x)
     stateLog = dataLog.state
     postFitLog = dataLog.postFitRes
     covarLog = dataLog.covar

--- a/src/fswAlgorithms/attDetermination/sunlineEKF/_UnitTest/SunLineEKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineEKF/_UnitTest/SunLineEKF_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -88,7 +88,7 @@ def StateErrorCovarPlot(x, Pflat, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close('all')
@@ -169,7 +169,7 @@ def StatesPlotCompare(x, x2, Pflat, Pflat2, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesCompare', 'State error and covariance vs expected Values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesCompare', 'State error and covariance vs expected Values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -255,7 +255,7 @@ def PostFitResiduals(Res, noise, show_plots):
     plt.title('Eight CSS')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('PostFit', 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit', 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -296,7 +296,7 @@ def StatesVsExpected(stateLog, expectedStateArray, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesExpected', 'States vs true states in static case', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesExpected', 'States vs true states in static case', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -352,7 +352,7 @@ def StatesVsTargets(target1, target2, stateLog, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/attDetermination/sunlineEKF/_UnitTest/test_SunLineEKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineEKF/_UnitTest/test_SunLineEKF.py
@@ -24,9 +24,9 @@ import numpy as np
 import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import sunlineEKF
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 
 import SunLineEKF_test_utilities as FilterPlots
 
@@ -448,7 +448,7 @@ def StatePropStatic():
     unitTestSim.ConfigureStopTime(macros.sec2nano(8000.0))
     unitTestSim.ExecuteSimulation()
 
-    stateLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.state)
+    stateLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.state)
 
     for i in range(6):
         if (abs(stateLog[-1, i + 1] - stateLog[0, i + 1]) > 1.0E-10):
@@ -520,10 +520,10 @@ def StatePropVariable(show_plots):
     unitTestSim.ExecuteSimulation()
 
 
-    covarLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.state)
-    stateErrorLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.x)
-    stmLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.stateTransition)
+    covarLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.covar)
+    stateLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.state)
+    stateErrorLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.x)
+    stmLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.stateTransition)
 
 
     dt = 0.5
@@ -725,7 +725,7 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + SimHalfLength+1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    stateErrorLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.x)
+    stateErrorLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.x)
     stateLog = addTimeColumn(dataLog.times(), dataLog.state)
     postFitLog = addTimeColumn(dataLog.times(), dataLog.postFitRes)
     covarLog = addTimeColumn(dataLog.times(), dataLog.covar)

--- a/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/SunLineSEKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/SunLineSEKF_test_utilities.py
@@ -21,7 +21,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -82,7 +82,7 @@ def StatesPlot(x, Pflat, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -154,7 +154,7 @@ def StatesPlotCompare(x, x2, Pflat, Pflat2, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesCompare', 'State error and covariance vs expected Values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesCompare', 'State error and covariance vs expected Values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -240,7 +240,7 @@ def PostFitResiduals(Res, noise, show_plots):
     plt.title('Eight CSS')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('PostFit', 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit', 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -281,7 +281,7 @@ def StatesVsExpected(stateLog, expectedStateArray, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesExpected', 'States vs true states in static case', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesExpected', 'States vs true states in static case', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()
@@ -331,7 +331,7 @@ def StatesVsTargets(target1, target2, stateLog, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesTarget', 'States tracking target values', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/test_SunLineSEKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/test_SunLineSEKF.py
@@ -26,9 +26,9 @@ import numpy as np
 import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import sunlineSEKF
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros, RigidBodyKinematics
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 
 import SunLineSEKF_test_utilities as FilterPlots
 
@@ -612,7 +612,7 @@ def StatePropStatic():
     unitTestSim.ConfigureStopTime(macros.sec2nano(8000.0))
     unitTestSim.ExecuteSimulation()
 
-    stateLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.state)
+    stateLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.state)
 
     for i in range(numStates):
         if (abs(stateLog[-1, i + 1] - stateLog[0, i + 1]) > 1.0E-10):
@@ -679,10 +679,10 @@ def StatePropVariable(show_plots):
     unitTestSim.ExecuteSimulation()
 
 
-    covarLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.covar)
-    stateLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.state)
-    stateErrorLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.x)
-    stmLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.stateTransition)
+    covarLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.covar)
+    stateLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.state)
+    stateErrorLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.x)
+    stmLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.stateTransition)
 
     bVec = [1.,0.,0.]
     dt = 0.5
@@ -906,7 +906,7 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
         unitTestSim.ConfigureStopTime(macros.sec2nano((i + SimHalfLength+1) * 0.5))
         unitTestSim.ExecuteSimulation()
 
-    stateErrorLog = unitTestSupport.addTimeColumn(kfLog.times(), kfLog.x)
+    stateErrorLog = simHelpers.addTimeColumn(kfLog.times(), kfLog.x)
     stateLog = addTimeColumn(dataLog.times(), dataLog.state)
     postFitLog = addTimeColumn(dataLog.times(), dataLog.postFitRes)
     covarLog = addTimeColumn(dataLog.times(), dataLog.covar)

--- a/src/fswAlgorithms/attDetermination/sunlineSuKF/_UnitTest/SunLineSuKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSuKF/_UnitTest/SunLineSuKF_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -88,7 +88,7 @@ def StateCovarPlot(x, Pflat, show_plots):
     plt.title('Solar Intensity')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot', 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -175,7 +175,7 @@ def PostFitResiduals(Res, noise, show_plots):
     plt.title('Eight CSS')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('PostFit' , 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit' , 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/attDetermination/sunlineUKF/_UnitTest/SunLineuKF_test_utilities.py
+++ b/src/fswAlgorithms/attDetermination/sunlineUKF/_UnitTest/SunLineuKF_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -81,7 +81,7 @@ def StateCovarPlot(x, Pflat, testNum, show_plots):
     plt.title('Third rate component')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot' + str(testNum), 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot' + str(testNum), 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -168,7 +168,7 @@ def PostFitResiduals(Res, noise, testNum, show_plots):
     plt.title('Eight CSS')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('PostFit' + str(testNum), 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit' + str(testNum), 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
+++ b/src/fswAlgorithms/attGuidance/attTrackingError/_UnitTest/test_attTrackingError.py
@@ -45,6 +45,7 @@ from Basilisk.utilities import unitTestSupport              # general support fi
 from Basilisk.fswAlgorithms import attTrackingError                  # import the module that is to be tested
 from Basilisk.utilities import macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -143,9 +144,9 @@ def subModuleTestFunction(show_plots):
     if not unitTestSupport.isArrayEqual(moduleOutput, trueVector, 3, accuracy):
         testFailCount += 1
         testMessages.append("FAILED: " + module.ModelTag + " Module failed sigma_BR unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_sigBR", "FAILED", path)
+        simHelpers.writeTeXSnippet("passFail_sigBR", "FAILED", path)
     else:
-        unitTestSupport.writeTeXSnippet("passFail_sigBR", "PASSED", path)
+        simHelpers.writeTeXSnippet("passFail_sigBR", "PASSED", path)
 
     #
     # check omega_BR_B
@@ -159,9 +160,9 @@ def subModuleTestFunction(show_plots):
     if not unitTestSupport.isArrayEqual(moduleOutput, trueVector, 3, accuracy):
         testFailCount += 1
         testMessages.append("FAILED: " + module.ModelTag + " Module failed omega_BR_B unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_omega_BR_B", "FAILED", path)
+        simHelpers.writeTeXSnippet("passFail_omega_BR_B", "FAILED", path)
     else:
-        unitTestSupport.writeTeXSnippet("passFail_omega_BR_B", "PASSED", path)
+        simHelpers.writeTeXSnippet("passFail_omega_BR_B", "PASSED", path)
 
     #
     # check omega_RN_B
@@ -175,9 +176,9 @@ def subModuleTestFunction(show_plots):
     if not unitTestSupport.isArrayEqual(moduleOutput,trueVector,3,accuracy):
         testFailCount += 1
         testMessages.append("FAILED: " + module.ModelTag + " Module failed omega_RN_N unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_omega_RN_B", "FAILED", path)
+        simHelpers.writeTeXSnippet("passFail_omega_RN_B", "FAILED", path)
     else:
-        unitTestSupport.writeTeXSnippet("passFail_omega_RN_B", "PASSED", path)
+        simHelpers.writeTeXSnippet("passFail_omega_RN_B", "PASSED", path)
 
     #
     # check domega_RN_B
@@ -191,9 +192,9 @@ def subModuleTestFunction(show_plots):
     if not unitTestSupport.isArrayEqual(moduleOutput,trueVector,3,accuracy):
         testFailCount += 1
         testMessages.append("FAILED: " + module.ModelTag + " Module failed domega_RN_B unit test\n")
-        unitTestSupport.writeTeXSnippet("passFail_domega_RN_B", "FAILED", path)
+        simHelpers.writeTeXSnippet("passFail_domega_RN_B", "FAILED", path)
     else:
-        unitTestSupport.writeTeXSnippet("passFail_domega_RN_B", "PASSED", path)
+        simHelpers.writeTeXSnippet("passFail_domega_RN_B", "PASSED", path)
 
     # Note that we can continue to step the simulation however we feel like.
     # Just because we stop and query data does not mean everything has to stop for good

--- a/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/_UnitTest/test_celestialTwoBodyPoint.py
+++ b/src/fswAlgorithms/attGuidance/celestialTwoBodyPoint/_UnitTest/test_celestialTwoBodyPoint.py
@@ -35,6 +35,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import astroFunctions as af
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import astroConstants
 from numpy import linalg as la
 
@@ -220,9 +221,9 @@ def celestialTwoBodyPointTestFunction(show_plots):
             testMessages.append("FAILED: " + module.ModelTag + " Module failed sigma_RN unit test at t=" +
                                 str(moduleOutput[i, 0] * macros.NANO2SEC) +
                                 "sec\n")
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail11', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail11', textSnippetPassed, path)
 
     # check omega_RN_N
     moduleOutput = dataLog.omega_RN_N
@@ -235,9 +236,9 @@ def celestialTwoBodyPointTestFunction(show_plots):
             testMessages.append("FAILED: " + module.ModelTag + " Module failed omega_RN_N unit test at t=" +
                                 str(moduleOutput[i, 0] * macros.NANO2SEC) +
                                 "sec\n")
-            unitTestSupport.writeTeXSnippet('passFail12', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail12', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail12', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail12', textSnippetPassed, path)
 
     # check domega_RN_N
     moduleOutput = dataLog.domega_RN_N
@@ -250,9 +251,9 @@ def celestialTwoBodyPointTestFunction(show_plots):
             testMessages.append("FAILED: " + module.ModelTag + " Module failed domega_RN_N unit test at t=" +
                                 str(moduleOutput[i, 0] * macros.NANO2SEC) +
                                 "sec\n")
-            unitTestSupport.writeTeXSnippet('passFail13', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail13', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail13', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail13', textSnippetPassed, path)
 
     if testFailCount == 0:
         print("PASSED: " + "celestialTwoBodyPointTestFunction")
@@ -362,7 +363,7 @@ def secBodyCelestialTwoBodyPointTestFunction(show_plots):
 
     # compare the module results to the truth values
     accuracy = 1e-10
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     for i in range(0, len(moduleOutput)):
         # check a vector values
@@ -371,9 +372,9 @@ def secBodyCelestialTwoBodyPointTestFunction(show_plots):
             testMessages.append("FAILED: " + module.ModelTag + " Module failed sigma_RN unit test at t=" +
                                 str(dataLog.times()[i] * macros.NANO2SEC) +
                                 "sec\n")
-            unitTestSupport.writeTeXSnippet('passFail21', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail21', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail21', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail21', textSnippetPassed, path)
 
     # check omega_RN_N
     moduleOutput = dataLog.omega_RN_N
@@ -388,9 +389,9 @@ def secBodyCelestialTwoBodyPointTestFunction(show_plots):
             testMessages.append("FAILED: " + module.ModelTag + " Module failed omega_RN_N unit test at t=" +
                                 str(dataLog.times()[i] * macros.NANO2SEC) +
                                 "sec\n")
-            unitTestSupport.writeTeXSnippet('passFail22', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail22', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail22', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail22', textSnippetPassed, path)
 
     # check domega_RN_N
     moduleOutput = dataLog.domega_RN_N
@@ -406,9 +407,9 @@ def secBodyCelestialTwoBodyPointTestFunction(show_plots):
             testMessages.append("FAILED: " + module.ModelTag + " Module failed domega_RN_N unit test at t=" +
                                 str(dataLog.times()[i] * macros.NANO2SEC) +
                                 "sec\n")
-            unitTestSupport.writeTeXSnippet('passFail23', textSnippetFailed, path)
+            simHelpers.writeTeXSnippet('passFail23', textSnippetFailed, path)
         else:
-            unitTestSupport.writeTeXSnippet('passFail23', textSnippetPassed, path)
+            simHelpers.writeTeXSnippet('passFail23', textSnippetPassed, path)
 
     # Note that we can continue to step the simulation however we feel like.
     # Just because we stop and query data does not mean everything has to stop for good

--- a/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/_UnitTest/test_ConstrainedAttitudeManeuver.py
+++ b/src/fswAlgorithms/attGuidance/constrainedAttitudeManeuver/_UnitTest/test_ConstrainedAttitudeManeuver.py
@@ -37,6 +37,7 @@ from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 path = os.path.dirname(os.path.abspath(__file__))
 dataFileName = None
@@ -58,7 +59,7 @@ class constraint:
     def __init__(self, axis, color):
         self.axis =  axis / np.linalg.norm(axis)
         self.color = color
-        
+
 
 class node:
     def __init__(self, sigma_BN, constraints, **kwargs):
@@ -132,7 +133,7 @@ def distanceCart(n1, n2):
     return min(d1, d2, d3, d4)
 
 
-def distanceMRP(n1, n2):    
+def distanceMRP(n1, n2):
     s1 = n1.sigma_BN
     s2 = n2.sigma_BN
     sigma1norm2 = n1.sigma_BN[0]**2 + n1.sigma_BN[1]**2 + n1.sigma_BN[2]**2
@@ -166,7 +167,7 @@ def neighboringNodes(i, j, k):
 
 
 def generateGrid(n_start, n_goal, N, constraints, data):
-    
+
     u = np.linspace(0, 1, N, endpoint = True)
     nodes = {}
 
@@ -196,7 +197,7 @@ def generateGrid(n_start, n_goal, N, constraints, data):
                             for m in mirrorFunction(i, j, k+1):
                                 if (m[0], m[1], m[2]) not in nodes:
                                     nodes[(m[0], m[1], m[2])] = node([np.sign(m[0])*u[i], np.sign(m[1])*u[j], np.sign(m[2])*(1-u[i]**2-u[j]**2)**0.5], constraints, **data)
-    
+
     # link nodes
     for key1 in nodes:
         i = key1[0]
@@ -247,7 +248,7 @@ def generateGrid(n_start, n_goal, N, constraints, data):
         n_start.neighbors[key] = n_s.neighbors[key]
     for key in n_g.neighbors:
         nodes[key].neighbors[key_g] = n_goal
-    nodes[key_s] = n_start 
+    nodes[key_s] = n_start
     nodes[key_g] = n_goal
 
     return nodes
@@ -429,7 +430,7 @@ def effortBasedAStar(nodes, n_start, n_goal, omegaS, omegaG, avgOmega, I):
 # of the multiple test runs for this test.
 @pytest.mark.parametrize("N", [5,6])
 @pytest.mark.parametrize("keepOutFov", [20])
-@pytest.mark.parametrize("keepInFov", [70]) 
+@pytest.mark.parametrize("keepInFov", [70])
 @pytest.mark.parametrize("costFcnType", [0,1])
 @pytest.mark.parametrize("accuracy", [1e-12])
 def test_constrainedAttitudeManeuver(show_plots, N, keepOutFov, keepInFov, costFcnType, accuracy):
@@ -452,14 +453,14 @@ def test_constrainedAttitudeManeuver(show_plots, N, keepOutFov, keepInFov, costF
     **Description of Variables Being Tested**
 
     The tests to show the correctness of the module are the following:
-    
+
     - First of all, an equivalent grid is built in python. The first test consists in comparing the nodes generated
       in Python versus the nodes generated in C++. The check consists in verifying whether the same key indices
-      :math:`(i,j,k)` generate the same node coordinates :math:`\sigma_{BN}`. Secondly, it is checked whether 
+      :math:`(i,j,k)` generate the same node coordinates :math:`\sigma_{BN}`. Secondly, it is checked whether
       the same node is constraint-compliant or -incompliant both in Python and in C++.
 
     - After running the graph-search algorithm, a check is conduced to ensure the equivalence of the computed paths.
-      Note that this unit test does not run the effort-based version of A*, due to the slow nature of the Python 
+      Note that this unit test does not run the effort-based version of A*, due to the slow nature of the Python
       implementation. If the user wishes, it is possible to uncomment line 429 to also test the effort-based
       graph-search algorithm.
 
@@ -486,7 +487,7 @@ def CAMTestFunction(N, keepOutFov, keepInFov, costFcnType, accuracy):
     Inertia = [0.02 / 3,  0.,         0.,
                0.,        0.1256 / 3, 0.,
                0.,        0.,         0.1256 / 3]
-    InertiaTensor = unitTestSupport.np2EigenMatrix3d(Inertia)
+    InertiaTensor = simHelpers.np2EigenMatrix3d(Inertia)
     PlanetInertialPosition = np.array([10, 0, 0])
     SCInertialPosition = np.array([1, 0, 0])
     SCInitialAttitude = np.array([0, 0, -0.5])
@@ -503,7 +504,7 @@ def CAMTestFunction(N, keepOutFov, keepInFov, costFcnType, accuracy):
     constraints = {'keepOut' : [], 'keepIn' : []}
     constraints['keepOut'].append( constraint(PlanetInertialPosition-SCInertialPosition, 'r') )
     constraints['keepIn'].append( constraint(PlanetInertialPosition-SCInertialPosition, 'g') )
-    data =  {'keepOut_b' : keepOutBoresight_B, 'keepOut_fov' : [keepOutFov], 
+    data =  {'keepOut_b' : keepOutBoresight_B, 'keepOut_fov' : [keepOutFov],
              'keepIn_b' : keepInBoresight_B, 'keepIn_fov' : [keepInFov, keepInFov]}
     n_start = node(SCInitialAttitude, constraints, **data)
     n_goal  = node(SCTargetAttitude, constraints, **data)
@@ -524,7 +525,7 @@ def CAMTestFunction(N, keepOutFov, keepInFov, costFcnType, accuracy):
     testProcessRate = macros.sec2nano(0.5)     # update process rate update time
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
-    
+
     testModule = constrainedAttitudeManeuver.ConstrainedAttitudeManeuver(N)
     testModule.sigma_BN_goal = SCTargetAttitude
     testModule.omega_BN_B_goal = SCTargetAngRate
@@ -536,7 +537,7 @@ def CAMTestFunction(N, keepOutFov, keepInFov, costFcnType, accuracy):
     testModule.appendKeepInDirection(keepInBoresight_B[1], keepInFov)
     testModule.ModelTag = "testModule"
     unitTestSim.AddModelToTask(unitTaskName, testModule)
-	
+
     # connect messages
     SCStatesMsgData = messaging.SCStatesMsgPayload()
     SCStatesMsgData.r_BN_N = SCInertialPosition
@@ -555,7 +556,7 @@ def CAMTestFunction(N, keepOutFov, keepInFov, costFcnType, accuracy):
     testModule.keepInCelBodyInMsg.subscribeTo(PlanetStateMsg)
 
     numDataPoints = 200
-    samplingTime = unitTestSupport.samplingTime(simulationTime, testProcessRate, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, testProcessRate, numDataPoints)
 
     CAMLog = testModule.attRefOutMsg.recorder(samplingTime)
     unitTestSim.AddModelToTask(unitTaskName, CAMLog)
@@ -676,11 +677,11 @@ def CAMTestFunction(N, keepOutFov, keepInFov, costFcnType, accuracy):
             testMessages.append("FAILED: " + testModule.ModelTag + " Error in C attitude reference message at t = {} sec \n".format(t))
         if not unitTestSupport.isVectorEqual(omegaDot_RN_N, CAMLogC.domega_RN_N[n], accuracy):
             testFailCount += 1
-            testMessages.append("FAILED: " + testModule.ModelTag + " Error in C attitude reference message at t = {} sec \n".format(t)) 
+            testMessages.append("FAILED: " + testModule.ModelTag + " Error in C attitude reference message at t = {} sec \n".format(t))
 
 
     return [testFailCount, ''.join(testMessages)]
-	   
+
 
 #
 # This statement below ensures that the unitTestScript can be run as a

--- a/src/fswAlgorithms/attGuidance/inertial3D/_UnitTest/test_inertial3D.py
+++ b/src/fswAlgorithms/attGuidance/inertial3D/_UnitTest/test_inertial3D.py
@@ -38,6 +38,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 from Basilisk.fswAlgorithms import inertial3D                   # import the module that is to be tested
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -129,7 +130,7 @@ def subModuleTestFunction(show_plots):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     for i in range(0,len(trueVector)):
         # check a vector values
@@ -169,7 +170,7 @@ def subModuleTestFunction(show_plots):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     # each test method requires a single assert method to be called

--- a/src/fswAlgorithms/attGuidance/mrpRotation/_UnitTest/test_mrpRotation.py
+++ b/src/fswAlgorithms/attGuidance/mrpRotation/_UnitTest/test_mrpRotation.py
@@ -39,6 +39,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 from Basilisk.fswAlgorithms import mrpRotation                    # import the module that is to be tested
 from Basilisk.utilities import macros as mc
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -96,8 +97,8 @@ def run(show_plots, cmdStateFlag, testReset):
     module.mrpSet = sigma_RR0
     omega_RR0_R = np.array([0.1, 0.0, 0.0]) * mc.D2R
     module.omega_RR0_R = omega_RR0_R
-    unitTestSupport.writeTeXSnippet("sigma_RR0", str(sigma_RR0), path)
-    unitTestSupport.writeTeXSnippet("omega_RR0_R", str(omega_RR0_R*mc.R2D) + "deg/sec", path)
+    simHelpers.writeTeXSnippet("sigma_RR0", str(sigma_RR0), path)
+    simHelpers.writeTeXSnippet("omega_RR0_R", str(omega_RR0_R*mc.R2D) + "deg/sec", path)
 
 
     if cmdStateFlag:
@@ -109,8 +110,8 @@ def run(show_plots, cmdStateFlag, testReset):
         desInMsg = messaging.AttStateMsg().write(desiredAtt)
         module.desiredAttInMsg.subscribeTo(desInMsg)
 
-        unitTestSupport.writeTeXSnippet("sigma_RR0Cmd", str(sigma_RR0), path)
-        unitTestSupport.writeTeXSnippet("omega_RR0_RCmd", str(omega_RR0_R * mc.R2D) + "deg/sec", path)
+        simHelpers.writeTeXSnippet("sigma_RR0Cmd", str(sigma_RR0), path)
+        simHelpers.writeTeXSnippet("omega_RR0_RCmd", str(omega_RR0_R * mc.R2D) + "deg/sec", path)
 
 
     #
@@ -151,7 +152,7 @@ def run(show_plots, cmdStateFlag, testReset):
     # This pulls the actual data log from the simulation run.
     # Note that range(3) will provide [0, 1, 2]  Those are the elements you get from the vector (all of them)
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
     trueSigma, trueOmega, truedOmega, \
         = truth.results(sigma_RR0,omega_RR0_R,RefStateInData,updateTime, cmdStateFlag, testReset)
 
@@ -185,7 +186,7 @@ def run(show_plots, cmdStateFlag, testReset):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     # each test method requires a single assert method to be called

--- a/src/fswAlgorithms/attGuidance/opNavPoint/_UnitTest/test_opNavPoint.py
+++ b/src/fswAlgorithms/attGuidance/opNavPoint/_UnitTest/test_opNavPoint.py
@@ -40,6 +40,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import opNavPoint                   # import the module that is to be tested
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros as mc
+from Basilisk.utilities import simHelpers
 
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -159,7 +160,7 @@ def opNavPointTestFunction(show_plots, case):
         ]
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     for i in range(0,len(trueVector)):
         # check a vector values
@@ -245,7 +246,7 @@ def opNavPointTestFunction(show_plots, case):
         colorText = 'Red'
         print("FAILED: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
 

--- a/src/fswAlgorithms/attGuidance/sunSafePoint/_UnitTest/test_sunSafePoint.py
+++ b/src/fswAlgorithms/attGuidance/sunSafePoint/_UnitTest/test_sunSafePoint.py
@@ -43,6 +43,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import sunSafePoint                   # import the module that is to be tested
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros as mc
+from Basilisk.utilities import simHelpers
 
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -196,7 +197,7 @@ def sunSafePointTestFunction(show_plots, case):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     for i in range(0,len(trueVector)):
         # check a vector values
@@ -287,7 +288,7 @@ def sunSafePointTestFunction(show_plots, case):
         print("FAILED: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
         print(testMessages)
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
 

--- a/src/fswAlgorithms/dvGuidance/dvAttGuidance/_UnitTest/test_dvGuidance.py
+++ b/src/fswAlgorithms/dvGuidance/dvAttGuidance/_UnitTest/test_dvGuidance.py
@@ -13,6 +13,7 @@ from Basilisk.fswAlgorithms import dvGuidance
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -97,7 +98,7 @@ def dvGuidanceTestFunction(show_plots):
                  [0.00000000e+00, 0.00000000e+00, 0.00000000e+00]]
 
     accuracy = 1e-9
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     for i in range(len(trueSigma)):
         # check a vector values
@@ -157,7 +158,7 @@ def dvGuidanceTestFunction(show_plots):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorqueParametrized.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorTorque/_UnitTest/test_rwMotorTorqueParametrized.py
@@ -40,6 +40,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
 from Basilisk.fswAlgorithms import rwMotorTorque
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 from Support import results_rwMotorTorque
 
@@ -253,10 +254,10 @@ def rwMotorTorqueTest(show_plots, numControlAxes, numWheels, RWAvailMsg):
     snippetTex = "Requested:\t" + requestedTex + "\n"
     snippetTex += "Received:\t" + receivedTex + "\n"
 
-    unitTestSupport.writeTeXSnippet(snippetName, snippetTex, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetTex, path)
 
     #   print out success message if no error were found
-    unitTestSupport.writeTeXSnippet('toleranceValue', str(accuracy), path)
+    simHelpers.writeTeXSnippet('toleranceValue', str(accuracy), path)
 
     snippentName = "passFail_"+str(numControlAxes) + str(numWheels) + RWAvailMsg
     if testFailCount == 0:
@@ -267,7 +268,7 @@ def rwMotorTorqueTest(show_plots, numControlAxes, numWheels, RWAvailMsg):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     # each test method requires a single assert method to be called

--- a/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/_UnitTest/test_rwMotorVoltage.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwMotorVoltage/_UnitTest/test_rwMotorVoltage.py
@@ -34,6 +34,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import rwMotorVoltage
 from Basilisk.utilities import fswSetupRW
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -167,7 +168,7 @@ def run(show_plots, useLargeVoltage, useAvailability, useTorqueLoop, testName):
         rwSpeedMessage.wheelSpeeds = [1.0, 2.0, 1.5, -3.0]      # rad/sec Omega's
         rwSpeedInMsg = messaging.RWSpeedMsg().write(rwSpeedMessage)
         module.rwSpeedInMsg.subscribeTo(rwSpeedInMsg)
-        unitTestSupport.writeTeXSnippet("Omega1", r"$\bm\Omega = " \
+        simHelpers.writeTeXSnippet("Omega1", r"$\bm\Omega = " \
                                         + str(rwSpeedMessage.wheelSpeeds[0:4]) + "$"
                                         , path)
 
@@ -228,7 +229,7 @@ def run(show_plots, useLargeVoltage, useAvailability, useTorqueLoop, testName):
     if useTorqueLoop:
         rwSpeedMessage.wheelSpeeds = [1.1, 2.1, 1.1, -4.1]  # rad/sec Omega's
         rwSpeedInMsg.write(rwSpeedMessage)
-        unitTestSupport.writeTeXSnippet("Omega2", r"$\bm\Omega = " \
+        simHelpers.writeTeXSnippet("Omega2", r"$\bm\Omega = " \
                                         + str(rwSpeedMessage.wheelSpeeds[0:4]) + "$"
                                         , path)
     unitTestSim.ConfigureStopTime(macros.sec2nano(1.5))        # seconds to stop simulation
@@ -322,7 +323,7 @@ def run(show_plots, useLargeVoltage, useAvailability, useTorqueLoop, testName):
     else:
         colorText = 'Red'
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # write TeX Tables for documentation
     moduleOutput = addTimeColumn(dataLog.times(), dataLog.voltage)[:, :numRW+1]
@@ -336,13 +337,13 @@ def run(show_plots, useLargeVoltage, useAvailability, useTorqueLoop, testName):
     caption = 'RW voltage output for case {\\tt useLargeVoltage = ' + str(useLargeVoltage) \
               + ', useAvailability = ' + str(useAvailability) \
               + ', useTorqueLoop = ' + str(useTorqueLoop) + '}.'
-    unitTestSupport.writeTableLaTeX(
+    simHelpers.writeTableLaTeX(
         tableName,
         tableHeaders,
         caption,
         resultTable,
         path)
-    unitTestSupport.writeTeXSnippet("us"+ str(useLargeVoltage) + str(useAvailability) + str(useTorqueLoop)
+    simHelpers.writeTeXSnippet("us"+ str(useLargeVoltage) + str(useAvailability) + str(useTorqueLoop)
                                     , "$\\bm u_s = " + str(usMessageData.motorTorque[0:numRW]) + "$"
                                     , path)
 

--- a/src/fswAlgorithms/effectorInterfaces/rwNullSpace/_UnitTest/test_rwNullSpace.py
+++ b/src/fswAlgorithms/effectorInterfaces/rwNullSpace/_UnitTest/test_rwNullSpace.py
@@ -12,6 +12,7 @@ import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import rwNullSpace
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import simHelpers
 from numpy.linalg import inv
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -170,7 +171,7 @@ def rwNullSpaceTestFunction(numWheels, defaultDesired):
 
 
     accuracy = 1e-6
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     # At each timestep, make sure the vehicleConfig values haven't changed from the initial values
     testFailCount, testMessages = unitTestSupport.compareArrayND(trueVector, outputCrtlData,
@@ -188,7 +189,7 @@ def rwNullSpaceTestFunction(numWheels, defaultDesired):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     return [testFailCount, ''.join(testMessages)]

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/_UnitTest/test_thrFiringRemainder.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringRemainder/_UnitTest/test_thrFiringRemainder.py
@@ -46,6 +46,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import thrFiringRemainder            # import the module that is to be tested
 from Basilisk.utilities import macros
 from Basilisk.utilities import fswSetupThrusters
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -225,7 +226,7 @@ def thrFiringRemainderTestFunction(show_plots, resetCheck, dvOn):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     testFailCount, testMessages = unitTestSupport.compareArray(trueVector, moduleOutput, accuracy,
                                                                "OnTimeRequest", testFailCount, testMessages)
@@ -239,7 +240,7 @@ def thrFiringRemainderTestFunction(show_plots, resetCheck, dvOn):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # First set a non-zero thruster force request
     thrMessageData.thrForce = [0.5, 0.05, 0.1, 0.15, 0.19, 0.0, 0.2, 0.49]

--- a/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/_UnitTest/test_thrFiringSchmitt.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrFiringSchmitt/_UnitTest/test_thrFiringSchmitt.py
@@ -45,6 +45,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import thrFiringSchmitt            # import the module that is to be tested
 from Basilisk.utilities import macros
 from Basilisk.utilities import fswSetupThrusters
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -257,7 +258,7 @@ def thrFiringSchmittTestFunction(show_plots, resetCheck, dvOn):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     testFailCount, testMessages = unitTestSupport.compareArray(trueVector, moduleOutput, accuracy,
                                                                "OnTimeRequest", testFailCount, testMessages)
@@ -271,7 +272,7 @@ def thrFiringSchmittTestFunction(show_plots, resetCheck, dvOn):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # First set a non-zero thruster force request
     inputMessageData.thrForce = [0.5, 0.05, 0.09, 0.11, 0.16, 0.18, 0.2, 0.49]

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/test_thrForceMap_configErr.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/test_thrForceMap_configErr.py
@@ -39,6 +39,7 @@ from Basilisk.utilities import (
     unitTestSupport,  # general support file with common unit test functions
 )
 from Basilisk.utilities import SimulationBaseClass, fswSetupThrusters, macros
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -271,7 +272,7 @@ def thrusterForceTest(show_plots, useDVThruster, useCOMOffset, dropThruster, asy
                                                                  numThrusters, testFailCount, testMessages)
 
 
-    unitTestSupport.writeTeXSnippet('toleranceValue', str(accuracy), path)
+    simHelpers.writeTeXSnippet('toleranceValue', str(accuracy), path)
 
     snippentName = "passFail_" + str(useDVThruster) + "_" + str(useCOMOffset) + "_" + str(dropThruster) + "_" + str(
         numControlAxis) + "_" + str(saturateThrusters) + "_" + str(misconfigThruster)
@@ -283,7 +284,7 @@ def thrusterForceTest(show_plots, useDVThruster, useCOMOffset, dropThruster, asy
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/test_thrForceMapping.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrForceMapping/_UnitTest/test_thrForceMapping.py
@@ -36,6 +36,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import thrForceMapping
 from Basilisk.utilities import macros
 from Basilisk.utilities import fswSetupThrusters
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 import numpy as np
@@ -360,17 +361,17 @@ def thrusterForceTest(show_plots, useDVThruster, useCOMOffset, dropThruster, asy
     # Any solutions that dont have the correct torque, but do have the correct unit direction are called successful.
 
     if testFailCount > 0:
-        unitTestSupport.writeTeXSnippet(directory+"Failed/"+snippetName, snippetTex, path)
+        simHelpers.writeTeXSnippet(directory+"Failed/"+snippetName, snippetTex, path)
         print("FAILED: " + module.ModelTag)
         testMessages.append("FAILED: " + module.ModelTag + " Module failed  unit test at t=" +
                             str(dataLog.times()[0] * macros.NANO2SEC) +
                             "sec\n")
     else:
-        unitTestSupport.writeTeXSnippet(directory+"/Passed/" + snippetName, snippetTex, path)
+        simHelpers.writeTeXSnippet(directory+"/Passed/" + snippetName, snippetTex, path)
         print("PASSED: " + module.ModelTag)
 
 
-    unitTestSupport.writeTeXSnippet('toleranceValue', str(accuracy), path)
+    simHelpers.writeTeXSnippet('toleranceValue', str(accuracy), path)
 
     snippentName = "passFail_" + str(useDVThruster) + "_" + str(useCOMOffset) + "_" + str(dropThruster) + "_" + str(
         numControlAxis) + "_" + str(saturateThrusters) + "_" + str(misconfigThruster)
@@ -382,7 +383,7 @@ def thrusterForceTest(show_plots, useDVThruster, useCOMOffset, dropThruster, asy
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     if testFailCount > 0:
         print("Python:\t " + str(F))

--- a/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/_UnitTest/test_thrMomentumDumping.py
+++ b/src/fswAlgorithms/effectorInterfaces/thrMomentumDumping/_UnitTest/test_thrMomentumDumping.py
@@ -37,6 +37,7 @@ from Basilisk.utilities import unitTestSupport                  # general suppor
 from Basilisk.fswAlgorithms import thrMomentumDumping            # import the module that is to be tested
 from Basilisk.utilities import macros
 from Basilisk.utilities import fswSetupThrusters
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
@@ -210,7 +211,7 @@ def thrMomentumDumpingTestFunction(show_plots, resetCheck, largeMinFireTime):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     testFailCount, testMessages = unitTestSupport.compareArray(trueVector, moduleOutput, accuracy,
                                                                "OnTimeRequest", testFailCount, testMessages)
@@ -224,7 +225,7 @@ def thrMomentumDumpingTestFunction(show_plots, resetCheck, largeMinFireTime):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/fswAlgorithms/formationFlying/spacecraftPointing/_UnitTest/test_spacecraftPointing.py
+++ b/src/fswAlgorithms/formationFlying/spacecraftPointing/_UnitTest/test_spacecraftPointing.py
@@ -42,6 +42,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 from Basilisk.fswAlgorithms import spacecraftPointing           # import the module that is to be tested
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 import numpy as np
 from Basilisk.architecture import messaging
 
@@ -198,7 +199,7 @@ def spacecraftPointingTestFunction(show_plots, case):
                    ]
         # compare the module results to the truth values
         accuracy = 1e-12
-        unitTestSupport.writeTeXSnippet("toleranceValue1", str(accuracy), path)
+        simHelpers.writeTeXSnippet("toleranceValue1", str(accuracy), path)
         for i in range(0,len(trueVector)):
             # check a vector values
             if not unitTestSupport.isArrayEqual(moduleOutput[i],trueVector[i],3,accuracy):
@@ -225,7 +226,7 @@ def spacecraftPointingTestFunction(show_plots, case):
         # compare the module results to the truth values
         # The first three values of the simulation have to be ignored for omega_RN_N. For this reason, comparing from index 3.
         accuracy = 1e-9
-        unitTestSupport.writeTeXSnippet("toleranceValue2", str(accuracy), path)
+        simHelpers.writeTeXSnippet("toleranceValue2", str(accuracy), path)
         for i in range(0,len(trueVector)):
             # check a vector values
             if not unitTestSupport.isArrayEqual(moduleOutput[i],trueVector[i],3,accuracy):
@@ -251,7 +252,7 @@ def spacecraftPointingTestFunction(show_plots, case):
         # compare the module results to the truth values
         # The first three values of the simulation have to be ignored for domega_RN_N. For this reason, comparing from index 3.
         accuracy = 1e-12
-        unitTestSupport.writeTeXSnippet("toleranceValue3", str(accuracy), path)
+        simHelpers.writeTeXSnippet("toleranceValue3", str(accuracy), path)
         for i in range(0,len(trueVector)):
             # check a vector values
             if not unitTestSupport.isArrayEqual(moduleOutput[i],trueVector[i],3,accuracy):
@@ -263,7 +264,7 @@ def spacecraftPointingTestFunction(show_plots, case):
         trueVector = [-1.0/3.0, 1.0/3.0, -1.0/3.0]
         # compare the module results to the truth values
         accuracy = 1e-12
-        unitTestSupport.writeTeXSnippet("toleranceValue4", str(accuracy), path)
+        simHelpers.writeTeXSnippet("toleranceValue4", str(accuracy), path)
         # check a vector values
         if not unitTestSupport.isVectorEqual(np.array(module.sigma_BA), np.array(trueVector), accuracy):
             testFailCount += 1
@@ -279,7 +280,7 @@ def spacecraftPointingTestFunction(show_plots, case):
         colorText = 'Red'
         print("FAILED: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/fswAlgorithms/formationFlying/spacecraftReconfig/_UnitTest/test_spacecraftReconfig.py
+++ b/src/fswAlgorithms/formationFlying/spacecraftReconfig/_UnitTest/test_spacecraftReconfig.py
@@ -28,6 +28,7 @@ import pytest
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import spacecraftReconfig  # import the module that is to be tested
 # Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import fswSetupThrusters
 from Basilisk.utilities import macros
@@ -159,7 +160,7 @@ def spacecraftReconfigTestFunction(show_plots, useRefAttitude, accuracy):
 
     # This pulls the actual data log from the simulation run.
     attOutput = dataLog.sigma_RN
-    resetPeriod = unitTestSupport.addTimeColumn(moduleLog.times(), moduleLog.resetPeriod)
+    resetPeriod = simHelpers.addTimeColumn(moduleLog.times(), moduleLog.resetPeriod)
     # set the filtered output truth states
     if useRefAttitude:
         trueVector = [[1.0,0.0,0.0]]

--- a/src/fswAlgorithms/imageProcessing/horizonOpNav/_UnitTest/test_horizonOpNav.py
+++ b/src/fswAlgorithms/imageProcessing/horizonOpNav/_UnitTest/test_horizonOpNav.py
@@ -12,7 +12,11 @@ import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import horizonOpNav
 from Basilisk.utilities import RigidBodyKinematics as rbk
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -367,8 +371,8 @@ def horizonOpNav_update():
 
     posErr = 1e-3 #(m)
     covarErr = 1e-5
-    unitTestSupport.writeTeXSnippet("toleranceValuePos", str(posErr), path)
-    unitTestSupport.writeTeXSnippet("toleranceValueVel", str(covarErr), path)
+    simHelpers.writeTeXSnippet("toleranceValuePos", str(posErr), path)
+    simHelpers.writeTeXSnippet("toleranceValueVel", str(covarErr), path)
 
     outputR = dataLog.r_BN_C
     outputCovar = dataLog.covar_C
@@ -394,7 +398,7 @@ def horizonOpNav_update():
         print("Failed: " + opNav.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
         print(testMessages)
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     return [testFailCount, ''.join(testMessages)]

--- a/src/fswAlgorithms/imageProcessing/pixelLineConverter/_UnitTest/test_pixelLineConverter.py
+++ b/src/fswAlgorithms/imageProcessing/pixelLineConverter/_UnitTest/test_pixelLineConverter.py
@@ -11,7 +11,11 @@ import numpy as np
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import pixelLineConverter
 from Basilisk.utilities import RigidBodyKinematics as rbk
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -139,8 +143,8 @@ def pixelLineConverterTestFunction():
 
     posErr = 1e-10
     covarErr = 1e-10
-    unitTestSupport.writeTeXSnippet("toleranceValuePos", str(posErr), path)
-    unitTestSupport.writeTeXSnippet("toleranceValueVel", str(covarErr), path)
+    simHelpers.writeTeXSnippet("toleranceValuePos", str(posErr), path)
+    simHelpers.writeTeXSnippet("toleranceValueVel", str(covarErr), path)
 
     outputR = dataLog.r_BN_N
     outputCovar = dataLog.covar_N
@@ -171,7 +175,7 @@ def pixelLineConverterTestFunction():
         colorText = 'Red'
         print("Failed: " + pixelLine.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     return [testFailCount, ''.join(testMessages)]

--- a/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/_UnitTest/pixelLineBias_test_utilities.py
+++ b/src/fswAlgorithms/opticalNavigation/pixelLineBiasUKF/_UnitTest/pixelLineBias_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -75,7 +75,7 @@ def StatePlot(x, testName, show_plots):
     plt.title('Third rate component (m/s)')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot' + testName, 'State error', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot' + testName, 'State error', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -93,7 +93,7 @@ def EnergyPlot(t, energy, testName, show_plots):
     plt.grid()
 
 
-    unitTestSupport.writeFigureLaTeX('Energy' + testName, 'Orbital Energy', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('Energy' + testName, 'Orbital Energy', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -157,7 +157,7 @@ def StateCovarPlot(x, Pflat, testName, show_plots):
     plt.title('Third rate component (m/s)')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot' + testName, 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot' + testName, 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -203,7 +203,7 @@ def PostFitResiduals(Res, noise, testName, show_plots):
     plt.grid()
 
 
-    unitTestSupport.writeFigureLaTeX('PostFit' + testName, 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit' + testName, 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/opticalNavigation/relativeODuKF/_UnitTest/relativeODuKF_test_utilities.py
+++ b/src/fswAlgorithms/opticalNavigation/relativeODuKF/_UnitTest/relativeODuKF_test_utilities.py
@@ -19,7 +19,7 @@ import inspect
 import os
 
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -75,7 +75,7 @@ def StatePlot(x, testName, show_plots):
     plt.title('Third rate component (m/s)')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot' + testName, 'State error', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot' + testName, 'State error', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -93,7 +93,7 @@ def EnergyPlot(t, energy, testName, show_plots):
     plt.grid()
 
 
-    unitTestSupport.writeFigureLaTeX('Energy' + testName, 'Orbital Energy', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('Energy' + testName, 'Orbital Energy', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -157,7 +157,7 @@ def StateCovarPlot(x, Pflat, testName, show_plots):
     plt.title('Third rate component (m/s)')
     plt.grid()
 
-    unitTestSupport.writeFigureLaTeX('StatesPlot' + testName, 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('StatesPlot' + testName, 'State error and covariance', plt, 'height=0.9\\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close()
@@ -203,7 +203,7 @@ def PostFitResiduals(Res, noise, testName, show_plots):
     plt.grid()
 
 
-    unitTestSupport.writeFigureLaTeX('PostFit' + testName, 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('PostFit' + testName, 'Post Fit Residuals', plt, 'height=0.9\\textwidth, keepaspectratio', path)
 
     if show_plots:
         plt.show()

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/_UnitTest/test_smallBodyWaypointFeedback.py
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/_UnitTest/test_smallBodyWaypointFeedback.py
@@ -23,7 +23,7 @@ from Basilisk.fswAlgorithms import smallBodyWaypointFeedback
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 # @pytest.mark.parametrize("accuracy", [1e-12])
@@ -75,12 +75,12 @@ def smallBodyWaypointFeedbackTestFunction1():
 
     module.A_sc = 1.  # Surface area of the spacecraft, m^2
     module.M_sc = 300  # Mass of the spacecraft, kg
-    module.IHubPntC_B = unitTestSupport.np2EigenMatrix3d([82.12, 0.0, 0.0, 0.0, 98.40, 0.0, 0.0, 0.0, 121.0])  # sc inertia
+    module.IHubPntC_B = simHelpers.np2EigenMatrix3d([82.12, 0.0, 0.0, 0.0, 98.40, 0.0, 0.0, 0.0, 121.0])  # sc inertia
     module.mu_ast = 4.892  # Gravitational constant of the asteroid
     module.x1_ref = [-2000., 0., 0.]
     module.x2_ref = [0.0, 0.0, 0.0]
-    module.K1 = unitTestSupport.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
-    module.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
+    module.K1 = simHelpers.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
+    module.K2 = simHelpers.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Set the orbital parameters of the asteroid
     oeAsteroid = orbitalMotion.ClassicElements()
@@ -163,12 +163,12 @@ def smallBodyWaypointFeedbackTestFunction2():
 
     module.A_sc = 1.  # Surface area of the spacecraft, m^2
     module.M_sc = 300  # Mass of the spacecraft, kg
-    module.IHubPntC_B = unitTestSupport.np2EigenMatrix3d([82.12, 0.0, 0.0, 0.0, 98.40, 0.0, 0.0, 0.0, 121.0])  # sc inertia
+    module.IHubPntC_B = simHelpers.np2EigenMatrix3d([82.12, 0.0, 0.0, 0.0, 98.40, 0.0, 0.0, 0.0, 121.0])  # sc inertia
     module.mu_ast = 4.892  # Gravitational constant of the asteroid
     module.x1_ref = [-2000., 0., 0.]
     module.x2_ref = [0.0, 0.0, 0.0]
-    module.K1 = unitTestSupport.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
-    module.K2 = unitTestSupport.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
+    module.K1 = simHelpers.np2EigenMatrix3d([5e-4, 0e-5, 0e-5, 0e-5, 5e-4, 0e-5, 0e-5, 0e-5, 5e-4])
+    module.K2 = simHelpers.np2EigenMatrix3d([1., 0., 0., 0., 1., 0., 0., 0., 1.])
 
     # Set the orbital parameters of the asteroid
     oeAsteroid = orbitalMotion.ClassicElements()

--- a/src/fswAlgorithms/sensorInterfaces/CSSSensorData/_UnitTest/test_cssComm.py
+++ b/src/fswAlgorithms/sensorInterfaces/CSSSensorData/_UnitTest/test_cssComm.py
@@ -13,6 +13,7 @@ from Basilisk.fswAlgorithms import cssComm
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -110,7 +111,7 @@ def cssCommTestFunction(numSensors, sensorData):
                                                                  MAX_NUM_CSS_SENSORS, testFailCount, testMessages)
 
     #   print out success message if no error were found
-    unitTestSupport.writeTeXSnippet('toleranceValue', str(accuracy), path)
+    simHelpers.writeTeXSnippet('toleranceValue', str(accuracy), path)
 
     snippentName = "passFail_"+str(numSensors)
     if testFailCount == 0:
@@ -121,7 +122,7 @@ def cssCommTestFunction(numSensors, sensorData):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/fswAlgorithms/sensorInterfaces/TAMSensorData/_UnitTest/test_tamComm.py
+++ b/src/fswAlgorithms/sensorInterfaces/TAMSensorData/_UnitTest/test_tamComm.py
@@ -38,6 +38,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
 from Basilisk.fswAlgorithms import tamComm
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
@@ -92,7 +93,7 @@ def tamCommTestFunction(show_plots):
 
     # Initialize the test module configuration data
     dcm3, _ = np.linalg.qr(np.random.normal(0, 1, (3, 3)))
-    module.dcm_BS = unitTestSupport.flattenList(dcm3)
+    module.dcm_BS = simHelpers.flattenList(dcm3)
 
     # Create input message and size it because the regular creator of that message
     # is not part of the test.

--- a/src/fswAlgorithms/stateEstimation/thrustCMEstimation/_UnitTest/test_thrustCMEstimation.py
+++ b/src/fswAlgorithms/stateEstimation/thrustCMEstimation/_UnitTest/test_thrustCMEstimation.py
@@ -24,7 +24,10 @@ import pytest
 from Basilisk import __path__
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import thrustCMEstimation
-from Basilisk.utilities import SimulationBaseClass, macros, unitTestSupport
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 
 bskPath = __path__[0]
 fileName = os.path.basename(os.path.splitext(__file__)[0])

--- a/src/fswAlgorithms/transDetermination/dvAccumulation/_UnitTest/test_dvAccumulation.py
+++ b/src/fswAlgorithms/transDetermination/dvAccumulation/_UnitTest/test_dvAccumulation.py
@@ -12,6 +12,7 @@ from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import dvAccumulation
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from numpy import random
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -137,7 +138,7 @@ def dvAccumulationTestFunction():
     trueTime = np.array([7.2123026e+07, 7.2123026e+07, 7.2123026e+07, 7.6667436e+07, 7.6667436e+07]) * macros.NANO2SEC
 
     accuracy = 1e-6
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     # At each timestep, make sure the vehicleConfig values haven't changed from the initial values
     testFailCount, testMessages = unitTestSupport.compareArrayND(trueDVVector, outputNavMsgData,
@@ -157,7 +158,7 @@ def dvAccumulationTestFunction():
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/fswAlgorithms/transDetermination/ephemDifference/_UnitTest/test_ephemDifference.py
+++ b/src/fswAlgorithms/transDetermination/ephemDifference/_UnitTest/test_ephemDifference.py
@@ -15,6 +15,7 @@ path = os.path.dirname(os.path.abspath(filename))
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
 from Basilisk.fswAlgorithms import ephemDifference
 from Basilisk.utilities import astroFunctions
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 @pytest.mark.parametrize("ephBdyCount", [3, 0])
@@ -108,8 +109,8 @@ def ephemDifferenceTestFunction(ephBdyCount):
 
         posAcc = 1e1
         velAcc = 1e-4
-        unitTestSupport.writeTeXSnippet("toleranceValuePos", str(posAcc), path)
-        unitTestSupport.writeTeXSnippet("toleranceValueVel", str(velAcc), path)
+        simHelpers.writeTeXSnippet("toleranceValuePos", str(posAcc), path)
+        simHelpers.writeTeXSnippet("toleranceValueVel", str(velAcc), path)
 
         for i in range(ephBdyCount):
 
@@ -145,7 +146,7 @@ def ephemDifferenceTestFunction(ephBdyCount):
         colorText = 'Red'
         print("Failed: " + ephemDiff.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/fswAlgorithms/transDetermination/ephemNavConverter/_UnitTest/test_ephemNavConverter.py
+++ b/src/fswAlgorithms/transDetermination/ephemNavConverter/_UnitTest/test_ephemNavConverter.py
@@ -11,6 +11,7 @@ from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import ephemNavConverter
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
 from Basilisk.utilities import astroFunctions
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -102,7 +103,7 @@ def ephemNavConverterTestFunction():
         colorText = 'Red'
         print("Failed: " + ephemNav.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     return [testFailCount, ''.join(testMessages)]

--- a/src/fswAlgorithms/transDetermination/navAggregate/_UnitTest/test_navAggregate.py
+++ b/src/fswAlgorithms/transDetermination/navAggregate/_UnitTest/test_navAggregate.py
@@ -45,6 +45,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
 from Basilisk.fswAlgorithms import navAggregate
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
@@ -181,22 +182,22 @@ def navAggregateTestFunction(show_plots, numAttNav, numTransNav):
         module.dvIdx = numTransNav-1
 
     # write TeX snippets for the message values
-    unitTestSupport.writeTeXSnippet("navAtt1Msg.timeTag", str(navAtt1Msg.timeTag), path)
-    unitTestSupport.writeTeXSnippet("navAtt1Msg.sigma_BN", str(navAtt1Msg.sigma_BN), path)
-    unitTestSupport.writeTeXSnippet("navAtt1Msg.omega_BN_B", str(navAtt1Msg.omega_BN_B), path)
-    unitTestSupport.writeTeXSnippet("navAtt1Msg.vehSunPntBdy", str(navAtt1Msg.vehSunPntBdy), path)
-    unitTestSupport.writeTeXSnippet("navAtt2Msg.timeTag", str(navAtt2Msg.timeTag), path)
-    unitTestSupport.writeTeXSnippet("navAtt2Msg.sigma_BN", str(navAtt2Msg.sigma_BN), path)
-    unitTestSupport.writeTeXSnippet("navAtt2Msg.omega_BN_B", str(navAtt2Msg.omega_BN_B), path)
-    unitTestSupport.writeTeXSnippet("navAtt2Msg.vehSunPntBdy", str(navAtt2Msg.vehSunPntBdy), path)
-    unitTestSupport.writeTeXSnippet("navTrans1Msg.timeTag", str(navTrans1Msg.timeTag), path)
-    unitTestSupport.writeTeXSnippet("navTrans1Msg.r_BN_N", str(navTrans1Msg.r_BN_N), path)
-    unitTestSupport.writeTeXSnippet("navTrans1Msg.v_BN_N", str(navTrans1Msg.v_BN_N), path)
-    unitTestSupport.writeTeXSnippet("navTrans1Msg.vehAccumDV", str(navTrans1Msg.vehAccumDV), path)
-    unitTestSupport.writeTeXSnippet("navTrans2Msg.timeTag", str(navTrans2Msg.timeTag), path)
-    unitTestSupport.writeTeXSnippet("navTrans2Msg.r_BN_N", str(navTrans2Msg.r_BN_N), path)
-    unitTestSupport.writeTeXSnippet("navTrans2Msg.v_BN_N", str(navTrans2Msg.v_BN_N), path)
-    unitTestSupport.writeTeXSnippet("navTrans2Msg.vehAccumDV", str(navTrans2Msg.vehAccumDV), path)
+    simHelpers.writeTeXSnippet("navAtt1Msg.timeTag", str(navAtt1Msg.timeTag), path)
+    simHelpers.writeTeXSnippet("navAtt1Msg.sigma_BN", str(navAtt1Msg.sigma_BN), path)
+    simHelpers.writeTeXSnippet("navAtt1Msg.omega_BN_B", str(navAtt1Msg.omega_BN_B), path)
+    simHelpers.writeTeXSnippet("navAtt1Msg.vehSunPntBdy", str(navAtt1Msg.vehSunPntBdy), path)
+    simHelpers.writeTeXSnippet("navAtt2Msg.timeTag", str(navAtt2Msg.timeTag), path)
+    simHelpers.writeTeXSnippet("navAtt2Msg.sigma_BN", str(navAtt2Msg.sigma_BN), path)
+    simHelpers.writeTeXSnippet("navAtt2Msg.omega_BN_B", str(navAtt2Msg.omega_BN_B), path)
+    simHelpers.writeTeXSnippet("navAtt2Msg.vehSunPntBdy", str(navAtt2Msg.vehSunPntBdy), path)
+    simHelpers.writeTeXSnippet("navTrans1Msg.timeTag", str(navTrans1Msg.timeTag), path)
+    simHelpers.writeTeXSnippet("navTrans1Msg.r_BN_N", str(navTrans1Msg.r_BN_N), path)
+    simHelpers.writeTeXSnippet("navTrans1Msg.v_BN_N", str(navTrans1Msg.v_BN_N), path)
+    simHelpers.writeTeXSnippet("navTrans1Msg.vehAccumDV", str(navTrans1Msg.vehAccumDV), path)
+    simHelpers.writeTeXSnippet("navTrans2Msg.timeTag", str(navTrans2Msg.timeTag), path)
+    simHelpers.writeTeXSnippet("navTrans2Msg.r_BN_N", str(navTrans2Msg.r_BN_N), path)
+    simHelpers.writeTeXSnippet("navTrans2Msg.v_BN_N", str(navTrans2Msg.v_BN_N), path)
+    simHelpers.writeTeXSnippet("navTrans2Msg.vehAccumDV", str(navTrans2Msg.vehAccumDV), path)
 
     # Setup logging on the test module output message so that we get all the writes to it
     dataAttLog = module.navAttOutMsg.recorder()
@@ -266,7 +267,7 @@ def navAggregateTestFunction(show_plots, numAttNav, numTransNav):
 
     # compare the module results to the truth values
     accuracy = 1e-12
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     # check if the module output matches the truth data
     testFailCount, testMessages = unitTestSupport.compareArrayND(trueAttTimeTag, attTimeTag,
@@ -336,7 +337,7 @@ def navAggregateTestFunction(show_plots, numAttNav, numTransNav):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
+++ b/src/fswAlgorithms/transDetermination/oeStateEphem/_UnitTest/test_oeStateEphem.py
@@ -28,7 +28,6 @@ from Basilisk.topLevelModules import pyswice
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities.pyswice_spk_utilities import spkRead
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
@@ -36,13 +35,14 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split("fswAlgorithms")
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 
 orbitPosAccuracy = 10000.0
 orbitVelAccuracy = 1.0
-unitTestSupport.writeTeXSnippet("tolerancePosValue", str(orbitPosAccuracy), path)
-unitTestSupport.writeTeXSnippet("toleranceVelValue", str(orbitVelAccuracy), path)
+simHelpers.writeTeXSnippet("tolerancePosValue", str(orbitPosAccuracy), path)
+simHelpers.writeTeXSnippet("toleranceVelValue", str(orbitVelAccuracy), path)
 
 
 @pytest.mark.parametrize(
@@ -257,14 +257,14 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
             plt.plot(
                 dataLog.times() * macros.NANO2HOUR,
                 posChebData[:, idx] / 1000,
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 linewidth=0.5,
                 label="$r_{fit," + str(idx) + "}$",
             )
             plt.plot(
                 dataLog.times() * macros.NANO2HOUR,
                 tdrssPosList[:, idx] / 1000,
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 linestyle="dashed",
                 linewidth=2,
                 label="$r_{true," + str(idx) + "}$",
@@ -279,14 +279,14 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
             plt.plot(
                 dataLog.times() * macros.NANO2HOUR,
                 velChebData[:, idx] / 1000,
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 linewidth=0.5,
                 label="$v_{fit," + str(idx) + "}$",
             )
             plt.plot(
                 dataLog.times() * macros.NANO2HOUR,
                 tdrssVelList[:, idx] / 1000,
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 linestyle="dashed",
                 linewidth=2,
                 label="$v_{true," + str(idx) + "}$",
@@ -302,7 +302,7 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
             plt.plot(
                 dataLog.times() * macros.NANO2HOUR,
                 posChebData[:, idx] - tdrssPosList[:, idx],
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 linewidth=0.5,
                 label=r"$\Delta r_{" + str(idx) + "}$",
             )
@@ -329,7 +329,7 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
             plt.plot(
                 dataLog.times() * macros.NANO2HOUR,
                 velChebData[:, idx] - tdrssVelList[:, idx],
-                color=unitTestSupport.getLineColor(idx, 3),
+                color=simHelpers.getLineColor(idx, 3),
                 linewidth=0.5,
                 label=r"$\Delta v_{" + str(idx) + "}$",
             )
@@ -362,7 +362,7 @@ def chebyPosFitAllTest(show_plots, validChebyCurveTime, anomFlag):
         colorText = "Red"
         print("Failed: " + oeStateModel.ModelTag)
         passedText = r"\textcolor{" + colorText + "}{" + "Failed" + "}"
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # return fail count and join into a single string all messages in the list
     # testMessage

--- a/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplate.py
+++ b/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplate.py
@@ -32,6 +32,7 @@ from Basilisk.architecture import bskLogging
 from Basilisk.architecture import messaging  # import the message definitions
 from Basilisk.moduleTemplates import cModuleTemplate  # import the module that is to be tested
 # Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
@@ -59,7 +60,7 @@ def test_module(show_plots):     # update "module" in this function name to refl
     - ``dataVector[3]``
 
     **General Documentation Comments**
-    
+
     If the script generates figures, these figures will be automatically pulled from ``matplotlib`` and included below.
     Make sure that the figures have appropriate axes labels and a figure title if needed.  The figures content
     should be understood by just looking at the figure.
@@ -142,7 +143,7 @@ def fswModuleTestFunction(show_plots):
 
     # This pulls the actual data log from the simulation run.
     # Note that range(3) will provide [0, 1, 2]  Those are the elements you get from the vector (all of them)
-    variableState = unitTestSupport.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
+    variableState = simHelpers.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
 
     # set the filtered output truth states
     trueVector = [
@@ -197,7 +198,7 @@ def fswModuleTestFunction(show_plots):
     plt.figure(2)
     for idx in range(3):
         plt.plot(dataLog.times() * macros.NANO2MIN, dataLog.dataVector[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$s_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplateParametrized.py
+++ b/src/moduleTemplates/cModuleTemplate/_UnitTest/test_cModuleTemplateParametrized.py
@@ -42,6 +42,7 @@ splitPath = path.split(bskName)
 
 
 # Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 import matplotlib.pyplot as plt
@@ -185,7 +186,7 @@ def fswModuleTestFunction(show_plots, param1, param2, accuracy):
 
     # This pulls the BSK module internal varialbe log from the simulation run.
     # Note, this should only be done for debugging as it is a slow process
-    variableState = unitTestSupport.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
+    variableState = simHelpers.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
 
     # set the filtered output truth states
     trueVector = []
@@ -255,7 +256,7 @@ def fswModuleTestFunction(show_plots, param1, param2, accuracy):
     plt.figure(2)
     for idx in range(3):
         plt.plot(dataLog.times() * macros.NANO2MIN, dataLog.dataVector[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$s_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/src/moduleTemplates/cppModuleTemplate/_UnitTest/test_cppModuleTemplateParametrized.py
+++ b/src/moduleTemplates/cppModuleTemplate/_UnitTest/test_cppModuleTemplateParametrized.py
@@ -42,6 +42,7 @@ splitPath = path.split(bskName)
 
 
 # Import all of the modules that we are going to be called in this simulation
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 import matplotlib.pyplot as plt
@@ -186,7 +187,7 @@ def cppModuleTestFunction(show_plots, param1, param2, accuracy):
 
     # This pulls the BSK module internal varialbe log from the simulation run.
     # Note, this should only be done for debugging as it is a slow process
-    variableState = unitTestSupport.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
+    variableState = simHelpers.addTimeColumn(moduleLog.times(), getattr(moduleLog, variableName))
 
     # set the filtered output truth states
     trueVector = []
@@ -256,7 +257,7 @@ def cppModuleTestFunction(show_plots, param1, param2, accuracy):
     plt.figure(2)
     for idx in range(3):
         plt.plot(dataLog.times() * macros.NANO2MIN, dataLog.dataVector[:, idx],
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label=r'$s_' + str(idx) + '$')
     plt.legend(loc='lower right')
     plt.xlabel('Time [min]')

--- a/src/simulation/communication/linkBudget/_UnitTest/test_linkBudget.py
+++ b/src/simulation/communication/linkBudget/_UnitTest/test_linkBudget.py
@@ -42,7 +42,6 @@ import pytest
 
 from Basilisk import __path__
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros, orbitalMotion
 from Basilisk.simulation import linkBudget

--- a/src/simulation/deviceInterface/motorVoltageInterface/_UnitTest/test_motorVoltageInterface.py
+++ b/src/simulation/deviceInterface/motorVoltageInterface/_UnitTest/test_motorVoltageInterface.py
@@ -39,6 +39,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 from Basilisk.simulation import motorVoltageInterface           # import the module that is to be tested
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 
@@ -167,7 +168,7 @@ def run(show_plots, voltage):
     tableName = "baseVoltage" + str(voltage)
     tableHeaders = ["time [s]", "$u_{s,1}$ (Nm)", "Error", "$u_{s,2}$ (Nm)", "Error", "$u_{u,3}$ (Nm)", "Error"]
     caption = 'RW motoor torque output for Base Voltaget = ' + str(voltage) + 'V.'
-    unitTestSupport.writeTableLaTeX(
+    simHelpers.writeTableLaTeX(
         tableName,
         tableHeaders,
         caption,
@@ -184,7 +185,7 @@ def run(show_plots, voltage):
     else:
         colorText = "Red"
         passedText = r'\textcolor{' + colorText + '}{' + "FAILED" + '}'
-    unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+    simHelpers.writeTeXSnippet(snippetName, passedText, path)
 
 
     # each test method requires a single assert method to be called

--- a/src/simulation/dynamics/DynOutput/boreAngCalc/_UnitTest/test_bore_ang_calc.py
+++ b/src/simulation/dynamics/DynOutput/boreAngCalc/_UnitTest/test_bore_ang_calc.py
@@ -37,6 +37,7 @@ from Basilisk.utilities import RigidBodyKinematics
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 path = os.path.dirname(os.path.abspath(__file__))
 
@@ -51,7 +52,7 @@ class ResultsStore:
             elif self.PassFail[i] == 'FAILED':
                 textColor = 'Red'
             texSnippet =  r'\textcolor{' + textColor + '}{'+ self.PassFail[i] + '}'
-            unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+            simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
 @pytest.fixture(scope="module")
 def testFixture():

--- a/src/simulation/dynamics/DynOutput/orbElemConvert/_UnitTest/test_orb_elem_convert.py
+++ b/src/simulation/dynamics/DynOutput/orbElemConvert/_UnitTest/test_orb_elem_convert.py
@@ -42,7 +42,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.simulation import orbElemConvert
 from Basilisk.utilities import macros
 from Basilisk.utilities import macros as mc
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 from Basilisk.utilities.pythonVariableLogger import PythonVariableLogger
 
@@ -514,7 +514,7 @@ def orbElem(a, e, i, AN, AP, f, mu, name, DispPlot):
     plt.legend(loc='lower right')
 
     if name != 0:
-        unitTestSupport.writeFigureLaTeX(name, "$e = " + str(e) + "$ and $a = 10^" + str(int(fact)) + "$km",
+        simHelpers.writeFigureLaTeX(name, "$e = " + str(e) + "$ and $a = 10^" + str(int(fact)) + "$km",
                                          plt, 'height=0.7\\textwidth, keepaspectratio', path)
         if testFailCount2 == 0:
             colorText = 'ForestGreen'
@@ -530,11 +530,11 @@ def orbElem(a, e, i, AN, AP, f, mu, name, DispPlot):
         # Write some snippets for AutoTex
         snippetName = name + "PassedText2"
         snippetContent = passedText
-        unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+        simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
 
         snippetName = name + "PassFailMsg2"
         snippetContent = passFailMsg
-        unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+        simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
 
     if DispPlot:
         plt.show()

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -30,7 +30,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import deprecated
 from Basilisk.utilities import macros
 from Basilisk.utilities import simIncludeThruster
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -143,9 +143,9 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
     stopTime = 60.0 * 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
 
     thrust = thrLog.thrustForce_B
     thrustPercentage = thrLog.thrustFactor

--- a/src/simulation/dynamics/GravityGradientEffector/_UnitTest/test_gravityGradient.py
+++ b/src/simulation/dynamics/GravityGradientEffector/_UnitTest/test_gravityGradient.py
@@ -37,6 +37,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import simIncludeGravBody, orbitalMotion, RigidBodyKinematics
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 bskPath = __path__[0]
 
@@ -192,7 +193,7 @@ def run(show_plots, cmOffset, planetCase, simTime):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 50
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     dataLogGG = ggEff.gravityGradientOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
@@ -228,7 +229,7 @@ def run(show_plots, cmOffset, planetCase, simTime):
         plt.figure(1)
         for idx in range(0, 3):
             plt.plot(dataLog.times() * macros.NANO2MIN, attData[:, idx],
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$\sigma_' + str(idx) + '$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [min]')
@@ -237,7 +238,7 @@ def run(show_plots, cmOffset, planetCase, simTime):
         plt.figure(2)
         for idx in range(0, 3):
             plt.plot(dataLog.times() * macros.NANO2MIN, posData[:, idx]/1000,
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$r_' + str(idx) + '$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [min]')
@@ -246,7 +247,7 @@ def run(show_plots, cmOffset, planetCase, simTime):
         plt.figure(3)
         for idx in range(0, 3):
             plt.plot(dataLogGG.times() * macros.NANO2MIN, ggData[:, idx] ,
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$r_' + str(idx) + '$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [min]')

--- a/src/simulation/dynamics/HingedRigidBodies/_UnitTest/test_hingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/HingedRigidBodies/_UnitTest/test_hingedRigidBodyStateEffector.py
@@ -28,6 +28,7 @@ splitPath = path.split('simulation')
 
 
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib.pyplot as plt
@@ -184,7 +185,7 @@ def hingedRigidBodyMotorTorque(show_plots, useScPlus):
     sB2N = dataPanel2Log.sigma_BN[0]
     oB2N = dataPanel2Log.omega_BN_B[0]
 
-    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
 
     # Get the last sigma and position
     dataPos = [rOut_CN_N[-1]]
@@ -216,13 +217,13 @@ def hingedRigidBodyMotorTorque(show_plots, useScPlus):
     plt.figure()
     plt.clf()
     plt.plot(dataLog.times() * macros.NANO2SEC, sigma_BN[:, 0],
-             color=unitTestSupport.getLineColor(0, 3),
+             color=simHelpers.getLineColor(0, 3),
              label=r'$\sigma_{1}$')
     plt.plot(dataLog.times() * macros.NANO2SEC, sigma_BN[:, 1],
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              label=r'$\sigma_{2}$')
     plt.plot(dataLog.times() * macros.NANO2SEC, sigma_BN[:, 2],
-             color=unitTestSupport.getLineColor(2, 3),
+             color=simHelpers.getLineColor(2, 3),
              label=r'$\sigma_{3}$')
     plt.legend(loc='lower right')
     plt.xlabel('time (s)')
@@ -231,10 +232,10 @@ def hingedRigidBodyMotorTorque(show_plots, useScPlus):
     plt.figure()
     plt.clf()
     plt.plot(dataPanel1.times() * macros.NANO2SEC, theta1*macros.R2D,
-             color=unitTestSupport.getLineColor(0, 3),
+             color=simHelpers.getLineColor(0, 3),
              label=r'$\theta_{1}$')
     plt.plot(dataPanel2.times() * macros.NANO2SEC, theta2*macros.R2D,
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              label=r'$\theta_{2}$')
     plt.legend(loc='lower right')
     plt.xlabel('time (s)')
@@ -421,8 +422,8 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    theta1Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta1)
-    theta2Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta2)
+    theta1Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.theta1)
+    theta2Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.theta2)
 
     rOut_BN_N = dataLog.r_BN_N
     sigmaOut_BN = dataLog.sigma_BN
@@ -486,7 +487,7 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     PlotName = "XPositionLagrangianVsBasilisk"
     PlotTitle = "X Position Lagrangian Vs Basilisk"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     plt.figure()
     plt.clf()
@@ -499,7 +500,7 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     PlotName = "YPositionLagrangianVsBasilisk"
     PlotTitle = "Y Position Lagrangian Vs Basilisk"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     plt.figure()
     plt.clf()
@@ -512,7 +513,7 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     PlotName = "ThetaLagrangianVsBasilisk"
     PlotTitle = "Theta Lagrangian Vs Basilisk"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     plt.figure()
     plt.clf()
@@ -525,7 +526,7 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     PlotName = "Theta1LagrangianVsBasilisk"
     PlotTitle = "Theta 1 Position Lagrangian Vs Basilisk"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     plt.figure()
     plt.clf()
@@ -538,7 +539,7 @@ def hingedRigidBodyLagrangVsBasilisk(show_plots):
     PlotName = "Theta2LagrangianVsBasilisk"
     PlotTitle = "Theta 2 Lagrangian Vs Basilisk"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     if show_plots:
         plt.show()

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_Integrators.py
@@ -38,6 +38,7 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import simHelpers
 
 # @cond DOXYGEN_IGNORE
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -201,7 +202,7 @@ def run(doUnitTests, show_plots, integratorCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 
@@ -250,7 +251,7 @@ def run(doUnitTests, show_plots, integratorCase):
         rData.append(oeData.rmag)
         fData.append(oeData.f + oeData.omega - oe.omega)
     plt.plot(rData * np.cos(fData) / 1000, rData * np.sin(fData) / 1000
-             # , color=unitTestSupport.getLineColor(labelStrings.index(integratorCase) + 1, len(labelStrings))
+             # , color=simHelpers.getLineColor(labelStrings.index(integratorCase) + 1, len(labelStrings))
              , label=integratorCase
              , linewidth=3.0
              )
@@ -268,14 +269,14 @@ def run(doUnitTests, show_plots, integratorCase):
     plt.legend(loc='lower right')
     plt.grid()
     if doUnitTests:  # only save off the figure if doing a unit test run
-        # unitTestSupport.saveScenarioFigure(
+        # simHelpers.saveScenarioFigure(
         #     fileNameString
         #     , plt, path)
-        # unitTestSupport.saveFigurePDF(
+        # simHelpers.saveFigurePDF(
         #     fileNameString
         #     , plt, path
         # )
-        unitTestSupport.writeFigureLaTeX(
+        simHelpers.writeFigureLaTeX(
             "scenarioIntegrators",
             "Illustration of the BSK integrated trajectories",
             plt,
@@ -358,11 +359,11 @@ def run(doUnitTests, show_plots, integratorCase):
                 snippetContent += message
             snippetContent += r"\end{verbatim}"
         snippetMsgName = fileNameString + 'Msg-' + integratorCase
-        unitTestSupport.writeTeXSnippet(snippetMsgName, snippetContent,
+        simHelpers.writeTeXSnippet(snippetMsgName, snippetContent,
                                         path)
         snippetPassFailName = fileNameString + 'TestMsg-' + integratorCase
         snippetContent = r'\textcolor{' + colorText + '}{' + passFailText + '}'
-        unitTestSupport.writeTeXSnippet(snippetPassFailName, snippetContent,
+        simHelpers.writeTeXSnippet(snippetPassFailName, snippetContent,
                                         path)
 
     # each test method requires a single assert method to be called

--- a/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
+++ b/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
@@ -26,6 +26,7 @@ import pytest
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 from Basilisk.simulation import spacecraft
@@ -212,14 +213,14 @@ def fuelSloshTest(show_plots,useFlag,testCase):
     if testCase == 'MassDepletion':
         fuelMass = dataTank.fuelMass
         fuelMassDot = dataTank.fuelMassDot
-        mass1Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.mass1)
-        mass2Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.mass2)
-        mass3Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.mass3)
+        mass1Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.mass1)
+        mass2Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.mass2)
+        mass3Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.mass3)
 
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
 
     initialOrbAngMom_N = [
                 [orbAngMom_N[0,1], orbAngMom_N[0,2], orbAngMom_N[0,3]]
@@ -260,26 +261,26 @@ def fuelSloshTest(show_plots,useFlag,testCase):
         plt.plot(orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,1] - orbAngMom_N[0,1])/orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,2] - orbAngMom_N[0,2])/orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,3] - orbAngMom_N[0,3])/orbAngMom_N[0,3])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase, "Change in Orbital Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase, "Change in Orbital Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
         plt.figure()
         plt.clf()
         plt.plot(orbEnergy[:,0]*1e-9, (orbEnergy[:,1] - orbEnergy[0,1])/orbEnergy[0,1])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt, r"width=0.8\textwidth", path)
         plt.figure()
         plt.clf()
         plt.plot(rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,1] - rotAngMom_N[0,1])/rotAngMom_N[0,1], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,2] - rotAngMom_N[0,2])/rotAngMom_N[0,2], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,3] - rotAngMom_N[0,3])/rotAngMom_N[0,3])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase, "Change in Rotational Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase, "Change in Rotational Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
     if testCase == 'Gravity' or testCase == 'NoGravity':
         plt.figure()
         plt.clf()
         plt.plot(rotEnergy[:,0]*1e-9, (rotEnergy[:,1] - rotEnergy[0,1])/rotEnergy[0,1])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase, plt, r"width=0.8\textwidth", path)
     if testCase == 'MassDepletion':
         plt.figure()
         plt.plot(dataTank.times()*1e-9, fuelMass)

--- a/src/simulation/dynamics/MtbEffector/_UnitTest/test_MtbEffector.py
+++ b/src/simulation/dynamics/MtbEffector/_UnitTest/test_MtbEffector.py
@@ -31,6 +31,7 @@ from Basilisk.simulation import spacecraft, magneticFieldWMM
 from Basilisk.utilities import SimulationBaseClass, simIncludeGravBody, orbitalMotion, RigidBodyKinematics
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 bskPath = __path__[0]
@@ -120,7 +121,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
          0., 0., 6.75]
     scObject.hub.mHub = 10.0  # kg - spacecraft mass (arbitrary)
     scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # m - position vector of body-fixed point B relative to CM
-    scObject.hub.IHubPntBc_B = unitTestSupport.np2EigenMatrix3d(I)
+    scObject.hub.IHubPntBc_B = simHelpers.np2EigenMatrix3d(I)
 
     oe = orbitalMotion.ClassicElements()
     oe.a = 6778.14 * 1000.  # meters
@@ -145,7 +146,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
     magModule.ModelTag = "WMM"
     wmm_path = get_path(DataFile.MagneticFieldData.WMM)
     magModule.configureWMMFile(str(wmm_path))
-    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg('2020 May 12, 00:00:0.0 (UTC)')
+    epochMsg = simHelpers.timeStringToGregorianUTCMsg('2020 May 12, 00:00:0.0 (UTC)')
     magModule.epochInMsg.subscribeTo(epochMsg)
     magModule.addSpacecraftToModel(scObject.scStateOutMsg)  # this command can be repeated if multiple
     scSim.AddModelToTask(simTaskName, magModule)
@@ -184,7 +185,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
 
     # Setup data logging before the simulation is initialized
     numDataPoints = 3600
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     dataLogMag = magModule.envOutMsgs[0].recorder(samplingTime)
     dataLogMTB = mtbEff.mtbOutMsg.recorder(samplingTime)
@@ -213,7 +214,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
         plt.figure(1)
         for idx in range(0, 3):
             plt.plot(dataLogMTB.times() * macros.NANO2SEC, mtbData[:, idx],
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$\tau_' + str(idx) + '$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [s]')
@@ -223,7 +224,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
         plt.figure(2)
         for idx in range(3):
             plt.plot(dataLogMag.times() * macros.NANO2SEC, dataMagField[:, idx] * 1e9,
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$B\_N_{' + str(idx) + '}$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [s]')
@@ -233,7 +234,7 @@ def MtbEffectorTestFunction(show_plots, accuracy, maxDipole):
         plt.figure(3)
         for idx in range(0, 3):
             plt.plot(dataLog.times() * macros.NANO2SEC, attData[:, idx],
-                     color=unitTestSupport.getLineColor(idx, 3),
+                     color=simHelpers.getLineColor(idx, 3),
                      label=r'$\sigma_' + str(idx) + '$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [s]')

--- a/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
@@ -32,6 +32,7 @@ sys.path.append(splitPath[0] + '/PythonModules')
 
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import nHingedRigidBodyStateEffector
 from Basilisk.simulation import gravityEffector
@@ -185,13 +186,13 @@ def nHingedRigidBody(show_plots, testCase):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    nHingedRigidBody1ThetasOut = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta1)
-    nHingedRigidBody2ThetasOut = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.theta2)
+    nHingedRigidBody1ThetasOut = simHelpers.addTimeColumn(stateLog.times(), stateLog.theta1)
+    nHingedRigidBody2ThetasOut = simHelpers.addTimeColumn(stateLog.times(), stateLog.theta2)
 
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
 
     initialOrbAngMom_N = [[orbAngMom_N[0, 1], orbAngMom_N[0, 2], orbAngMom_N[0, 3]]]
 

--- a/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
+++ b/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiationPressure.py
@@ -42,6 +42,7 @@ splitPath = path.split('simulation')
 #Import all of the modules that we are going to call in this simulation
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import radiationPressure
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion as om
@@ -159,13 +160,13 @@ def unitRadiationPressure(show_plots, modelType, eclipseOn):
     srpDynEffector2.computeForceTorque(unitTestSim.TotalSim.CurrentNanos, testTaskRate)
     unitTestSim.TotalSim.SingleStepProcesses()
 
-    srpDataForce_B = unitTestSupport.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].forceExternal_B)
-    srpDataForce_N = unitTestSupport.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].forceExternal_N)
-    srpTorqueData = unitTestSupport.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].torqueExternalPntB_B)
+    srpDataForce_B = simHelpers.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].forceExternal_B)
+    srpDataForce_N = simHelpers.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].forceExternal_N)
+    srpTorqueData = simHelpers.addTimeColumn(srpDynEffectorLog[0].times(), srpDynEffectorLog[0].torqueExternalPntB_B)
 
-    srp2DataForce_B = unitTestSupport.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].forceExternal_B)
-    srp2DataForce_N = unitTestSupport.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].forceExternal_N)
-    srp2TorqueData = unitTestSupport.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].torqueExternalPntB_B)
+    srp2DataForce_B = simHelpers.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].forceExternal_B)
+    srp2DataForce_N = simHelpers.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].forceExternal_N)
+    srp2TorqueData = simHelpers.addTimeColumn(srpDynEffectorLog[1].times(), srpDynEffectorLog[1].torqueExternalPntB_B)
 
     errTol = 1E-12
     if modelType == "cannonball":
@@ -247,7 +248,7 @@ def unitRadiationPressure(show_plots, modelType, eclipseOn):
         colorText = 'ForestGreen'  # color to write auto-documented "PASSED" message in in LATEX
         snippetName = modelType + 'FailMsg'
         snippetContent = ""
-        unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)  # write formatted LATEX string to file to be used by auto-documentation.
+        simHelpers.writeTeXSnippet(snippetName, snippetContent, path)  # write formatted LATEX string to file to be used by auto-documentation.
     else:
         passFailText = 'FAILED'
         colorText = 'Red'  # color to write auto-documented "FAILED" message in in LATEX
@@ -256,19 +257,19 @@ def unitRadiationPressure(show_plots, modelType, eclipseOn):
         for message in testMessages:
             snippetContent += ". " + message
         snippetContent += "."
-        unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)  # write formatted LATEX string to file to be used by auto-documentation.
+        simHelpers.writeTeXSnippet(snippetName, snippetContent, path)  # write formatted LATEX string to file to be used by auto-documentation.
     snippetName = modelType + 'PassFail'  # name of file to be written for auto-documentation which specifies if this test was passed or failed.
     snippetContent = r'\textcolor{' + colorText + '}{' + passFailText + '}' #write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path) #write formatted LATEX string to file to be used by auto-documentation.
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path) #write formatted LATEX string to file to be used by auto-documentation.
 
     # write test accuracy to LATEX file for AutoTex
     snippetName = modelType + 'Accuracy'
     snippetContent = '{:1.1e}'.format(errTol)#write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path) #write formatted LATEX string to file to be used by auto-documentation.
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path) #write formatted LATEX string to file to be used by auto-documentation.
     if modelType == 'lookupWithEclipse' or modelType == 'lookup' or modelType == 'cannonballLookup':
         snippetName = modelType + 'TorqueAccuracy'
         snippetContent = '{:1.1e}'.format(errTolTorque)  # write formatted LATEX string to file to be used by auto-documentation.
-        unitTestSupport.writeTeXSnippet(snippetName, snippetContent,
+        simHelpers.writeTeXSnippet(snippetName, snippetContent,
                                         path)  # write formatted LATEX string to file to be used by auto-documentation.
 
     if testFailCount:

--- a/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiation_pressure_integrated.py
+++ b/src/simulation/dynamics/RadiationPressure/_UnitTest/test_radiation_pressure_integrated.py
@@ -34,6 +34,7 @@ bskPath = __path__[0]
 from Basilisk.simulation import spacecraft, radiationPressure
 from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion,
                                 unitTestSupport)
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.simIncludeGravBody import gravBodyFactory
 
 
@@ -185,7 +186,7 @@ def radiationPressureIntegratedTest(show_plots):
     ax.ticklabel_format(useOffset=False, style='plain')
     for idx in range(0, 3):
         plt.plot(dataLog.times() * macros.NANO2SEC / P, pos_rel_earth[:, idx] / 1000.,
-                 color=unitTestSupport.getLineColor(idx, 3),
+                 color=simHelpers.getLineColor(idx, 3),
                  label='$r_{BN,' + str(idx) + '}$')
 
     plt.legend(loc='lower right')

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_ThrusterDynamicsUnit.py
@@ -43,6 +43,7 @@ splitPath = path.split('simulation')
 
 #Import all of the modules that we are going to call in this simulation
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 import matplotlib.pyplot as plt
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.simulation import thrusterDynamicEffector
@@ -63,7 +64,7 @@ class ResultsStore:
             elif self.PassFail[i] == 'FAILED':
                 textColor = 'Red'
             texSnippet =  r'\textcolor{' + textColor + '}{'+ self.PassFail[i] + '}'
-            unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+            simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
 @pytest.fixture(scope="module")
 def testFixture():
@@ -257,9 +258,9 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
         executeSimRun(TotalSim, thrusterSet, testRate, int(thrDurationTime+sparetime))
 
         # Gather the Force and Torque results
-        thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
-        thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
-        mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+        thrForce = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+        thrTorque = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+        mDotData = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
         mDotData = fixMDotData(mDotData)
 
         # Auto Generate LaTex Figures
@@ -287,7 +288,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                           " thrusters for " + str(duration) + " seconds. The test rate is " +
                           str(int(1. / (testRate * macros.NANO2SEC))) + " steps per second. Swirl torque is set to " +
                           str(int(swirlTorque)) + " Newton meters and blow down effects are " + blowDown + ".")
-        unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+        simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
         PlotName = ("Force_" + str(thrustNumber) + "Thrusters_" + str(int(duration)) + "s_" + str(int(long_angle)) +
                     "deg_" + "Loc" + str(int(location[2][0])) + "_Rate" + str(int(1./(testRate*macros.NANO2SEC))) +
@@ -303,7 +304,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
         plt.xlabel('Time(s)')
         plt.ylabel('Thrust Factor (N)')
         plt.ylim(-0.2,1)
-        unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+        simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
         if show_plots==True:
             plt.show()
             plt.close('all')
@@ -321,7 +322,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
         plt.xlabel('Time(s)')
         plt.ylabel('Thrust Torque (Nm)')
         plt.ylim(-1.5, 2)
-        unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+        simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
         if show_plots==True:
             plt.show()
             plt.close('all')
@@ -345,7 +346,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
         plt.xlabel('Time(s)')
         plt.ylim(-1.5, 2)
         plt.legend(loc='upper right')
-        unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+        simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
         if show_plots==True:
             plt.show()
             plt.close('all')
@@ -433,9 +434,9 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                 executeSimRun(TotalSim, thrusterSet, testRate, int(thrDurationTime+sparetime))
 
                 # Extract log variables and plot the results
-                thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
-                thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
-                mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+                thrForce = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+                thrTorque = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+                mDotData = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
                 mDotData = fixMDotData(mDotData)
 
                 snippetName = ("Snippet" + "Ramp_" + str(rampsteps) + "steps_" + str(int(duration)) + "s" + "_Cutoff" +
@@ -449,7 +450,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                               " seconds with a test rate of " + str(int(1. / (testRate * macros.NANO2SEC))) +
                               " steps per second. The Cutoff test is " + cutoff + ", swirl torque is set to " +
                               str(int(swirlTorque)) + " Newton meters, and blow down effects are " + blowDown + ".")
-                unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+                simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
                 PlotName = ("Ramp_" + str(rampsteps) + "steps_Cutoff" + cutoff + "_" + str(int(duration)) + "s" +
                             "_testRate" + str(int(1. / (testRate * macros.NANO2SEC))) + "_Swirl" + str(int(swirlTorque))
@@ -471,7 +472,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                 plt.xlabel('Time(s)')
                 plt.ylim(-1.5, 2)
                 plt.legend(loc='upper left')
-                unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+                simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
                 if show_plots == True:
                     plt.show()
                     plt.close('all')
@@ -556,9 +557,9 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                 executeSimRun(TotalSim, thrusterSet, testRate, int(COrestart * 1.0 / macros.NANO2SEC + sparetime))
 
                 # Extract log variables and plot the results
-                thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
-                thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
-                mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+                thrForce = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+                thrTorque = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+                mDotData = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
                 mDotData = fixMDotData(mDotData)
 
                 PlotName = ("Ramp_" + str(rampsteps) + "steps_Cutoff" + cutoff + "_" + str(int(duration)) + "s" +
@@ -580,7 +581,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                               " seconds with a test rate of " + str(int(1. / (testRate * macros.NANO2SEC))) +
                               " steps per second. The Cutoff test is " + cutoff + ", swirl torque is set to " +
                               str(int(swirlTorque)) + " Newton meters, and blow down effects are " + blowDown + ".")
-                unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+                simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
                 plt.figure(55)
                 plt.clf()
@@ -594,7 +595,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                 plt.xlabel('Time(s)')
                 plt.ylim(-1.5, 2)
                 plt.legend(loc='upper left')
-                unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+                simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
                 if show_plots == True:
                     plt.show()
                     plt.close('all')
@@ -668,9 +669,9 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
             executeSimRun(TotalSim, thrusterSet, testRate, int(RDlength * 1.0 / macros.NANO2SEC + sparetime))
 
             # Extract log variables and plot the results
-            thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
-            thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
-            mDotData = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+            thrForce = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+            thrTorque = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+            mDotData = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
             mDotData = fixMDotData(mDotData)
 
             PlotName = ("Ramp_" + str(rampsteps) + "steps_Cutoff" + cutoff + "rampDown" + rampDown+"_testRate" +
@@ -692,7 +693,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
                           " steps per second. The Cutoff test is " + cutoff + ", the RampDown test is " + rampDown +
                           ", swirl torque is set to " + str(int(swirlTorque)) + " Newton meters, and blow down effects are "
                           + blowDown + ".")
-            unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+            simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
             plt.figure(55)
             plt.clf()
@@ -706,7 +707,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
             plt.xlabel('Time(s)')
             plt.ylim(-1.5, 2)
             plt.legend(loc='upper left')
-            unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+            simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
             if show_plots == True:
                 plt.show()
                 plt.close('all')
@@ -747,7 +748,7 @@ def unitThrusters(testFixture, show_plots, ramp, thrustNumber, duration, long_an
             plt.xlabel('Time(s)')
             plt.ylabel('Ramp(-)')
             plt.ylim(-1.5, 2)
-            unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+            simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
             if show_plots == True:
                 plt.show()
                 plt.close('all')

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_dynamics_attached_body.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_dynamics_attached_body.py
@@ -25,6 +25,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros, RigidBodyKinematics as rbk
 from Basilisk.simulation import spacecraft, thrusterDynamicEffector
 from Basilisk.architecture import messaging
@@ -180,8 +181,8 @@ def unitThrusters(show_plots, long_angle, lat_angle, location, rate):
     TotalSim.ExecuteSimulation()
 
     # Gather the Force, Torque and Mass Rate results
-    thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
-    thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
+    thrForce = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceExternal_B)
+    thrTorque = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueExternalPntB_B)
 
     # Generate the truth data (force, torque and mass rate)
     expectedThrustData = np.zeros([3, np.shape(thrForce)[0]])

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py
@@ -23,7 +23,6 @@ from Basilisk.simulation import thrusterDynamicEffector
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import simIncludeThruster
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import numpy
 
 

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/_UnitTest/test_ThrusterStateEffectorUnit.py
@@ -25,6 +25,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros, RigidBodyKinematics as rbk
 from Basilisk.simulation import spacecraft, thrusterStateEffector
 from Basilisk.architecture import messaging
@@ -44,7 +45,7 @@ class ResultsStore:
             elif self.PassFail[i] == 'FAILED':
                 textColor = 'Red'
             texSnippet = r'\textcolor{' + textColor + '}{' + self.PassFail[i] + '}'
-            unitTestSupport.writeTeXSnippet(snippetName, texSnippet, path)
+            simHelpers.writeTeXSnippet(snippetName, texSnippet, path)
 
 
 @pytest.fixture(scope="module")
@@ -284,9 +285,9 @@ def unitThrusters(testFixture, show_plots, thrustNumber, initialConditions, dura
         plt.show()
 
     # Gather the Force, Torque and Mass Rate results
-    thrForce = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceOnBody_B)
-    thrTorque = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueOnBodyPntB_B)
-    mDot = unitTestSupport.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
+    thrForce = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.forceOnBody_B)
+    thrTorque = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.torqueOnBodyPntB_B)
+    mDot = simHelpers.addTimeColumn(thrusterSetLog.times(), thrusterSetLog.mDotTotal)
 
     # Save the time vector
     timeSec = dataRec.times() * macros.NANO2SEC

--- a/src/simulation/dynamics/VSCMGs/_UnitTest/test_VSCMGStateEffector_integrated.py
+++ b/src/simulation/dynamics/VSCMGs/_UnitTest/test_VSCMGStateEffector_integrated.py
@@ -26,6 +26,7 @@ import pytest
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib as mpl
@@ -255,10 +256,10 @@ def VSCMGIntegratedTest(show_plots,useFlag,testCase):
 
     unitTestSim.ExecuteSimulation()
 
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     wheelSpeeds = speedLog.wheelSpeeds
     gimbalAngles = speedLog.gimbalAngles
@@ -343,27 +344,27 @@ def VSCMGIntegratedTest(show_plots,useFlag,testCase):
     plt.figure()
     plt.plot(orbAngMom_N[:,0]*1e-9, orbAngMom_N[:,1] - orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, orbAngMom_N[:,2] - orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, orbAngMom_N[:,3] - orbAngMom_N[0,3])
     plt.title("Change in Orbital Angular Momentum")
-    unitTestSupport.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase,
+    simHelpers.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase,
                                      "Change in Orbital Angular Momentum " + testCase, plt, "width=0.80\\textwidth",
                                      path)
 
     plt.figure()
     plt.plot(rotAngMom_N[:,0]*1e-9, rotAngMom_N[:,1] - rotAngMom_N[0,1], rotAngMom_N[:,0]*1e-9, rotAngMom_N[:,2] - rotAngMom_N[0,2], rotAngMom_N[:,0]*1e-9, rotAngMom_N[:,3] - rotAngMom_N[0,3])
     plt.title("Change in Rotational Angular Momentum")
-    unitTestSupport.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt,
+    simHelpers.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt,
                                      "width=0.80\\textwidth", path)
 
     plt.figure()
     plt.plot(orbEnergy[:,0]*1e-9, orbEnergy[:,1] - orbEnergy[0,1])
     plt.title("Change in Orbital Energy")
-    unitTestSupport.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase,
+    simHelpers.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase,
                                      "Change in Rotational Angular Momentum " + testCase, plt, "width=0.80\\textwidth",
                                      path)
 
     plt.figure()
     plt.plot(rotEnergy[:,0]*1e-9, rotEnergy[:,1] - rotEnergy[0,1])
     plt.title("Change in Rotational Energy")
-    unitTestSupport.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase,
+    simHelpers.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase,
                                      plt, "width=0.80\\textwidth", path)
 
     plt.figure()
@@ -504,13 +505,13 @@ def VSCMGIntegratedTest(show_plots,useFlag,testCase):
         passedText = r'\textcolor{' + colorText + '}{' + "PASSED" + '}'
         # Write some snippets for AutoTex
         snippetName = testCase + 'PassFail'
-        unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+        simHelpers.writeTeXSnippet(snippetName, passedText, path)
     elif testFailCount > 0:
         colorText = 'Red'
         passedText = r'\textcolor{' + colorText + '}{' + "FAILED" + '}'
         # Write some snippets for AutoTex
         snippetName = testCase + 'PassFail'
-        unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+        simHelpers.writeTeXSnippet(snippetName, passedText, path)
 
     if testFailCount == 0:
         print("PASSED: " + " VSCMG Integrated Sim Test")

--- a/src/simulation/dynamics/constraintEffector/_UnitTest/test_ConstraintDynamicEffectorUnit.py
+++ b/src/simulation/dynamics/constraintEffector/_UnitTest/test_ConstraintDynamicEffectorUnit.py
@@ -27,7 +27,12 @@ import pytest
 import matplotlib.pyplot as plt
 import numpy as np
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, orbitalMotion, macros, RigidBodyKinematics
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    orbitalMotion,
+    macros,
+    RigidBodyKinematics,
+)
 from Basilisk.simulation import spacecraft, constraintDynamicEffector, gravityEffector, svIntegrators
 
 # uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed

--- a/src/simulation/dynamics/constraintEffector/_UnitTest/test_InOutMessageFiltering.py
+++ b/src/simulation/dynamics/constraintEffector/_UnitTest/test_InOutMessageFiltering.py
@@ -28,7 +28,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from contextlib import nullcontext
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, orbitalMotion, macros, RigidBodyKinematics
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    orbitalMotion,
+    macros,
+    RigidBodyKinematics,
+)
 from Basilisk.simulation import spacecraft, constraintDynamicEffector, gravityEffector, svIntegrators
 from Basilisk.architecture import messaging
 from Basilisk.architecture.bskLogging import BasiliskError

--- a/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
+++ b/src/simulation/dynamics/dragEffector/_UnitTest/test_atmoDrag.py
@@ -41,6 +41,7 @@ from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import unitTestSupport, RigidBodyKinematics
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -296,7 +297,7 @@ def run(show_plots, orbitCase, planetCase):
     #
 
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     dataNewAtmoLog = newAtmo.envOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
@@ -370,7 +371,7 @@ def run(show_plots, orbitCase, planetCase):
         ax.ticklabel_format(useOffset=False, style='plain')
         for idx in range(0,3):
             plt.plot(dataLog.times()*macros.NANO2SEC/P, posData[:, idx]/1000.,
-                     color=unitTestSupport.getLineColor(idx,3),
+                     color=simHelpers.getLineColor(idx,3),
                      label='$r_{BN,'+str(idx)+'}$')
         plt.legend(loc='lower right')
         plt.xlabel('Time [orbits]')

--- a/src/simulation/dynamics/dualHingedRigidBodies/_UnitTest/test_dualhingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/dualHingedRigidBodies/_UnitTest/test_dualhingedRigidBodyStateEffector.py
@@ -29,6 +29,7 @@ splitPath = path.split('simulation')
 
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import dualHingedRigidBodyStateEffector
 from Basilisk.simulation import gravityEffector
@@ -159,10 +160,10 @@ def dualHingedRigidBodyTest(show_plots, useFlag, testCase):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
 
     initialOrbAngMom_N = [
                 [orbAngMom_N[0, 1], orbAngMom_N[0, 2], orbAngMom_N[0, 3]]
@@ -202,25 +203,25 @@ def dualHingedRigidBodyTest(show_plots, useFlag, testCase):
     plt.plot(orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,1] - orbAngMom_N[0,1])/orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,2] - orbAngMom_N[0,2])/orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,3] - orbAngMom_N[0,3])/orbAngMom_N[0,3])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase, "Change in Orbital Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase, "Change in Orbital Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(orbEnergy[:,0]*1e-9, (orbEnergy[:,1] - orbEnergy[0,1])/orbEnergy[0,1])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,1] - rotAngMom_N[0,1])/rotAngMom_N[0,1], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,2] - rotAngMom_N[0,2])/rotAngMom_N[0,2], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,3] - rotAngMom_N[0,3])/rotAngMom_N[0,3])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase, "Change in Rotational Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase, "Change in Rotational Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(rotEnergy[:,0]*1e-9, (rotEnergy[:,1] - rotEnergy[0,1])/rotEnergy[0,1])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase, plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase, plt, r"width=0.8\textwidth", path)
     if show_plots:
         plt.show()
         plt.close("all")
@@ -418,7 +419,7 @@ def dualHingedRigidBodyMotorTorque(show_plots, useScPlus):
     sB2N = data21Log.sigma_BN[0]
     oB2N = data21Log.omega_BN_B[0]
 
-    rotAngMom_N = unitTestSupport.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
 
     # Get the last sigma and position
     dataPos = [rOut_CN_N[-1]]
@@ -449,13 +450,13 @@ def dualHingedRigidBodyMotorTorque(show_plots, useScPlus):
     plt.figure()
     plt.clf()
     plt.plot(dataLog.times() * macros.NANO2SEC, sigma_BN[:, 0],
-             color=unitTestSupport.getLineColor(0, 3),
+             color=simHelpers.getLineColor(0, 3),
              label=r'$\sigma_{1}$')
     plt.plot(dataLog.times() * macros.NANO2SEC, sigma_BN[:, 1],
-             color=unitTestSupport.getLineColor(1, 3),
+             color=simHelpers.getLineColor(1, 3),
              label=r'$\sigma_{2}$')
     plt.plot(dataLog.times() * macros.NANO2SEC, sigma_BN[:, 2],
-             color=unitTestSupport.getLineColor(2, 3),
+             color=simHelpers.getLineColor(2, 3),
              label=r'$\sigma_{3}$')
     plt.legend(loc='lower right')
     plt.xlabel('time (s)')
@@ -464,16 +465,16 @@ def dualHingedRigidBodyMotorTorque(show_plots, useScPlus):
     plt.figure()
     plt.clf()
     plt.plot(dataPanel10Log.times() * macros.NANO2SEC, thetaP1A1*macros.R2D,
-             color=unitTestSupport.getLineColor(0, 4),
+             color=simHelpers.getLineColor(0, 4),
              label=r'Panel 1 $\theta_{1}$')
     plt.plot(dataPanel10Log.times() * macros.NANO2SEC, thetaP1A2*macros.R2D,
-             color=unitTestSupport.getLineColor(1, 4),
+             color=simHelpers.getLineColor(1, 4),
              label=r'Panel 1 $\theta_{2}$')
     plt.plot(dataPanel10Log.times() * macros.NANO2SEC, thetaP2A1 * macros.R2D,
-             color=unitTestSupport.getLineColor(2, 4),
+             color=simHelpers.getLineColor(2, 4),
              label=r'Panel 2 $\theta_{1}$')
     plt.plot(dataPanel10Log.times() * macros.NANO2SEC, thetaP2A2 * macros.R2D,
-             color=unitTestSupport.getLineColor(3, 4),
+             color=simHelpers.getLineColor(3, 4),
              label=r'Panel 2 $\theta_{2}$')
     plt.legend(loc='lower right')
     plt.xlabel('time (s)')

--- a/src/simulation/dynamics/facetDragEffector/_UnitTest/test_unitFacetDrag.py
+++ b/src/simulation/dynamics/facetDragEffector/_UnitTest/test_unitFacetDrag.py
@@ -51,7 +51,7 @@ from Basilisk.simulation import exponentialAtmosphere
 from Basilisk.simulation import facetDragDynamicEffector
 from Basilisk.simulation import simpleNav
 from Basilisk.simulation import zeroWindModel
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import simIncludeGravBody
 
 
@@ -156,8 +156,8 @@ def test_DragCalculation(scAreas, scCoeff, B_normals, B_locations):
     scSim.ExecuteSimulation()
 
     #   Retrieve logged data
-    dragDataForce_B = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.forceExternal_B)
-    dragTorqueData = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.torqueExternalPntB_B)
+    dragDataForce_B = simHelpers.addTimeColumn(newDragLog.times(), newDragLog.forceExternal_B)
+    dragTorqueData = simHelpers.addTimeColumn(newDragLog.times(), newDragLog.torqueExternalPntB_B)
     posData = dataLog.r_BN_N
     velData = dataLog.v_BN_N
     attData = dataLog.sigma_BN
@@ -292,8 +292,8 @@ def test_ShadowCalculation(scAreas, scCoeff, B_normals, B_locations):
     scSim.ExecuteSimulation()
 
     #   Retrieve logged data
-    dragDataForce_B = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.forceExternal_B)
-    dragTorqueData = unitTestSupport.addTimeColumn(newDragLog.times(), newDragLog.torqueExternalPntB_B)
+    dragDataForce_B = simHelpers.addTimeColumn(newDragLog.times(), newDragLog.forceExternal_B)
+    dragTorqueData = simHelpers.addTimeColumn(newDragLog.times(), newDragLog.torqueExternalPntB_B)
     posData = dataLog.r_BN_N
     velData = dataLog.v_BN_N
     attData = dataLog.sigma_BN

--- a/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravityDynEffector.py
+++ b/src/simulation/dynamics/gravityEffector/_UnitTest/test_gravityDynEffector.py
@@ -39,6 +39,7 @@ from Basilisk.topLevelModules import pyswice
 from Basilisk.utilities.pyswice_spk_utilities import spkRead
 from Basilisk.simulation import stateArchitecture
 from Basilisk.utilities import orbitalMotion as om
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 from Basilisk.simulation.gravityEffector import loadGravFromFileToList
 from Basilisk.architecture.bskLogging import BasiliskError
@@ -217,7 +218,7 @@ def independentSphericalHarmonics(show_plots):
     snippetContent = "{:1.1e}".format(
         accuracy
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 
@@ -227,7 +228,7 @@ def independentSphericalHarmonics(show_plots):
         colorText = "ForestGreen"  # color to write auto-documented "PASSED" message in in LATEX.
         snippetName = testCase + "FailMsg"
         snippetContent = ""
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     else:
@@ -238,7 +239,7 @@ def independentSphericalHarmonics(show_plots):
         for message in testMessages:
             snippetContent += ". " + message
         snippetContent += "."
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     snippetName = (
@@ -247,7 +248,7 @@ def independentSphericalHarmonics(show_plots):
     snippetContent = (
         r"\textcolor{" + colorText + "}{" + passFailText + "}"
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 
@@ -297,7 +298,7 @@ def sphericalHarmonics(show_plots):
     snippetContent = "{:1.1e}".format(
         accuracy
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 
@@ -314,7 +315,7 @@ def sphericalHarmonics(show_plots):
         colorText = "ForestGreen"  # color to write auto-documented "PASSED" message in in LATEX.
         snippetName = testCase + "FailMsg"
         snippetContent = ""
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     else:
@@ -325,7 +326,7 @@ def sphericalHarmonics(show_plots):
         for message in testMessages:
             snippetContent += ". " + message
         snippetContent += "."
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     snippetName = (
@@ -334,7 +335,7 @@ def sphericalHarmonics(show_plots):
     snippetContent = (
         r"\textcolor{" + colorText + "}{" + passFailText + "}"
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 
@@ -454,7 +455,7 @@ def singleGravityBody(show_plots):
     snippetContent = "{:1.1e}".format(
         accuracy
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 
@@ -477,7 +478,7 @@ def singleGravityBody(show_plots):
         )
         snippetName = testCase + "FailMsg"
         snippetContent = ""
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     else:
@@ -488,7 +489,7 @@ def singleGravityBody(show_plots):
         for message in testMessages:
             snippetContent += ". " + message
         snippetContent += "."
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     snippetName = (
@@ -497,7 +498,7 @@ def singleGravityBody(show_plots):
     snippetContent = (
         r"\textcolor{" + colorText + "}{" + passFailText + "}"
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 
@@ -660,7 +661,7 @@ def multiBodyGravity(show_plots):
     snippetContent = "{:1.1e}".format(
         accuracy
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
     if not unitTestSupport.isDoubleEqualRelative(
@@ -685,7 +686,7 @@ def multiBodyGravity(show_plots):
         )
         snippetName = testCase + "FailMsg"
         snippetContent = ""
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     else:
@@ -696,7 +697,7 @@ def multiBodyGravity(show_plots):
         for message in testMessages:
             snippetContent += ". " + message
         snippetContent += "."
-        unitTestSupport.writeTeXSnippet(
+        simHelpers.writeTeXSnippet(
             snippetName, snippetContent, path
         )  # write formatted LATEX string to file to be used by auto-documentation.
     snippetName = (
@@ -705,7 +706,7 @@ def multiBodyGravity(show_plots):
     snippetContent = (
         r"\textcolor{" + colorText + "}{" + passFailText + "}"
     )  # write formatted LATEX string to file to be used by auto-documentation.
-    unitTestSupport.writeTeXSnippet(
+    simHelpers.writeTeXSnippet(
         snippetName, snippetContent, path
     )  # write formatted LATEX string to file to be used by auto-documentation.
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
@@ -36,7 +36,10 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import spacecraft, linearTranslationNDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/_UnitTest/test_linearTranslationOneDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/_UnitTest/test_linearTranslationOneDOFStateEffector.py
@@ -33,7 +33,10 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import spacecraft, linearTranslationOneDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
 

--- a/src/simulation/dynamics/msmForceTorque/_UnitTest/test_msmForceTorque.py
+++ b/src/simulation/dynamics/msmForceTorque/_UnitTest/test_msmForceTorque.py
@@ -1,12 +1,12 @@
-# 
+#
 #  ISC License
-# 
+#
 #  Copyright (c) 2021, Autonomous Vehicle Systems Lab, University of Colorado Boulder
-# 
+#
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
 #  copyright notice and this permission notice appear in all copies.
-# 
+#
 #  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 #  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 #  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,8 +14,8 @@
 #  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-# 
-# 
+#
+#
 
 import pytest
 from Basilisk.architecture import messaging
@@ -23,6 +23,7 @@ from Basilisk.simulation import msmForceTorque
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 @pytest.mark.parametrize("accuracy", [1e-4])
@@ -106,13 +107,13 @@ def msmForceTorqueTestFunction(show_plots, accuracy):
     # add spacecraft to state
     module.addSpacecraftToModel(sc0StateInMsg
                                 , messaging.DoubleVector(rList[:-1])
-                                , unitTestSupport.npList2EigenXdVector(spPosList[:-1]))
+                                , simHelpers.npList2EigenXdVector(spPosList[:-1]))
     module.addSpacecraftToModel(sc1StateInMsg
                                 , messaging.DoubleVector(rList)
-                                , unitTestSupport.npList2EigenXdVector(spPosList))
+                                , simHelpers.npList2EigenXdVector(spPosList))
     module.addSpacecraftToModel(sc2StateInMsg
                                 , messaging.DoubleVector(rList[:-1])
-                                , unitTestSupport.npList2EigenXdVector(spPosList[:-1]))
+                                , simHelpers.npList2EigenXdVector(spPosList[:-1]))
 
     # subscribe input messages to module
     module.voltInMsgs[0].subscribeTo(volt0InMsg)
@@ -152,7 +153,7 @@ def msmForceTorqueTestFunction(show_plots, accuracy):
                                                        accuracy, "sc" + str(i) + " torque test",
                                                        testFailCount, testMessages)
 
-        charge = unitTestSupport.columnToRowList(module.chargeMsmOutMsgs[i].read().q)
+        charge = simHelpers.columnToRowList(module.chargeMsmOutMsgs[i].read().q)
         testFailCount, testMessages = \
             unitTestSupport.compareListRelative(charge, chargeTruth[i],
                                                        accuracy, "sc" + str(i) + " charge test",
@@ -168,5 +169,3 @@ def msmForceTorqueTestFunction(show_plots, accuracy):
 
 if __name__ == "__main__":
     test_msmForceTorque(False, 1e-4)
-
-

--- a/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffectorBranching.py
+++ b/src/simulation/dynamics/prescribedMotion/_UnitTest/test_PrescribedMotionStateEffectorBranching.py
@@ -24,7 +24,10 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import prescribedMotionStateEffector

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelMemoryLeak.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelMemoryLeak.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import macros
 from Basilisk.utilities import simIncludeRW

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_ConfigureRWRequests.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_ConfigureRWRequests.py
@@ -33,7 +33,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import reactionWheelStateEffector
 from Basilisk.architecture import messaging
 
@@ -198,7 +198,7 @@ def unitSimReactionWheel(show_plots, useFlag, testCase):
 
     # Write some snippets for AutoTex
     snippetName = testCase + 'PassFail'
-    unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+    simHelpers.writeTeXSnippet(snippetName, passedText, path)
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_integrated.py
@@ -26,6 +26,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib as mpl
@@ -264,10 +265,10 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     posData = scDataLog.r_BN_N
     sigmaData = scDataLog.sigma_BN
@@ -366,25 +367,25 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.plot(orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,1] - orbAngMom_N[0,1])/orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,2] - orbAngMom_N[0,2])/orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,3] - orbAngMom_N[0,3])/orbAngMom_N[0,3])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase, "Change in Orbital Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCase, "Change in Orbital Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
         plt.figure()
         plt.clf()
         plt.plot(orbEnergy[:,0]*1e-9, (orbEnergy[:,1] - orbEnergy[0,1])/orbEnergy[0,1])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCase, "Change in Orbital Energy " + testCase, plt, r"width=0.8\textwidth", path)
         plt.figure()
         plt.clf()
         plt.plot(rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,1] - rotAngMom_N[0,1])/rotAngMom_N[0,1], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,2] - rotAngMom_N[0,2])/rotAngMom_N[0,2], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,3] - rotAngMom_N[0,3])/rotAngMom_N[0,3])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase, "Change in Rotational Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCase, "Change in Rotational Angular Momentum " + testCase, plt, r"width=0.8\textwidth", path)
         plt.figure()
         plt.clf()
         plt.plot(rotEnergy[int(len(rotEnergy)/2)+1:,0]*1e-9, (rotEnergy[int(len(rotEnergy)/2)+1:,1] - rotEnergy[int(len(rotEnergy)/2)+1,1])/rotEnergy[int(len(rotEnergy)/2)+1,1])
         plt.xlabel("Time (s)")
         plt.ylabel("Relative Difference")
-        unitTestSupport.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInRotationalEnergy" + testCase, "Change in Rotational Energy " + testCase, plt, r"width=0.8\textwidth", path)
         if show_plots:
             plt.show()
             plt.close('all')
@@ -397,7 +398,7 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.legend(loc='upper left', numpoints=1)
         plt.xlabel("Time (s)")
         plt.ylabel("Theta (rad)")
-        unitTestSupport.writeFigureLaTeX("ReactionWheelBOETheta", "Reaction Wheel BOE Theta", plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ReactionWheelBOETheta", "Reaction Wheel BOE Theta", plt, r"width=0.8\textwidth", path)
 
         plt.figure()
         plt.clf()
@@ -406,7 +407,7 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.legend(loc='upper right', numpoints=1)
         plt.xlabel("Time (s)")
         plt.ylabel("Body Rate (rad/s)")
-        unitTestSupport.writeFigureLaTeX("ReactionWheelBOEBodyRate", "Reaction Wheel BOE Body Rate", plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ReactionWheelBOEBodyRate", "Reaction Wheel BOE Body Rate", plt, r"width=0.8\textwidth", path)
 
         plt.figure()
         plt.clf()
@@ -415,7 +416,7 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.legend(loc ='upper left', numpoints=1)
         plt.xlabel("Time (s)")
         plt.ylabel("Wheel Speed (rad/s)")
-        unitTestSupport.writeFigureLaTeX("ReactionWheelBOERWRate", "Reaction Wheel BOE RW Rate", plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ReactionWheelBOERWRate", "Reaction Wheel BOE RW Rate", plt, r"width=0.8\textwidth", path)
         if show_plots:
             plt.show()
             plt.close('all')
@@ -426,7 +427,7 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.plot(scDataLog.times()*1e-9, omegaData[:,2], label='Basilisk')
         plt.xlabel("Time (s)")
         plt.ylabel("Body Rate (rad/s)")
-        unitTestSupport.writeFigureLaTeX("ReactionWheel" + testCase + "TestBodyRates", "Reaction Wheel " + testCase + " Test Body Rates", plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ReactionWheel" + testCase + "TestBodyRates", "Reaction Wheel " + testCase + " Test Body Rates", plt, r"width=0.8\textwidth", path)
 
         plt.figure()
         plt.clf()
@@ -435,7 +436,7 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.legend(loc='upper right')
         plt.xlabel("Time (s)")
         plt.ylabel("Wheel Speed (rad/s)")
-        unitTestSupport.writeFigureLaTeX("ReactionWheel" + testCase + "TestWheelSpeed", "Reaction Wheel " + testCase + " Test Wheel Speed", plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ReactionWheel" + testCase + "TestWheelSpeed", "Reaction Wheel " + testCase + " Test Wheel Speed", plt, r"width=0.8\textwidth", path)
 
         print(wheelSpeedBeforeInteg1)
         print(frictionTorque1)
@@ -448,7 +449,7 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         plt.ylabel("Friction Torque (N-m)")
         axes = plt.gca()
         plt.xlim([-15, 15])
-        unitTestSupport.writeFigureLaTeX("ReactionWheel" + testCase + "TestFrictionTorque", "Reaction Wheel " + testCase + " Test Friction Torque", plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ReactionWheel" + testCase + "TestFrictionTorque", "Reaction Wheel " + testCase + " Test Friction Torque", plt, r"width=0.8\textwidth", path)
         if show_plots:
             plt.show()
             plt.close('all')
@@ -516,13 +517,13 @@ def reactionWheelIntegratedTest(show_plots,useFlag,testCase):
         passedText = r'\textcolor{' + colorText + '}{' + "PASSED" + '}'
         # Write some snippets for AutoTex
         snippetName = testCase + 'PassFail'
-        unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+        simHelpers.writeTeXSnippet(snippetName, passedText, path)
     elif testCase == 'JitterSimple' and testFailCount > 0:
         colorText = 'Red'
         passedText = r'\textcolor{' + colorText + '}{' + "FAILED" + '}'
         # Write some snippets for AutoTex
         snippetName = testCase + 'PassFail'
-        unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+        simHelpers.writeTeXSnippet(snippetName, passedText, path)
 
     assert testFailCount < 1, testMessages
 

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraft.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraft.py
@@ -26,6 +26,7 @@ from random import random
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 import matplotlib.pyplot as plt
@@ -136,8 +137,8 @@ def SCTranslation(show_plots):
     stopTime = 10.0
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     plt.close("all")
     plt.figure()
@@ -145,13 +146,13 @@ def SCTranslation(show_plots):
     plt.plot(orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,1] - orbAngMom_N[0,1])/orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,2] - orbAngMom_N[0,2])/orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,3] - orbAngMom_N[0,3])/orbAngMom_N[0,3])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInOrbitalAngularMomentumTranslationOnly", "Change in Orbital Angular Momentum Translation Only", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInOrbitalAngularMomentumTranslationOnly", "Change in Orbital Angular Momentum Translation Only", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(orbEnergy[:,0]*1e-9, (orbEnergy[:,1] - orbEnergy[0,1])/orbEnergy[0,1])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInOrbitalEnergyTranslationOnly", "Change in Orbital Energy Translation Only", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInOrbitalEnergyTranslationOnly", "Change in Orbital Energy Translation Only", plt, r"width=0.8\textwidth", path)
     if show_plots:
         plt.show()
         plt.close('all')
@@ -261,10 +262,10 @@ def SCTransAndRotation(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     r_BN_NOutput = dataLog.r_BN_N
     sigma_BNOutput = dataLog.sigma_BN
@@ -315,25 +316,25 @@ def SCTransAndRotation(show_plots):
     plt.plot(orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,1] - orbAngMom_N[0,1])/orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,2] - orbAngMom_N[0,2])/orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,3] - orbAngMom_N[0,3])/orbAngMom_N[0,3])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInOrbitalAngularMomentumTranslationAndRotation", "Change in Orbital Angular Momentum Translation And Rotation", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInOrbitalAngularMomentumTranslationAndRotation", "Change in Orbital Angular Momentum Translation And Rotation", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(orbEnergy[:,0]*1e-9, (orbEnergy[:,1] - orbEnergy[0,1])/orbEnergy[0,1])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInOrbitalEnergyTranslationAndRotation", "Change in Orbital Energy Translation And Rotation", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInOrbitalEnergyTranslationAndRotation", "Change in Orbital Energy Translation And Rotation", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,1] - rotAngMom_N[0,1])/rotAngMom_N[0,1], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,2] - rotAngMom_N[0,2])/rotAngMom_N[0,2], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,3] - rotAngMom_N[0,3])/rotAngMom_N[0,3])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInRotationalAngularMomentumTranslationAndRotation", "Change in Rotational Angular Momentum Translation And Rotation", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInRotationalAngularMomentumTranslationAndRotation", "Change in Rotational Angular Momentum Translation And Rotation", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(rotEnergy[:,0]*1e-9, (rotEnergy[:,1] - rotEnergy[0,1])/rotEnergy[0,1])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInRotationalEnergyTranslationAndRotation", "Change in Rotational Energy Translation And Rotation", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInRotationalEnergyTranslationAndRotation", "Change in Rotational Energy Translation And Rotation", plt, r"width=0.8\textwidth", path)
     if show_plots:
         plt.show()
         plt.close('all')
@@ -451,8 +452,8 @@ def SCRotation(show_plots):
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
     rotAngMomMag = numpy.zeros(len(rotAngMom_N))
     for i in range(0,len(rotAngMom_N)):
         rotAngMomMag[i] = numpy.linalg.norm(numpy.asarray(rotAngMom_N[i,1:4]))
@@ -525,7 +526,7 @@ def SCRotation(show_plots):
     plt.plot(moduleOutput[index-1,0]*1e-9, moduleOutput[index-1,1],'bo')
     plt.xlabel("Time (s)")
     plt.ylabel("MRPs")
-    unitTestSupport.writeFigureLaTeX("scPlusMRPs", "Attitude of Spacecraft in MRPs", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusMRPs", "Attitude of Spacecraft in MRPs", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(moduleOutput[index - 3: index + 3,0]*1e-9, moduleOutput[index - 3: index + 3,1],"b")
@@ -538,19 +539,19 @@ def SCRotation(show_plots):
     plt.legend(loc ='upper right',numpoints = 1)
     plt.xlabel("Time (s)")
     plt.ylabel("MRPs")
-    unitTestSupport.writeFigureLaTeX("scPlusMRPSwitching", "MRP Switching", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusMRPSwitching", "MRP Switching", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(rotAngMom_N[:,0]*1e-9, (rotAngMomMag - rotAngMomMag[0])/rotAngMomMag[0])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInRotationalAngularMomentumRotationOnly", "Change in Rotational Angular Momentum Rotation Only", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInRotationalAngularMomentumRotationOnly", "Change in Rotational Angular Momentum Rotation Only", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(rotEnergy[:,0]*1e-9, (rotEnergy[:,1] - rotEnergy[0,1])/rotEnergy[0,1])
     plt.xlabel("Time (s)")
     plt.ylabel("Relative Difference")
-    unitTestSupport.writeFigureLaTeX("scPlusChangeInRotationalEnergyRotationOnly", "Change in Rotational Energy Rotation Only", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusChangeInRotationalEnergyRotationOnly", "Change in Rotational Energy Rotation Only", plt, r"width=0.8\textwidth", path)
     plt.figure()
     plt.clf()
     plt.plot(omega_BNOutput[:,0]*1e-9,omega_BNOutput[:,1],label = r"$\omega_1$" + " Basilisk")
@@ -562,7 +563,7 @@ def SCRotation(show_plots):
     plt.xlabel("Time (s)")
     plt.ylabel("Angular Velocity (rad/s)")
     plt.legend(loc ='lower right',numpoints = 1, prop = {'size': 6.5})
-    unitTestSupport.writeFigureLaTeX("scPlusBasiliskVsBOECalcForRotation", "Basilisk Vs BOE Calc For Rotation", plt, r"width=0.8\textwidth", path)
+    simHelpers.writeFigureLaTeX("scPlusBasiliskVsBOECalcForRotation", "Basilisk Vs BOE Calc For Rotation", plt, r"width=0.8\textwidth", path)
     if show_plots:
         plt.show()
         plt.close("all")
@@ -718,7 +719,7 @@ def SCTransBOE(show_plots):
     PlotName = "scPlusTranslationPositionBOE"
     PlotTitle = "Translation Position BOE"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     plt.figure()
     plt.clf()
@@ -730,7 +731,7 @@ def SCTransBOE(show_plots):
     PlotName = "scPlusTranslationVelocityBOE"
     PlotTitle = "Translation Velocity BOE"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
     if show_plots:
         plt.show()
         plt.close('all')
@@ -883,7 +884,7 @@ def SCPointBVsPointC(show_plots):
     PlotName = "scPlusPointBVsPointCTranslation"
     PlotTitle = "PointB Vs PointC Translation"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
 
     plt.figure()
     plt.clf()
@@ -897,7 +898,7 @@ def SCPointBVsPointC(show_plots):
     PlotName = "scPlusPointBVsPointCAttitude"
     PlotTitle = "PointB Vs PointC Attitude"
     format = r"width=0.8\textwidth"
-    unitTestSupport.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
+    simHelpers.writeFigureLaTeX(PlotName, PlotTitle, plt, format, path)
     if show_plots:
         plt.show()
         plt.close('all')

--- a/src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
+++ b/src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
@@ -28,6 +28,7 @@ import pytest
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 from Basilisk.simulation import spacecraft
@@ -191,7 +192,7 @@ def sphericalPendulumTest(show_plots, useFlag,testCase):
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 100
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 
@@ -221,15 +222,15 @@ def sphericalPendulumTest(show_plots, useFlag,testCase):
     if testCase == 3:
         fuelMass = fuelLog.fuelMass
         fuelMassDot = fuelLog.fuelMassDot
-        mass1Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.sphericalPendulumMass1)
-        mass2Out = unitTestSupport.addTimeColumn(stateLog.times(), stateLog.sphericalPendulumMass2)
+        mass1Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.sphericalPendulumMass1)
+        mass2Out = simHelpers.addTimeColumn(stateLog.times(), stateLog.sphericalPendulumMass2)
 
 
     # request energy and momentum
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
 
     if timeStep == 0.01:
         testCaseName = "OneHundredth"
@@ -243,25 +244,25 @@ def sphericalPendulumTest(show_plots, useFlag,testCase):
         plt.plot(orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,1] - orbAngMom_N[0,1])/orbAngMom_N[0,1], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,2] - orbAngMom_N[0,2])/orbAngMom_N[0,2], orbAngMom_N[:,0]*1e-9, (orbAngMom_N[:,3] - orbAngMom_N[0,3])/orbAngMom_N[0,3])
         plt.xlabel('Time (s)')
         plt.ylabel('Relative Orbital Angular Momentum Variation')
-        unitTestSupport.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCaseName, "Change in Orbital Angular Momentum " + testCaseName, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInOrbitalAngularMomentum" + testCaseName, "Change in Orbital Angular Momentum " + testCaseName, plt, r"width=0.8\textwidth", path)
 
         plt.figure(2,figsize=(5,4))
         plt.plot(orbEnergy[:,0]*1e-9, (orbEnergy[:,1] - orbEnergy[0,1])/orbEnergy[0,1])
         plt.xlabel('Time (s)')
         plt.ylabel('Relative Orbital Energy Variation')
-        unitTestSupport.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCaseName, "Change in Orbital Energy " + testCaseName, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInOrbitalEnergy" + testCaseName, "Change in Orbital Energy " + testCaseName, plt, r"width=0.8\textwidth", path)
 
         plt.figure(3,figsize=(5,4))
         plt.plot(rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,1] - rotAngMom_N[0,1])/rotAngMom_N[0,1], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,2] - rotAngMom_N[0,2])/rotAngMom_N[0,2], rotAngMom_N[:,0]*1e-9, (rotAngMom_N[:,3] - rotAngMom_N[0,3])/rotAngMom_N[0,3])
         plt.xlabel('Time (s)')
         plt.ylabel('Relative Rotational Angular Momentum Variation')
-        unitTestSupport.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCaseName, "Change in Rotational Angular Momentum " + testCaseName, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInRotationalAngularMomentum" + testCaseName, "Change in Rotational Angular Momentum " + testCaseName, plt, r"width=0.8\textwidth", path)
 
         plt.figure(4,figsize=(5,4))
         plt.plot(rotEnergy[:,0]*1e-9, (rotEnergy[:,1] - rotEnergy[0,1])/rotEnergy[0,1])
         plt.xlabel('Time (s)')
         plt.ylabel('Relative Rotational Energy Variation')
-        unitTestSupport.writeFigureLaTeX("ChangeInRotationalEnergy" + testCaseName, "Change in Rotational Energy " + testCaseName, plt, r"width=0.8\textwidth", path)
+        simHelpers.writeFigureLaTeX("ChangeInRotationalEnergy" + testCaseName, "Change in Rotational Energy " + testCaseName, plt, r"width=0.8\textwidth", path)
     if testCase == 3:
         plt.figure()
         plt.plot(fuelLog.times()*1e-9, fuelMass)

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFStateEffector.py
@@ -32,7 +32,10 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
-from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+)
 from Basilisk.simulation import spacecraft, spinningBodyNDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/_UnitTest/test_spinningBodyOneDOFStateEffector.py
@@ -33,6 +33,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
 from Basilisk.simulation import spacecraft, spinningBodyOneDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
@@ -180,10 +181,10 @@ def spinningBody(show_plots, cmdTorque, lock, thetaRef):
     unitTestSim.ExecuteSimulation()
 
     # Extract the logged variables
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
     theta = thetaData.theta
     thetaDot = thetaData.thetaDot
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/_UnitTest/test_spinningBodyTwoDOFStateEffector.py
@@ -32,6 +32,7 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 splitPath = path.split('simulation')
 
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass, unitTestSupport, macros
 from Basilisk.simulation import spacecraft, spinningBodyTwoDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
@@ -208,10 +209,10 @@ def spinningBody(show_plots, cmdTorque1, lock1, theta1Ref, cmdTorque2, lock2, th
     unitTestSim.ExecuteSimulation()
 
     # Extract the logged variables
-    orbAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
-    rotAngMom_N = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
-    rotEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
-    orbEnergy = unitTestSupport.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
+    orbAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbAngMomPntN_N)
+    rotAngMom_N = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotAngMomPntC_N)
+    rotEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totRotEnergy)
+    orbEnergy = simHelpers.addTimeColumn(scObjectLog.times(), scObjectLog.totOrbEnergy)
     theta1 = theta1Data.theta
     theta1Dot = theta1Data.thetaDot
     theta2 = theta2Data.theta

--- a/src/simulation/environment/ExponentialAtmosphere/_UnitTest/test_integratedExponentialAtmosphere.py
+++ b/src/simulation/environment/ExponentialAtmosphere/_UnitTest/test_integratedExponentialAtmosphere.py
@@ -36,6 +36,7 @@ from Basilisk.utilities import orbitalMotion
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import exponentialAtmosphere
 from Basilisk.utilities import simIncludeGravBody
+from Basilisk.utilities import simHelpers
 
 
 def test_unitExponentialAtmosphere():
@@ -65,7 +66,7 @@ def test_unitExponentialAtmosphere():
     else:
         colorText = 'Red'
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippetName, passedText, path)
+    simHelpers.writeTeXSnippet(snippetName, passedText, path)
 
     if testSum == 0:
         print("Passed")
@@ -188,7 +189,7 @@ def TestExponentialAtmosphere():
     #   Setup data logging before the simulation is initialized
     #
     numDataPoints = 10
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = scObject.scStateOutMsg.recorder(samplingTime)
     denLog = newAtmo.envOutMsgs[0].recorder(samplingTime)
 
@@ -218,7 +219,7 @@ def TestExponentialAtmosphere():
 
     #   Compare to expected values
     accuracy = 1e-5
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     if len(densData) > 0:
         for ind in range(0,len(densData)):

--- a/src/simulation/environment/ExponentialAtmosphere/_UnitTest/test_unitTestExponentialAtmosphere.py
+++ b/src/simulation/environment/ExponentialAtmosphere/_UnitTest/test_unitTestExponentialAtmosphere.py
@@ -43,6 +43,7 @@ from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simSetPlanetEnvironment
+from Basilisk.utilities import simHelpers
 
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
@@ -176,7 +177,7 @@ def run(show_plots, useDefault, useMinReach, useMaxReach, usePlanetEphemeris):
 
     # compare the module results to the truth values
     accuracy = 1e-5
-    unitTestSupport.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
 
     # check the exponential atmosphere results
     #
@@ -214,7 +215,7 @@ def run(show_plots, useDefault, useMinReach, useMaxReach, usePlanetEphemeris):
         colorText = 'Red'
         print("Failed: " + testModule.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
+++ b/src/simulation/environment/MsisAtmosphere/_UnitTest/test_msiseAtmosphere.py
@@ -35,11 +35,11 @@ from Basilisk.simulation import msisAtmosphere
 # import simulation related support
 from Basilisk.simulation import spacecraft
 # import general simulation support files
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -99,7 +99,7 @@ def run(show_plots, orbitCase, setEpoch):
     newAtmo.ModelTag = "MsisAtmo"
 
     if setEpoch == "Msg":
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg('2019 Jan 01 00:00:00.00 (UTC)')
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg('2019 Jan 01 00:00:00.00 (UTC)')
         newAtmo.epochInMsg.subscribeTo(epochMsg)
 
         # setting epoch day of year info deliberately to a false value.  The epoch msg info should be used
@@ -214,7 +214,7 @@ def run(show_plots, orbitCase, setEpoch):
 
     accuracy = 1e-8
 
-    unitTestSupport.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
 
     #   Test atmospheric density calculation; note that refAtmoData is in g/cm^3,
     #   and must be adjusted by a factor of 1e-3 to match kg/m^3
@@ -241,7 +241,7 @@ def run(show_plots, orbitCase, setEpoch):
         print("Failed: " + newAtmo.ModelTag)
         passedText = '\\textcolor{' + colorText + '}{' + "Failed" + '}'
         print(testMessages)
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/simulation/environment/groundLocation/_UnitTest/test_unitGroundLocation.py
+++ b/src/simulation/environment/groundLocation/_UnitTest/test_unitGroundLocation.py
@@ -28,7 +28,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from matplotlib import pyplot as plt
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -89,7 +89,7 @@ def test_range(show_plots):
 
     # Log the access indicator
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog0 = groundTarget.accessOutMsgs[0].recorder(samplingTime)
     dataLog1 = groundTarget.accessOutMsgs[1].recorder(samplingTime)
     dataLog2 = groundTarget.accessOutMsgs[2].recorder(samplingTime)
@@ -173,7 +173,7 @@ def test_rotation(show_plots):
 
     # Log the access indicator
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = groundTarget.accessOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 
@@ -253,7 +253,7 @@ def test_AzElR_rates():
 
     # Log the Az,El,R and rates info
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = groundStation.accessOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 

--- a/src/simulation/environment/groundMapping/_UnitTest/test_groundMapping.py
+++ b/src/simulation/environment/groundMapping/_UnitTest/test_groundMapping.py
@@ -24,7 +24,6 @@ from Basilisk.architecture import messaging
 from Basilisk.simulation import groundMapping
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
 
 import pytest
 

--- a/src/simulation/environment/magneticFieldCenteredDipole/_UnitTest/test_magneticFieldCenteredDipole.py
+++ b/src/simulation/environment/magneticFieldCenteredDipole/_UnitTest/test_magneticFieldCenteredDipole.py
@@ -42,6 +42,7 @@ from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simSetPlanetEnvironment
+from Basilisk.utilities import simHelpers
 
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
@@ -190,7 +191,7 @@ def run(show_plots, useDefault, useMinReach, useMaxReach, usePlanetEphemeris):
 
     # compare the module results to the truth values
     accuracy = 1e-5
-    unitTestSupport.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
 
 
     # check the exponential atmosphere results
@@ -219,7 +220,7 @@ def run(show_plots, useDefault, useMinReach, useMaxReach, usePlanetEphemeris):
         colorText = 'Red'
         print("Failed: " + testModule.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
 
     # each test method requires a single assert method to be called

--- a/src/simulation/environment/magneticFieldWMM/_UnitTest/test_magneticFieldWMM.py
+++ b/src/simulation/environment/magneticFieldWMM/_UnitTest/test_magneticFieldWMM.py
@@ -36,6 +36,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import unitTestSupport  # general support file with common unit test functions
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -112,7 +113,7 @@ def run(show_plots, decimalYear, Height, Lat, Lon, BxTrue, ByTrue, BzTrue, useDe
 
     if useMsg:
         epochMsgData = messaging.EpochMsgPayload()
-        dt = unitTestSupport.decimalYearToDateTime(decimalYear)
+        dt = simHelpers.decimalYearToDateTime(decimalYear)
         epochMsgData.year = dt.year
         epochMsgData.month = dt.month
         epochMsgData.day = dt.day
@@ -199,7 +200,7 @@ def run(show_plots, decimalYear, Height, Lat, Lon, BxTrue, ByTrue, BzTrue, useDe
         return magField_N
 
     # compare the module results to the truth values
-    unitTestSupport.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("unitTestToleranceValue", str(accuracy), path)
 
     # check the exponential atmosphere results
     #
@@ -225,7 +226,7 @@ def run(show_plots, decimalYear, Height, Lat, Lon, BxTrue, ByTrue, BzTrue, useDe
         colorText = 'Red'
         print("Failed: " + testModule.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     return [testFailCount, ''.join(testMessages)]
 

--- a/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemeris.py
+++ b/src/simulation/environment/planetEphemeris/_UnitTest/test_planetEphemeris.py
@@ -41,6 +41,7 @@ from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import unitTestSupport                  # general support file with common unit test functions
 from Basilisk.simulation import planetEphemeris
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import bskLogging
 from Basilisk.architecture.bskLogging import BasiliskError
 
@@ -166,7 +167,7 @@ def planetEphemerisTest(show_plots, setRAN, setDEC, setLST, setRate):
     unitTestSim.ExecuteSimulation()
 
     accuracy = 1e-3
-    unitTestSupport.writeTeXSnippet("toleranceValue", str(accuracy), path)
+    simHelpers.writeTeXSnippet("toleranceValue", str(accuracy), path)
 
     # This pulls the actual data log from the simulation run.
     # Note that range(3) will provide [0, 1, 2]  Those are the elements you get from the vector (all of them)
@@ -261,7 +262,7 @@ def planetEphemerisTest(show_plots, setRAN, setDEC, setLST, setRate):
         colorText = 'Red'
         print("Failed: " + module.ModelTag)
         passedText = r'\textcolor{' + colorText + '}{' + "Failed" + '}'
-    unitTestSupport.writeTeXSnippet(snippentName, passedText, path)
+    simHelpers.writeTeXSnippet(snippentName, passedText, path)
 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found

--- a/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
+++ b/src/simulation/environment/spaceWeatherData/_UnitTest/test_spaceWeatherData.py
@@ -21,7 +21,8 @@ import pytest
 
 from Basilisk.architecture import bskLogging
 from Basilisk.simulation import spaceWeatherData
-from Basilisk.utilities import SimulationBaseClass, macros, unitTestSupport
+from Basilisk.utilities import simHelpers
+from Basilisk.utilities import SimulationBaseClass, macros
 from Basilisk.architecture.bskLogging import BasiliskError
 
 
@@ -67,7 +68,7 @@ def test_space_weather_data_celestrak_example_columns():
         module.loadSpaceWeatherFile(str(file_path))
 
         timeInitString = "2026 March 04 21:48:00.000000"
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg(timeInitString)
         module.epochInMsg.subscribeTo(epochMsg)
 
         sim.AddModelToTask(unit_task_name, module)
@@ -133,7 +134,7 @@ def test_space_weather_data_stops_at_first_invalid_row():
         module.loadSpaceWeatherFile(str(file_path))
 
         timeInitString = "2026 March 04 21:48:00.000000"
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg(timeInitString)
         module.epochInMsg.subscribeTo(epochMsg)
 
         sim.AddModelToTask(unit_task_name, module)
@@ -291,7 +292,7 @@ def test_reset_error_when_epoch_before_table():
         module.loadSpaceWeatherFile(str(file_path))
 
         # epoch one day before the table start — D0 = 2026-02-27, not in table
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2026 February 27 00:00:00.000000")
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg("2026 February 27 00:00:00.000000")
         module.epochInMsg.subscribeTo(epochMsg)
         sim.AddModelToTask(unit_task_name, module)
 
@@ -333,7 +334,7 @@ def test_stale_output_retained_on_missing_day():
         module.loadSpaceWeatherFile(str(file_path))
 
         # epoch on the last day in the table; after 24 h D0 = 2026-03-05 (absent)
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2026 March 04 00:00:00.000000")
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg("2026 March 04 00:00:00.000000")
         module.epochInMsg.subscribeTo(epochMsg)
         sim.AddModelToTask(unit_task_name, module)
 
@@ -390,7 +391,7 @@ def test_space_weather_data_epoch_update():
         module.loadSpaceWeatherFile(str(file_path))
 
         timeInitString = "2026 March 03 18:48:00.000000"
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(timeInitString)
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg(timeInitString)
         module.epochInMsg.subscribeTo(epochMsg)
 
         sim.AddModelToTask(unit_task_name, module)
@@ -618,7 +619,7 @@ def test_valid_date_feb_29_leap_accepted():
         file_path.write_text(csv_text)
         module.loadSpaceWeatherFile(str(file_path))
 
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2024 March 02 12:00:00.000000")
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg("2024 March 02 12:00:00.000000")
         module.epochInMsg.subscribeTo(epochMsg)
         sim.AddModelToTask(unit_task_name, module)
 
@@ -761,7 +762,7 @@ def test_failed_reload_preserves_previous_table():
             module.loadSpaceWeatherFile(str(bad_path))
 
         # Table from the good file must still be intact
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg("2026 March 04 21:48:00.000000")
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg("2026 March 04 21:48:00.000000")
         module.epochInMsg.subscribeTo(epochMsg)
         sim.AddModelToTask(unit_task_name, module)
         recorder = module.swDataOutMsgs[0].recorder()

--- a/src/simulation/environment/spacecraftLocation/_UnitTest/test_unitSpacecraftLocation.py
+++ b/src/simulation/environment/spacecraftLocation/_UnitTest/test_unitSpacecraftLocation.py
@@ -26,7 +26,6 @@ from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
-from Basilisk.utilities import unitTestSupport
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_unitSpice.py
@@ -38,7 +38,7 @@ bskPath = __path__[0]
 
 
 import datetime
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 import numpy
 from Basilisk.simulation import spiceInterface
@@ -96,11 +96,11 @@ def testPlottingFixture(show_plots):
     yield dataStore
 
     plt = dataStore.giveData()
-    unitTestSupport.writeFigureLaTeX('EphemMars', 'Ephemeris Error on Mars', plt, 'height=0.7\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('EphemMars', 'Ephemeris Error on Mars', plt, 'height=0.7\\textwidth, keepaspectratio', path)
     plt.ylim(0, 2E-2)
-    unitTestSupport.writeFigureLaTeX('EphemEarth', 'Ephemeris Error on Earth', plt, 'height=0.7\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('EphemEarth', 'Ephemeris Error on Earth', plt, 'height=0.7\\textwidth, keepaspectratio', path)
     plt.ylim(0, 5E-6)
-    unitTestSupport.writeFigureLaTeX('EphemSun', 'Ephemeris Error on Sun', plt, 'height=0.7\\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('EphemSun', 'Ephemeris Error on Sun', plt, 'height=0.7\\textwidth, keepaspectratio', path)
     if show_plots:
         dataStore.plotData()
 
@@ -185,7 +185,7 @@ def unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos
     TotalSim.AddModelToTask(unitTaskName, SpiceObject)
 
     if useMsg:
-        epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(DateSpice)
+        epochMsg = simHelpers.timeStringToGregorianUTCMsg(DateSpice)
         SpiceObject.epochInMsg.subscribeTo(epochMsg)
 
         # The following value is set, but should not be used by the module.  This checks that the above
@@ -203,8 +203,8 @@ def unitSpice(testPlottingFixture, show_plots, DateSpice, DatePlot, MarsTruthPos
     TotalSim.ExecuteSimulation()
 
     # Get the logged variables (GPS seconds, Julian Date)
-    DataGPSSec = unitTestSupport.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.GPSSeconds)
-    DataJD = unitTestSupport.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.julianDateCurrent)
+    DataGPSSec = simHelpers.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.GPSSeconds)
+    DataJD = simHelpers.addTimeColumn(spiceObjectLog.times(), spiceObjectLog.julianDateCurrent)
 
     # Get parametrized date from DatePlot
     year = "".join(("20", DatePlot[6:8]))
@@ -400,7 +400,7 @@ def test_59_999999_second_epoch():
 
     TotalSim.AddModelToTask(unitTaskName, SpiceObject)
 
-    epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(DateSpice)
+    epochMsg = simHelpers.timeStringToGregorianUTCMsg(DateSpice)
     SpiceObject.epochInMsg.subscribeTo(epochMsg)
 
     # Configure simulation

--- a/src/simulation/environment/stripLocation/_UnitTest/test_unitStripLocation.py
+++ b/src/simulation/environment/stripLocation/_UnitTest/test_unitStripLocation.py
@@ -28,7 +28,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -92,7 +92,7 @@ def test_range_degenerate_strip(show_plots):
 
     # Log the access indicator
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog0 = stripTarget.accessOutMsgs[0].recorder(samplingTime)
     dataLog1 = stripTarget.accessOutMsgs[1].recorder(samplingTime)
     dataLog2 = stripTarget.accessOutMsgs[2].recorder(samplingTime)
@@ -184,7 +184,7 @@ def test_rotation_degenerate_strip(show_plots):
 
     # Log the access indicator
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = stripTarget.accessOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 
@@ -658,7 +658,7 @@ def test_AzElR_rates():
 
     # Log the Az, El, R and rates info
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = stripStation.accessOutMsgs[0].recorder(samplingTime)
     scSim.AddModelToTask(simTaskName, dataLog)
 

--- a/src/simulation/navigation/pinholeCamera/_UnitTest/test_unitPinholeCamera.py
+++ b/src/simulation/navigation/pinholeCamera/_UnitTest/test_unitPinholeCamera.py
@@ -27,8 +27,8 @@ from Basilisk.utilities import simIncludeGravBody
 from Basilisk.architecture import messaging
 from Basilisk.simulation import pinholeCamera
 from Basilisk.simulation import spacecraft
-from Basilisk.utilities import unitTestSupport
 from Basilisk import __path__
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -135,7 +135,7 @@ def test_visibility():
 
     # Log the landmark messages
     numDataPoints = 2
-    samplingTime = unitTestSupport.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
+    samplingTime = simHelpers.samplingTime(simulationTime, simulationTimeStep, numDataPoints)
     dataLog = []
     for i in range(len(pos_lmk)):
         dataLog.append(camera.landmarkOutMsgs[i].recorder(samplingTime))

--- a/src/simulation/navigation/simpleNav/_UnitTest/test_simpleNav.py
+++ b/src/simulation/navigation/simpleNav/_UnitTest/test_simpleNav.py
@@ -28,7 +28,7 @@ from Basilisk.architecture import messaging
 from Basilisk.architecture.bskLogging import BasiliskError
 from Basilisk.simulation import simpleNav
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 def listNorm(inputList):
@@ -262,7 +262,7 @@ def unitSimpleNav(show_plots):
     plt.legend(loc='upper left')
     plt.xlabel('Time (s)')
     plt.ylabel('Position (m)')
-    unitTestSupport.writeFigureLaTeX('SimpleNavPos', 'Simple Navigation Position Signal', plt, r'height=0.4\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('SimpleNavPos', 'Simple Navigation Position Signal', plt, r'height=0.4\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
         plt.close('all')
@@ -275,7 +275,7 @@ def unitSimpleNav(show_plots):
     plt.legend(loc='upper left')
     plt.xlabel('Time (s)')
     plt.ylabel('Attitude (rad)')
-    unitTestSupport.writeFigureLaTeX('SimpleNavAtt', 'Simple Navigation Att Signal', plt, r'height=0.4\textwidth, keepaspectratio', path)
+    simHelpers.writeFigureLaTeX('SimpleNavAtt', 'Simple Navigation Att Signal', plt, r'height=0.4\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()
     plt.close('all')

--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_CSSConfig.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_CSSConfig.py
@@ -24,6 +24,7 @@ from Basilisk.simulation import coarseSunSensor
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 @pytest.mark.parametrize("accuracy", [1e-12])
@@ -128,7 +129,7 @@ def run(show_plots, accuracy):
     testFailCount, testMessages = unitTestSupport.compareArray([[0., 0., 0.]], dataCSS1pos,
                                                                accuracy, "CSS1 pos",
                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareArray([unitTestSupport.EigenVector3d2np(CSS1.nHat_B)], dataCSS1nHat,
+    testFailCount, testMessages = unitTestSupport.compareArray([simHelpers.EigenVector3d2np(CSS1.nHat_B)], dataCSS1nHat,
                                                                accuracy, "CSS1 nHat_B",
                                                                testFailCount, testMessages)
     testFailCount, testMessages = unitTestSupport.compareDoubleArray([CSS1.fov], dataCSS1fov,
@@ -148,10 +149,10 @@ def run(show_plots, accuracy):
                                                                      testFailCount, testMessages)
 
     # check CSS 2 output
-    testFailCount, testMessages = unitTestSupport.compareArray([unitTestSupport.EigenVector3d2np(CSS2.r_B)], dataCSS2pos,
+    testFailCount, testMessages = unitTestSupport.compareArray([simHelpers.EigenVector3d2np(CSS2.r_B)], dataCSS2pos,
                                                                accuracy, "CSS2 pos",
                                                                testFailCount, testMessages)
-    testFailCount, testMessages = unitTestSupport.compareArray([unitTestSupport.EigenVector3d2np(CSS2.nHat_B)], dataCSS2nHat,
+    testFailCount, testMessages = unitTestSupport.compareArray([simHelpers.EigenVector3d2np(CSS2.nHat_B)], dataCSS2nHat,
                                                                accuracy, "CSS2 nHat_B",
                                                                testFailCount, testMessages)
     testFailCount, testMessages = unitTestSupport.compareDoubleArray([CSS2.fov], dataCSS2fov,
@@ -187,4 +188,3 @@ if __name__ == "__main__":
         False,       # show_plots
         1e-12           # accuracy
     )
-

--- a/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
+++ b/src/simulation/sensors/coarseSunSensor/_UnitTest/test_coarseSunSensor.py
@@ -38,6 +38,7 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion as om
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from matplotlib import pyplot as plt
 
 path = os.path.dirname(os.path.abspath(__file__))
@@ -282,7 +283,7 @@ def run(show_plots, useConstellation, visibilityFactor, fov, kelly, scaleFactor,
         plt.xlabel('Time [min]')
         plt.ylabel('P2 Output Values [-]')
         plt.legend(loc='upper center')
-        unitTestSupport.writeFigureLaTeX('constellationPlots',
+        simHelpers.writeFigureLaTeX('constellationPlots',
                                          'Plot of first and second constellation outputs for comparision.\
                                           Note that the constellation starts pointing directly at the sun\
                                            and linearly rotates in time until it returns to a direct view.',
@@ -300,7 +301,7 @@ def run(show_plots, useConstellation, visibilityFactor, fov, kelly, scaleFactor,
         plt.xlabel('Time [min]')
         plt.ylabel('Output Value [-]')
         if name == "combined":
-            unitTestSupport.writeFigureLaTeX('combinedPlot',
+            simHelpers.writeFigureLaTeX('combinedPlot',
                                              'Plot of all cases of individual coarse sun sensor in comparison to\
                                               each other. Note that the incidence angle starts at direct and linearly\
                                                rotates in time until it returns to a direct view.',
@@ -350,62 +351,62 @@ def run(show_plots, useConstellation, visibilityFactor, fov, kelly, scaleFactor,
     # Write some snippets for AutoTex
     snippetName = name + "PassedText"
     snippetContent = passedText
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
 
     snippetName = name + "PassFailMsg"
     snippetContent = passFailMsg
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     print("\n", passFailMsg)
 
     # write pytest parameters to AutoTex folder
     # "useConstellation, visibilityFactor, fov, kelly, scaleFactor, bias, noiseStd, albedoValue, errTol, name, zLevel, lineWide"
     useConstellationSnippetName = name + "UseConstellation"
     useConstellationSnippetContent = str(useConstellation)
-    unitTestSupport.writeTeXSnippet(useConstellationSnippetName, useConstellationSnippetContent, path)
+    simHelpers.writeTeXSnippet(useConstellationSnippetName, useConstellationSnippetContent, path)
 
     visibilityFactorSnippetName = name + "VisibilityFactor"
     visibilityFactorSnippetContent = '{:1.2f}'.format(visibilityFactor)
-    unitTestSupport.writeTeXSnippet(visibilityFactorSnippetName, visibilityFactorSnippetContent, path)
+    simHelpers.writeTeXSnippet(visibilityFactorSnippetName, visibilityFactorSnippetContent, path)
 
     fovSnippetName = name + "Fov"
     fovSnippetContent = '{:1.4f}'.format(fov)
-    unitTestSupport.writeTeXSnippet(fovSnippetName, fovSnippetContent, path)
+    simHelpers.writeTeXSnippet(fovSnippetName, fovSnippetContent, path)
 
     kellySnippetName = name + "Kelly"
     kellySnippetContent = '{:1.2f}'.format(kelly)
-    unitTestSupport.writeTeXSnippet(kellySnippetName, kellySnippetContent, path)
+    simHelpers.writeTeXSnippet(kellySnippetName, kellySnippetContent, path)
 
     scaleFactorSnippetName = name + "ScaleFactor"
     scaleFactorSnippetContent = '{:1.2f}'.format(scaleFactor)
-    unitTestSupport.writeTeXSnippet(scaleFactorSnippetName, scaleFactorSnippetContent, path)
+    simHelpers.writeTeXSnippet(scaleFactorSnippetName, scaleFactorSnippetContent, path)
 
     biasSnippetName = name + "Bias"
     biasSnippetContent = '{:1.2f}'.format(bias)
-    unitTestSupport.writeTeXSnippet(biasSnippetName, biasSnippetContent, path)
+    simHelpers.writeTeXSnippet(biasSnippetName, biasSnippetContent, path)
 
     noiseStdSnippetName = name + "NoiseStd"
     noiseStdSnippetContent = '{:1.3f}'.format(noiseStd)
-    unitTestSupport.writeTeXSnippet(noiseStdSnippetName, noiseStdSnippetContent, path)
+    simHelpers.writeTeXSnippet(noiseStdSnippetName, noiseStdSnippetContent, path)
 
     albedoValueSnippetName = name + "AlbedoValue"
     albedoValueSnippetContent = '{:1.1f}'.format(albedoValue)
-    unitTestSupport.writeTeXSnippet(albedoValueSnippetName, albedoValueSnippetContent, path)
+    simHelpers.writeTeXSnippet(albedoValueSnippetName, albedoValueSnippetContent, path)
 
     locationSnippetName = name + "Location"
     locationSnippetContent = '{:1.1f}'.format(sunDistInput)
-    unitTestSupport.writeTeXSnippet(locationSnippetName, locationSnippetContent, path)
+    simHelpers.writeTeXSnippet(locationSnippetName, locationSnippetContent, path)
 
     saturationMaxSnippetName = name + "MaxSaturation"
     saturationMaxSnippetContent = '{:2.2f}'.format(maxIn)
-    unitTestSupport.writeTeXSnippet(saturationMaxSnippetName, saturationMaxSnippetContent, path)
+    simHelpers.writeTeXSnippet(saturationMaxSnippetName, saturationMaxSnippetContent, path)
 
     saturationMinSnippetName = name + "MinSaturation"
     saturationMinSnippetContent = '{:2.2f}'.format(minIn)
-    unitTestSupport.writeTeXSnippet(saturationMinSnippetName, saturationMinSnippetContent, path)
+    simHelpers.writeTeXSnippet(saturationMinSnippetName, saturationMinSnippetContent, path)
 
     errTolSnippetName = name + "ErrTol"
     errTolSnippetContent = '{:1.1e}'.format(errTol)
-    unitTestSupport.writeTeXSnippet(errTolSnippetName, errTolSnippetContent, path)
+    simHelpers.writeTeXSnippet(errTolSnippetName, errTolSnippetContent, path)
 
     if testFailCount == 0:
         print("PASSED")

--- a/src/simulation/sensors/imuSensor/_UnitTest/test_imu_sensor.py
+++ b/src/simulation/sensors/imuSensor/_UnitTest/test_imu_sensor.py
@@ -38,6 +38,7 @@ from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import macros
 from Basilisk.simulation import imuSensor
 from Basilisk.utilities import RigidBodyKinematics as rbk
+from Basilisk.utilities import simHelpers
 from Basilisk.architecture import messaging
 
 def addTimeColumn(time, data):
@@ -356,7 +357,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     plt.title("PRV Comparison")
     myLegend = plt.legend()
     myLegend.get_frame().set_facecolor('#909090')
-    unitTestSupport.writeFigureLaTeX(testCase + "PRVcomparison",
+    simHelpers.writeFigureLaTeX(testCase + "PRVcomparison",
                                      'Plot Comparing Time Step PRV Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the principal rotation vector.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
     plt.figure(4,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
@@ -372,7 +373,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     plt.title("Angular Rate Comparison")
     myLegend = plt.legend()
     myLegend.get_frame().set_facecolor('#909090')
-    unitTestSupport.writeFigureLaTeX(testCase + "omegaComparison",
+    simHelpers.writeFigureLaTeX(testCase + "omegaComparison",
                                      'Plot Comparing Angular Rate Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the angular rate.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
     plt.figure(7,figsize=(7, 5), dpi=80, facecolor='w', edgecolor='k')
@@ -388,7 +389,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     plt.title("Acceleration Comparison")
     myLegend = plt.legend()
     myLegend.get_frame().set_facecolor('#909090')
-    unitTestSupport.writeFigureLaTeX(testCase + "accelComparison",
+    simHelpers.writeFigureLaTeX(testCase + "accelComparison",
                                      'Plot Comparing Sensor Linear Accelertaion Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the acceleration.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
 
@@ -405,7 +406,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     plt.title("DV Comparison")
     myLegend = plt.legend()
     myLegend.get_frame().set_facecolor('#909090')
-    unitTestSupport.writeFigureLaTeX(testCase + "DVcomparison",
+    simHelpers.writeFigureLaTeX(testCase + "DVcomparison",
                                      'Plot Comparing Time Step DV Truth and Output for test: ' + testCase +'. Note that 1, 2, and 3 indicate the components of the velocity delta.', plt,
                                      'height=0.7\\textwidth, keepaspectratio', path)
 
@@ -490,7 +491,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
         plt.xlabel("Time[s]")
         plt.ylabel("DV Noise [um/s]")
         plt.title("DV Noise")
-        unitTestSupport.writeFigureLaTeX("DVnoise",
+        simHelpers.writeFigureLaTeX("DVnoise",
                                          'Plot of DeltaV noise along each component for the noise test.',
                                          plt,
                                          'height=0.7\\textwidth, keepaspectratio', path)
@@ -500,7 +501,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
         plt.xlabel("Time[s]")
         plt.ylabel("Acceleration Noise [m/s/s]")
         plt.title("Acceleration Noise")
-        unitTestSupport.writeFigureLaTeX("AccelNoise",
+        simHelpers.writeFigureLaTeX("AccelNoise",
                                          'Plot of acceleration noise along each component for the noise test.',
                                          plt,
                                          'height=0.7\\textwidth, keepaspectratio', path)
@@ -510,7 +511,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
         plt.xlabel("Time[s]")
         plt.ylabel("DR Noise [rad]")
         plt.title("DR Noise")
-        unitTestSupport.writeFigureLaTeX("DRnoise",
+        simHelpers.writeFigureLaTeX("DRnoise",
                                          'Plot of PRV noise along each component for the noise test.',
                                          plt,
                                          'height=0.7\\textwidth, keepaspectratio', path)
@@ -520,7 +521,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
         plt.xlabel("Time[s]")
         plt.ylabel("Angular Rate Noise [rad/s]")
         plt.title("Angular Rate Noise")
-        unitTestSupport.writeFigureLaTeX("omegaNoise",
+        simHelpers.writeFigureLaTeX("omegaNoise",
                                          'Plot of Angular Rate noise along each component for the noise test.',
                                          plt,
                                          'height=0.7\\textwidth, keepaspectratio', path)
@@ -533,7 +534,7 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
     #
     accuracySnippetName = testCase+"accuracy"
     accuracySnippetContent = '{:1.0e}'.format(accuracy)
-    unitTestSupport.writeTeXSnippet(accuracySnippetName, accuracySnippetContent, path)
+    simHelpers.writeTeXSnippet(accuracySnippetName, accuracySnippetContent, path)
 
     if testFailCount == 0:
         colorText = 'ForestGreen'
@@ -544,32 +545,32 @@ def unitSimIMU(show_plots,   testCase,       stopTime,       procRate, gyroLSBIn
 
     passFailSnippetName = testCase+"passFail"
     passFailSnippetContent = passedText
-    unitTestSupport.writeTeXSnippet(passFailSnippetName, passFailSnippetContent, path)
+    simHelpers.writeTeXSnippet(passFailSnippetName, passFailSnippetContent, path)
 
     snippetName = testCase + "gyroLSB"
     snippetContent = '{:1.0e}'.format(gyroLSBIn)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "accelLSB"
     snippetContent = '{:1.0e}'.format(accelLSBIn)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "rotMax"
     snippetContent = '{:1.1e}'.format(senRotMaxIn)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "transMax"
     snippetContent = '{:1.1e}'.format(senTransMaxIn)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "rotNoise"
     snippetContent = '{:0.1f}'.format(senRotNoiseStd)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "transNoise"
     snippetContent = '{:0.1f}'.format(senTransNoiseStd)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "rotBias"
     snippetContent = '{:1.1e}'.format(senRotBiasIn)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
     snippetName = testCase + "transBias"
     snippetContent = '{:1.1e}'.format(senTransBiasIn)
-    unitTestSupport.writeTeXSnippet(snippetName, snippetContent, path)
+    simHelpers.writeTeXSnippet(snippetName, snippetContent, path)
 
     if testFailCount:
         print(testMessages)

--- a/src/simulation/sensors/simpleVoltEstimator/_UnitTest/test_simpleVoltEstimator.py
+++ b/src/simulation/sensors/simpleVoltEstimator/_UnitTest/test_simpleVoltEstimator.py
@@ -27,7 +27,7 @@ from Basilisk.architecture import messaging
 from Basilisk.architecture.bskLogging import BasiliskError
 from Basilisk.simulation import simpleVoltEstimator
 from Basilisk.utilities import SimulationBaseClass
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -132,7 +132,7 @@ def unitSimpleVoltEstimator(show_plots):
 
     plt.xlabel('Time (s)')
     plt.ylabel('Voltage (V)')
-    unitTestSupport.writeFigureLaTeX('SimpleVolt', 'Simple Voltage Estimator Voltage Signal', plt,
+    simHelpers.writeFigureLaTeX('SimpleVolt', 'Simple Voltage Estimator Voltage Signal', plt,
                                      r'height=0.4\textwidth, keepaspectratio', path)
     if show_plots:
         plt.show()

--- a/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
+++ b/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
@@ -44,8 +44,15 @@ splitPath = path.split(bskName)
 
 
 # Import all modules that are going to be called in this simulation
-from Basilisk.utilities import (SimulationBaseClass, macros, orbitalMotion, simIncludeGravBody, unitTestSupport,
-                                vizSupport, simIncludeThruster)
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    orbitalMotion,
+    simIncludeGravBody,
+    vizSupport,
+    simIncludeThruster,
+)
+from Basilisk.utilities import simHelpers
 from Basilisk.simulation import spacecraft
 from Basilisk.architecture import messaging, bskLogging
 from Basilisk.simulation import thrusterDynamicEffector
@@ -178,7 +185,7 @@ def vizInterfaceTest(show_plots, accuracy):
     scData.spacecraftName = scObject.ModelTag
     scData.scStateInMsg.subscribeTo(scObject.scStateOutMsg)
 
-    samplingTime = unitTestSupport.samplingTime(simulationTime, testProcessRate, 100)
+    samplingTime = simHelpers.samplingTime(simulationTime, testProcessRate, 100)
 
     # Create data recorders
     scState_dataRec = scObject.scStateOutMsg.recorder(samplingTime)

--- a/src/tests/test_bskPrinciples.py
+++ b/src/tests/test_bskPrinciples.py
@@ -35,7 +35,7 @@ import sys
 
 import pytest
 from Basilisk.architecture import bskLogging
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -71,7 +71,7 @@ def test_scenarioBskPrinciples(show_plots, bskScript):
         # save the figures to the RST scenario images folder
         if(figureList and figureList != {}):
             for pltName, plt in list(figureList.items()):
-                unitTestSupport.saveScenarioFigure(pltName, plt, path)
+                simHelpers.saveScenarioFigure(pltName, plt, path)
     except OSError as err:
         testFailCount = testFailCount + 1
         testMessages.append("OS error: {0}".format(err))

--- a/src/tests/test_bskTestOpNav.py
+++ b/src/tests/test_bskTestOpNav.py
@@ -34,7 +34,7 @@ import sys
 
 import pytest
 from Basilisk.architecture import bskLogging
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -92,7 +92,7 @@ def test_opnavBskScenarios(show_plots):
             # save the figures to the RST scenario images folder
             if figureList != {} and figureList is not None:
                 for pltName, plt in list(figureList.items()):
-                    unitTestSupport.saveScenarioFigure(pltName, plt, path)
+                    simHelpers.saveScenarioFigure(pltName, plt, path)
 
         except OSError as err:
             testFailCount = testFailCount + 1

--- a/src/tests/test_bskTestScript.py
+++ b/src/tests/test_bskTestScript.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -77,7 +77,7 @@ def test_scenarioBskScenarios(show_plots, bskSimCase):
 
         if(figureList != {}):
             for pltName, plt in list(figureList.items()):
-                unitTestSupport.saveScenarioFigure(pltName, plt, path)
+                simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount = testFailCount + 1

--- a/src/tests/test_scenarioAerocapture.py
+++ b/src/tests/test_scenarioAerocapture.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +62,7 @@ def test_scenarioAerocapture(show_plots, planetCase):
         figureList = scenarioAerocapture.run(show_plots, planetCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioAlbedo.py
+++ b/src/tests/test_scenarioAlbedo.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -66,7 +66,7 @@ def test_scenarioAlbedo(show_plots, albedoData, multipleInstrument, multiplePlan
         figureList = scenarioAlbedo.run(show_plots, albedoData, multipleInstrument, multiplePlanet, useEclipse, 25)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -83,4 +83,3 @@ def test_scenarioAlbedo(show_plots, albedoData, multipleInstrument, multiplePlan
     # this check below just makes sure no sub-test failures were found
 
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttGuidMultiSat.py
+++ b/src/tests/test_scenarioAttGuidMultiSat.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -43,7 +43,7 @@ def test_scenarioAttGuidMultiSat(show_plots, numberSpacecraft):
         figureList = scenario_AttGuidMultiSat.run(show_plots, numberSpacecraft)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioAttGuideHyperbolic.py
+++ b/src/tests/test_scenarioAttGuideHyperbolic.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -67,7 +67,7 @@ def test_bskAttGuide_Hyperbolic(show_plots, useAltBodyFrame):
         figureList = scenarioAttGuideHyperbolic.run(show_plots, useAltBodyFrame)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -83,5 +83,3 @@ def test_bskAttGuide_Hyperbolic(show_plots, useAltBodyFrame):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-
-

--- a/src/tests/test_scenarioAttLocPoint.py
+++ b/src/tests/test_scenarioAttLocPoint.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +62,7 @@ def test_bskAttitudeGuidance(show_plots):
         figureList = scenarioAttLocPoint.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -78,6 +78,3 @@ def test_bskAttitudeGuidance(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-
-
-

--- a/src/tests/test_scenarioAttitudeConstrainedManeuver.py
+++ b/src/tests/test_scenarioAttitudeConstrainedManeuver.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -69,7 +69,7 @@ def test_bskAttitudeConstrainedManeuver(show_plots, use2SunSensors, starTrackerF
         figureList = scenarioAttitudeConstrainedManeuver.run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -85,4 +85,3 @@ def test_bskAttitudeConstrainedManeuver(show_plots, use2SunSensors, starTrackerF
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeConstraintViolation.py
+++ b/src/tests/test_scenarioAttitudeConstraintViolation.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -52,7 +52,7 @@ import scenarioAttitudeConstraintViolation
 # of the multiple test runs for this test.
 
 
-@pytest.mark.parametrize("use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCase", [(False, 20, 70, 0), 
+@pytest.mark.parametrize("use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCase", [(False, 20, 70, 0),
                                                                                            (True,  20, 70, 0),
                                                                                            (True,  20, 70, 1),
 																						   (True,  20, 70, 2),
@@ -71,7 +71,7 @@ def test_bskAttitudeConstraintViolation(show_plots, use2SunSensors, starTrackerF
         figureList = scenarioAttitudeConstraintViolation.run(show_plots, use2SunSensors, starTrackerFov, sunSensorFov, attitudeSetCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -87,4 +87,3 @@ def test_bskAttitudeConstraintViolation(show_plots, use2SunSensors, starTrackerF
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeFeedback.py
+++ b/src/tests/test_scenarioAttitudeFeedback.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -68,7 +68,7 @@ def test_bskAttitudeFeedback(show_plots, useUnmodeledTorque, useIntGain, useKnow
         figureList = scenarioAttitudeFeedback.run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque, useCMsg)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -84,4 +84,3 @@ def test_bskAttitudeFeedback(show_plots, useUnmodeledTorque, useIntGain, useKnow
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeFeedback2T.py
+++ b/src/tests/test_scenarioAttitudeFeedback2T.py
@@ -35,7 +35,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -68,7 +68,7 @@ def test_bskAttitudeFeedback2T(show_plots, useUnmodeledTorque, useIntGain):
         figureList = scenarioAttitudeFeedback2T.run(show_plots, useUnmodeledTorque, useIntGain)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioAttitudeFeedback2T_TH.py
+++ b/src/tests/test_scenarioAttitudeFeedback2T_TH.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -65,7 +65,7 @@ def test_bskAttitudeFeedback2T_TH(show_plots, useDVThrusters):
         figureList = scenarioAttitudeFeedback2T_TH.run(show_plots, useDVThrusters)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -81,4 +81,3 @@ def test_bskAttitudeFeedback2T_TH(show_plots, useDVThrusters):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeFeedback2T_stateEffTH.py
+++ b/src/tests/test_scenarioAttitudeFeedback2T_stateEffTH.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -65,7 +65,7 @@ def test_bskAttitudeFeedback2T_stateEffTH(show_plots, useDVThrusters):
         figureList = scenarioAttitudeFeedback2T_stateEffTH.run(show_plots, useDVThrusters)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -81,4 +81,3 @@ def test_bskAttitudeFeedback2T_stateEffTH(show_plots, useDVThrusters):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeFeedbackNoEarth.py
+++ b/src/tests/test_scenarioAttitudeFeedbackNoEarth.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -68,7 +68,7 @@ def test_bskAttitudeFeedbackNoEarth(show_plots, useUnmodeledTorque, useIntGain, 
         figureList = scenarioAttitudeFeedbackNoEarth.run(show_plots, useUnmodeledTorque, useIntGain, useKnownTorque)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -84,4 +84,3 @@ def test_bskAttitudeFeedbackNoEarth(show_plots, useUnmodeledTorque, useIntGain, 
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeFeedbackNumba.py
+++ b/src/tests/test_scenarioAttitudeFeedbackNumba.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path     = os.path.dirname(os.path.abspath(filename))
@@ -59,7 +59,7 @@ def test_scenarioAttitudeFeedbackNumba(show_plots,
         figureList = scenarioAttitudeFeedbackNumba.run(
             show_plots, useUnmodeledTorque, useIntGain, useKnownTorque)
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
     except OSError:
         testFailCount += 1
         testMessages.append("scenarioAttitudeFeedbackNumba test failed.")

--- a/src/tests/test_scenarioAttitudeFeedbackRW.py
+++ b/src/tests/test_scenarioAttitudeFeedbackRW.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -65,7 +65,7 @@ def test_bskAttitudeFeedbackRW(show_plots, useJitterSimple, useRWVoltageIO):
         figureList = scenarioAttitudeFeedbackRW.run(show_plots, useJitterSimple, useRWVoltageIO)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -81,4 +81,3 @@ def test_bskAttitudeFeedbackRW(show_plots, useJitterSimple, useRWVoltageIO):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeFeedbackRWPower.py
+++ b/src/tests/test_scenarioAttitudeFeedbackRWPower.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -74,7 +74,7 @@ def test_bskAttitudeFeedbackRW(show_plots, useRwPowerGeneration):
 
         # save the figures to the doc scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -90,4 +90,3 @@ def test_bskAttitudeFeedbackRW(show_plots, useRwPowerGeneration):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeGG.py
+++ b/src/tests/test_scenarioAttitudeGG.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -63,7 +63,7 @@ def test_scenarioAttitudeGG(show_plots):
 
         # save the figures to the doc scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -79,4 +79,3 @@ def test_scenarioAttitudeGG(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudeGuidance.py
+++ b/src/tests/test_scenarioAttitudeGuidance.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -65,7 +65,7 @@ def test_bskAttitudeGuidance(show_plots, useAltBodyFrame):
         figureList = scenarioAttitudeGuidance.run(show_plots, useAltBodyFrame)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -81,6 +81,3 @@ def test_bskAttitudeGuidance(show_plots, useAltBodyFrame):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-
-
-

--- a/src/tests/test_scenarioAttitudePointing.py
+++ b/src/tests/test_scenarioAttitudePointing.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +62,7 @@ def test_bskAttitudePointing(show_plots, useLargeTumble):
         figureList = scenarioAttitudePointing.run(show_plots, useLargeTumble)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -78,4 +78,3 @@ def test_bskAttitudePointing(show_plots, useLargeTumble):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudePointingNumba.py
+++ b/src/tests/test_scenarioAttitudePointingNumba.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -64,7 +64,7 @@ def test_bskAttitudePointingNumba(show_plots):
     try:
         figureList = scenarioAttitudePointingNumba.run(show_plots)
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioAttitudePointingPy.py
+++ b/src/tests/test_scenarioAttitudePointingPy.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -61,7 +61,7 @@ def test_bskAttitudePointingPD(show_plots):
         figureList = scenarioAttitudePointingPy.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -70,4 +70,3 @@ def test_bskAttitudePointingPD(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioAttitudePrescribed.py
+++ b/src/tests/test_scenarioAttitudePrescribed.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +62,7 @@ def test_bskAttitudeGuidance(show_plots, useAltBodyFrame):
         figureList = scenarioAttitudePrescribed.run(show_plots, useAltBodyFrame)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -78,6 +78,3 @@ def test_bskAttitudeGuidance(show_plots, useAltBodyFrame):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-
-
-

--- a/src/tests/test_scenarioAttitudeSteering.py
+++ b/src/tests/test_scenarioAttitudeSteering.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -66,7 +66,7 @@ def test_bskAttitudeFeedbackRW(show_plots, simCase):
         figureList = scenarioAttitudeSteering.run(show_plots, simCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -82,4 +82,3 @@ def test_bskAttitudeFeedbackRW(show_plots, simCase):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioBasicOrbit.py
+++ b/src/tests/test_scenarioBasicOrbit.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -72,7 +72,7 @@ def test_scenarioBasicOrbit(show_plots, orbitCase, useSphericalHarmonics, planet
         posData, figureList = scenarioBasicOrbit.run(show_plots, orbitCase, useSphericalHarmonics, planetCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioBasicOrbitMultiSat.py
+++ b/src/tests/test_scenarioBasicOrbitMultiSat.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -43,7 +43,7 @@ def test_scenarioBasicOrbitMultiSat(show_plots, numberSpacecraft, environment):
         figureList = scenario_BasicOrbitMultiSat.run(show_plots, numberSpacecraft, environment)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioBasicOrbitMultiSat_MT.py
+++ b/src/tests/test_scenarioBasicOrbitMultiSat_MT.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -43,7 +43,7 @@ def test_scenarioBasicOrbitMultiSat(show_plots, numberSpacecraft, environment):
         figureList = scenario_BasicOrbitMultiSat_MT.run(show_plots, numberSpacecraft, environment, 4)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioCSS.py
+++ b/src/tests/test_scenarioCSS.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +62,7 @@ def test_bskAttitudeFeedback(show_plots, useCSSConstellation, usePlatform, useEc
         figureList = scenarioCSS.run(show_plots, useCSSConstellation, usePlatform, useEclipse, useKelly)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -79,4 +79,3 @@ def test_bskAttitudeFeedback(show_plots, useCSSConstellation, usePlatform, useEc
     # this check below just makes sure no sub-test failures were found
 
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioCentralBody.py
+++ b/src/tests/test_scenarioCentralBody.py
@@ -33,6 +33,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -69,7 +70,7 @@ def test_scenarioCentralBody(show_plots, useCentral):
         out_r, out_v, truth_r, truth_v, figureList = scenarioCentralBody.run(show_plots, useCentral)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -92,4 +93,3 @@ def test_scenarioCentralBody(show_plots, useCentral):
     # this check below just makes sure no sub-test failures were found
 
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioConstellationFromTle.py
+++ b/src/tests/test_scenarioConstellationFromTle.py
@@ -13,7 +13,8 @@ import pathlib
 import sys
 
 import pytest
-from Basilisk.utilities import tleHandling, unitTestSupport
+from Basilisk.utilities import tleHandling
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -37,7 +38,7 @@ def test_scenarioConstellationFromTle(show_plots, tleFile, numThreads):
         tleData = tleHandling.satTle2elem(DATA_DIR / tleFile)
         figureList = scenario_constellationFromTle.run(show_plots, tleData, numThreads)
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
     except OSError:
         testFailCount += 1
         testMessages.append("scenario_constellationFromTle test failed.")

--- a/src/tests/test_scenarioConstrainedDynamics.py
+++ b/src/tests/test_scenarioConstrainedDynamics.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -60,7 +60,7 @@ def test_scenarioConstrainedDynamics(show_plots):
         figureList = scenarioConstrainedDynamics.run(show_plots, 'Gravity')
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioConstrainedDynamicsComponentAnalysis.py
+++ b/src/tests/test_scenarioConstrainedDynamicsComponentAnalysis.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -61,7 +61,7 @@ def test_scenarioConstrainedDynamicsComponentAnalysis(show_plots, component_list
         figureList = scenarioConstrainedDynamicsComponentAnalysis.run(show_plots, component_list, sc_model)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioConstrainedDynamicsFrequencyAnalysis.py
+++ b/src/tests/test_scenarioConstrainedDynamicsFrequencyAnalysis.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -61,7 +61,7 @@ def test_scenarioConstrainedDynamicsFrequencyAnalysis(show_plots, gain_list, sc_
         figureList = scenarioConstrainedDynamicsFrequencyAnalysis.run(show_plots, gain_list, sc_model)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioConstraintDynamicsManeuverAnalysis.py
+++ b/src/tests/test_scenarioConstraintDynamicsManeuverAnalysis.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -63,7 +63,7 @@ def test_scenarioConstrainedDynamicsManeuverAnalysis(show_plots, gain_list, relp
         figureList = scenarioConstrainedDynamicsManeuverAnalysis.run(show_plots, gain_list, relpos_config, orbit_config, maneuver_config, sc_model)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioCustomGravBody.py
+++ b/src/tests/test_scenarioCustomGravBody.py
@@ -22,7 +22,7 @@ import sys
 
 import pytest
 from Basilisk.architecture import bskLogging
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -48,7 +48,7 @@ def test_simplePowerDemo(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -57,5 +57,3 @@ def test_simplePowerDemo(show_plots):
     assert testFailCount < 1, testMessages
 
     return
-
-

--- a/src/tests/test_scenarioDataDemo.py
+++ b/src/tests/test_scenarioDataDemo.py
@@ -22,7 +22,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -44,7 +44,7 @@ def test_simpleDataDemo(show_plots):
 
         # save the figures to the Sphinx scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except  OSError as err:
         testFailCount += 1
@@ -55,5 +55,3 @@ def test_simpleDataDemo(show_plots):
     assert testFailCount < 1, testMessages
 
     return
-
-

--- a/src/tests/test_scenarioDataToViz.py
+++ b/src/tests/test_scenarioDataToViz.py
@@ -22,7 +22,7 @@ import sys
 
 import pytest
 from Basilisk.architecture import bskLogging
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -49,7 +49,7 @@ def test_simplePowerDemo(show_plots, attType):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -60,5 +60,3 @@ def test_simplePowerDemo(show_plots, attType):
     assert testFailCount < 1, testMessages
 
     return
-
-

--- a/src/tests/test_scenarioDebrisReorbitET.py
+++ b/src/tests/test_scenarioDebrisReorbitET.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -64,7 +64,7 @@ def test_scenarioDebrisReorbitET(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioDragDeorbit.py
+++ b/src/tests/test_scenarioDragDeorbit.py
@@ -28,7 +28,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -64,7 +64,7 @@ def test_scenarioDragDeorbit(show_plots, initialAlt, deorbitAlt, model):
         figureList = scenarioDragDeorbit.run(show_plots, initialAlt, deorbitAlt, model)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioDragRendezvous.py
+++ b/src/tests/test_scenarioDragRendezvous.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -50,7 +50,7 @@ def test_scenarioDragRendezvous(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -66,4 +66,3 @@ def test_scenarioDragRendezvous(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioDragSensitivity.py
+++ b/src/tests/test_scenarioDragSensitivity.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -46,7 +46,7 @@ def test_scenarioDragSensitivity(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -62,4 +62,3 @@ def test_scenarioDragSensitivity(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioFlexiblePanel.py
+++ b/src/tests/test_scenarioFlexiblePanel.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -60,7 +60,7 @@ def test_scenarioFlexiblePanel(show_plots):
 
         # save the figures to the doc scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError:
         testFailCount += 1

--- a/src/tests/test_scenarioFormationBasic.py
+++ b/src/tests/test_scenarioFormationBasic.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -63,7 +63,7 @@ def test_scenarioFormationBasic(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -79,4 +79,3 @@ def test_scenarioFormationBasic(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioFormationMeanOEFeedback.py
+++ b/src/tests/test_scenarioFormationMeanOEFeedback.py
@@ -22,6 +22,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -122,7 +123,7 @@ def test_bskFormationMeanOEFeedback(show_plots, useClassicElem):
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
     #   print out success message if no error were found
     if testFailCount == 0:

--- a/src/tests/test_scenarioFormationReconfig.py
+++ b/src/tests/test_scenarioFormationReconfig.py
@@ -22,6 +22,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -150,14 +151,14 @@ def test_scenarioFormationReconfig(show_plots, useRefAttitude):
     testFailCount, testMessages = unitTestSupport.compareArrayRelative(
         trueVel2, dataVel2, accuracy, "deputy v2_BN_N Vector",
         testFailCount, testMessages)
-    
+
     testFailCount, testMessages = unitTestSupport.compareArray(
         trueAttErr, dataAttErr, accuracy, "deputy attitude Error",
         testFailCount, testMessages)
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
     #   print out success message if no error were found
     if testFailCount == 0:

--- a/src/tests/test_scenarioFuelSlosh.py
+++ b/src/tests/test_scenarioFuelSlosh.py
@@ -23,7 +23,7 @@ import sys
 
 import numpy as np
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -66,7 +66,7 @@ def test_scenarioFuelSlosh(show_plots, damping_parameter, timeStep):
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
     if testFailCount == 0:
         print("PASSED ")

--- a/src/tests/test_scenarioGaussMarkovRandomWalk.py
+++ b/src/tests/test_scenarioGaussMarkovRandomWalk.py
@@ -20,7 +20,7 @@ import inspect
 import os
 import sys
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -46,12 +46,12 @@ def test_scenarioGaussMarkovRandomWalk(show_plots, processNoiseLevel, walkBounds
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
         # Also save the static layout diagram if it exists
         if hasattr(scenarioGaussMarkovRandomWalk, 'getStaticDiagram'):
             staticFig = scenarioGaussMarkovRandomWalk.getStaticDiagram()
-            unitTestSupport.saveScenarioFigure('test_scenarioGaussMarkovRandomWalk', staticFig, path)
+            simHelpers.saveScenarioFigure('test_scenarioGaussMarkovRandomWalk', staticFig, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioGroundMapping.py
+++ b/src/tests/test_scenarioGroundMapping.py
@@ -22,7 +22,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -44,7 +44,7 @@ def test_scenarioGroundMapping(show_plots):
 
         # save the figures to the Sphinx scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -53,5 +53,3 @@ def test_scenarioGroundMapping(show_plots):
     assert testFailCount < 1, testMessages
 
     return
-
-

--- a/src/tests/test_scenarioHingedRigidBody.py
+++ b/src/tests/test_scenarioHingedRigidBody.py
@@ -35,7 +35,7 @@ import sys
 
 import numpy as np
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -74,7 +74,7 @@ def test_scenarioOrbitManeuver(doUnitTests, show_plots):
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
     # print out success message if no error were found
     if testFailCount == 0:
@@ -87,4 +87,3 @@ def test_scenarioOrbitManeuver(doUnitTests, show_plots):
     # this check below just makes sure no sub-test failures were found
 
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioHohmann.py
+++ b/src/tests/test_scenarioHohmann.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -63,7 +63,7 @@ def test_bskAttitudeGuidance(show_plots, rFirst, rSecond):
         figureList = scenarioHohmann.run(show_plots, rFirst, rSecond)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -79,6 +79,3 @@ def test_bskAttitudeGuidance(show_plots, rFirst, rSecond):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-
-
-

--- a/src/tests/test_scenarioIntegrators.py
+++ b/src/tests/test_scenarioIntegrators.py
@@ -32,6 +32,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -123,7 +124,7 @@ def test_scenarioIntegrators(show_plots):
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
     #   print out success message if no error were found
     if testFailCount == 0:

--- a/src/tests/test_scenarioIntegratorsComparison.py
+++ b/src/tests/test_scenarioIntegratorsComparison.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -55,7 +55,7 @@ def test_scenarioIntegrators(show_plots):
         figureList = scenarioIntegratorsComparison.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioLagrangePointOrbit.py
+++ b/src/tests/test_scenarioLagrangePointOrbit.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -67,7 +67,7 @@ def test_scenarioLagrangePointOrbit(lagrangePoint, nOrbits, timestep, showPlots)
         figureList = scenarioLagrangePointOrbit.run(lagrangePoint, nOrbits, timestep, showPlots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioMagneticFieldCenteredDipole.py
+++ b/src/tests/test_scenarioMagneticFieldCenteredDipole.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -68,7 +68,7 @@ def test_scenarioMagneticField(show_plots, orbitCase, planetCase):
         figureList = scenarioMagneticFieldCenteredDipole.run(show_plots, orbitCase, planetCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -85,4 +85,3 @@ def test_scenarioMagneticField(show_plots, orbitCase, planetCase):
     # this check below just makes sure no sub-test failures were found
 
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioMagneticFieldWMM.py
+++ b/src/tests/test_scenarioMagneticFieldWMM.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -65,7 +65,7 @@ def test_scenarioMagneticField(show_plots, orbitCase):
         figureList = scenarioMagneticFieldWMM.run(show_plots, orbitCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioMomentumDumping.py
+++ b/src/tests/test_scenarioMomentumDumping.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -66,7 +66,7 @@ def test_bskMomentumDumping(show_plots):
         figureList = scenarioMomentumDumping.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -82,4 +82,3 @@ def test_bskMomentumDumping(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioMujoco.py
+++ b/src/tests/test_scenarioMujoco.py
@@ -23,13 +23,12 @@ import sys
 import os
 import inspect
 import importlib
-from Basilisk.utilities import unitTestSupport
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 try:
     from Basilisk.simulation import mujoco
@@ -76,7 +75,7 @@ def test_scenarios(scenario: str):
 
     for pltName, plt in figureList.items():
         print(f"Saving MuJoCo scenario figure: {pltName} (from '{scenario}')")
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/src/tests/test_scenarioOrbitManeuver.py
+++ b/src/tests/test_scenarioOrbitManeuver.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -64,7 +64,7 @@ def test_scenarioOrbitManeuver(show_plots, maneuverCase):
         figureList = scenarioOrbitManeuver.run(show_plots, maneuverCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioOrbitMultiBody.py
+++ b/src/tests/test_scenarioOrbitMultiBody.py
@@ -33,6 +33,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +63,7 @@ def test_scenarioOrbitMultiBodyCopy(show_plots, scCase):
         rBSK, rTrue, figureList = scenarioOrbitMultiBody.run(show_plots, scCase)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -83,4 +84,3 @@ def test_scenarioOrbitMultiBodyCopy(show_plots, scCase):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
         assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioPatchedConics.py
+++ b/src/tests/test_scenarioPatchedConics.py
@@ -34,6 +34,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -59,7 +60,7 @@ def test_scenarioPatchedConics(show_plots):
         dataPos, figureList = scenarioPatchedConics.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioPowerDemo.py
+++ b/src/tests/test_scenarioPowerDemo.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -44,7 +44,7 @@ def test_simplePowerDemo(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -55,5 +55,3 @@ def test_simplePowerDemo(show_plots):
     assert testFailCount < 1, testMessages
 
     return
-
-

--- a/src/tests/test_scenarioRotatingPanel.py
+++ b/src/tests/test_scenarioRotatingPanel.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -63,7 +63,7 @@ def test_scenarioAttitudeGG(show_plots):
 
         # save the figures to the doc scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -79,4 +79,3 @@ def test_scenarioAttitudeGG(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioSatelliteConstellation.py
+++ b/src/tests/test_scenarioSatelliteConstellation.py
@@ -29,7 +29,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -57,7 +57,7 @@ def test_bskAttitudePointing(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -73,4 +73,3 @@ def test_bskAttitudePointing(show_plots):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioSepMomentumManagement.py
+++ b/src/tests/test_scenarioSepMomentumManagement.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -71,7 +71,7 @@ def test_sepMomentumManagement(withFunction):
                                                        withSaMomManagement, withCmEstimation, False)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioSmallBodyLandmarks.py
+++ b/src/tests/test_scenarioSmallBodyLandmarks.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -66,7 +66,7 @@ def test_scenarioSmallBodyLandmarks(show_plots, useBatch):
         batch_diff, figureList = scenarioSmallBodyLandmarks.run(show_plots, useBatch)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioSpacecraftLocation.py
+++ b/src/tests/test_scenarioSpacecraftLocation.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -65,7 +65,7 @@ def test_scenarioBasicOrbit(show_plots):
         figureList = scenarioSpacecraftLocation.run(show_plots)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioSpinningBodiesTwoDOF.py
+++ b/src/tests/test_scenarioSpinningBodiesTwoDOF.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -62,7 +62,7 @@ def test_scenarioSpinningBodiesTwoDOF(show_plots, numberPanels):
         figureList = scenarioSpinningBodiesTwoDOF.run(show_plots, numberPanels)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioStationKeepingMultiSat.py
+++ b/src/tests/test_scenarioStationKeepingMultiSat.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -43,7 +43,7 @@ def test_scenarioStationKeepingMultiSat(show_plots, numberSpacecraft, relativeNa
         figureList = scenario_StationKeepingMultiSat.run(show_plots, numberSpacecraft, relativeNavigation)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioStochasticDragSpacecraft.py
+++ b/src/tests/test_scenarioStochasticDragSpacecraft.py
@@ -21,7 +21,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -43,7 +43,7 @@ def test_scenarioStochasticDragSpacecraft(show_plots):
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError:
         testFailCount += 1

--- a/src/tests/test_scenarioSweepingSpacecraft.py
+++ b/src/tests/test_scenarioSweepingSpacecraft.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 import numpy as np
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -38,7 +38,7 @@ def test_scenarioSweepingSpacecraft(show_plots, useAltBodyFrame, angle_rate_comm
 
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioTAM.py
+++ b/src/tests/test_scenarioTAM.py
@@ -31,6 +31,7 @@ import sys
 
 import pytest
 from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -113,7 +114,7 @@ def test_scenarioTAM(show_plots, orbitCase, planetCase, useBias, useBounds):
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
     #   print out success message if no error were found
     if testFailCount == 0:
@@ -126,4 +127,3 @@ def test_scenarioTAM(show_plots, orbitCase, planetCase, useBias, useBounds):
     # this check below just makes sure no sub-test failures were found
 
     assert testFailCount < 1, testMessages
-

--- a/src/tests/test_scenarioTAMcomparison.py
+++ b/src/tests/test_scenarioTAMcomparison.py
@@ -31,7 +31,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -70,7 +70,7 @@ def test_scenarioTAMcomparison(show_plots, orbitCase, useBias1, useBias2, useBou
         figureList = scenarioTAMcomparison.run(show_plots, orbitCase, useBias1, useBias2, useBounds1, useBounds2)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1

--- a/src/tests/test_scenarioTest.py
+++ b/src/tests/test_scenarioTest.py
@@ -33,7 +33,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -94,7 +94,7 @@ def test_scenarioBskScenarios(show_plots, scenarioCase):
 
         if figureList != {}:
             for pltName, plt in list(figureList.items()):
-                unitTestSupport.saveScenarioFigure(pltName, plt, path)
+                simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount = testFailCount + 1

--- a/src/tests/test_scenarioVariableTimeStepIntegrators.py
+++ b/src/tests/test_scenarioVariableTimeStepIntegrators.py
@@ -35,10 +35,10 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 
-from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import macros
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -73,7 +73,7 @@ def test_scenarioIntegrators(show_plots):
 
     # save the figures to the Doxygen scenario images folder
     for pltName, plt in list(figureList.items()):
-        unitTestSupport.saveScenarioFigure(pltName, plt, path)
+        simHelpers.saveScenarioFigure(pltName, plt, path)
 
 def getAnalyticalSolution(r0, v0, dt):
     mu = simIncludeGravBody.gravBodyFactory().createEarth().mu

--- a/src/tests/test_scenarioVizPoint.py
+++ b/src/tests/test_scenarioVizPoint.py
@@ -32,7 +32,7 @@ import os
 import sys
 
 import pytest
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -72,7 +72,7 @@ def test_scenarioViz(show_plots, missionType):
         figureList = scenarioVizPoint.run(show_plots, missionType, False)
         # save the figures to the Doxygen scenario images folder
         for pltName, plt in list(figureList.items()):
-            unitTestSupport.saveScenarioFigure(pltName, plt, path)
+            simHelpers.saveScenarioFigure(pltName, plt, path)
 
     except OSError as err:
         testFailCount += 1
@@ -88,4 +88,3 @@ def test_scenarioViz(show_plots, missionType):
     # each test method requires a single assert method to be called
     # this check below just makes sure no sub-test failures were found
         assert testFailCount < 1, testMessages
-

--- a/src/utilities/MonteCarlo/RetentionPolicy.py
+++ b/src/utilities/MonteCarlo/RetentionPolicy.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 
 class VariableRetentionParameters:
@@ -110,7 +110,7 @@ class RetentionPolicy:
                 # record the message variables
                 for varName in msgParam.retainedVars:
                     msgData = getattr(simInstance.msgRecList[msgParam.msgRecName], varName)
-                    msgData = unitTestSupport.addTimeColumn(msgTimes, msgData)
+                    msgData = simHelpers.addTimeColumn(msgTimes, msgData)
                     data["messages"][msgParam.msgRecName + "." + varName] = msgData
 
             for variable in retentionPolicy.varLogList:

--- a/src/utilities/simHelpers.py
+++ b/src/utilities/simHelpers.py
@@ -1,0 +1,429 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+"""General-purpose simulation helpers.
+
+These utilities are used by modules such as :ref:`simIncludeGravBody` and
+:ref:`vizSupport`.  They are kept here so that importing those user-facing
+modules does not pull in the test-only ``pytest`` dependency that
+``unitTestSupport`` transitively would introduce.
+"""
+
+import errno
+import math
+import os
+import shutil
+import sys
+from datetime import datetime, timedelta
+
+import numpy as np
+
+from Basilisk import __path__
+from Basilisk.architecture import messaging
+from Basilisk.architecture import bskUtilities
+from Basilisk.topLevelModules import pyswice
+from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
+
+bskPath = __path__[0]
+_matplotlibDefaultsApplied = False
+
+
+def _applyMatplotlibDefaults(mpl):
+    """Apply Basilisk scenario plot defaults once."""
+    global _matplotlibDefaultsApplied
+    if _matplotlibDefaultsApplied:
+        return
+
+    mpl.rc("figure", facecolor="white")
+    mpl.rc("xtick", labelsize=9)
+    mpl.rc("ytick", labelsize=9)
+    mpl.rc("figure", figsize=(5.75, 2.5))
+    mpl.rc("axes", labelsize=10)
+    mpl.rc("legend", fontsize=9)
+    mpl.rc("figure", autolayout=True)
+    mpl.rc("figure", max_open_warning=30)
+    mpl.rc("legend", loc="lower right")
+    _matplotlibDefaultsApplied = True
+
+
+def _getPyplot():
+    """Return ``matplotlib.pyplot`` after applying scenario plot defaults."""
+    import matplotlib as mpl
+    import matplotlib.pyplot as pyplot
+
+    _applyMatplotlibDefaults(mpl)
+    return pyplot
+
+
+def _getTabulate():
+    """Return Basilisk's LaTeX-friendly ``tabulate`` function."""
+    from Basilisk.utilities import tabulate as tabulateModule
+
+    for escapeKey in ("$", "\\", "_", "{", "}"):
+        tabulateModule.LATEX_ESCAPE_RULES.pop(escapeKey, None)
+    return tabulateModule.tabulate
+
+
+if "matplotlib" in sys.modules:
+    _applyMatplotlibDefaults(sys.modules["matplotlib"])
+
+
+def EigenVector3d2np(eig):
+    """convert Eigen vector3d to numpy"""
+    return np.array([eig[0][0], eig[1][0], eig[2][0]])
+
+
+def EigenVector3d2list(eig):
+    """convert Eigen vector3d to list"""
+    return EigenVector3d2np(eig).tolist()
+
+
+def addTimeColumn(time, data):
+    """Add a time column to the data set"""
+    return np.transpose(np.vstack([[time], np.transpose(data)]))
+
+
+def timeStringToGregorianUTCMsg(DateSpice, **kwargs):
+    """convert a general time/date string to a gregoarian UTC msg object"""
+    # set the data path
+    if "dataPath" in kwargs:
+        dataPath = kwargs["dataPath"]
+        if not isinstance(dataPath, str):
+            print("ERROR: dataPath must be a string argument")
+            exit(1)
+    else:
+        dataPath = bskPath + "/supportData/EphemerisData/"  # default value
+
+    # load spice kernel and convert the string into a UTC date/time string
+    naif0012_path = get_path(DataFile.EphemerisData.naif0012)
+    pyswice.furnsh_c(str(naif0012_path))
+    et = pyswice.new_doubleArray(1)
+    pyswice.str2et_c(DateSpice, et)
+    etEpoch = pyswice.doubleArray_getitem(et, 0)
+    ep1 = pyswice.et2utc_c(etEpoch, "C", 6, 255, "Yo")
+    pyswice.unload_c(str(naif0012_path))
+
+    try:
+        # convert UTC string to datetime object
+        datetime_object = datetime.strptime(ep1, "%Y %b %d %H:%M:%S.%f")
+
+        # Validate month is in range 1-12
+        if datetime_object.month < 1 or datetime_object.month > 12:
+            raise ValueError(f"Invalid month value: {datetime_object.month}")
+
+        # populate the epochMsg with the gregorian UTC date/time information
+        epochMsgStructure = messaging.EpochMsgPayload()
+        epochMsgStructure.year = datetime_object.year
+        epochMsgStructure.month = datetime_object.month
+        epochMsgStructure.day = datetime_object.day
+        epochMsgStructure.hours = datetime_object.hour
+        epochMsgStructure.minutes = datetime_object.minute
+        epochMsgStructure.seconds = (
+            datetime_object.second + datetime_object.microsecond / 1e6
+        )
+
+        epochMsg = messaging.EpochMsg().write(epochMsgStructure)
+
+        # Store the message in a global registry to prevent garbage collection
+        if not hasattr(timeStringToGregorianUTCMsg, "_msg_registry"):
+            timeStringToGregorianUTCMsg._msg_registry = []
+        timeStringToGregorianUTCMsg._msg_registry.append(epochMsg)
+
+        return epochMsg
+
+    except Exception as e:
+        print(f"Error processing date string '{ep1}': {str(e)}")
+        print(f"Original input string was: {DateSpice}")
+        raise
+
+
+def writeTableLaTeX(tableName, tableHeaders, caption, array, path):
+    """Take a list and return equivalent LaTeX table code."""
+
+    texFileName = path + "/../_Documentation/AutoTeX/" + tableName + ".tex"
+
+    if not os.path.exists(os.path.dirname(texFileName)):
+        try:
+            os.makedirs(os.path.dirname(texFileName))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+    with open(texFileName, "w") as texTable:
+        table = _getTabulate()(array, tableHeaders, tablefmt="latex", numalign="center")
+
+        texTable.write(r"\begin{table}[htbp]")
+        texTable.write(r"\caption{" + caption + "}")
+        texTable.write(r"\label{tbl:" + tableName + "}")
+        texTable.write(r"\centering")
+        texTable.write(table)
+        texTable.write(r"\end{table}")
+
+
+def writeTeXSnippet(snippetName, texSnippet, path):
+    """Write a LaTeX snippet to a file."""
+
+    texFileName = path + "/../_Documentation/AutoTeX/" + snippetName + ".tex"
+
+    if not os.path.exists(os.path.dirname(texFileName)):
+        try:
+            os.makedirs(os.path.dirname(texFileName))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+    with open(texFileName, "w") as fileHandler:
+        fileHandler.write(texSnippet)
+
+
+def getScenarioFigureFileName(figureName, path, extension=".svg"):
+    """Return the documentation image path for a scenario figure."""
+    if not extension.startswith("."):
+        extension = "." + extension
+
+    searchPath = os.path.abspath(path)
+    if os.path.isfile(searchPath):
+        searchPath = os.path.dirname(searchPath)
+
+    while True:
+        if os.path.isdir(os.path.join(searchPath, "docs", "source")):
+            scenarioFigurePath = os.path.join(
+                searchPath,
+                "docs",
+                "source",
+                "_images",
+                "Scenarios",
+            )
+            return os.path.join(scenarioFigurePath, figureName + extension)
+
+        parentPath = os.path.dirname(searchPath)
+        if parentPath == searchPath:
+            scenarioFigurePath = os.path.join(
+                path,
+                "..",
+                "..",
+                "docs",
+                "source",
+                "_images",
+                "Scenarios",
+            )
+            return os.path.abspath(
+                os.path.join(scenarioFigurePath, figureName + extension)
+            )
+
+        searchPath = parentPath
+
+
+def _createScenarioFigurePath(imgFileName):
+    """Create the documentation image folder if needed."""
+    if not os.path.exists(os.path.dirname(imgFileName)):
+        try:
+            os.makedirs(os.path.dirname(imgFileName))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+
+
+def saveScenarioFigure(figureName, plt, path, extension=".svg"):
+    """Save a Python scenario result into the documentation image folder."""
+    imgFileName = getScenarioFigureFileName(figureName, path, extension)
+    _createScenarioFigurePath(imgFileName)
+    plt.savefig(imgFileName, transparent=True)
+    try:
+        _getPyplot().close(plt)
+    except Exception:
+        try:
+            plt.close()
+        except Exception:
+            pass
+
+
+def saveScenarioGraphvizFigure(
+    figureName,
+    simulationBase,
+    path,
+    extension=".svg",
+    show_plots=False,
+    **kwargs
+):
+    """Save a Graphviz message flow figure into the documentation image folder."""
+    if shutil.which("dot") is None:
+        return None
+
+    imgFileName = getScenarioFigureFileName(figureName, path, extension)
+    graphvizFormat = extension.lstrip(".")
+    _createScenarioFigurePath(imgFileName)
+    return simulationBase.ShowMessageConnectionFigure(
+        renderer="graphviz",
+        fileName=imgFileName,
+        show_plots=show_plots,
+        graphvizFormat=graphvizFormat,
+        **kwargs
+    )
+
+
+def saveFigurePDF(figureName, plt, path):
+    """Save a figure as a PDF."""
+    figFileName = os.path.join(path, figureName + ".pdf")
+    if not os.path.exists(os.path.dirname(figFileName)):
+        try:
+            os.makedirs(os.path.dirname(figFileName))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+    plt.savefig(figFileName, transparent=True, pad_inches=0.05)
+
+
+def writeFigureLaTeX(figureName, caption, plt, format, path):
+    """Save a figure and associated TeX code snippet."""
+    texFileName = os.path.join(
+        path, "..", "_Documentation", "AutoTeX", figureName + ".tex"
+    )
+    if not os.path.exists(os.path.dirname(texFileName)):
+        try:
+            os.makedirs(os.path.dirname(texFileName))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+    with open(texFileName, "w") as texFigure:
+        texFigure.write(r"\begin{figure}[htbp]")
+        texFigure.write(r"\centerline{")
+        texFigure.write(
+            r"\includegraphics[" + format + "]{AutoTeX/" + figureName + r"}}"
+        )
+        texFigure.write(r"\caption{" + caption + r"}")
+        texFigure.write(r"\label{fig:" + figureName + r"}")
+        texFigure.write(r"\end{figure}")
+
+        texFileName = path + "/../_Documentation/AutoTeX/" + figureName + ".pdf"
+        plt.savefig(texFileName, transparent=True)
+
+
+def getLineColor(idx, maxNum):
+    """Pick a color from a scenario plotting color map."""
+    import matplotlib as mpl
+    import matplotlib.cm as cmx
+    import matplotlib.colors as colors
+    import matplotlib.pyplot as pyplot
+
+    _applyMatplotlibDefaults(mpl)
+    values = list(range(0, maxNum + 2))
+    colorMap = pyplot.get_cmap("gist_earth")
+    cNorm = colors.Normalize(vmin=0, vmax=values[-1])
+    scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=colorMap)
+    return scalarMap.to_rgba(values[idx + 1])
+
+
+def np2EigenMatrix3d(mat):
+    """Convert a 3D NumPy matrix to an Eigen matrix."""
+    return [
+        [mat[0], mat[1], mat[2]],
+        [mat[3], mat[4], mat[5]],
+        [mat[6], mat[7], mat[8]],
+    ]
+
+
+def np2EigenVectorXd(vec):
+    """Convert a NumPy vector to an Eigen vector."""
+    npVec = []
+    for item in vec:
+        npVec.extend([[item]])
+
+    return npVec
+
+
+def npList2EigenXdVector(list):
+    """Convert a list of arrays to a list of Eigen values."""
+    eigenList = bskUtilities.Eigen3dVector()
+    for pos in list:
+        eigenList.push_back(pos)
+    return eigenList
+
+
+def flattenList(matrix):
+    """Return a flattened list.
+
+    Args:
+        matrix: List of lists.
+
+    Returns:
+        Flattened list.
+    """
+    flatList = []
+    for row in matrix:
+        flatList.extend(row)
+    return flatList
+
+
+def pullVectorSetFromData(inpMat):
+    """Extract vector data from a matrix whose first column is time data."""
+    outMat = np.array(inpMat).transpose()
+    return outMat[1:].transpose()
+
+
+def decimalYearToDateTime(start):
+    """Convert a decimal year to a :class:`datetime.datetime` object."""
+    year = int(start)
+    rem = start - year
+
+    base = datetime(year, 1, 1)
+    return base + timedelta(
+        seconds=(base.replace(year=base.year + 1) - base).total_seconds() * rem
+    )
+
+
+def columnToRowList(set):
+    """Loop through a column list and return a row list."""
+    ans = []
+    for item in set:
+        ans.append(item[0])
+    return ans
+
+
+def checkMethodKeyword(karglist, kwargs):
+    """Check that keyword arguments are in the allowed keyword list."""
+    for key in kwargs:
+        if key not in karglist:
+            print(
+                "ERROR: you tried to use an incorrect keyword "
+                + key
+                + ". Options include:"
+            )
+            print(karglist)
+            exit(1)
+
+
+def removeTimeFromData(dataList):
+    """Remove the time column from a data list."""
+    return (dataList.transpose()[1 : len(dataList[0])]).transpose()
+
+
+def samplingTime(simTime, baseTimeStep, numDataPoints):
+    """Return a sample time that approximates a target number of samples.
+
+    Args:
+        simTime: [ns] Total simulation duration.
+        baseTimeStep: [ns] Baseline sampling period.
+        numDataPoints: Nominal desired number of data points over the
+            simulation duration.
+
+    Returns:
+        [ns] Sampling period.
+    """
+    deltaTime = math.floor(simTime / baseTimeStep / (numDataPoints - 1)) * baseTimeStep
+    if deltaTime < 1:
+        deltaTime = 1  # [ns]
+    return deltaTime

--- a/src/utilities/simIncludeGravBody.py
+++ b/src/utilities/simIncludeGravBody.py
@@ -38,7 +38,7 @@ from Basilisk.simulation.gravityEffector import (
 from Basilisk.simulation.gravityEffector import (
     loadPolyFromFile as loadPolyFromFile_python,
 )
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 
 from Basilisk.utilities.deprecated import deprecationWarn
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile, POOCH
@@ -584,7 +584,7 @@ class gravBodyFactory:
             )
 
         if epochInMsg:
-            self.epochMsg = unitTestSupport.timeStringToGregorianUTCMsg(
+            self.epochMsg = simHelpers.timeStringToGregorianUTCMsg(
                 time, dataPath=str(path)
             )
             self.spiceObject.epochInMsg.subscribeTo(self.epochMsg)

--- a/src/utilities/tests/test_SimulationBaseClass.py
+++ b/src/utilities/tests/test_SimulationBaseClass.py
@@ -12,7 +12,8 @@ import matplotlib.pyplot as plt
 from Basilisk.architecture import messaging
 from Basilisk.moduleTemplates import cModuleTemplate, cppModuleTemplate
 from Basilisk.simulation import simpleNav
-from Basilisk.utilities import SimulationBaseClass, macros, unitTestSupport
+from Basilisk.utilities import SimulationBaseClass, macros
+from Basilisk.utilities import simHelpers
 
 
 @pytest.mark.parametrize("stopTime1", [0.0, 8.0, 10.0, 12.0])
@@ -321,8 +322,8 @@ def test_saveScenarioGraphvizFigure_uses_documentation_image_path(tmp_path):
     scSim = MagicMock()
     scSim.ShowMessageConnectionFigure.return_value = str(expectedPath)
 
-    with patch("Basilisk.utilities.unitTestSupport.shutil.which", return_value="dot"):
-        renderedPath = unitTestSupport.saveScenarioGraphvizFigure(
+    with patch("Basilisk.utilities.simHelpers.shutil.which", return_value="dot"):
+        renderedPath = simHelpers.saveScenarioGraphvizFigure(
             "messageFlow",
             scSim,
             str(scenarioPath),
@@ -348,8 +349,8 @@ def test_saveScenarioGraphvizFigure_returns_none_without_graphviz(tmp_path):
     scenarioPath.mkdir()
     scSim = MagicMock()
 
-    with patch("Basilisk.utilities.unitTestSupport.shutil.which", return_value=None):
-        renderedPath = unitTestSupport.saveScenarioGraphvizFigure(
+    with patch("Basilisk.utilities.simHelpers.shutil.which", return_value=None):
+        renderedPath = simHelpers.saveScenarioGraphvizFigure(
             "messageFlow",
             scSim,
             str(scenarioPath),

--- a/src/utilities/tests/test_unitTestSupport.py
+++ b/src/utilities/tests/test_unitTestSupport.py
@@ -1,0 +1,78 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import numpy as np
+import pytest
+
+from Basilisk.utilities import deprecated, simHelpers, unitTestSupport
+
+
+SIM_HELPER_COMPATIBILITY_METHODS = (
+    "EigenVector3d2list",
+    "EigenVector3d2np",
+    "addTimeColumn",
+    "checkMethodKeyword",
+    "columnToRowList",
+    "decimalYearToDateTime",
+    "flattenList",
+    "getLineColor",
+    "getScenarioFigureFileName",
+    "np2EigenMatrix3d",
+    "np2EigenVectorXd",
+    "npList2EigenXdVector",
+    "pullVectorSetFromData",
+    "removeTimeFromData",
+    "samplingTime",
+    "saveFigurePDF",
+    "saveScenarioFigure",
+    "saveScenarioGraphvizFigure",
+    "timeStringToGregorianUTCMsg",
+    "writeFigureLaTeX",
+    "writeTableLaTeX",
+    "writeTeXSnippet",
+)
+
+
+def _callCompatibilityMethod():
+    """Call a simple compatibility wrapper with deterministic input."""
+    timeData = np.array([0.0, 1.0])  # [s]
+    data = np.array([[2.0], [3.0]])
+    return unitTestSupport.addTimeColumn(timeData, data)
+
+
+@pytest.mark.parametrize("methodName", SIM_HELPER_COMPATIBILITY_METHODS)
+def test_unitTestSupportProvidesSimHelperCompatibilityMethods(methodName):
+    """Check that moved helpers remain available from ``unitTestSupport``."""
+    compatibilityMethod = getattr(unitTestSupport, methodName, None)
+
+    assert compatibilityMethod is not None
+    assert callable(compatibilityMethod)
+    assert callable(getattr(simHelpers, methodName))
+
+
+def test_unitTestSupportCompatibilityMethodCanStillBeCalled():
+    """Check a moved helper remains callable from ``unitTestSupport``."""
+    # If this test starts emitting a ``BSKUrgentDeprecationWarning``, then the
+    # compatibility deadline has passed and these wrappers should be removed.
+    with deprecated.ignore(r"Basilisk\.utilities\.unitTestSupport\.addTimeColumn"):
+        result = _callCompatibilityMethod()
+
+    np.testing.assert_array_equal(
+        result,
+        simHelpers.addTimeColumn(np.array([0.0, 1.0]), np.array([[2.0], [3.0]])),
+    )

--- a/src/utilities/unitTestSupport.py
+++ b/src/utilities/unitTestSupport.py
@@ -21,33 +21,128 @@ import numpy as np
 import pytest
 
 from Basilisk import __path__
-from Basilisk.utilities import macros
-from Basilisk.utilities.simHelpers import (
-    EigenVector3d2list,
-    EigenVector3d2np,
-    addTimeColumn,
-    checkMethodKeyword,
-    columnToRowList,
-    decimalYearToDateTime,
-    flattenList,
-    getLineColor,
-    getScenarioFigureFileName,
-    np2EigenMatrix3d,
-    np2EigenVectorXd,
-    npList2EigenXdVector,
-    pullVectorSetFromData,
-    removeTimeFromData,
-    samplingTime,
-    saveFigurePDF,
-    saveScenarioFigure,
-    saveScenarioGraphvizFigure,
-    timeStringToGregorianUTCMsg,
-    writeFigureLaTeX,
-    writeTableLaTeX,
-    writeTeXSnippet,
-)
+from Basilisk.utilities import deprecated, macros
+from Basilisk.utilities import simHelpers as _simHelpers
 
 bskPath = __path__[0]
+_SIM_HELPER_REMOVAL_DATE = "2027/06/23"
+
+
+def _deprecatedSimHelper(func):
+    """Apply standard Basilisk deprecation behavior to a moved helper."""
+    return deprecated.deprecated(
+        _SIM_HELPER_REMOVAL_DATE, f"Use simHelpers.{func.__name__} instead."
+    )(func)
+
+
+@_deprecatedSimHelper
+def EigenVector3d2list(*args, **kwargs):
+    return _simHelpers.EigenVector3d2list(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def EigenVector3d2np(*args, **kwargs):
+    return _simHelpers.EigenVector3d2np(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def addTimeColumn(*args, **kwargs):
+    return _simHelpers.addTimeColumn(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def checkMethodKeyword(*args, **kwargs):
+    return _simHelpers.checkMethodKeyword(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def columnToRowList(*args, **kwargs):
+    return _simHelpers.columnToRowList(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def decimalYearToDateTime(*args, **kwargs):
+    return _simHelpers.decimalYearToDateTime(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def flattenList(*args, **kwargs):
+    return _simHelpers.flattenList(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def getLineColor(*args, **kwargs):
+    return _simHelpers.getLineColor(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def getScenarioFigureFileName(*args, **kwargs):
+    return _simHelpers.getScenarioFigureFileName(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def np2EigenMatrix3d(*args, **kwargs):
+    return _simHelpers.np2EigenMatrix3d(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def np2EigenVectorXd(*args, **kwargs):
+    return _simHelpers.np2EigenVectorXd(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def npList2EigenXdVector(*args, **kwargs):
+    return _simHelpers.npList2EigenXdVector(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def pullVectorSetFromData(*args, **kwargs):
+    return _simHelpers.pullVectorSetFromData(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def removeTimeFromData(*args, **kwargs):
+    return _simHelpers.removeTimeFromData(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def samplingTime(*args, **kwargs):
+    return _simHelpers.samplingTime(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def saveFigurePDF(*args, **kwargs):
+    return _simHelpers.saveFigurePDF(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def saveScenarioFigure(*args, **kwargs):
+    return _simHelpers.saveScenarioFigure(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def saveScenarioGraphvizFigure(*args, **kwargs):
+    return _simHelpers.saveScenarioGraphvizFigure(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def timeStringToGregorianUTCMsg(*args, **kwargs):
+    return _simHelpers.timeStringToGregorianUTCMsg(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def writeFigureLaTeX(*args, **kwargs):
+    return _simHelpers.writeFigureLaTeX(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def writeTableLaTeX(*args, **kwargs):
+    return _simHelpers.writeTableLaTeX(*args, **kwargs)
+
+
+@_deprecatedSimHelper
+def writeTeXSnippet(*args, **kwargs):
+    return _simHelpers.writeTeXSnippet(*args, **kwargs)
 
 
 def isVectorEqual(result, truth, accuracy):

--- a/src/utilities/unitTestSupport.py
+++ b/src/utilities/unitTestSupport.py
@@ -15,60 +15,39 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
-import errno
 import math
-import os
-import shutil
-from datetime import datetime, timedelta
 
-import matplotlib as mpl
-import matplotlib.pyplot as pyplot
 import numpy as np
 import pytest
-from Basilisk.architecture import bskUtilities
-from Basilisk.architecture import messaging
-from Basilisk.topLevelModules import pyswice
-from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
-
-
-mpl.rc("figure", facecolor="white")
-mpl.rc("xtick", labelsize=9)
-mpl.rc("ytick", labelsize=9)
-mpl.rc("figure", figsize=(5.75, 2.5))
-mpl.rc("axes", labelsize=10)
-mpl.rc("legend", fontsize=9)
-mpl.rc("figure", autolayout=True)
-mpl.rc("figure", max_open_warning=30)
-mpl.rc("legend", loc="lower right")
-
-import matplotlib.colors as colors
-import matplotlib.cm as cmx
-
-from Basilisk.utilities import macros
 
 from Basilisk import __path__
+from Basilisk.utilities import macros
+from Basilisk.utilities.simHelpers import (
+    EigenVector3d2list,
+    EigenVector3d2np,
+    addTimeColumn,
+    checkMethodKeyword,
+    columnToRowList,
+    decimalYearToDateTime,
+    flattenList,
+    getLineColor,
+    getScenarioFigureFileName,
+    np2EigenMatrix3d,
+    np2EigenVectorXd,
+    npList2EigenXdVector,
+    pullVectorSetFromData,
+    removeTimeFromData,
+    samplingTime,
+    saveFigurePDF,
+    saveScenarioFigure,
+    saveScenarioGraphvizFigure,
+    timeStringToGregorianUTCMsg,
+    writeFigureLaTeX,
+    writeTableLaTeX,
+    writeTeXSnippet,
+)
 
 bskPath = __path__[0]
-
-try:
-    from Basilisk.utilities import tabulate as T
-
-    # '''
-    # del(T.LATEX_ESCAPE_RULES['$'])
-    # del(T.LATEX_ESCAPE_RULES['\\'])
-    # del(T.LATEX_ESCAPE_RULES['_'])
-    # del(T.LATEX_ESCAPE_RULES['{'])
-    # del(T.LATEX_ESCAPE_RULES['}'])
-    # '''
-
-    del T.LATEX_ESCAPE_RULES["$"]
-    del T.LATEX_ESCAPE_RULES["\\"]
-    del T.LATEX_ESCAPE_RULES["_"]
-    del T.LATEX_ESCAPE_RULES["{"]
-    del T.LATEX_ESCAPE_RULES["}"]
-    from Basilisk.utilities.tabulate import *
-except:
-    pass
 
 
 def isVectorEqual(result, truth, accuracy):
@@ -352,358 +331,9 @@ def compareList(trueStates, dataStates, accuracy, msg, testFailCount, testMessag
     return testFailCount, testMessages
 
 
-def writeTableLaTeX(tableName, tableHeaders, caption, array, path):
-    """Take a list and return equivalent LaTeX table code"""
-
-    texFileName = path + "/../_Documentation/AutoTeX/" + tableName + ".tex"
-
-    if not os.path.exists(os.path.dirname(texFileName)):
-        try:
-            os.makedirs(os.path.dirname(texFileName))
-        except OSError as exc:  # Guard against race condition
-            if exc.errno != errno.EEXIST:
-                raise
-    with open(texFileName, "w") as texTable:
-        table = tabulate(array, tableHeaders, tablefmt="latex", numalign="center")
-
-        texTable.write(r"\begin{table}[htbp]")
-        texTable.write(r"\caption{" + caption + "}")
-        texTable.write(r"\label{tbl:" + tableName + "}")
-        texTable.write(r"\centering")
-        texTable.write(table)
-        texTable.write(r"\end{table}")
-        texTable.close()
-
-    return
-
-
-def writeTeXSnippet(snippetName, texSnippet, path):
-    """Write a LaTeX snippet to a file"""
-
-    texFileName = path + "/../_Documentation/AutoTeX/" + snippetName + ".tex"
-
-    if not os.path.exists(os.path.dirname(texFileName)):
-        try:
-            os.makedirs(os.path.dirname(texFileName))
-        except OSError as exc:  # Guard against race condition
-            if exc.errno != errno.EEXIST:
-                raise
-    with open(texFileName, "w") as fileHandler:
-        fileHandler.write(texSnippet)
-        fileHandler.close()
-
-    return
-
-
-def getScenarioFigureFileName(figureName, path, extension=".svg"):
-    """Return the documentation image path for a scenario figure."""
-    if not extension.startswith("."):
-        extension = "." + extension
-
-    searchPath = os.path.abspath(path)
-    if os.path.isfile(searchPath):
-        searchPath = os.path.dirname(searchPath)
-
-    while True:
-        if os.path.isdir(os.path.join(searchPath, "docs", "source")):
-            scenarioFigurePath = os.path.join(
-                searchPath,
-                "docs",
-                "source",
-                "_images",
-                "Scenarios",
-            )
-            return os.path.join(scenarioFigurePath, figureName + extension)
-
-        parentPath = os.path.dirname(searchPath)
-        if parentPath == searchPath:
-            scenarioFigurePath = os.path.join(
-                path,
-                "..",
-                "..",
-                "docs",
-                "source",
-                "_images",
-                "Scenarios",
-            )
-            return os.path.abspath(
-                os.path.join(scenarioFigurePath, figureName + extension)
-            )
-
-        searchPath = parentPath
-
-
-def _createScenarioFigurePath(imgFileName):
-    """Create the documentation image folder if needed."""
-    if not os.path.exists(os.path.dirname(imgFileName)):
-        try:
-            os.makedirs(os.path.dirname(imgFileName))
-        except OSError as exc:  # Guard against race condition
-            if exc.errno != errno.EEXIST:
-                raise
-
-
-def saveScenarioFigure(figureName, plt, path, extension=".svg"):
-    """save a python scenario result into the documentation image folder"""
-    imgFileName = getScenarioFigureFileName(figureName, path, extension)
-    _createScenarioFigurePath(imgFileName)
-    plt.savefig(imgFileName, transparent=True)
-    # Close the saved figure to avoid accumulating open figures during CI.
-    try:
-        pyplot.close(plt)
-    except Exception:
-        try:
-            plt.close()
-        except Exception:
-            pass
-
-
-def saveScenarioGraphvizFigure(
-    figureName,
-    simulationBase,
-    path,
-    extension=".svg",
-    show_plots=False,
-    **kwargs
-):
-    """Save a Graphviz message flow figure into the documentation image folder."""
-    if shutil.which("dot") is None:
-        return None
-
-    imgFileName = getScenarioFigureFileName(figureName, path, extension)
-    graphvizFormat = extension.lstrip(".")
-    _createScenarioFigurePath(imgFileName)
-    return simulationBase.ShowMessageConnectionFigure(
-        renderer="graphviz",
-        fileName=imgFileName,
-        show_plots=show_plots,
-        graphvizFormat=graphvizFormat,
-        **kwargs
-    )
-
-
-def saveFigurePDF(figureName, plt, path):
-    """Save a Figure as a PDF"""
-    figFileName = os.path.join(path, figureName + ".pdf")
-    if not os.path.exists(os.path.dirname(figFileName)):
-        try:
-            os.makedirs(os.path.dirname(figFileName))
-        except OSError as exc:  # Guard against race condition
-            if exc.errno != errno.EEXIST:
-                raise
-    plt.savefig(figFileName, transparent=True, pad_inches=0.05)
-
-
-def writeFigureLaTeX(figureName, caption, plt, format, path):
-    """Save a figure and associated TeX code snippet"""
-    texFileName = os.path.join(
-        path, "..", "_Documentation", "AutoTeX", figureName + ".tex"
-    )
-    if not os.path.exists(os.path.dirname(texFileName)):
-        try:
-            os.makedirs(os.path.dirname(texFileName))
-        except OSError as exc:  # Guard against race condition
-            if exc.errno != errno.EEXIST:
-                raise
-    with open(texFileName, "w") as texFigure:
-        texFigure.write(r"\begin{figure}[htbp]")
-        texFigure.write(r"\centerline{")
-        texFigure.write(
-            r"\includegraphics[" + format + "]{AutoTeX/" + figureName + r"}}"
-        )
-        texFigure.write(r"\caption{" + caption + r"}")
-        texFigure.write(r"\label{fig:" + figureName + r"}")
-        texFigure.write(r"\end{figure}")
-        texFigure.close()
-
-        texFileName = path + "/../_Documentation/AutoTeX/" + figureName + ".pdf"
-        plt.savefig(texFileName, transparent=True)
-
-    return
-
-
 def foundNAN(array):
     """check if an array contains NAN values"""
     if np.isnan(np.sum(array)):
         print("Warning: found NaN value.")
         return 1  # return 1 to indicate a NaN value was found
     return 0
-
-
-def getLineColor(idx, maxNum):
-    """pick a nicer color pattern to plot 3 vector components"""
-    values = list(range(0, maxNum + 2))
-    colorMap = mpl.pyplot.get_cmap("gist_earth")
-    cNorm = colors.Normalize(vmin=0, vmax=values[-1])
-    scalarMap = cmx.ScalarMappable(norm=cNorm, cmap=colorMap)
-    return scalarMap.to_rgba(values[idx + 1])
-
-
-def np2EigenMatrix3d(mat):
-    """convert 3D numpy matrix to Eigen matrix"""
-    return [
-        [mat[0], mat[1], mat[2]],
-        [mat[3], mat[4], mat[5]],
-        [mat[6], mat[7], mat[8]],
-    ]
-
-
-def np2EigenVectorXd(vec):
-    """Convert numpy to Eigen vector"""
-    npVec = []
-    for item in vec:
-        npVec.extend([[item]])
-
-    return npVec
-
-
-def npList2EigenXdVector(list):
-    """Conver a list of arrays to a list of eigen values"""
-    eigenList = bskUtilities.Eigen3dVector()
-    for pos in list:
-        eigenList.push_back(pos)
-    return eigenList
-
-
-def EigenVector3d2np(eig):
-    """convert Eigen vector3d to numpy"""
-    return np.array([eig[0][0], eig[1][0], eig[2][0]])
-
-
-def flattenList(matrix):
-    """
-    returns a flattened list
-    Args:
-        matrix: list of list
-
-    Returns: flattened list
-
-    """
-    flat_list = []
-    for row in matrix:
-        flat_list.extend(row)
-    return flat_list
-
-
-def EigenVector3d2list(eig):
-    """convert Eigen vector3d to list"""
-    return EigenVector3d2np(eig).tolist()
-
-
-def pullVectorSetFromData(inpMat):
-    """extract the vector data set from a data matrix where the 1st column is the time information"""
-    outMat = np.array(inpMat).transpose()
-    return outMat[1:].transpose()
-
-
-def addTimeColumn(time, data):
-    """Add a time column to the data set"""
-    return np.transpose(np.vstack([[time], np.transpose(data)]))
-
-
-def decimalYearToDateTime(start):
-    """convert a decimal Year format to a regular dataTime object"""
-    year = int(start)
-    rem = start - year
-
-    base = datetime(year, 1, 1)
-    return base + timedelta(
-        seconds=(base.replace(year=base.year + 1) - base).total_seconds() * rem
-    )
-
-
-def timeStringToGregorianUTCMsg(DateSpice, **kwargs):
-    """convert a general time/date string to a gregoarian UTC msg object"""
-    # set the data path
-    if "dataPath" in kwargs:
-        dataPath = kwargs["dataPath"]
-        if not isinstance(dataPath, str):
-            print("ERROR: dataPath must be a string argument")
-            exit(1)
-    else:
-        dataPath = bskPath + "/supportData/EphemerisData/"  # default value
-
-    # load spice kernel and convert the string into a UTC date/time string
-    naif0012_path = get_path(DataFile.EphemerisData.naif0012)
-    pyswice.furnsh_c(str(naif0012_path))
-    et = pyswice.new_doubleArray(1)
-    pyswice.str2et_c(DateSpice, et)
-    etEpoch = pyswice.doubleArray_getitem(et, 0)
-    ep1 = pyswice.et2utc_c(etEpoch, "C", 6, 255, "Yo")
-    pyswice.unload_c(str(naif0012_path))
-
-    try:
-        # convert UTC string to datetime object
-        datetime_object = datetime.strptime(ep1, "%Y %b %d %H:%M:%S.%f")
-
-        # Validate month is in range 1-12
-        if datetime_object.month < 1 or datetime_object.month > 12:
-            raise ValueError(f"Invalid month value: {datetime_object.month}")
-
-        # populate the epochMsg with the gregorian UTC date/time information
-        epochMsgStructure = messaging.EpochMsgPayload()
-        epochMsgStructure.year = datetime_object.year
-        epochMsgStructure.month = datetime_object.month
-        epochMsgStructure.day = datetime_object.day
-        epochMsgStructure.hours = datetime_object.hour
-        epochMsgStructure.minutes = datetime_object.minute
-        epochMsgStructure.seconds = (
-            datetime_object.second + datetime_object.microsecond / 1e6
-        )
-
-        epochMsg = messaging.EpochMsg().write(epochMsgStructure)
-
-        # Store the message in a global registry to prevent garbage collection
-        if not hasattr(timeStringToGregorianUTCMsg, "_msg_registry"):
-            timeStringToGregorianUTCMsg._msg_registry = []
-        timeStringToGregorianUTCMsg._msg_registry.append(epochMsg)
-
-        return epochMsg
-
-    except Exception as e:
-        print(f"Error processing date string '{ep1}': {str(e)}")
-        print(f"Original input string was: {DateSpice}")
-        raise
-
-
-def columnToRowList(set):
-    """Loop through a column list and return a row list"""
-    ans = []
-    for item in set:
-        ans.append(item[0])
-    return ans
-
-
-def checkMethodKeyword(karglist, kwargs):
-    """loop through list of method keyword arguments and make sure that an approved keyword is used."""
-    for key in kwargs:
-        if key not in karglist:
-            print(
-                "ERROR: you tried to use an incorrect keyword "
-                + key
-                + ". Options include:"
-            )
-            print(karglist)
-            exit(1)
-
-
-def removeTimeFromData(dataList):
-    """pull out the time column out of a 4xN data list"""
-    return (dataList.transpose()[1 : len(dataList[0])]).transpose()
-
-
-def samplingTime(simTime, baseTimeStep, numDataPoints):
-    """
-    Given a simulation duration, this routine returns
-    a sampling time that yields the closest integer match to a desired number of sampling points
-
-    Args:
-        simTime: [ns] total simulation duration
-        baseTimeStep: [ns] baseline sampling period
-        numDataPoints: nominal desired number of data points over the simulation duration
-
-    """
-    deltaTime = math.floor(simTime / baseTimeStep / (numDataPoints - 1)) * baseTimeStep
-    if deltaTime < 1:
-        deltaTime = 1
-    return deltaTime

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -24,7 +24,7 @@ from Basilisk.architecture import messaging
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import deprecated
 from Basilisk.utilities import quadMapSupport as qms
-from Basilisk.utilities import unitTestSupport
+from Basilisk.utilities import simHelpers
 from matplotlib import colors
 from matplotlib.colors import is_color_like
 from typing import Optional, Sequence
@@ -268,7 +268,7 @@ def addLocation(
         try:
             vizElement.r_GP_P = r_GP_P
         except TypeError:
-            vizElement.r_GP_P = unitTestSupport.EigenVector3d2np(r_GP_P).tolist()
+            vizElement.r_GP_P = simHelpers.EigenVector3d2np(r_GP_P).tolist()
     if lla_GP is not None:
         # find gravity body
         gravBody = next(
@@ -370,7 +370,7 @@ def changeLocation(
         try:
             vizElement.r_GP_P = r_GP_P
         except TypeError:
-            vizElement.r_GP_P = unitTestSupport.EigenVector3d2np(r_GP_P).tolist()
+            vizElement.r_GP_P = simHelpers.EigenVector3d2np(r_GP_P).tolist()
     if lla_GP is not None:
         # find gravity body
         gravBody = next(


### PR DESCRIPTION
* **Tickets addressed:** #1410 
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
Importing utilities like `simIncludeGravBody` and `vizSupport` transitively pulled in `unitTestSupport`, which imports the test-only `pytest` package at module load. Thus importing these modules in the `bsk` wheel would cause an error since  no `pytest` was including in the wheel builds.

The solution is to break this transitive include so that only running the test suite requires `pytest`.

## Verification
Built a local wheel and imported from `simIncludeGravBody`.

## Documentation
N/A

## Future work
N/A
