### PR TITLE
fix: free leaked SWIG array in timeStringToGregorianUTCMsg [#548]

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -56,6 +56,9 @@ Version |release|
   import these utilities. The few general-purpose helpers those utilities needed have been moved into a
   new :ref:`simHelpers` module, so user-facing code no longer depends on ``unitTestSupport`` (or ``pytest``)
   at all. This is fixed in the current version.
+- BSK-548: :ref:`simHelpers` ``timeStringToGregorianUTCMsg`` leaked the SWIG-allocated ``doubleArray``
+  scratch buffer used to receive the ``str2et_c`` result (about 32 bytes per call). The buffer is now
+  freed with ``delete_doubleArray``. This is fixed in the current version.
 
 
 Version 2.10.0 (April 2, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/548-simhelpers-doublearray-leak.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/548-simhelpers-doublearray-leak.rst
@@ -1,0 +1,3 @@
+- Fixed a memory leak in :ref:`simHelpers` ``timeStringToGregorianUTCMsg``. The SWIG-allocated scratch
+  ``doubleArray`` used to receive the ``str2et_c`` result was never released (about 32 bytes leaked per
+  call); it is now freed with ``delete_doubleArray`` once the value has been read (issue #548).

--- a/src/utilities/simHelpers.py
+++ b/src/utilities/simHelpers.py
@@ -115,6 +115,7 @@ def timeStringToGregorianUTCMsg(DateSpice, **kwargs):
     et = pyswice.new_doubleArray(1)
     pyswice.str2et_c(DateSpice, et)
     etEpoch = pyswice.doubleArray_getitem(et, 0)
+    pyswice.delete_doubleArray(et)  # free the SWIG-allocated array (leaked otherwise)
     ep1 = pyswice.et2utc_c(etEpoch, "C", 6, 255, "Yo")
     pyswice.unload_c(str(naif0012_path))
 


### PR DESCRIPTION
Partially addresses #548.

## Context

#548 reported `gravFactory.createSpiceInterface(epochInMsg=True)` getting ~100× slower over repeated calls, with time accumulating in `timeStringToGregorianUTCMsg`. The maintainer's comment suspected (a) a leaked `EpochMsg` and (b) leaked `new_doubleArray` calls.

I re-measured on current `develop` (the code has changed since the 2023 report — the old `.disown()` is now an explicit registry). Findings:

- **The timing symptom no longer reproduces.** `timeStringToGregorianUTCMsg` is flat at **~1.04 ms/call over 3000 calls** (trend slope ≈ 0). `str2et_c`/`et2utc_c` only read the leapseconds kernel, so they are independent of accumulated SPK/PCK kernels and of call count.
- **The dominant remaining leak is the EpochMsg retention**, not the doubleArray: with fresh-process isolation, the module-global `_msg_registry.append(epochMsg)` retains ~**712 bytes/call**. That registry keeps subscribed stand-alone messages alive and is squarely in the scope of the in-flight messaging keep-alive work (#676 / #1433), so this PR does **not** touch it.
- **The `new_doubleArray` leak is real and independently fixable:** ~**32 bytes/call** (200k isolated calls leak ~6 MB; 0 with the free).

## Change

Free the one-element SWIG array with `pyswice.delete_doubleArray(et)` once `etEpoch` has been read. `et2utc_c` uses the already-extracted `etEpoch`, not `et`, so the free is safe. Verified the function still returns the correct epoch and runs 50× without error.

This is the small, self-contained part of #548. The larger `_msg_registry` retention and the (now-resolved) timing concern are noted in a comment on the issue.