### PR TITLE
Add fuel tank leak parameter

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
@@ -1,3 +1,3 @@
 - Add the ``fuelLeakRate`` parameter to the :ref:`FuelTank` module to simulate fuel leaks that cause a loss of fuel mass without imparting momentum.
-- Stop :ref:`FuelTank` leak depletion when the available tank propellant reaches zero.
+- Stop :ref:`FuelTank` leak depletion when the available tank propellant reaches zero and log a ``BSK_WARNING``.
 - Added setter and getter methods for :ref:`FuelTank` configuration variables and deprecated direct Python access to ``nameOfMassState``, ``dcm_TB``, ``r_TB_B``, ``updateOnly``, and ``fuelLeakRate``.

--- a/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
@@ -1,2 +1,3 @@
 - Add the ``fuelLeakRate`` parameter to the :ref:`FuelTank` module to simulate fuel leaks that cause a loss of fuel mass without imparting momentum.
+- Stop :ref:`FuelTank` leak depletion when the available tank propellant reaches zero.
 - Added setter and getter methods for :ref:`FuelTank` configuration variables and deprecated direct Python access to ``nameOfMassState``, ``dcm_TB``, ``r_TB_B``, ``updateOnly``, and ``fuelLeakRate``.

--- a/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
@@ -1,0 +1,2 @@
+- Add the ``fuelLeakRate`` parameter to the :ref:`FuelTank` module to simulate fuel leaks that cause a loss of fuel mass without imparting momentum.
+- Added setter and getter methods for :ref:`FuelTank` configuration variables and deprecated direct Python access to ``nameOfMassState``, ``dcm_TB``, ``r_TB_B``, ``updateOnly``, and ``fuelLeakRate``.

--- a/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/fuel-tank-leak.rst
@@ -1,3 +1,4 @@
 - Add the ``fuelLeakRate`` parameter to the :ref:`FuelTank` module to simulate fuel leaks that cause a loss of fuel mass without imparting momentum.
+- Add the ``MassFlowRateMsgPayload`` C message type and optional :ref:`FuelTank` ``fuelLeakRateInMsg`` input to override the configured leak rate.
 - Stop :ref:`FuelTank` leak depletion when the available tank propellant reaches zero and log a ``BSK_WARNING``.
 - Added setter and getter methods for :ref:`FuelTank` configuration variables and deprecated direct Python access to ``nameOfMassState``, ``dcm_TB``, ``r_TB_B``, ``updateOnly``, and ``fuelLeakRate``.

--- a/examples/MultiSatBskSim/modelsMultiSat/BSK_MultiSatDynamics.py
+++ b/examples/MultiSatBskSim/modelsMultiSat/BSK_MultiSatDynamics.py
@@ -180,10 +180,10 @@ class BSKDynamicModels:
         self.tankModel.propMassInit = 50.0
         self.tankModel.maxFuelMass = 75.0
         self.tankModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]
-        self.fuelTankStateEffector.r_TB_B = [[0.0], [0.0], [0.0]]
+        self.fuelTankStateEffector.setR_TB_B([[0.0], [0.0], [0.0]])  # [m]
         self.tankModel.radiusTankInit = 1
         self.tankModel.lengthTank = 1
-        
+
         # Add the tank and connect the thrusters
         self.scObject.addStateEffector(self.fuelTankStateEffector)
         self.fuelTankStateEffector.addThrusterSet(self.thrusterDynamicEffector)

--- a/examples/scenarioConstrainedDynamicsComponentAnalysis.py
+++ b/examples/scenarioConstrainedDynamicsComponentAnalysis.py
@@ -499,12 +499,12 @@ def set_up_additional_effectors(scSim, component_list):
         tankModel.radiusTankInit = slosh_fuel_tank_geometry.radiusTankInit
         tankModel.this.disown()
         scSim.tank1.setTankModel(tankModel)
-        scSim.tank1.r_TB_B = slosh_fuel_tank_geometry.r_TB_B
-        scSim.tank1.nameOfMassState = "fuelTankMass1"
+        scSim.tank1.setR_TB_B(slosh_fuel_tank_geometry.r_TB_B)
+        scSim.tank1.setNameOfMassState("fuelTankMass1")
         scSim.tank1.pushFuelSloshParticle(scSim.particle1)
         scSim.tank1.pushFuelSloshParticle(scSim.particle2)
         scSim.tank1.pushFuelSloshParticle(scSim.particle3)
-        scSim.tank1.updateOnly = True
+        scSim.tank1.setUpdateOnly(True)
 
         # add fuel slosh to the servicer spacecraft
         scSim.scObject1.addStateEffector(scSim.tank1)
@@ -550,12 +550,12 @@ def set_up_additional_effectors(scSim, component_list):
         tankModelT.radiusTankInit = slosh_fuel_tank_geometry.radiusTankInit
         tankModelT.this.disown()
         scSim.tank2.setTankModel(tankModelT)
-        scSim.tank2.r_TB_B = slosh_fuel_tank_geometry.r_TB_B + scSim.r_B1C - scSim.r_BcC
-        scSim.tank2.nameOfMassState = "fuelTankMass2"
+        scSim.tank2.setR_TB_B(slosh_fuel_tank_geometry.r_TB_B + scSim.r_B1C - scSim.r_BcC)
+        scSim.tank2.setNameOfMassState("fuelTankMass2")
         scSim.tank2.pushFuelSloshParticle(scSim.particle4)
         scSim.tank2.pushFuelSloshParticle(scSim.particle5)
         scSim.tank2.pushFuelSloshParticle(scSim.particle6)
-        scSim.tank2.updateOnly = True
+        scSim.tank2.setUpdateOnly(True)
 
         # add fuel slosh to the servicer spacecraft
         scSim.scObjectT.addStateEffector(scSim.tank2)

--- a/examples/scenarioFuelSlosh.py
+++ b/examples/scenarioFuelSlosh.py
@@ -261,12 +261,12 @@ def run(show_plots, damping_parameter, timeStep):
     tankModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]  # m
     tankModel.radiusTankInit = 0.5  # m
     scSim.tank1.setTankModel(tankModel)
-    scSim.tank1.r_TB_B = [[0], [0], [0.1]]  # m
-    scSim.tank1.nameOfMassState = "fuelTankMass1"
+    scSim.tank1.setR_TB_B([[0], [0], [0.1]])  # [m]
+    scSim.tank1.setNameOfMassState("fuelTankMass1")
     scSim.tank1.pushFuelSloshParticle(scSim.particle1)
     scSim.tank1.pushFuelSloshParticle(scSim.particle2)
     scSim.tank1.pushFuelSloshParticle(scSim.particle3)
