### PR TITLE
fix: correct post-fit residual dimension in sunlineSEKF [#1353]

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -59,6 +59,11 @@ Version |release|
 - BSK-548: :ref:`simHelpers` ``timeStringToGregorianUTCMsg`` leaked the SWIG-allocated ``doubleArray``
   scratch buffer used to receive the ``str2et_c`` result (about 32 bytes per call). The buffer is now
   freed with ``delete_doubleArray``. This is fixed in the current version.
+- BSK-1353: :ref:`sunlineSEKF` and :ref:`okeefeEKF` computed the post-fit residual ``measMat * x`` using the
+  full ``SKF_N_STATES`` width rather than each filter's reduced state width, striding the measurement matrix
+  across the wrong row width and over-reading the state-error vector. This corrupted the reported post-fit
+  residuals during the convergence transient (the state and covariance estimates were unaffected). This is
+  fixed in the current version.
 
 
 Version 2.10.0 (April 2, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/1353-sunline-filter-postfit-dim.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1353-sunline-filter-postfit-dim.rst
@@ -1,0 +1,6 @@
+- Fixed the post-fit residual dimension in :ref:`sunlineSEKF` and :ref:`okeefeEKF`. The residual term
+  ``Hx = measMat * x`` used the full ``SKF_N_STATES`` width instead of the reduced state width each filter
+  actually carries (``EKF_N_STATES_SWITCH`` for the SEKF, ``SKF_N_STATES_HALF`` for okeefe), so the multiply
+  strode the measurement matrix across the wrong row width and over-read the state-error vector, corrupting
+  the reported ``postFitRes`` during the convergence transient. The state and covariance estimates were
+  unaffected (issue #1353).

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/test_okeefeEKF.py
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/_UnitTest/test_okeefeEKF.py
@@ -706,8 +706,16 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
     module.x = (np.array(stateTarget1) - np.array(stateGuess)).tolist()
     kfLog = module.logger("x", testProcessRate)
     unitTestSim.AddModelToTask(unitTaskName, kfLog)
+    # Log the internal measurement matrix, measurement vector, post-fit residuals,
+    # and observation count so the residual dimensioning can be checked (issue #1353).
+    measMatLog = module.logger("measMat", testProcessRate)
+    yMeasLog = module.logger("yMeas", testProcessRate)
+    postFitsLog = module.logger("postFits", testProcessRate)
+    numObsLog = module.logger("numObs", testProcessRate)
     dataLog = module.filtDataOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
+    for extraLog in (measMatLog, yMeasLog, postFitsLog, numObsLog):
+        unitTestSim.AddModelToTask(unitTaskName, extraLog)
 
     unitTestSim.InitializeSimulation()
 
@@ -771,6 +779,28 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
     stateLog = dataLog.state
     postFitLog = dataLog.postFitRes
     covarLog = dataLog.covar
+
+    # Post-fit residuals must equal yMeas - H @ x, with H the (numObs x NUMSTATES)
+    # measurement matrix (issue #1353). Recompute them independently from the module's
+    # own logged H, x, and yMeas. Using the wrong column count makes the residual
+    # multiply stride across the wrong row width and over-read x; the corruption is
+    # largest during the convergence transient and vanishes as x -> 0, so it is checked
+    # every step rather than only at the end.
+    measMatHist = np.array(measMatLog.measMat)
+    yMeasHist = np.array(yMeasLog.yMeas)
+    xHist = np.array(kfLog.x)
+    numObsHist = np.array(numObsLog.numObs)
+    postFitHist = np.array(postFitsLog.postFits)
+    for step in range(len(numObsHist)):
+        numObsStep = int(numObsHist[step])
+        if numObsStep <= 0:
+            continue
+        hMat = measMatHist[step].reshape(-1, NUMSTATES)[:numObsStep, :]
+        expectedRes = yMeasHist[step, :numObsStep] - hMat @ xHist[step]
+        if np.linalg.norm(postFitHist[step, :numObsStep] - expectedRes) > 1.0E-9:
+            testFailCount += 1
+            testMessages.append("Post-fit residual dimension mismatch (issue #1353)")
+            break
 
 
     if not AddMeasNoise:

--- a/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.c
+++ b/src/fswAlgorithms/attDetermination/okeefeEKF/okeefeEKF.c
@@ -144,8 +144,11 @@ void Update_okeefeEKF(okeefeEKFConfig *configData, uint64_t callTime,
         mCopy(configData->covarBar, SKF_N_STATES_HALF, SKF_N_STATES_HALF, configData->covar);
     }
 
-    /* Compute post fit residuals once that data has been processed */
-    mMultM(configData->measMat, (size_t) configData->numObs, SKF_N_STATES, configData->x, SKF_N_STATES, 1, Hx);
+    /* Compute post fit residuals once that data has been processed.
+       The okeefe filter carries SKF_N_STATES_HALF states, so the measurement matrix and
+       state-error vector are that wide; using SKF_N_STATES here strode mMultM across the
+       wrong row width and over-read x, corrupting postFits (issue #1353). */
+    mMultM(configData->measMat, (size_t) configData->numObs, SKF_N_STATES_HALF, configData->x, SKF_N_STATES_HALF, 1, Hx);
     mSubtract(configData->yMeas, (size_t) configData->numObs, 1, Hx, configData->postFits);
 
     /*! - Write the sunline estimate into the copy of the navigation message structure*/

--- a/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/test_SunLineSEKF.py
+++ b/src/fswAlgorithms/attDetermination/sunlineSEKF/_UnitTest/test_SunLineSEKF.py
@@ -853,9 +853,17 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
     module.x = (np.array(stateTarget1) - np.array(stateGuess)).tolist()
 
     kfLog = module.logger("x", testProcessRate)
+    # Log the internal measurement matrix, measurement vector, post-fit residuals,
+    # and observation count so the residual dimensioning can be checked (issue #1353).
+    measMatLog = module.logger("measMat", testProcessRate)
+    yMeasLog = module.logger("yMeas", testProcessRate)
+    postFitsLog = module.logger("postFits", testProcessRate)
+    numObsLog = module.logger("numObs", testProcessRate)
     dataLog = module.filtDataOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
     unitTestSim.AddModelToTask(unitTaskName, kfLog)
+    for extraLog in (measMatLog, yMeasLog, postFitsLog, numObsLog):
+        unitTestSim.AddModelToTask(unitTaskName, extraLog)
 
     unitTestSim.InitializeSimulation()
 
@@ -911,7 +919,27 @@ def StateUpdateSunLine(show_plots, SimHalfLength, AddMeasNoise, testVector1, tes
     postFitLog = addTimeColumn(dataLog.times(), dataLog.postFitRes)
     covarLog = addTimeColumn(dataLog.times(), dataLog.covar)
 
-
+    # Post-fit residuals must equal yMeas - H @ x, with H the (numObs x numStates)
+    # measurement matrix (issue #1353). Recompute them independently from the module's
+    # own logged H, x, and yMeas. Using the wrong column count makes the residual
+    # multiply stride across the wrong row width and over-read x; the corruption is
+    # largest during the convergence transient and vanishes as x -> 0, so it is checked
+    # every step rather than only at the end.
+    measMatHist = np.array(measMatLog.measMat)
+    yMeasHist = np.array(yMeasLog.yMeas)
+    xHist = np.array(kfLog.x)
+    numObsHist = np.array(numObsLog.numObs)
+    postFitHist = np.array(postFitsLog.postFits)
+    for step in range(len(numObsHist)):
+        numObsStep = int(numObsHist[step])
+        if numObsStep <= 0:
+            continue
+        hMat = measMatHist[step].reshape(-1, numStates)[:numObsStep, :]
+        expectedRes = yMeasHist[step, :numObsStep] - hMat @ xHist[step]
+        if np.linalg.norm(postFitHist[step, :numObsStep] - expectedRes) > 1.0E-9:
+            testFailCount += 1
+            testMessages.append("Post-fit residual dimension mismatch (issue #1353)")
+            break
 
     for i in range(numStates):
         if (abs(covarLog[-1, i * numStates + 1 + i] - covarLog[0, i * numStates + 1 + i] / 100.) > 1E-1):

--- a/src/fswAlgorithms/attDetermination/sunlineSEKF/sunlineSEKF.c
+++ b/src/fswAlgorithms/attDetermination/sunlineSEKF/sunlineSEKF.c
@@ -158,8 +158,11 @@ void Update_sunlineSEKF(sunlineSEKFConfig *configData, uint64_t callTime,
         mCopy(configData->covarBar, EKF_N_STATES_SWITCH, EKF_N_STATES_SWITCH, configData->covar);
     }
 
-    /* Compute post fit residuals once that data has been processed */
-    mMultM(configData->measMat, configData->numObs, SKF_N_STATES, configData->x, SKF_N_STATES, 1, Hx);
+    /* Compute post fit residuals once that data has been processed.
+       The SEKF carries EKF_N_STATES_SWITCH states, so the measurement matrix and
+       state-error vector are that wide; using SKF_N_STATES here strode mMultM across
+       the wrong row width and over-read x, corrupting postFits (issue #1353). */
+    mMultM(configData->measMat, configData->numObs, EKF_N_STATES_SWITCH, configData->x, EKF_N_STATES_SWITCH, 1, Hx);
     mSubtract(configData->yMeas, configData->numObs, 1, Hx, configData->postFits);
 
     /* Switch the rates back to omega_BN instead of oemga_SB */


### PR DESCRIPTION
Fixes the dimension mismatch flagged in #1353 (follow-up to #1350).

## The bug

`Update_sunlineSEKF` computes the post-fit residual term `Hx = measMat * x` with:

```c
mMultM(configData->measMat, configData->numObs, SKF_N_STATES, configData->x, SKF_N_STATES, 1, Hx);
```

`SKF_N_STATES` is **6** (the non-switch EKF state count). The switch filter carries **`EKF_N_STATES_SWITCH` = 5** states, and `measMat`/`x` are allocated at that width (`measMat[MAX_N_CSS_MEAS*EKF_N_STATES_SWITCH]`, `x[EKF_N_STATES_SWITCH]`). `mMultM` indexes row-major as `m[i*cols + k]`, so a column count of 6 against a physically 5-wide `measMat` strides across the wrong row boundary for every observation after the first, and reads `x[5]` — one past the 5-element state-error array, into the adjacent `xBar`.

Every other dimension in the module already uses `EKF_N_STATES_SWITCH`; this was the lone `SKF_N_STATES`. The 6-state sibling `sunlineEKF` uses `SKF_N_STATES` correctly throughout, which is the likely origin of the copy-paste.

## Impact

`Hx` feeds **only** `postFits = yMeas - Hx`, a diagnostic output (`filtDataOutMsg.postFitRes`). The state and covariance estimates are not affected, which is why the filter "produced no errors." The corruption is largest during the convergence transient and shrinks to zero as `x -> 0`, so it is invisible at steady state. Measured on a representative scenario: the reported post-fit residual deviated from the true `yMeas - H*x` by up to ~2.8 (vs a 3-sigma measurement bound of 0.003) during the transient.

## Fix

Use `EKF_N_STATES_SWITCH` for both the column width and the state-error length, matching the allocation and the rest of the module.

## Regression test

Added to the integrated test (`StateUpdateSunLine`, all 5 parametrized scenarios): recompute the post-fit residuals independently as `yMeas - H @ x` from the module's **own** logged measurement matrix, state error, and measurement vector, and assert they match the module's `postFitRes` to 1e-9 at every step. This is convergence-independent (it does not rely on the residuals being small), so it catches the transient corruption. Verified to **fail on the pre-fix build and pass after the fix**.