### PR TITLE
perf: dedup DOF mass-matrix inverse in NDOF state effectors

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/perf-ndof-effector-inverse-dedup.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/perf-ndof-effector-inverse-dedup.rst
@@ -1,0 +1,1 @@
+- Improved the runtime performance of :ref:`spinningBodyNDOFStateEffector` and :ref:`linearTranslationNDOFStateEffector` by computing the degree-of-freedom mass-matrix inverse once per ``updateContributions`` call instead of three times. Results are numerically identical; the speedup grows with the number of degrees of freedom.

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -310,9 +310,10 @@ void LinearTranslationNDOFStateEffector::updateContributions(double integTime, B
     this->computeBRhoStar(BRhoStar);
     this->computeCRhoStar(CRhoStar, g_N);
 
-    this->ARho = MRho.inverse() * ARhoStar;
-    this->BRho = MRho.inverse() * BRhoStar;
-    this->CRho = MRho.inverse() * CRhoStar;
+    Eigen::MatrixXd MRhoInv = MRho.inverse();
+    this->ARho = MRhoInv * ARhoStar;
+    this->BRho = MRhoInv * BRhoStar;
+    this->CRho = MRhoInv * CRhoStar;
 
     this->computeBackSubContributions(backSubContr);
 }

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -358,9 +358,10 @@ void SpinningBodyNDOFStateEffector::updateContributions(double integTime,
     this->computeBThetaStar(BThetaStar);
     this->computeCThetaStar(CThetaStar, g_N);
 
-    this->ATheta = MTheta.inverse() * AThetaStar;
-    this->BTheta = MTheta.inverse() * BThetaStar;
-    this->CTheta = MTheta.inverse() * CThetaStar;
+    Eigen::MatrixXd MThetaInv = MTheta.inverse();
+    this->ATheta = MThetaInv * AThetaStar;
+    this->BTheta = MThetaInv * BThetaStar;
+    this->CTheta = MThetaInv * CThetaStar;
 
     this->computeBackSubMatrices(backSubContr);
     this->computeBackSubVectors(backSubContr);


### PR DESCRIPTION
* **Tickets addressed:** N/A (self-contained performance cleanup)
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
`spinningBodyNDOFStateEffector` and `linearTranslationNDOFStateEffector` each inverted the NxN degree-of-freedom mass matrix (`MTheta` / `MRho`) **three times** in consecutive statements inside `updateContributions`, which runs once per Runge-Kutta stage. For these dynamically-sized `Eigen::MatrixXd` matrices, `.inverse()` is an out-of-line, heap-allocating LU solve that the compiler cannot common-subexpression away, so the repeated calls were genuinely wasted work (2 redundant inversions + 2 redundant heap allocations per call).

The fix computes the inverse once into a local and reuses it for the three products. Single commit, one idea.

**Fixed-size effectors were deliberately left untouched.** I also profiled the hub (`Matrix3d`) and `spinningBodyTwoDOF` (`Matrix2d`) sites. At `-O3` the compiler already eliminates the redundancy for small fixed-size inverses (2x2 measured 1.00x; forcing materialization of the 3x3 measured *slower*), so changing them would add churn for no benefit. Only the dynamically-sized cases are a real win.

## Verification
- **Numerically identical:** a deterministic 20-DOF / 4000-step propagation produces final hub state (`r_BN_N`, `v_BN_N`, `sigma_BN`, `omega_BN_B`) matching the unpatched build to all 17 significant digits — expected, since one deterministic inverse replaces three identical ones.
- **Full dynamics suite:** `pytest src/simulation/dynamics/` → **690 passed, 21 skipped** (1 unrelated skip: a memory-leak test needs `psutil`, absent from the env). No tests added/rebaselined because the change is provably bit-identical; existing coverage is sufficient.
- **Performance:** the inversion itself is ~2.4x cheaper (isolated GCC -O3 microbenchmark); a 20-DOF whole-simulation run is ~4% faster wall-clock, scaling with the degree-of-freedom count.

## Documentation
Added a release-notes snippet (`bskReleaseNotesSnippets/perf-ndof-effector-inverse-dedup.rst`). No module documentation is invalidated — behavior is unchanged.

## Future work
The numerically-preferable idiom `M.lu().solve(X)` would avoid forming the explicit inverse entirely, but it changes rounding slightly and would need tolerance-based re-baselining; deliberately out of scope to keep this PR bit-for-bit safe.