-    scSim.tank1.updateOnly = True
+    scSim.tank1.setUpdateOnly(True)
 
     # ACTIVATE FUEL SLOSH
     scObject.addStateEffector(scSim.tank1)

--- a/src/architecture/msgPayloadDefC/MassFlowRateMsgPayload.h
+++ b/src/architecture/msgPayloadDefC/MassFlowRateMsgPayload.h
@@ -1,0 +1,28 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#ifndef MASS_FLOW_RATE_MSG_PAYLOAD_H
+#define MASS_FLOW_RATE_MSG_PAYLOAD_H
+
+/*! @brief Message containing a scalar mass flow rate. */
+typedef struct {
+    double massFlowRate;              //!< [kg/s] scalar mass flow rate
+}MassFlowRateMsgPayload;
+
+#endif

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -261,6 +261,59 @@ def test_leakyTank():
     assert np.isclose(fuelMass[-1], initialFuelMass - stopTime * leakRate, rtol=1e-6)
 
 
+def test_leakyTankInputMessageOverridesSetter():
+    """Module Unit Test"""
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    #   Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.1)  # [s]
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Make Fuel Tank
+    unitTestSim.fuelTankStateEffector = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelConstantVolume()
+    unitTestSim.fuelTankStateEffector.setTankModel(tankModel)
+    initialFuelMass = 40.0  # [kg]
+    tankModel.propMassInit = initialFuelMass
+
+    # Add tank
+    scObject.addStateEffector(unitTestSim.fuelTankStateEffector)
+
+    # Make the tank leaky using the input message to override the configured value
+    configuredLeakRate = 1.0e-5  # [kg/s]
+    messageLeakRate = 2.0e-5  # [kg/s]
+    unitTestSim.fuelTankStateEffector.setFuelLeakRate(configuredLeakRate)
+    leakRateMsgPayload = messaging.MassFlowRateMsgPayload()
+    leakRateMsgPayload.massFlowRate = messageLeakRate
+    leakRateMsg = messaging.MassFlowRateMsg().write(leakRateMsgPayload)
+    unitTestSim.fuelTankStateEffector.fuelLeakRateInMsg.subscribeTo(leakRateMsg)
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, unitTestSim.fuelTankStateEffector)
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+
+    fuelLog = unitTestSim.fuelTankStateEffector.fuelTankOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, fuelLog)
+    unitTestSim.InitializeSimulation()
+
+    stopTime = 1000.0  # [s]
+    unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
+    unitTestSim.ExecuteSimulation()
+
+    fuelMass = fuelLog.fuelMass
+    fuelMassDot = fuelLog.fuelMassDot
+
+    assert np.allclose(fuelMassDot, -messageLeakRate, rtol=1e-6)
+    assert np.isclose(fuelMass[-1], initialFuelMass - stopTime * messageLeakRate, rtol=1e-6)
+
+
 @pytest.mark.parametrize("tankModelConstructor", [fuelTank.FuelTankModelConstantVolume,
                                                   fuelTank.FuelTankModelConstantDensity,
                                                   fuelTank.FuelTankModelEmptying,

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -44,6 +44,13 @@ def _usesExpiredDeprecation(accessor, message):
     return any(issubclass(w.category, deprecated.BSKUrgentDeprecationWarning) for w in warningList)
 
 
+def _configureTankGeometry(tankModel):
+    if hasattr(tankModel, "radiusTankInit"):
+        tankModel.radiusTankInit = 1.0  # [m]
+    if hasattr(tankModel, "lengthTank"):
+        tankModel.lengthTank = 1.0  # [m]
+
+
 @pytest.mark.parametrize("thrusterConstructor", [thrusterDynamicEffector.ThrusterDynamicEffector,
                                                  thrusterStateEffector.ThrusterStateEffector])
 def test_massDepletionTest(show_plots, thrusterConstructor):
@@ -205,6 +212,7 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
                                err_msg="Thruster mass depletion not ramped up")
     np.testing.assert_allclose(fuelMassDot[-1], 0, rtol=1e-12, err_msg="Thruster mass depletion not ramped down")
 
+
 def test_leakyTank():
     """Module Unit Test"""
     scObject = spacecraft.Spacecraft()
@@ -251,6 +259,66 @@ def test_leakyTank():
 
     assert np.allclose(fuelMassDot, -leakRate, rtol=1e-6)
     assert np.isclose(fuelMass[-1], initialFuelMass - stopTime * leakRate, rtol=1e-6)
+
+
+@pytest.mark.parametrize("tankModelConstructor", [fuelTank.FuelTankModelConstantVolume,
+                                                  fuelTank.FuelTankModelConstantDensity,
+                                                  fuelTank.FuelTankModelEmptying,
+                                                  fuelTank.FuelTankModelUniformBurn,
+                                                  fuelTank.FuelTankModelCentrifugalBurn])
+def test_leakyTankRunsOutOfFuel(tankModelConstructor):
+    """Module Unit Test"""
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    unitTaskName = "unitTask"
+    unitProcessName = "TestProcess"
+
+    #   Create a sim module as an empty container
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+
+    # Create test thread
+    testProcessRate = macros.sec2nano(0.1)  # [s]
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
+
+    # Make Fuel Tank
+    unitTestSim.fuelTankStateEffector = fuelTank.FuelTank()
+    tankModel = tankModelConstructor()
+    _configureTankGeometry(tankModel)
+    unitTestSim.fuelTankStateEffector.setTankModel(tankModel)
+    initialFuelMass = 1.0e-4  # [kg]
+    tankModel.propMassInit = initialFuelMass
+
+    # Add tank
+    scObject.addStateEffector(unitTestSim.fuelTankStateEffector)
+
+    # Make the tank leaky
+    leakRate = 1.0e-5  # [kg/s]
+    unitTestSim.fuelTankStateEffector.setFuelLeakRate(leakRate)
+
+    # Add test module to runtime call list
+    unitTestSim.AddModelToTask(unitTaskName, unitTestSim.fuelTankStateEffector)
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+
+    fuelLog = unitTestSim.fuelTankStateEffector.fuelTankOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, fuelLog)
+    unitTestSim.InitializeSimulation()
+
+    stopTime = 20.0  # [s]
+    unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
+    unitTestSim.ExecuteSimulation()
+
+    fuelMass = fuelLog.fuelMass
+    fuelMassDot = fuelLog.fuelMassDot
+    fuelMassTolerance = 1e-14  # [kg]
+    fuelMassDotTolerance = 1e-14  # [kg/s]
+
+    assert np.all(np.isfinite(fuelMass))
+    assert np.all(np.isfinite(fuelMassDot))
+    assert np.all(fuelMass >= -fuelMassTolerance)
+    assert np.isclose(fuelMass[-1], 0.0, atol=fuelMassTolerance)
+    assert np.isclose(fuelMassDot[-1], 0.0, atol=fuelMassDotTolerance)
+    assert np.any(np.isclose(fuelMassDot, -leakRate, rtol=1e-6))
 
 
 def test_deprecatedPublicVariables():

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -16,6 +16,7 @@
 
 import inspect
 import os
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,12 +27,21 @@ from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import thrusterDynamicEffector, thrusterStateEffector
 from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import deprecated
 from Basilisk.utilities import macros
 from Basilisk.utilities import simIncludeThruster
 from Basilisk.utilities import unitTestSupport
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
+
+
+def _usesExpiredDeprecation(accessor, message):
+    """Return true if deprecated public access has reached the urgent warning phase."""
+    expectedWarnings = (deprecated.BSKDeprecationWarning, deprecated.BSKUrgentDeprecationWarning)
+    with pytest.warns(expectedWarnings, match=message) as warningList:
+        accessor()
+    return any(issubclass(w.category, deprecated.BSKUrgentDeprecationWarning) for w in warningList)
 
 
 @pytest.mark.parametrize("thrusterConstructor", [thrusterDynamicEffector.ThrusterDynamicEffector,
@@ -53,7 +63,7 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.1)
+    testProcessRate = macros.sec2nano(0.1)  # [s]
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
@@ -72,9 +82,10 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
     unitTestSim.fuelTankStateEffector = fuelTank.FuelTank()
     tankModel = fuelTank.FuelTankModelConstantVolume()
     unitTestSim.fuelTankStateEffector.setTankModel(tankModel)
-    tankModel.propMassInit = 40.0
+    initialFuelMass = 40.0  # [kg]
+    tankModel.propMassInit = initialFuelMass
     tankModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]
