### PR TITLE
Fix plugin message subscriptions in generated bindings

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -24,6 +24,10 @@ Version |release|
   translational response to applied forces. :ref:`spacecraft` and :ref:`spacecraftSystem` now verify
   on reset that ``mHub`` is strictly positive and ``IHubPntBc_B`` is symmetric positive definite.
   This is fixed in the current version.
+- Plugin-generated custom messages using ``bsk_generate_messages(GENERATE_C_INTERFACE)`` could fail to subscribe
+  Python readers to C-interface output messages because generated bindings imported the built-in
+  ``Basilisk.architecture.messaging`` package. Generated bindings now resolve peer message classes from their own
+  module. This is fixed in the current version.
 - BSK-1446: Several BSK modules deallocated output message objects created with C++ ``new`` by calling
   ``free()``, and retained image buffers in :ref:`camera` and :ref:`vizInterface` were not released during
   module destruction. This could cause invalid deallocation behavior or memory leaks when these modules were

--- a/docs/source/Support/bskReleaseNotesSnippets/plugin-message-subscribe-imports.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/plugin-message-subscribe-imports.rst
@@ -1,0 +1,1 @@
+- Generated message bindings now resolve peer message classes from their own module, fixing custom plugin messages built with ``bsk_generate_messages(GENERATE_C_INTERFACE)`` outside ``Basilisk.architecture.messaging``.

--- a/src/architecture/messaging/CMakeLists.txt
+++ b/src/architecture/messaging/CMakeLists.txt
@@ -61,7 +61,9 @@ function(generate_messages searchDir generateCCode outEqualityHeaders)
       COMMAND ${Python3_EXECUTABLE} generateSWIGModules.py ${COMP_OUT_NAME} ${msgFile} ${TARGET_NAME} ${searchDir}
               ${generateCCode} ${MSG_META_OUTPUT} ${RECORDER_PROPERTY_ROLLBACK}
       DEPENDS ${msgFile} ${MSG_META_OUTPUT} ${EQUALITY_OUT_NAME}
-              msgAutoSource/generateSWIGModules.py msgAutoSource/msgInterfacePy.i.in
+              msgAutoSource/generateSWIGModules.py
+              msgAutoSource/msgInterfacePy.i.in
+              msgAutoSource/cMsgCInterfacePy.i.in
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/msgAutoSource/)
     set_property(SOURCE ${COMP_OUT_NAME} PROPERTY CPLUSPLUS ON)
 
@@ -91,6 +93,8 @@ function(generate_messages searchDir generateCCode outEqualityHeaders)
       SOURCES ${COMP_OUT_NAME} OUTFILE_DIR "${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging/"
               OUTPUT_DIR "${CMAKE_BINARY_DIR}/Basilisk/architecture/messaging/")
 
+    set_property(TARGET ${TARGET_NAME} APPEND PROPERTY SWIG_DEPENDS
+                 "${CMAKE_CURRENT_SOURCE_DIR}/newMessaging.ih")
     add_dependencies(${TARGET_NAME} swigtrick)
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "architecture/messaging/derivedCode")
     set_target_properties(${SWIG_MODULE_${TARGET_NAME}_REAL_NAME}

--- a/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
+++ b/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
@@ -15,15 +15,78 @@
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-"""Unit tests for ``generatePayloadEqualityHeader.py``."""
+"""Unit tests for message auto-source generators."""
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "msgAutoSource"))
+MSG_AUTO_SOURCE_DIR = Path(__file__).parent.parent / "msgAutoSource"
+NEW_MESSAGING_TEMPLATE = Path(__file__).parent.parent / "newMessaging.ih"
+
+sys.path.insert(0, str(MSG_AUTO_SOURCE_DIR))
 from generatePayloadEqualityHeader import generateEqualityHeader
