### PR TITLE
test: assert BSKLogger flushes WARNING-level output [#1444]

### DIFF
--- a/src/architecture/utilities/tests/test_bskLogging.py
+++ b/src/architecture/utilities/tests/test_bskLogging.py
@@ -27,3 +27,21 @@ def test_bsk_error_treats_python_message_as_text():
 
     with pytest.raises(bskLogging.BasiliskError, match="preformatted %s message"):
         bsk_logger.bskError("preformatted %s message")
+
+
+def test_warning_level_output_is_flushed(capfd):
+    """A ``BSK_WARNING`` must reach stdout at log time (issue #1444).
+
+    ``bskLog`` flushes warning-level (and higher) output, so it is observable to
+    ``capfd`` before the process exits. Without that flush the C runtime fully
+    buffers the line when stdout is not a TTY (pytest capture, pipes, redirection)
+    and it would be lost on a crash and invisible to this assertion. The log level
+    is set on the instance so the test does not depend on the global default level
+    left behind by other tests."""
+    bsk_logger = bskLogging.BSKLogger()
+    bsk_logger.setLogLevel(bskLogging.BSK_WARNING)
+
+    bsk_logger.bskLog(bskLogging.BSK_WARNING, "flush regression marker")
+
+    out, _ = capfd.readouterr()
+    assert "flush regression marker" in out


### PR DESCRIPTION
## Summary

Adds a direct regression test for the WARNING-level `fflush(stdout)` merged in PR #1440 (commit `[#1352] Flush warning-level BSKLogger output`). The test lives at its canonical home — the `bskLogging` unit tests — and asserts that a `BSK_WARNING` is observable to `capfd` at log time.

This is the regression-coverage half of the #1444 follow-up evaluation. The policy analysis (don't broaden flush to INFO/DEBUG; don't route to stderr) is written up in a comment on #1444.

## Why it's a real guard

`bskLog` writes WARNING+ to `stdout` via `printf` then flushes. When stdout is not a TTY (pytest capture, pipes, redirection), libc fully buffers; without the flush the line sits in the buffer past pytest's capture point. Verified on archon:

- **Unflushed build → test FAILS** (`capfd` captures `''`).
- **Flushed build → test PASSES.**

So the test genuinely guards the behavior. Previously the flush was only covered indirectly via `test_gravityNonRotatingWarning.py` and `test_numbaModel.py`.

The log level is set on the logger instance so the test does not depend on the global default level left by other tests (hermetic).

## Verification

- `test_warning_level_output_is_flushed` PASSES on a flushed build; FAILS on an unflushed build.
- Existing `test_bsk_error_treats_python_message_as_text` still passes.
- No source change — the `fflush` itself is already on `develop`.