### PR TITLE
[#338] Guard C-message payload offset at compile time

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/338-cmsg-recorder-offset-guard.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/338-cmsg-recorder-offset-guard.rst
@@ -1,0 +1,1 @@
+- Added a compile-time guard to the generated C message structs ensuring the payload immediately follows the message header with no padding. The C message read path (used by message recorders and C-to-C subscriptions) relies on this layout via pointer arithmetic; the guard turns any future layout change into a build error instead of a silent mis-read (issue #338).

--- a/src/architecture/messaging/_UnitTest/test_CMsgRecorderReadsLiveMessage.py
+++ b/src/architecture/messaging/_UnitTest/test_CMsgRecorderReadsLiveMessage.py
@@ -1,0 +1,79 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+#
+#   Unit Test Script
+#   Module Name:        messaging (C-message recorder)
+#   Author:             robotrocketscience (https://github.com/robotrocketscience)
+#   Creation Date:      June 24, 2026
+#
+
+"""
+Regression test for issue #338.
+
+A recorder attached to a C module's C output message must read the module's
+live message data, not a stale snapshot. The C-message read path reaches the
+payload by pointer arithmetic from the start of the ``{type}_C`` struct, so this
+test verifies end-to-end that the recorded payload tracks the values the module
+actually writes over time (and is not constant, which would indicate the
+recorder is bound to the wrong / a copied address).
+"""
+
+import numpy as np
+from Basilisk.architecture import bskLogging
+from Basilisk.moduleTemplates import cModuleTemplate
+from Basilisk.utilities import SimulationBaseClass, macros
+
+
+def test_cMsgRecorderReadsLiveMessage():
+    """The C-message recorder must capture the module's live, time-varying output."""
+    bskLogging.setDefaultLogLevel(bskLogging.BSK_WARNING)
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    process = scSim.CreateNewProcess("testProcess")
+    process.addTask(scSim.CreateNewTask("testTask", macros.sec2nano(1.0)))
+
+    module = cModuleTemplate.cModuleTemplate()
+    module.ModelTag = "cModule"
+    scSim.AddModelToTask("testTask", module)
+
+    # Record the module's C output message.
+    rec = module.dataOutMsg.recorder()
+    scSim.AddModelToTask("testTask", rec)
+
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(macros.sec2nano(5.0))
+    scSim.ExecuteSimulation()
+
+    recorded = np.array(rec.dataVector)
+
+    # With no input message linked, cModuleTemplate writes dataVector = [dummy, 0, 0]
+    # where dummy increments by 1 each step (reset to 0). So the first component must
+    # be the strictly increasing series 1, 2, 3, ... matching what the module wrote.
+    firstComponent = recorded[:, 0]
+    expected = np.arange(1, len(firstComponent) + 1, dtype=float)
+    np.testing.assert_allclose(firstComponent, expected, atol=1e-12)
+
+    # Guard the #338 failure mode directly: a recorder bound to a stale copy would
+    # report a constant value rather than the live, time-varying message.
+    assert len(np.unique(firstComponent)) > 1, \
+        "recorded C message is constant; recorder is not reading the live message"
+
+
+if __name__ == "__main__":
+    test_cMsgRecorderReadsLiveMessage()

--- a/src/architecture/messaging/cMsgCInterface/msg_C.h.in
+++ b/src/architecture/messaging/cMsgCInterface/msg_C.h.in
@@ -9,6 +9,7 @@
 #define @MSG_AUTOSOURCE_TYPE@_C_H
 
 #include <stdint.h>
+#include <stddef.h>
 #include "@MSG_AUTOSOURCE_HEADER@"
 #include "architecture/messaging/msgHeader.h"
 
@@ -19,6 +20,17 @@ typedef struct {
     @MSG_AUTOSOURCE_TYPE@Payload *payloadPointer;	    //!< pointer to message
     MsgHeader *headerPointer;      //!< pointer to message header
 } @MSG_AUTOSOURCE_TYPE@_C;
+
+/* The C++ message read path (Recorder and ReadFunctor::subscribeToC) reaches the
+ * payload by advancing one MsgHeader past the start of this struct, which assumes
+ * the payload immediately follows the header with no padding. Guarantee that
+ * invariant at compile time so any future layout change (e.g. a wider MsgHeader or
+ * a payload requiring stricter alignment) fails the build rather than silently
+ * reading the wrong address. See issue #338. */
+#ifdef __cplusplus
+static_assert(offsetof(@MSG_AUTOSOURCE_TYPE@_C, payload) == sizeof(MsgHeader),
+    "@MSG_AUTOSOURCE_TYPE@_C: payload must immediately follow the header with no padding");
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #338.

## Investigation
I reproduced the reported scenario on current `develop` and found that the general C-message recorder mechanism works correctly: a recorder attached to a C module's C output message reads the module's live data (member access returns the real shared `Msg_C` object, not a copy — verified by write-persistence and by the existing `cModuleTemplate` recorder test). The original report's large address discrepancy could not be reproduced with standard (`%c_wrap`) modules and was likely specific to that custom module.

What remains real is the **latent fragility** the issue and the code comments call out. The C-message read path — `Recorder(void*)` in `messaging.h` and `ReadFunctor::subscribeToC` — reaches the payload by advancing one `MsgHeader` from the start of the `{type}_C` struct:

```cpp
MsgHeader* pt = (MsgHeader*) message;
payloadPointer = (messageType*) (++pt);
```

This assumes the payload immediately follows the header with no padding. It holds today only because `MsgHeader` is exactly 32 bytes and message payloads align to ≤ 8 bytes (`offsetof(payload) == sizeof(MsgHeader) == 32`). If that ever changed (a wider header, or a payload requiring stricter alignment), recordings would be **silently** corrupted — exactly the failure mode described.

## Change
- Add a compile-time `static_assert` to the generated C message struct (`msg_C.h.in`) that `offsetof({type}_C, payload) == sizeof(MsgHeader)`. Any future layout drift now fails the build with a clear message instead of silently mis-reading message data. The guard is C++-scoped (`#ifdef __cplusplus`), since the pointer-arithmetic consumers are C++.
- Add a C++-only compile-time `static_assert` to each generated `{type}_C` message header requiring `offsetof({type}_C, payload) == sizeof(MsgHeader)`. The C++ paths that read C messages, specifically `Recorder(void*)` and `ReadFunctor::subscribeToC`, derive the payload pointer by advancing one `MsgHeader` from the start of the C-message wrapper, so they require the payload to immediately follow the header with no padding. This guard documents and enforces that layout invariant: if a future `MsgHeader` change or stricter payload alignment inserts padding, the build fails clearly instead of allowing C-message recorders or C++ subscribers to silently read the wrong address.

## Verification (Linux)
- Full rebuild regenerates the guard into every `{type}_C.h`; the assertion holds for **all** message types (0 failures across the build).
- Negative test confirms the guard is effective: a deliberately over-aligned payload (forcing padding) fails compilation with the expected message.
- `offsetof(payload) == sizeof(MsgHeader) == 32` confirmed empirically.
- Messaging + `cModuleTemplate` unit suites pass (111 tests).