+
+
+def _generate_swig_interface(tmp_path, generate_c_info):
+    """Generate a SWIG interface file for a simple test message payload."""
+
+    # The generator normally consumes metadata emitted by libclang.  This test
+    # only needs enough metadata to exercise the Python binding templates, so a
+    # single scalar field keeps the fixture small while still producing a valid
+    # payload extension block.
+    meta = {
+        "complete": True,
+        "size_bytes": 8,  # [byte]
+        "fields": [
+            {
+                "name": "value",
+                "kind": "primitive",
+                "ctype": "double",
+                "offset_bytes": 0,  # [byte]
+                "size_bytes": 8,  # [byte]
+            },
+        ],
+    }
+    meta_path = tmp_path / "CustomMsgPayload.json"
+    output_path = tmp_path / "CustomMsgPayload.i"
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    # Run the real generator instead of duplicating its formatting logic in the
+    # test.  The header path does not need to exist because generateSWIGModules.py
+    # only splices the path into the SWIG template.
+    subprocess.run(
+        [
+            sys.executable,
+            "generateSWIGModules.py",
+            str(output_path),
+            str(tmp_path / "CustomMsgPayload.h"),
+            "CustomMsgPayload",
+            str(tmp_path),
+            str(generate_c_info),
+            str(meta_path),
+            "0",
+        ],
+        cwd=MSG_AUTO_SOURCE_DIR,
+        check=True,
+    )
+
+    return output_path.read_text(encoding="utf-8")
+
+
+def test_generated_message_bindings_use_module_local_classes(tmp_path):
+    """Generated subscription helpers do not assume the Basilisk package path."""
+
+    generated = _generate_swig_interface(tmp_path, True)
+    new_messaging_template = NEW_MESSAGING_TEMPLATE.read_text(encoding="utf-8")
+
+    assert "from Basilisk.architecture.messaging.messageType" not in new_messaging_template
+    assert "if type(source) == messageType ## _C:" in new_messaging_template
+    assert "from Basilisk.architecture.messaging import {type}" not in generated
+    assert "elif type(source) == CustomMsg:" in generated
 
 
 def test_payload_equality_generates_fixed_array_comparison():

--- a/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
+++ b/src/architecture/messaging/_UnitTest/test_generateSWIGModules.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
+
+import pytest
 
 MSG_AUTO_SOURCE_DIR = Path(__file__).parent.parent / "msgAutoSource"
 NEW_MESSAGING_TEMPLATE = Path(__file__).parent.parent / "newMessaging.ih"
@@ -77,6 +80,43 @@ def _generate_swig_interface(tmp_path, generate_c_info):
     return output_path.read_text(encoding="utf-8")
 
 
+def _render_read_functor_namespace():
+    """Render the generated ``ReadFunctor`` Python helpers for execution."""
+
+    template = NEW_MESSAGING_TEMPLATE.read_text(encoding="utf-8")
+    start = template.index("            def subscribeTo(self, source):")
+    end = template.index("        %}", start)
+    read_functor_methods = template[start:end]
+    read_functor_methods = read_functor_methods.replace("messageType ## _C", "CustomMsg_C")
+    read_functor_methods = read_functor_methods.replace("messageTypePayload", "CustomMsgPayload")
+    read_functor_methods = read_functor_methods.replace("messageType", "CustomMsg")
+    read_functor_methods = textwrap.indent(textwrap.dedent(read_functor_methods).strip(), "    ")
+
+    namespace = {}
+    class_source = "\n".join([
+        "class CustomMsg:",
+        "    pass",
+        "",
+        "class OtherMsg:",
+        "    pass",
+        "",
+        "class CustomMsgReader:",
+        "    def __init__(self):",
+        "        self.subscribed_to = None",
+        "",
+        "    def __subscribe_to(self, source):",
+        "        self.subscribed_to = source",
+        "",
+        "    def __is_subscribed_to(self, source):",
+        "        return source is self.subscribed_to",
+        "",
+        read_functor_methods,
+    ])
+    exec(class_source, namespace)
+
+    return namespace
+
+
 def test_generated_message_bindings_use_module_local_classes(tmp_path):
     """Generated subscription helpers do not assume the Basilisk package path."""
 
@@ -87,6 +127,31 @@ def test_generated_message_bindings_use_module_local_classes(tmp_path):
     assert "if type(source) == messageType ## _C:" in new_messaging_template
     assert "from Basilisk.architecture.messaging import {type}" not in generated
     assert "elif type(source) == CustomMsg:" in generated
