### PR TITLE
Fix BSK module memory deallocation

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,11 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
+- BSK-1446: Several BSK modules deallocated output message objects created with C++ ``new`` by calling
+  ``free()``, and retained image buffers in :ref:`camera` and :ref:`vizInterface` were not released during
+  module destruction. This could cause invalid deallocation behavior or memory leaks when these modules were
+  destroyed. These cleanup paths now use C++ ``delete`` for the message objects and release the retained image
+  buffers. This is fixed in the current version.
 - BSK-2026-001, BSK-2026-002, BSK-2026-003, and related fixed-buffer string handling and format-string
   logging issues are fixed in the current version.
 - Additional build-helper command execution, temporary file cleanup, remote example download, and image buffer

--- a/docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst
@@ -1,0 +1,1 @@
+- Fixed several BSK modules to deallocate dynamically allocated output message objects with C++ ``delete``.

--- a/docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst
@@ -1,2 +1,3 @@
 - Fixed several BSK modules to deallocate dynamically allocated output message objects with C++ ``delete``.
 - Fixed the camera module to release its retained image output buffer on destruction.
+- Fixed the Vizard interface to release retained image output buffers on destruction.

--- a/docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst
@@ -1,1 +1,2 @@
 - Fixed several BSK modules to deallocate dynamically allocated output message objects with C++ ``delete``.
+- Fixed the camera module to release its retained image output buffer on destruction.

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -49,7 +49,7 @@ ThrusterDynamicEffector::ThrusterDynamicEffector()
 ThrusterDynamicEffector::~ThrusterDynamicEffector()
 {
     for (long unsigned int c=0; c<this->thrusterOutMsgs.size(); c++) {
-        free(this->thrusterOutMsgs.at(c));
+        delete this->thrusterOutMsgs.at(c);
     }
     return;
 }

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -62,7 +62,7 @@ ThrusterStateEffector::~ThrusterStateEffector()
 {
     // Free memory to avoid errors
     for (long unsigned int c=0; c<this->thrusterOutMsgs.size(); c++) {
-        free(this->thrusterOutMsgs.at(c));
+        delete this->thrusterOutMsgs.at(c);
     }
 
     this->effectorID = 1;    /* reset the panel ID*/

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -45,7 +45,7 @@ VSCMGStateEffector::VSCMGStateEffector()
 VSCMGStateEffector::~VSCMGStateEffector()
 {
     for (long unsigned int c=0; c<this->vscmgOutMsgs.size(); c++) {
-        free(this->vscmgOutMsgs.at(c));
+        delete this->vscmgOutMsgs.at(c);
     }
     return;
 }

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -80,8 +80,8 @@ uint64_t DualHingedRigidBodyStateEffector::effectorID = 1;
 DualHingedRigidBodyStateEffector::~DualHingedRigidBodyStateEffector()
 {
     for (int c=0; c<2; c++) {
-        free(this->dualHingedRigidBodyOutMsgs.at(c));
-        free(this->dualHingedRigidBodyConfigLogOutMsgs.at(c));
+        delete this->dualHingedRigidBodyOutMsgs.at(c);
+        delete this->dualHingedRigidBodyConfigLogOutMsgs.at(c);
     }
 
     this->effectorID = 1;    /* reset the panel ID*/

--- a/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
+++ b/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
@@ -28,7 +28,7 @@ EphemerisConverter::EphemerisConverter()
 EphemerisConverter::~EphemerisConverter()
 {
     for (long unsigned int c=0; c<this->ephemOutMsgs.size(); c++) {
-        free(this->ephemOutMsgs.at(c));
+        delete this->ephemOutMsgs.at(c);
     }
 }
 

--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -44,7 +44,13 @@ Camera::Camera()
 }
 
 /*! This is the destructor */
-Camera::~Camera() = default;
+Camera::~Camera()
+{
+    if (this->pointImageOut != nullptr) {
+        free(this->pointImageOut);
+        this->pointImageOut = nullptr;
+    }
+}
 
 /*! This method performs a complete reset of the module.  Local module variables that retain time varying states
  * between function calls are reset to their default values.

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -65,6 +65,11 @@ VizInterface::~VizInterface()
         delete this->opnavImageOutMsgs.at(c);
     }
 
+    for (size_t c=0; c<this->bskImagePtrs.size(); c++) {
+        free(this->bskImagePtrs.at(c));
+        this->bskImagePtrs.at(c) = NULL;
+    }
+
     return;
 }
 


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Fixes several C++ memory deallocation issues in BSK modules. Output message objects allocated with `new` are now released with `delete` instead of `free()`. The Camera and Vizard interface modules now also release retained image buffers during destruction.

A release-note snippet was added for the memory-management fixes.

## Verification
Validated with targeted tests:

- `git diff --check`
- `.venv/bin/pytest -q src/simulation/sensors/camera/_UnitTest/test_camera.py`
- `.venv/bin/pytest -q src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py`

No tests were added because the changes are destructor/deallocation fixes with no intended behavioral change.

## Documentation
Added release-note snippet:

- `docs/source/Support/bskReleaseNotesSnippets/message-deallocation-delete.rst`

No user-facing documentation was invalidated.

## Future work
A broader follow-up could replace some raw image/ZMQ byte-buffer ownership with RAII containers where compatible with the existing message payload and ZeroMQ APIs.