-    unitTestSim.fuelTankStateEffector.r_TB_B = [[0.0], [0.0], [0.0]]
+    unitTestSim.fuelTankStateEffector.setR_TB_B([[0.0], [0.0], [0.0]])  # [m]
     tankModel.radiusTankInit = 46.0 / 2.0 / 3.2808399 / 12.0
 
     # Add tank
@@ -192,7 +203,7 @@ def test_massDepletionTest(show_plots, thrusterConstructor):
     # target value computed from MaxThrust / (EARTH_GRAV * steadyIsp)
     np.testing.assert_allclose(fuelMassDot[100], -0.000403404216123, rtol=1e-3,
                                err_msg="Thruster mass depletion not ramped up")
-    np.testing.assert_allclose(fuelMassDot[-1],0, rtol=1e-12, err_msg="Thruster mass depletion not ramped down")
+    np.testing.assert_allclose(fuelMassDot[-1], 0, rtol=1e-12, err_msg="Thruster mass depletion not ramped down")
 
 def test_leakyTank():
     """Module Unit Test"""
@@ -205,7 +216,7 @@ def test_leakyTank():
     unitTestSim = SimulationBaseClass.SimBaseClass()
 
     # Create test thread
-    testProcessRate = macros.sec2nano(0.1)
+    testProcessRate = macros.sec2nano(0.1)  # [s]
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
@@ -213,14 +224,15 @@ def test_leakyTank():
     unitTestSim.fuelTankStateEffector = fuelTank.FuelTank()
     tankModel = fuelTank.FuelTankModelConstantVolume()
     unitTestSim.fuelTankStateEffector.setTankModel(tankModel)
-    tankModel.propMassInit = 40.0
+    initialFuelMass = 40.0  # [kg]
+    tankModel.propMassInit = initialFuelMass
 
     # Add tank
     scObject.addStateEffector(unitTestSim.fuelTankStateEffector)
 
     # Make the tank leaky
-    leakRate = 1e-5  # kg/s
-    unitTestSim.fuelTankStateEffector.fuelLeakRate = leakRate # kg/s
+    leakRate = 1e-5  # [kg/s]
+    unitTestSim.fuelTankStateEffector.setFuelLeakRate(leakRate)
 
     # Add test module to runtime call list
     unitTestSim.AddModelToTask(unitTaskName, unitTestSim.fuelTankStateEffector)
@@ -230,7 +242,7 @@ def test_leakyTank():
     unitTestSim.AddModelToTask(unitTaskName, fuelLog)
     unitTestSim.InitializeSimulation()
 
-    stopTime = 1000.0
+    stopTime = 1000.0  # [s]
     unitTestSim.ConfigureStopTime(macros.sec2nano(stopTime))
     unitTestSim.ExecuteSimulation()
 
@@ -238,8 +250,55 @@ def test_leakyTank():
     fuelMassDot = fuelLog.fuelMassDot
 
     assert np.allclose(fuelMassDot, -leakRate, rtol=1e-6)