+
+
+def test_generated_read_functor_without_c_interface_uses_cpp_message(tmp_path):
+    """Generated helpers still work when no C-interface symbol exists."""
+
+    generated = _generate_swig_interface(tmp_path, False)
+
+    assert "cMsgCInterface/CustomMsg_C.h" not in generated
+    assert "%extend CustomMsg_C" not in generated
+    assert "CustomMsg_C" not in generated
+
+    namespace = _render_read_functor_namespace()
+    assert "CustomMsg_C" not in namespace
+
+    reader = namespace["CustomMsgReader"]()
+    source = namespace["CustomMsg"]()
+    reader.subscribeTo(source)
+
+    assert reader.subscribed_to is source
+    assert reader.isSubscribedTo(source) is True
+
+    other_source = namespace["OtherMsg"]()
+    assert reader.isSubscribedTo(other_source) == 0
+    with pytest.raises(Exception, match="tried to subscribe ReadFunctor<CustomMsgPayload>"):
+        reader.subscribeTo(other_source)
 
 
 def test_payload_equality_generates_fixed_array_comparison():

--- a/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
+++ b/src/architecture/messaging/msgAutoSource/cMsgCInterfacePy.i.in
@@ -15,7 +15,6 @@ typedef struct {type};
 
     def subscribeTo(self, source):
         """subscribe to another message source"""
-        from Basilisk.architecture.messaging import {type}
         if type(source) == type(self):
             {type}_C_subscribe(self, source)
         elif type(source) == {type}:
@@ -31,7 +30,6 @@ typedef struct {type};
 
     def isSubscribedTo(self, source):
         """check if self is subscribed to another message source"""
-        from Basilisk.architecture.messaging import {type}
         if type(source) == type(self):
             return ({type}_C_isSubscribedTo(self, source))
         elif type(source) == {type}:

--- a/src/architecture/messaging/newMessaging.ih
+++ b/src/architecture/messaging/newMessaging.ih
@@ -95,11 +95,10 @@ pprint.PrettyPrinter._dispatch[messageTypePayload.__repr__] = _pprint_ ## messag
                     return
 
                 try:
-                    from Basilisk.architecture.messaging.messageType ## Payload import messageType ## _C
                     if type(source) == messageType ## _C:
                         self.__subscribe_to_C(source)
                         return
-                except ImportError:
+                except NameError:
                     pass
 
                 raise Exception('tried to subscribe ReadFunctor<messageTypePayload> to output message type'
@@ -111,13 +110,10 @@ pprint.PrettyPrinter._dispatch[messageTypePayload.__repr__] = _pprint_ ## messag
                     return self.__is_subscribed_to(source)
 
                 try:
-                    from Basilisk.architecture.messaging.messageType ## Payload import messageType ## _C
-                except ImportError:
+                    if type(source) == messageType ## _C:
+                        return self.__is_subscribed_to_C(source)
                     return 0
-
-                if type(source) == messageType ## _C:
-                    return self.__is_subscribed_to_C(source)
-                else:
+                except NameError:
                     return 0
         %}
 };


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
The BSK-SDK issue https://github.com/AVSLab/bsk_sdk/issues/11 is resolved in this PR.

This PR fixes generated Python message bindings so they work when custom messages are generated into a plugin package rather than into `Basilisk.architecture.messaging`.

Previously, the generated `subscribeTo()` and `isSubscribedTo()` helpers hard-coded imports from `Basilisk.architecture.messaging`. That worked for built-in Basilisk messages, but failed for plugin-defined messages generated with `bsk_generate_messages(GENERATE_C_INTERFACE)` because their generated classes live under the plugin's own messaging package.

The fix removes those hard-coded package imports. Generated helpers now resolve peer message classes from their own generated module:
- `ReadFunctor` uses the module-local optional `_C` message class when present.
- The generated C-interface wrapper uses the module-local C++ message class directly.

Commits are organized for review:
1. Template fix for generated subscriptions.
2. Regression test for the generator output.
3. Release notes and known-issues documentation.

## Verification

Added a focused regression test in `src/architecture/messaging/_UnitTest/test_generateSWIGModules.py`. The test runs the real `generateSWIGModules.py` script with synthetic metadata and verifies that generated C-interface bindings no longer emit hard-coded `Basilisk.architecture.messaging` imports.

Validated with:

```bash
.venv/bin/pytest -q src/architecture/messaging/_UnitTest/test_generateSWIGModules.py