### PR TITLE
[#499] Include Eigen SWIG typemaps to fix module property leaks

### DIFF
--- a/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/_UnitTest/test_hingedJointArrayMotor.py
+++ b/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/_UnitTest/test_hingedJointArrayMotor.py
@@ -103,6 +103,14 @@ def test_hingedJointArrayMotor(nonActForces, maxTorque, numJoints, numSpacecraft
     Ptheta = 2.0 * np.sqrt(10.0) * np.eye(numJoints * numSpacecraft)
     module.setKtheta(Ktheta.flatten().tolist())
     module.setPtheta(Ptheta.flatten().tolist())
+
+    # Regression for the Eigen SWIG typemap leak (bsk-499/bsk-422): the getters
+    # return Eigen::MatrixXd by value, which leaked a raw pointer wrapper when the
+    # Eigen typemaps were not included. They should now round-trip as plain lists.
+    assert isinstance(module.getKtheta(), list)
+    assert isinstance(module.getPtheta(), list)
+    np.testing.assert_allclose(module.getKtheta(), Ktheta)
+    np.testing.assert_allclose(module.getPtheta(), Ptheta)
     if maxTorque:
         uMax = [0.03] * (numJoints * numSpacecraft)
         module.setUMax(uMax)

--- a/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.i
+++ b/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.i
@@ -36,6 +36,7 @@
 %include "swig_conly_data.i"
 
 %include "sys_model.i"
+%include "swig_eigen.i"
 %include "hingedJointArrayMotor.h"
 
 %include "architecture/msgPayloadDefCpp/MJSysMassMatrixMsgPayload.h"

--- a/src/fswAlgorithms/formationFlying/inertialCartFeedback/_UnitTest/test_inertialCartFeedback.py
+++ b/src/fswAlgorithms/formationFlying/inertialCartFeedback/_UnitTest/test_inertialCartFeedback.py
@@ -89,6 +89,15 @@ def test_inertialCartFeedback(useMu, nonNaturalMotion, accuracy):
          0.0, 6.0e-2, 0.0,
          0.0, 0.0, 7.0e-2]
     module.setP(P)
+
+    # Regression for the Eigen SWIG typemap leak (bsk-499/bsk-422): the getters
+    # return Eigen::Matrix3d by value, which leaked a raw pointer wrapper when the
+    # Eigen typemaps were not included. They should now round-trip as plain lists.
+    assert isinstance(module.getK(), list)
+    assert isinstance(module.getP(), list)
+    np.testing.assert_allclose(module.getK(), np.array(K).reshape((3, 3)))
+    np.testing.assert_allclose(module.getP(), np.array(P).reshape((3, 3)))
+
     unitTestSim.AddModelToTask(unitTaskName, module)
 
     deputyData = messaging.NavTransMsgPayload()

--- a/src/fswAlgorithms/formationFlying/inertialCartFeedback/inertialCartFeedback.i
+++ b/src/fswAlgorithms/formationFlying/inertialCartFeedback/inertialCartFeedback.i
@@ -35,6 +35,7 @@
 %template(DoubleVector) std::vector<double>;
 
 %include "sys_model.i"
+%include "swig_eigen.i"
 %include "inertialCartFeedback.h"
 
 %include "architecture/msgPayloadDefC/NavTransMsgPayload.h"


### PR DESCRIPTION
* **Tickets addressed:** #499, #422
* **Review:** By commit
* **Merge strategy:** Squash and merge

## Description

`inertialCartFeedback` and `hingedJointArrayMotor` expose Eigen-returning getters (`getK`/`getP`, `getKtheta`/`getPtheta`) whose `.i` files did not pull in `swig_eigen.i`. Without the typemaps, SWIG returned a raw Eigen pointer wrapper with no registered destructor, leaking on every access:

```
swig/python detected a memory leak of type 'Eigen::Matrix3d *', no destructor found.
```

This is the residual form of the leak described in #422/#499. The fix is a one-line `%include "swig_eigen.i"` in each of the two affected modules (matching the established pattern used by `dynParamManager.i`, `swig_common_model.i`, etc.), so the values now marshal by value into Python lists.

Scope note: I checked every module that exposes an `Eigen::` member without (transitively) including the typemaps. Most either already pull `swig_eigen.i` in through `swig_common_model.i`/`dynParamManager.i`, or expose Eigen only via private/nested members and methods (no Python surface). These two modules are the only ones with a genuine public leak surface.

## Verification

Built and tested on Linux (`make inertialCartFeedback hingedJointArrayMotor`):

- **Before:** `module.getK()` → `<Swig Object of type 'Eigen::Matrix3d *'>` and prints the leak warning above on collection.
- **After:** `module.getK()` / `module.getKtheta()` → plain Python `list`, no warning.
- Added list round-trip assertions to both modules' unit tests (`getK`/`getP` and `getKtheta`/`getPtheta`). Both suites pass (`20 passed`).

## Documentation

None invalidated. The getters now return Python lists, consistent with every other Eigen-marshalling module in the codebase.

## Future work

The Eigen typemap rewrite resolved the broad leak originally reported in #499; the SWIG typemaps themselves no longer leak. Two coverage gaps remain in `swig_eigen.i` but are not currently exposed publicly anywhere (so they do not leak today): `Eigen::Vector2d` is not wrapped at all, and `std::vector<Eigen::Vector3d>` members have no per-element marshalling. Worth tracking separately if a future module needs to expose either.