-    assert np.isclose(fuelMass[-1], 40.0 - stopTime * leakRate, rtol=1e-6)
+    assert np.isclose(fuelMass[-1], initialFuelMass - stopTime * leakRate, rtol=1e-6)
+
+
+def test_deprecatedPublicVariables():
+    """Module Unit Test"""
+    tank = fuelTank.FuelTank()
+
+    dcm_TB = np.eye(3)
+    r_TB_B = [[1.0], [2.0], [3.0]]  # [m]
+    fuelLeakRate = 2.0e-5  # [kg/s]
+    nameOfMassState = "fuelTankMassDeprecated"
+    expiredDeprecation = False
+
+    expiredDeprecation |= _usesExpiredDeprecation(
+        lambda: setattr(tank, "nameOfMassState", nameOfMassState),
+        "setNameOfMassState"
+    )
+    assert tank.getNameOfMassState() == nameOfMassState
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: getattr(tank, "nameOfMassState"), "getNameOfMassState")
+
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: setattr(tank, "dcm_TB", dcm_TB), "setDcm_TB")
+    np.testing.assert_allclose(tank.getDcm_TB(), dcm_TB, rtol=1e-15)
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: getattr(tank, "dcm_TB"), "getDcm_TB")
+
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: setattr(tank, "r_TB_B", r_TB_B), "setR_TB_B")
+    np.testing.assert_allclose(tank.getR_TB_B(), r_TB_B, rtol=1e-15)
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: getattr(tank, "r_TB_B"), "getR_TB_B")
+
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: setattr(tank, "updateOnly", False), "setUpdateOnly")
+    assert tank.getUpdateOnly() is False
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: getattr(tank, "updateOnly"), "getUpdateOnly")
+
+    expiredDeprecation |= _usesExpiredDeprecation(
+        lambda: setattr(tank, "fuelLeakRate", fuelLeakRate),
+        "setFuelLeakRate"
+    )
+    assert tank.getFuelLeakRate() == pytest.approx(fuelLeakRate)
+    expiredDeprecation |= _usesExpiredDeprecation(lambda: getattr(tank, "fuelLeakRate"), "getFuelLeakRate")
+
+    if expiredDeprecation:
+        warnings.warn(
+            "The cutoff date for deprecated FuelTank public variable access has passed. "
+            "Remove the deprecated direct Python access to nameOfMassState, dcm_TB, r_TB_B, "
+            "updateOnly, and fuelLeakRate from fuelTank.i and update this compatibility test.",
+            UserWarning,
+            stacklevel=1
+        )
 
 
 if __name__ == "__main__":
     test_massDepletionTest(True, thrusterDynamicEffector.ThrusterDynamicEffector)
+    test_deprecatedPublicVariables()

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -106,6 +106,7 @@ void FuelTank::updateEffectorMassProps(double integTime) {
 
     // Mass depletion (call thrusters attached to this tank to get their mDot, and contributions)
     this->fuelConsumption = 0.0;
+    this->fuelConsumption += this->fuelLeakRate;
     for (auto &dynEffector: this->thrDynEffectors) {
         dynEffector->computeStateContribution(integTime);
         this->fuelConsumption += dynEffector->stateDerivContribution(0);

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -28,13 +28,13 @@ FuelTank::FuelTank() {
     this->effProps.rEff_CB_B.setZero();
     this->effProps.rEffPrime_CB_B.setZero();
     this->effProps.IEffPrimePntB_B.setZero();
-    this->dcm_TB = Eigen::Matrix3d::Identity();
-    this->r_TB_B.setZero();
+    this->setDcm_TB(Eigen::Matrix3d::Identity());
+    this->setR_TB_B(Eigen::Vector3d::Zero());
     this->ITankPntT_B = Eigen::Matrix3d::Identity();
     this->r_TcB_B.setZero();
 
     this->effectorID++;
-    this->nameOfMassState = "fuelTankMass" + std::to_string(this->effectorID);
+    this->setNameOfMassState("fuelTankMass" + std::to_string(this->effectorID));
 }
 
 uint64_t FuelTank::effectorID = 1;
@@ -44,8 +44,53 @@ FuelTank::~FuelTank() {
 }
 
 /*! optionally set the name of the mass state to be used by the state manager */
-void FuelTank::setNameOfMassState(const std::string nameOfMassState) {
+void FuelTank::setNameOfMassState(const std::string &nameOfMassState) {
     this->nameOfMassState = nameOfMassState;
+}
+
+/*! get the name of the mass state used by the state manager */
+std::string FuelTank::getNameOfMassState() const {
+    return this->nameOfMassState;
+}
+
+/*! set fuel tank orientation relative to the hub frame */
+void FuelTank::setDcm_TB(const Eigen::Matrix3d &dcm_TB) {
+    this->dcm_TB = dcm_TB;
+}
+
+/*! get fuel tank orientation relative to the hub frame */
+Eigen::Matrix3d FuelTank::getDcm_TB() const {
+    return this->dcm_TB;
+}
+
+/*! set fuel tank location relative to the hub frame */
+void FuelTank::setR_TB_B(const Eigen::Vector3d &r_TB_B) {
+    this->r_TB_B = r_TB_B;
+}
+
+/*! get fuel tank location relative to the hub frame */
+Eigen::Vector3d FuelTank::getR_TB_B() const {
+    return this->r_TB_B;
+}
+
+/*! set update only mass depletion flag */
+void FuelTank::setUpdateOnly(bool updateOnly) {
+    this->updateOnly = updateOnly;
+}
+
+/*! get update only mass depletion flag */
+bool FuelTank::getUpdateOnly() const {
+    return this->updateOnly;
+}
+
+/*! set fuel leak rate */
+void FuelTank::setFuelLeakRate(double fuelLeakRate) {
+    this->fuelLeakRate = fuelLeakRate;
+}
+
+/*! get fuel leak rate */
+double FuelTank::getFuelLeakRate() const {
+    return this->fuelLeakRate;
 }
 
 /*! set fuel tank model
@@ -84,7 +129,7 @@ void FuelTank::linkInStates(DynParamManager &statesIn) {
 void FuelTank::registerStates(DynParamManager &statesIn) {
     // Register the mass state associated with the tank
     Eigen::MatrixXd massMatrix(1, 1);
-    this->massState = statesIn.registerState(1, 1, this->nameOfMassState);
+    this->massState = statesIn.registerState(1, 1, this->getNameOfMassState());
     massMatrix(0, 0) = this->fuelTankModel->propMassInit;
     this->massState->setState(massMatrix);
 }
@@ -94,9 +139,10 @@ void FuelTank::updateEffectorMassProps(double integTime) {
     // Add contributions of the mass of the tank
     double massLocal = this->massState->getState()(0, 0);
     this->fuelTankModel->computeTankProps(massLocal);
-    this->r_TcB_B = r_TB_B + this->dcm_TB.transpose() * this->fuelTankModel->r_TcT_T;
+    const Eigen::Matrix3d dcm_TBLocal = this->getDcm_TB();
+    this->r_TcB_B = this->getR_TB_B() + dcm_TBLocal.transpose() * this->fuelTankModel->r_TcT_T;
     this->effProps.mEff = massLocal;
-    this->ITankPntT_B = this->dcm_TB.transpose() * fuelTankModel->ITankPntT_T * this->dcm_TB;
+    this->ITankPntT_B = dcm_TBLocal.transpose() * fuelTankModel->ITankPntT_T * dcm_TBLocal;
     this->effProps.IEffPntB_B = ITankPntT_B + massLocal * (r_TcB_B.dot(r_TcB_B) * Eigen::Matrix3d::Identity()
                                                            - r_TcB_B * r_TcB_B.transpose());
     this->effProps.rEff_CB_B = this->r_TcB_B;
@@ -106,7 +152,7 @@ void FuelTank::updateEffectorMassProps(double integTime) {
 
     // Mass depletion (call thrusters attached to this tank to get their mDot, and contributions)
     this->fuelConsumption = 0.0;
-    this->fuelConsumption += this->fuelLeakRate;
+    this->fuelConsumption += this->getFuelLeakRate();
     for (auto &dynEffector: this->thrDynEffectors) {
         dynEffector->computeStateContribution(integTime);
         this->fuelConsumption += dynEffector->stateDerivContribution(0);
@@ -169,7 +215,7 @@ void FuelTank::updateContributions(double integTime,
     rPrime_TB_BLocal = this->fuelTankModel->rPrime_TcT_T;
     rPPrime_TB_BLocal = this->fuelTankModel->rPPrime_TcT_T;
     omega_BN_BLocal = this->omegaState->getState();
-    if (!this->updateOnly) {
+    if (!this->getUpdateOnly()) {
         backSubContr.vecRot = -this->massState->getState()(0, 0) * r_TB_BLocal.cross(rPPrime_TB_BLocal)
                               - this->massState->getState()(0, 0) * omega_BN_BLocal.cross(r_TB_BLocal.cross(rPrime_TB_BLocal))
                               - this->massState->getStateDeriv()(0, 0) * r_TB_BLocal.cross(rPrime_TB_BLocal);

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -132,6 +132,7 @@ void FuelTank::registerStates(DynParamManager &statesIn) {
     this->massState = statesIn.registerState(1, 1, this->getNameOfMassState());
     massMatrix(0, 0) = this->fuelTankModel->propMassInit;
     this->massState->setState(massMatrix);
+    this->emptyTankWarningPrinted = false;
 }
 
 /*! Fuel tank add its contributions the mass of the vehicle. */
@@ -181,6 +182,11 @@ void FuelTank::updateEffectorMassProps(double integTime) {
         totalMass += (*fuelSloshInt)->fuelMass;
     }
     if (totalMass <= 0.0) {
+        if (this->fuelConsumption > 0.0 && !this->emptyTankWarningPrinted) {
+            this->bskLogger.bskLog(BSK_WARNING,
+                                   "FuelTank: available propellant has reached zero. Fuel mass depletion is stopped.");
+            this->emptyTankWarningPrinted = true;
+        }
         this->fuelConsumption = 0.0;  // [kg/s]
         for (auto fuelSloshInt = this->fuelSloshParticles.begin();
              fuelSloshInt < this->fuelSloshParticles.end();

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -138,6 +138,13 @@ void FuelTank::registerStates(DynParamManager &statesIn) {
 void FuelTank::updateEffectorMassProps(double integTime) {
     // Add contributions of the mass of the tank
     double massLocal = this->massState->getState()(0, 0);
+    if (massLocal < 0.0) {
+        // Clamp integration overshoot at empty before tank models compute mass properties.
+        massLocal = 0.0;  // [kg]
+        Eigen::MatrixXd massMatrix(1, 1);
+        massMatrix(0, 0) = massLocal;
+        this->massState->setState(massMatrix);
+    }
     this->fuelTankModel->computeTankProps(massLocal);
     const Eigen::Matrix3d dcm_TBLocal = this->getDcm_TB();
     this->r_TcB_B = this->getR_TB_B() + dcm_TBLocal.transpose() * this->fuelTankModel->r_TcT_T;
@@ -172,6 +179,21 @@ void FuelTank::updateEffectorMassProps(double integTime) {
         (*fuelSloshInt)->retrieveMassValue(integTime);
         // Add fuelSlosh mass to total mass of tank
         totalMass += (*fuelSloshInt)->fuelMass;
+    }
+    if (totalMass <= 0.0) {
+        this->fuelConsumption = 0.0;  // [kg/s]
+        for (auto fuelSloshInt = this->fuelSloshParticles.begin();
+             fuelSloshInt < this->fuelSloshParticles.end();
+             fuelSloshInt++) {
+            (*fuelSloshInt)->massToTotalTankMassRatio = 0.0;
+            (*fuelSloshInt)->fuelMassDot = 0.0;  // [kg/s]
+        }
+        for (auto &dynEffector: this->thrDynEffectors) {
+            dynEffector->fuelMass = 0.0;  // [kg]
+        }
+        this->tankFuelConsumption = 0.0;  // [kg/s]
+        this->effProps.mEffDot = 0.0;  // [kg/s]
+        return;
     }
     // Set mass depletion rate of fuelSloshParticles
     for (auto fuelSloshInt = this->fuelSloshParticles.begin();
@@ -209,15 +231,23 @@ void FuelTank::updateContributions(double integTime,
     backSubContr.vecTrans = backSubContr.vecRot = Eigen::Vector3d::Zero();
 
     // Calculate the fuel consumption properties for the tank
-    this->tankFuelConsumption = this->fuelConsumption * this->massState->getState()(0, 0) / this->effProps.mEff;
-    this->fuelTankModel->computeTankPropDerivs(this->massState->getState()(0, 0), -this->tankFuelConsumption);
+    double massLocal = this->massState->getState()(0, 0);
+    if (massLocal < 0.0) {
+        massLocal = 0.0;  // [kg]
+    }
+    if (this->effProps.mEff > 0.0) {
+        this->tankFuelConsumption = this->fuelConsumption * massLocal / this->effProps.mEff;
+    } else {
+        this->tankFuelConsumption = 0.0;  // [kg/s]
+    }
+    this->fuelTankModel->computeTankPropDerivs(massLocal, -this->tankFuelConsumption);
     r_TB_BLocal = this->fuelTankModel->r_TcT_T;
     rPrime_TB_BLocal = this->fuelTankModel->rPrime_TcT_T;
     rPPrime_TB_BLocal = this->fuelTankModel->rPPrime_TcT_T;
     omega_BN_BLocal = this->omegaState->getState();
     if (!this->getUpdateOnly()) {
-        backSubContr.vecRot = -this->massState->getState()(0, 0) * r_TB_BLocal.cross(rPPrime_TB_BLocal)
-                              - this->massState->getState()(0, 0) * omega_BN_BLocal.cross(r_TB_BLocal.cross(rPrime_TB_BLocal))
+        backSubContr.vecRot = -massLocal * r_TB_BLocal.cross(rPPrime_TB_BLocal)
+                              - massLocal * omega_BN_BLocal.cross(r_TB_BLocal.cross(rPrime_TB_BLocal))
                               - this->massState->getStateDeriv()(0, 0) * r_TB_BLocal.cross(rPrime_TB_BLocal);
         backSubContr.vecRot -= this->fuelTankModel->IPrimeTankPntT_T * omega_BN_BLocal;
     }
@@ -230,7 +260,12 @@ void FuelTank::computeDerivatives(double integTime,
                                   Eigen::Vector3d omegaDot_BN_B,
                                   Eigen::Vector3d sigma_BN) {
     Eigen::MatrixXd conv(1, 1);
-    conv(0, 0) = -this->tankFuelConsumption;
+    double massLocal = this->massState->getState()(0, 0);
+    double tankFuelConsumptionLocal = this->tankFuelConsumption;
+    if (massLocal <= 0.0 && tankFuelConsumptionLocal > 0.0) {
+        tankFuelConsumptionLocal = 0.0;  // [kg/s]
+    }
+    conv(0, 0) = -tankFuelConsumptionLocal;
     this->massState->setDerivative(conv);
 }
 

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -160,7 +160,12 @@ void FuelTank::updateEffectorMassProps(double integTime) {
 
     // Mass depletion (call thrusters attached to this tank to get their mDot, and contributions)
     this->fuelConsumption = 0.0;
-    this->fuelConsumption += this->getFuelLeakRate();
+    double fuelLeakRateLocal = this->getFuelLeakRate();
+    if (this->fuelLeakRateInMsg.isLinked()) {
+        MassFlowRateMsgPayload fuelLeakRateInMsgBuffer = this->fuelLeakRateInMsg();
+        fuelLeakRateLocal = fuelLeakRateInMsgBuffer.massFlowRate;
+    }
+    this->fuelConsumption += fuelLeakRateLocal;
     for (auto &dynEffector: this->thrDynEffectors) {
         dynEffector->computeStateContribution(integTime);
         this->fuelConsumption += dynEffector->stateDerivContribution(0);

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -270,6 +270,7 @@ public:
     bool updateOnly = true;                             //!< -- Sets whether to use update only mass depletion
     Message<FuelTankMsgPayload> fuelTankOutMsg{};       //!< -- fuel tank output message name
     FuelTankMsgPayload fuelTankMassPropMsg{};           //!< instance of messaging system message struct
+    double fuelLeakRate{};                              //!< [kg/s] rate of fuel leaking from tank; does not produce force
 
 private:
     StateData *omegaState{};                            //!< -- state data for omega_BN of the hub

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -281,6 +281,7 @@ private:
     Eigen::Matrix3d ITankPntT_B;
     Eigen::Vector3d r_TcB_B;
     static uint64_t effectorID;                         //!< [] ID number of this fuel tank effector
+    bool emptyTankWarningPrinted = false;               //!< -- flag indicating if the empty tank warning has been logged
 
 public:
     FuelTank();

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -21,6 +21,7 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"
+#include "architecture/msgPayloadDefC/MassFlowRateMsgPayload.h"
 #include "architecture/messaging/messaging.h"
 #include "simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.h"
 #include "simulation/dynamics/_GeneralModuleFiles/fuelSlosh.h"
@@ -264,6 +265,7 @@ public:
     std::vector<FuelSlosh *> fuelSloshParticles;        //!< -- vector of fuel slosh particles
     std::vector<ThrusterDynamicEffector *> thrDynEffectors;        //!< -- Vector of dynamic effectors for thrusters
     std::vector<ThrusterStateEffector *> thrStateEffectors;        //!< -- Vector of state effectors for thrusters
+    ReadFunctor<MassFlowRateMsgPayload> fuelLeakRateInMsg; //!< (optional) fuel leak mass flow rate input message
     Message<FuelTankMsgPayload> fuelTankOutMsg{};       //!< -- fuel tank output message name
     FuelTankMsgPayload fuelTankMassPropMsg{};           //!< instance of messaging system message struct
     std::string nameOfMassState{};                      //!< -- Legacy public mass state name; Python users should use accessors

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -261,16 +261,16 @@ public:
 class FuelTank :
         public StateEffector, public SysModel {
 public:
-    std::string nameOfMassState{};                      //!< -- name of mass state
     std::vector<FuelSlosh *> fuelSloshParticles;        //!< -- vector of fuel slosh particles
     std::vector<ThrusterDynamicEffector *> thrDynEffectors;        //!< -- Vector of dynamic effectors for thrusters
     std::vector<ThrusterStateEffector *> thrStateEffectors;        //!< -- Vector of state effectors for thrusters
-    Eigen::Matrix3d dcm_TB;                             //!< -- DCM from body frame to tank frame
-    Eigen::Vector3d r_TB_B;                             //!< [m] position of tank in B frame
-    bool updateOnly = true;                             //!< -- Sets whether to use update only mass depletion
     Message<FuelTankMsgPayload> fuelTankOutMsg{};       //!< -- fuel tank output message name
     FuelTankMsgPayload fuelTankMassPropMsg{};           //!< instance of messaging system message struct
-    double fuelLeakRate{};                              //!< [kg/s] rate of fuel leaking from tank; does not produce force
+    std::string nameOfMassState{};                      //!< -- Legacy public mass state name; Python users should use accessors
+    Eigen::Matrix3d dcm_TB;                             //!< -- Legacy public DCM from body frame to tank frame
+    Eigen::Vector3d r_TB_B;                             //!< [m] Legacy public tank position in B frame; Python users should use accessors
+    bool updateOnly = true;                             //!< -- Legacy public update-only flag; Python users should use accessors
+    double fuelLeakRate{};                              //!< [kg/s] Legacy public leak rate; Python users should use accessors
 
 private:
     StateData *omegaState{};                            //!< -- state data for omega_BN of the hub
@@ -288,11 +288,20 @@ public:
     void writeOutputMessages(uint64_t currentClock);
     void UpdateState(uint64_t currentSimNanos) override;
     void setTankModel(FuelTankModel *model);
+    void setDcm_TB(const Eigen::Matrix3d &dcm_TB);       //!< -- Setter for the tank frame orientation
+    Eigen::Matrix3d getDcm_TB() const;                   //!< -- Getter for the tank frame orientation
+    void setR_TB_B(const Eigen::Vector3d &r_TB_B);       //!< [m] Setter for the tank location
+    Eigen::Vector3d getR_TB_B() const;                   //!< [m] Getter for the tank location
+    void setUpdateOnly(bool updateOnly);                 //!< -- Setter for update only mass depletion
+    bool getUpdateOnly() const;                          //!< -- Getter for update only mass depletion
+    void setFuelLeakRate(double fuelLeakRate);           //!< [kg/s] Setter for the fuel leak rate
+    double getFuelLeakRate() const;                      //!< [kg/s] Getter for the fuel leak rate
     void pushFuelSloshParticle(FuelSlosh *particle);            //!< -- Attach fuel slosh particle
     void registerStates(DynParamManager &states) override;      //!< -- Register mass state with state manager
     void linkInStates(DynParamManager &states) override;        //!< -- Give the tank access to other states
     void updateEffectorMassProps(double integTime) override;    //!< -- Add contribution mass props from the tank
-    void setNameOfMassState(const std::string nameOfMassState); //!< -- Setter for fuel tank mass state name
+    void setNameOfMassState(const std::string &nameOfMassState); //!< -- Setter for fuel tank mass state name
+    std::string getNameOfMassState() const;              //!< -- Getter for fuel tank mass state name
     void addThrusterSet(ThrusterDynamicEffector *dynEff);       //!< -- Add DynamicEffector thruster
     void addThrusterSet(ThrusterStateEffector *stateEff);       //!< -- Add StateEffector thruster
     void updateContributions(double integTime,

--- a/src/simulation/dynamics/FuelTank/fuelTank.i
+++ b/src/simulation/dynamics/FuelTank/fuelTank.i
@@ -32,10 +32,41 @@ from Basilisk.architecture.swig_common_model import *
 %include "std_string.i"
 %include "swig_eigen.i"
 %include "swig_conly_data.i"
+%include "swig_deprecated.i"
 
 %include "sys_model.i"
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
+%deprecated_variable(
+    FuelTank,
+    nameOfMassState,
+    "2027/06/22",
+    "Direct access to nameOfMassState is deprecated. Use setNameOfMassState() and getNameOfMassState() instead."
+)
+%deprecated_variable(
+    FuelTank,
+    dcm_TB,
+    "2027/06/22",
+    "Direct access to dcm_TB is deprecated. Use setDcm_TB() and getDcm_TB() instead."
+)
+%deprecated_variable(
+    FuelTank,
+    r_TB_B,
+    "2027/06/22",
+    "Direct access to r_TB_B is deprecated. Use setR_TB_B() and getR_TB_B() instead."
+)
+%deprecated_variable(
+    FuelTank,
+    updateOnly,
+    "2027/06/22",
+    "Direct access to updateOnly is deprecated. Use setUpdateOnly() and getUpdateOnly() instead."
+)
+%deprecated_variable(
+    FuelTank,
+    fuelLeakRate,
+    "2027/06/22",
+    "Direct access to fuelLeakRate is deprecated. Use setFuelLeakRate() and getFuelLeakRate() instead."
+)
 %include "fuelTank.h"
 
 %include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"

--- a/src/simulation/dynamics/FuelTank/fuelTank.i
+++ b/src/simulation/dynamics/FuelTank/fuelTank.i
@@ -71,6 +71,8 @@ from Basilisk.architecture.swig_common_model import *
 
 %include "architecture/msgPayloadDefC/FuelTankMsgPayload.h"
 struct FuelTankMsg_C;
+%include "architecture/msgPayloadDefC/MassFlowRateMsgPayload.h"
+struct MassFlowRateMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/simulation/dynamics/FuelTank/fuelTank.rst
+++ b/src/simulation/dynamics/FuelTank/fuelTank.rst
@@ -54,7 +54,7 @@ The configurable values are:
   Set this to ``False`` to include the additional mass-depletion back-substitution contributions.
 - ``setFuelLeakRate()`` / ``getFuelLeakRate()``: positive fuel mass flow rate leaving the tank in kg/s. This leak rate is
   added to any attached thruster fuel consumption and reduces the reported fuel mass without applying force or torque to
-  the spacecraft.
+  the spacecraft. The leak stops when the available tank propellant reaches zero.
 
 .. code-block:: python
 

--- a/src/simulation/dynamics/FuelTank/fuelTank.rst
+++ b/src/simulation/dynamics/FuelTank/fuelTank.rst
@@ -54,7 +54,8 @@ The configurable values are:
   Set this to ``False`` to include the additional mass-depletion back-substitution contributions.
 - ``setFuelLeakRate()`` / ``getFuelLeakRate()``: positive fuel mass flow rate leaving the tank in kg/s. This leak rate is
   added to any attached thruster fuel consumption and reduces the reported fuel mass without applying force or torque to
-  the spacecraft. The leak stops when the available tank propellant reaches zero.
+  the spacecraft. The leak stops when the available tank propellant reaches zero, and the module logs a ``BSK_WARNING``
+  the first time depletion reaches an empty tank.
 
 .. code-block:: python
 

--- a/src/simulation/dynamics/FuelTank/fuelTank.rst
+++ b/src/simulation/dynamics/FuelTank/fuelTank.rst
@@ -39,6 +39,33 @@ The fuel tank effector module must be passed a tank model
     tankModel = fuelTank.FuelTankModelConstantVolume()
     fuelTankEffector.setTankModel(tankModel)
 
+Fuel tank configuration values should be set and read with the module setter and getter methods. Direct Python access to
+the legacy public variables ``nameOfMassState``, ``dcm_TB``, ``r_TB_B``, ``updateOnly``, and ``fuelLeakRate`` is
+deprecated and raises a deprecation warning.
+
+The configurable values are:
+
+- ``setNameOfMassState()`` / ``getNameOfMassState()``: optional state name used when registering the fuel tank mass
+  state. Set this before simulation initialization if a custom state name is required.
+- ``setDcm_TB()`` / ``getDcm_TB()``: direction cosine matrix from the body frame ``B`` to the tank frame ``T``.
+- ``setR_TB_B()`` / ``getR_TB_B()``: position vector from the body-frame origin to the tank point, expressed in body-frame
+  components in meters.
+- ``setUpdateOnly()`` / ``getUpdateOnly()``: flag selecting update-only mass depletion. The default value is ``True``.
+  Set this to ``False`` to include the additional mass-depletion back-substitution contributions.
+- ``setFuelLeakRate()`` / ``getFuelLeakRate()``: positive fuel mass flow rate leaving the tank in kg/s. This leak rate is
+  added to any attached thruster fuel consumption and reduces the reported fuel mass without applying force or torque to
+  the spacecraft.
+
+.. code-block:: python
+
+    fuelTankEffector.setNameOfMassState("fuelTankMass1")
+    fuelTankEffector.setDcm_TB([[1.0, 0.0, 0.0],
+                                [0.0, 1.0, 0.0],
+                                [0.0, 0.0, 1.0]])
+    fuelTankEffector.setR_TB_B([[0.0], [0.0], [0.1]])  # [m]
+    fuelTankEffector.setUpdateOnly(True)
+    fuelTankEffector.setFuelLeakRate(1.0e-5)  # [kg/s]
+
 A thruster effector can be attached to a tank effector to simulate fuel mass depletion by thruster operation.
 
 .. code-block:: python

--- a/src/simulation/dynamics/FuelTank/fuelTank.rst
+++ b/src/simulation/dynamics/FuelTank/fuelTank.rst
@@ -28,6 +28,8 @@ provides information on what this message is used for.
 
     output fuelTankOutMsg FuelTankMsgPayload
         fuel tank output message name
+    input fuelLeakRateInMsg MassFlowRateMsgPayload
+        optional fuel leak mass flow rate input message that overrides ``setFuelLeakRate()``
 
 User Guide
 ----------
@@ -57,6 +59,9 @@ The configurable values are:
   the spacecraft. The leak stops when the available tank propellant reaches zero, and the module logs a ``BSK_WARNING``
   the first time depletion reaches an empty tank.
 
+The leak rate can also be supplied through the optional ``fuelLeakRateInMsg`` input message. If this message is
+connected, the message ``massFlowRate`` value overrides the value configured with ``setFuelLeakRate()``.
+
 .. code-block:: python
 
     fuelTankEffector.setNameOfMassState("fuelTankMass1")
@@ -66,6 +71,11 @@ The configurable values are:
     fuelTankEffector.setR_TB_B([[0.0], [0.0], [0.1]])  # [m]
     fuelTankEffector.setUpdateOnly(True)
     fuelTankEffector.setFuelLeakRate(1.0e-5)  # [kg/s]
+
+    fuelLeakRateMsgData = messaging.MassFlowRateMsgPayload()
+    fuelLeakRateMsgData.massFlowRate = 2.0e-5  # [kg/s]
+    fuelLeakRateMsg = messaging.MassFlowRateMsg().write(fuelLeakRateMsgData)
+    fuelTankEffector.fuelLeakRateInMsg.subscribeTo(fuelLeakRateMsg)
 
 A thruster effector can be attached to a tank effector to simulate fuel mass depletion by thruster operation.
 

--- a/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
+++ b/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
@@ -129,7 +129,7 @@ def fuelSloshTest(show_plots,useFlag,testCase):
         unitTestSim.fuelTankStateEffector.setTankModel(tankModel)
         tankModel.propMassInit = 40.0
         tankModel.r_TcT_TInit = [[0.0],[0.0],[0.0]]
-        unitTestSim.fuelTankStateEffector.r_TB_B = [[0.0],[0.0],[0.0]]
+        unitTestSim.fuelTankStateEffector.setR_TB_B([[0.0],[0.0],[0.0]])  # [m]
         tankModel.radiusTankInit = 46.0 / 2.0 / 3.2808399 / 12.0
 
         # Add tank and thruster

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py
@@ -82,7 +82,7 @@ def thrusterIntegratedTest(show_plots):
     unitTestSim.fuelTankStateEffector.setTankModel(tankModel)
     tankModel.propMassInit = 40.0
     tankModel.r_TcT_TInit = [[0.0],[0.0],[0.0]]
-    unitTestSim.fuelTankStateEffector.r_TB_B = [[0.0],[0.0],[0.0]]
+    unitTestSim.fuelTankStateEffector.setR_TB_B([[0.0],[0.0],[0.0]])  # [m]
     tankModel.radiusTankInit = 46.0 / 2.0 / 3.2808399 / 12.0
 
     unitTestSim.fuelTankStateEffector.addThrusterSet(thrustersDynamicEffector)

--- a/src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
+++ b/src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
@@ -124,7 +124,7 @@ def sphericalPendulumTest(show_plots, useFlag,testCase):
         scSim.fuelTankStateEffector.setTankModel(tankModel)
         tankModel.propMassInit = 40.0
         tankModel.r_TcT_TInit = [[0.0],[0.0],[0.0]]
-        scSim.fuelTankStateEffector.r_TB_B = [[0.0],[0.0],[0.0]]
+        scSim.fuelTankStateEffector.setR_TB_B([[0.0],[0.0],[0.0]])  # [m]
         tankModel.radiusTankInit = 46.0 / 2.0 / 3.2808399 / 12.0
 
         # Add tank and thruster


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adds a `fuelLeakRate` configuration value to the `FuelTank` module so fuel mass can be depleted independently of thruster force/torque application.

This PR also adds setter/getter methods for `nameOfMassState`, `dcm_TB`, `r_TB_B`, `updateOnly`, and `fuelLeakRate`. Direct Python access to these legacy public variables is deprecated through the Basilisk SWIG deprecation mechanism, with removal after `2027/06/22`. No native C++ deprecation warnings are emitted.

Existing examples and tests that configured FuelTank through direct Python variable access were updated to use the new setter methods.

## Verification
Validated with:

```bash
.venv/bin/cmake --build dist3 --target fuelTank -j 4
.venv/bin/pytest -q src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
.venv/bin/pytest -q src/tests/test_scenarioFuelSlosh.py src/tests/test_scenarioConstrainedDynamicsComponentAnalysis.py src/tests/test_scenarioBasicOrbitMultiSat.py
.venv/bin/pytest -q src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py src/simulation/dynamics/Thrusters/thrusterDynamicEffector/_UnitTest/test_thruster_integrated_sim.py src/simulation/dynamics/sphericalPendulum/_UnitTest/test_sphericalPendulum.py
PATH=/Users/hp/Repos/basilisk/.venv/bin:$PATH make -C docs html SPHINXOPTS="-W"
git diff --check develop
```

Added unit coverage for leak-driven mass depletion and deprecated Python public-variable access.

## Documentation
Updated the FuelTank module documentation to describe the new setter/getter configuration interface and `fuelLeakRate` behavior. Added a release-note snippet under `docs/source/Support/bskReleaseNotesSnippets/`.

## Future work
After the deprecation period ends, remove direct Python access to the legacy public FuelTank variables from the SWIG interface and update the compatibility test accordingly.