### PR TITLE
Add performance benchmarks and optimize state effector cross products

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_custom_target(benchmark_smoke_tests)
+
+add_subdirectory("utilities")

--- a/benchmarks/dynamics/benchmark_state_effectors.py
+++ b/benchmarks/dynamics/benchmark_state_effectors.py
@@ -1,0 +1,1042 @@
+#!/usr/bin/env python3
+#
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+r"""Benchmark selected Basilisk spacecraft dynamics effectors.
+
+This optional developer benchmark runs compact spacecraft simulations that isolate
+selected dynamics effectors.  Each trial builds a fresh
+``spacecraft.Spacecraft`` object, attaches the requested effector load, disables
+recorders and plotting, runs the default RK4 integration loop, and reports
+wall-clock timing.
+
+The benchmark is intended for local before/after comparisons while optimizing
+state effectors, dynamic effectors, or the spacecraft integration path.  It is not
+a numerical validation test and it is not run by CI.
+
+Running the Benchmark
+---------------------
+
+Run the benchmark from the Basilisk repository root directory after building the
+Basilisk Python package:
+
+.. code-block:: bash
+
+   cd /path/to/basilisk
+   .venv/bin/python benchmarks/dynamics/benchmark_state_effectors.py --case all
+
+Run a single case with a longer measurement:
+
+.. code-block:: bash
+
+   .venv/bin/python benchmarks/dynamics/benchmark_state_effectors.py \
+      --case SpinningBodyTwoDOFStateEffector --steps 10000 --trials 7
+
+Use ``--components`` to scale the number of repeated devices in cases that
+support repetition.  Use ``--segments`` to scale the per-effector body count in
+the NDOF translator and hinged-body cases:
+
+.. code-block:: bash
+
+   .venv/bin/python benchmarks/dynamics/benchmark_state_effectors.py \
+      --case LinearTranslationNDOFStateEffector --components 2 --segments 8
+
+Supported Cases
+---------------
+
+The ``--case`` option accepts either the canonical benchmark names or the
+corresponding effector class-style aliases:
+
+- ``spacecraft``
+- ``dual-hinged-rigid-body``
+- ``gravity-gradient``
+- ``hinged-rigid-body``
+- ``linear-spring-mass-damper``
+- ``linear-translation-ndof``
+- ``linear-translation-one-dof``
+- ``n-hinged-rigid-body``
+- ``prescribed-motion``
+- ``reaction-wheel``
+- ``spherical-pendulum``
+- ``spinning-body-ndof``
+- ``spinning-body-one-dof``
+- ``spinning-body-two-dof``
+- ``vscmg``
+
+Expected Terminal Output
+------------------------
+
+The exact timings will vary by machine.  An abridged representative all-case run
+looks like:
+
+.. code-block:: text
+
+   Dynamics effector benchmark
+   Cases: all
+   Steps per trial: 2000
+   Time step: 0.010000 s
+   Simulated time per trial: 20.000 s
+   Trials: 5
+   Warmup steps: 200
+   Components per case: 4
+   Segments per NDOF case: 4
+   Gravity: disabled except gravity-gradient case
+   Recorders: disabled
+   Spacecraft integrator: RK4 default
+
+   Case                                      median [s]   median us/step      min [s]    min us/step
+   spacecraft                                  0.012345            6.173     0.012120          6.060
+   hinged-rigid-body                           0.045678           22.839     0.045100         22.550
+
+Interpreting the Columns
+------------------------
+
+``median [s]``
+   Median wall-clock time across measured trials for one
+   ``ExecuteSimulation()`` call.
+
+``median us/step``
+   Median wall-clock microseconds per integration step.
+
+``min [s]``
+   Fastest measured trial wall-clock time.
+
+``min us/step``
+   Fastest measured trial wall-clock microseconds per integration step.
+"""
+
+import argparse
+from dataclasses import dataclass
+import math
+import os
+import statistics
+import tempfile
+import time
+from typing import Callable
+
+import numpy as np
+
+
+def _configure_headless_environment():
+    """Set plotting-related environment defaults before Basilisk imports."""
+
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    if "MPLCONFIGDIR" not in os.environ:
+        mplConfigDirectory = os.path.join(tempfile.gettempdir(), "basilisk-mplconfig")
+        os.makedirs(mplConfigDirectory, exist_ok=True)
+        os.environ["MPLCONFIGDIR"] = mplConfigDirectory
+
+
+_configure_headless_environment()
+
+from Basilisk.architecture import messaging
+from Basilisk.simulation import GravityGradientEffector
+from Basilisk.simulation import dualHingedRigidBodyStateEffector
+from Basilisk.simulation import gravityEffector
+from Basilisk.simulation import hingedRigidBodyStateEffector
+from Basilisk.simulation import linearSpringMassDamper
+from Basilisk.simulation import linearTranslationNDOFStateEffector
+from Basilisk.simulation import linearTranslationOneDOFStateEffector
+from Basilisk.simulation import nHingedRigidBodyStateEffector
+from Basilisk.simulation import prescribedMotionStateEffector
+from Basilisk.simulation import reactionWheelStateEffector
+from Basilisk.simulation import spacecraft
+from Basilisk.simulation import sphericalPendulum
+from Basilisk.simulation import spinningBodyNDOFStateEffector
+from Basilisk.simulation import spinningBodyOneDOFStateEffector
+from Basilisk.simulation import spinningBodyTwoDOFStateEffector
+from Basilisk.simulation import vscmgStateEffector
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import simIncludeRW
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Container for dynamics effector benchmark timing controls."""
+
+    selectedCases: tuple[str, ...]
+    numberOfSteps: int = 2000
+    numberOfTrials: int = 5
+    numberOfWarmupSteps: int = 200
+    timeStepSec: float = 0.01  # [s]
+    numberOfComponents: int = 4
+    numberOfSegments: int = 4
+
+
+@dataclass
+class BenchmarkContext:
+    """Simulation objects shared by one benchmark case setup."""
+
+    scSim: SimulationBaseClass.SimBaseClass
+    scObject: spacecraft.Spacecraft
+    taskName: str
+    config: BenchmarkConfig
+    keepAlive: list
+
+
+@dataclass(frozen=True)
+class CaseDefinition:
+    """One benchmark case description and setup callback."""
+
+    displayName: str
+    setupFunction: Callable[[BenchmarkContext], None]
+
+
+def _positive_int(value):
+    """Return ``value`` as a positive integer for ``argparse``."""
+
+    parsedValue = int(value)
+    if parsedValue < 1:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsedValue
+
+
+def _nonnegative_int(value):
+    """Return ``value`` as a nonnegative integer for ``argparse``."""
+
+    parsedValue = int(value)
+    if parsedValue < 0:
+        raise argparse.ArgumentTypeError("value must be nonnegative")
+    return parsedValue
+
+
+def _positive_float(value):
+    """Return ``value`` as a positive floating-point value for ``argparse``."""
+
+    parsedValue = float(value)
+    if parsedValue <= 0.0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsedValue
+
+
+def _column(vector):
+    """Return ``vector`` as a Basilisk column vector list."""
+
+    return [[value] for value in vector]
+
+
+def _unit_vector(vector):
+    """Return ``vector`` normalized as a Basilisk column vector list."""
+
+    norm = math.sqrt(sum(value * value for value in vector))
+    return [[value / norm] for value in vector]
+
+
+def _rotation_identity():
+    """Return a 3-by-3 identity direction cosine matrix."""
+
+    return [[1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0]]
+
+
+def _set_hub_properties(scObject, useOrbitState=False):
+    """Configure the spacecraft hub mass properties and initial state."""
+
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    scObject.hub.IHubPntBc_B = [
+        [900.0, 0.0, 0.0],
+        [0.0, 800.0, 0.0],
+        [0.0, 0.0, 600.0],
+    ]  # [kg*m^2]
+
+    if useOrbitState:
+        scObject.hub.r_CN_NInit = [[7000.0e3], [0.0], [0.0]]  # [m]
+        scObject.hub.v_CN_NInit = [[0.0], [7500.0], [100.0]]  # [m/s]
+    else:
+        scObject.hub.r_CN_NInit = [[0.1], [-0.2], [0.3]]  # [m]
+        scObject.hub.v_CN_NInit = [[0.02], [-0.01], [0.03]]  # [m/s]
+
+    scObject.hub.sigma_BNInit = [[0.01], [-0.02], [0.03]]
+    scObject.hub.omega_BN_BInit = [[0.08], [0.01], [-0.03]]  # [rad/s]
+
+
+def _add_task_model(context, model):
+    """Keep ``model`` alive and add it to the benchmark task."""
+
+    context.keepAlive.append(model)
+    context.scSim.AddModelToTask(context.taskName, model)
+
+
+def _add_state_effector(context, effector):
+    """Attach ``effector`` to the spacecraft and benchmark task."""
+
+    context.scObject.addStateEffector(effector)
+    _add_task_model(context, effector)
+
+
+def _add_dynamic_effector(context, effector):
+    """Attach ``effector`` to the spacecraft and benchmark task."""
+
+    context.scObject.addDynamicEffector(effector)
+    _add_task_model(context, effector)
+
+
+def _setup_spacecraft_only(context):
+    """Run the baseline spacecraft dynamics case without extra effectors."""
+
+
+def _setup_gravity_gradient(context):
+    """Attach gravity-gradient dynamic effectors."""
+
+    _set_hub_properties(context.scObject, useOrbitState=True)
+
+    earthGravBody = gravityEffector.GravBodyData()
+    earthGravBody.planetName = "earth_planet_data"
+    earthGravBody.mu = 0.3986004415e15  # [m^3/s^2]
+    earthGravBody.isCentralBody = True
+    context.keepAlive.append(earthGravBody)
+    context.scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        ggEffector = GravityGradientEffector.GravityGradientEffector()
+        ggEffector.ModelTag = f"gravityGradient{effectorIndex}"
+        ggEffector.addPlanetName(earthGravBody.planetName)
+        _add_dynamic_effector(context, ggEffector)
+
+
+def _make_dual_hinged_body(effectorIndex):
+    """Create one dual-hinged rigid-body state effector."""
+
+    sideSign = -1.0 if effectorIndex % 2 else 1.0
+    panel = dualHingedRigidBodyStateEffector.DualHingedRigidBodyStateEffector()
+    panel.ModelTag = f"dualHingedRigidBody{effectorIndex}"
+    panel.mass1 = 50.0  # [kg]
+    panel.IPntS1_S1 = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]  # [kg*m^2]
+    panel.d1 = 0.75  # [m]
+    panel.l1 = 1.5  # [m]
+    panel.k1 = 100.0  # [N*m/rad]
+    panel.c1 = 0.02  # [N*m*s/rad]
+    panel.r_H1B_B = [[sideSign * 0.5], [0.0], [1.0]]  # [m]
+    panel.dcm_H1B = [[sideSign, 0.0, 0.0], [0.0, sideSign, 0.0], [0.0, 0.0, 1.0]]
+    panel.mass2 = 50.0  # [kg]
+    panel.IPntS2_S2 = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]  # [kg*m^2]
+    panel.d2 = 0.75  # [m]
+    panel.k2 = 100.0  # [N*m/rad]
+    panel.c2 = 0.02  # [N*m*s/rad]
+    panel.theta1Init = sideSign * 5.0 * macros.D2R  # [rad]
+    panel.theta1DotInit = 0.02  # [rad/s]
+    panel.theta2Init = -sideSign * 3.0 * macros.D2R  # [rad]
+    panel.theta2DotInit = -0.01  # [rad/s]
+    return panel
+
+
+def _setup_dual_hinged_rigid_body(context):
+    """Attach repeated dual-hinged rigid-body state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        _add_state_effector(context, _make_dual_hinged_body(effectorIndex))
+
+
+def _make_hinged_body(effectorIndex):
+    """Create one hinged rigid-body state effector."""
+
+    sideSign = -1.0 if effectorIndex % 2 else 1.0
+    panel = hingedRigidBodyStateEffector.HingedRigidBodyStateEffector()
+    panel.ModelTag = f"hingedRigidBody{effectorIndex}"
+    panel.mass = 100.0  # [kg]
+    panel.IPntS_S = [[100.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]  # [kg*m^2]
+    panel.d = 1.5  # [m]
+    panel.k = 25.0  # [N*m/rad]
+    panel.c = 0.02  # [N*m*s/rad]
+    panel.r_HB_B = [[sideSign * 0.5], [0.0], [1.0]]  # [m]
+    panel.dcm_HB = [[sideSign, 0.0, 0.0], [0.0, sideSign, 0.0], [0.0, 0.0, 1.0]]
+    panel.thetaInit = sideSign * 4.0 * macros.D2R  # [rad]
+    panel.thetaDotInit = 0.02  # [rad/s]
+    return panel
+
+
+def _setup_hinged_rigid_body(context):
+    """Attach repeated hinged rigid-body state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        _add_state_effector(context, _make_hinged_body(effectorIndex))
+
+
+def _setup_linear_spring_mass_damper(context):
+    """Attach repeated linear spring mass damper state effectors."""
+
+    axes = (
+        _unit_vector((1.0, 1.0, 1.0)),
+        _unit_vector((1.0, -1.0, -1.0)),
+        _unit_vector((-1.0, -1.0, 1.0)),
+        _unit_vector((-1.0, 1.0, -1.0)),
+    )
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        sign = -1.0 if effectorIndex % 2 else 1.0
+        particle = linearSpringMassDamper.LinearSpringMassDamper()
+        particle.ModelTag = f"linearSpringMassDamper{effectorIndex}"
+        particle.k = 100.0  # [N/m]
+        particle.c = 0.5  # [N*s/m]
+        particle.r_PB_B = [[sign * 0.1], [0.05 * effectorIndex], [-sign * 0.1]]  # [m]
+        particle.pHat_B = axes[effectorIndex % len(axes)]
+        particle.rhoInit = sign * (0.02 + 0.005 * effectorIndex)  # [m]
+        particle.rhoDotInit = 0.01  # [m/s]
+        particle.massInit = 10.0 + effectorIndex  # [kg]
+        _add_state_effector(context, particle)
+
+
+def _make_translating_body_one_dof(effectorIndex):
+    """Create one linear translation one-DOF state effector."""
+
+    sign = -1.0 if effectorIndex % 2 else 1.0
+    translatingBody = linearTranslationOneDOFStateEffector.LinearTranslationOneDOFStateEffector()
+    translatingBody.ModelTag = f"linearTranslationOneDOF{effectorIndex}"
+    translatingBody.setMass(20.0 + effectorIndex)  # [kg]
+    translatingBody.setK(100.0)  # [N/m]
+    translatingBody.setC(0.5)  # [N*s/m]
+    translatingBody.setRhoInit(sign * 0.5)  # [m]
+    translatingBody.setRhoDotInit(0.05)  # [m/s]
+    translatingBody.setFHat_B(_unit_vector((3.0, 4.0, 0.0)))
+    translatingBody.setR_FcF_F([[-1.0], [1.0], [0.0]])  # [m]
+    translatingBody.setR_F0B_B([[sign * -1.0], [0.5 * effectorIndex], [0.3]])  # [m]
+    translatingBody.setIPntFc_F([[50.0, 0.0, 0.0],
+                                 [0.0, 80.0, 0.0],
+                                 [0.0, 0.0, 60.0]])  # [kg*m^2]
+    translatingBody.setDCM_FB([[0.0, -1.0, 0.0],
+                               [0.0, 0.0, -1.0],
+                               [1.0, 0.0, 0.0]])
+    return translatingBody
+
+
+def _setup_linear_translation_one_dof(context):
+    """Attach repeated linear translation one-DOF state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        _add_state_effector(context, _make_translating_body_one_dof(effectorIndex))
+
+
+def _make_ndof_translating_body(bodyIndex):
+    """Create one body for a linear translation NDOF state effector."""
+
+    sign = -1.0 if bodyIndex % 2 else 1.0
+    body = linearTranslationNDOFStateEffector.TranslatingBody()
+    body.setMass(8.0 + bodyIndex)  # [kg]
+    body.setIPntFc_F([[12.0 + bodyIndex, 0.0, 0.0],
+                      [0.0, 14.0 + bodyIndex, 0.0],
+                      [0.0, 0.0, 16.0 + bodyIndex]])  # [kg*m^2]
+    body.setDCM_FP(_rotation_identity())
+    body.setR_FcF_F([[0.05 * sign], [0.02 * bodyIndex], [0.03]])  # [m]
+    body.setR_F0P_P([[0.15 * sign], [0.04 * bodyIndex], [0.02]])  # [m]
+    body.setFHat_P(_unit_vector((3.0, 4.0, 0.0)) if bodyIndex % 3 else _column((0.0, 0.0, 1.0)))
+    body.setRhoInit(sign * (0.2 + 0.02 * bodyIndex))  # [m]
+    body.setRhoDotInit(0.02)  # [m/s]
+    body.setK(20.0 + bodyIndex)  # [N/m]
+    body.setC(0.2)  # [N*s/m]
+    return body
+
+
+def _setup_linear_translation_ndof(context):
+    """Attach linear translation NDOF state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        effector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
+        effector.ModelTag = f"linearTranslationNDOF{effectorIndex}"
+        for bodyIndex in range(context.config.numberOfSegments):
+            effector.addTranslatingBody(_make_ndof_translating_body(bodyIndex))
+        _add_state_effector(context, effector)
+
+
+def _make_hinged_panel(panelIndex):
+    """Create one panel for an N-hinged rigid-body state effector."""
+
+    sign = -1.0 if panelIndex % 2 else 1.0
+    panel = nHingedRigidBodyStateEffector.HingedPanel()
+    panel.mass = 50.0  # [kg]
+    panel.IPntS_S = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]  # [kg*m^2]
+    panel.d = 0.75  # [m]
+    panel.k = 100.0  # [N*m/rad]
+    panel.c = 0.02  # [N*m*s/rad]
+    panel.thetaInit = sign * (2.0 + panelIndex) * macros.D2R  # [rad]
+    panel.thetaDotInit = 0.01 * sign  # [rad/s]
+    panel.theta_0 = 0.0  # [rad]
+    return panel
+
+
+def _setup_n_hinged_rigid_body(context):
+    """Attach N-hinged rigid-body state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        sideSign = -1.0 if effectorIndex % 2 else 1.0
+        effector = nHingedRigidBodyStateEffector.NHingedRigidBodyStateEffector()
+        effector.ModelTag = f"nHingedRigidBody{effectorIndex}"
+        effector.r_HB_B = [[sideSign * 0.5], [0.0], [1.0]]  # [m]
+        effector.dcm_HB = [[sideSign, 0.0, 0.0], [0.0, sideSign, 0.0], [0.0, 0.0, 1.0]]
+        for panelIndex in range(context.config.numberOfSegments):
+            effector.addHingedPanel(_make_hinged_panel(panelIndex))
+        _add_state_effector(context, effector)
+
+
+def _setup_prescribed_motion(context):
+    """Attach prescribed-motion state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        sign = -1.0 if effectorIndex % 2 else 1.0
+        massKg = 50.0 + effectorIndex  # [kg]
+        prescribedBody = prescribedMotionStateEffector.PrescribedMotionStateEffector()
+        prescribedBody.ModelTag = f"prescribedMotion{effectorIndex}"
+        prescribedBody.setMass(massKg)
+        prescribedBody.setIPntPc_P([[5.0, 0.0, 0.0],
+                                    [0.0, 4.0, 0.0],
+                                    [0.0, 0.0, 3.0]])  # [kg*m^2]
+        prescribedBody.setR_MB_B([sign * 0.5, 0.0, 0.0])  # [m]
+        prescribedBody.setR_PcP_P([0.5, 0.0, 0.0])  # [m]
+        prescribedBody.setR_PM_M([0.0, 0.0, 0.0])  # [m]
+        prescribedBody.setRPrime_PM_M(np.array([0.01 * sign, 0.0, 0.0]))  # [m/s]
+        prescribedBody.setRPrimePrime_PM_M(np.array([0.001 * sign, 0.0, 0.0]))  # [m/s^2]
+        prescribedBody.setOmega_PM_P(np.array([0.0, 0.01 * sign, 0.0]))  # [rad/s]
+        prescribedBody.setOmegaPrime_PM_P(np.array([0.0, 0.001 * sign, 0.0]))  # [rad/s^2]
+        prescribedBody.setSigma_PM([0.001 * sign, 0.0, 0.0])
+        prescribedBody.setSigma_MB([0.0, 0.0, 0.0])
+        _add_state_effector(context, prescribedBody)
+
+
+def _setup_reaction_wheel(context):
+    """Attach a reaction wheel state effector with repeated wheels."""
+
+    axes = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0),
+            (1.0, 1.0, 0.0), (1.0, 0.0, 1.0), (0.0, 1.0, 1.0))
+    rwFactory = simIncludeRW.rwFactory()
+    maxMomentumNms = 100.0  # [N*m*s]
+
+    for wheelIndex in range(context.config.numberOfComponents):
+        axis = axes[wheelIndex % len(axes)]
+        rwFactory.create(
+            "Honeywell_HR16",
+            [value / math.sqrt(sum(component * component for component in axis)) for value in axis],
+            Omega=(500.0 - 75.0 * wheelIndex),  # [RPM]
+            rWB_B=[0.05 * wheelIndex, 0.02 * (wheelIndex % 2), 0.1],  # [m]
+            maxMomentum=maxMomentumNms,
+            RWModel=reactionWheelStateEffector.JitterFullyCoupled,
+        )
+
+    rwEffector = reactionWheelStateEffector.ReactionWheelStateEffector()
+    rwFactory.addToSpacecraft("reactionWheelBenchmark", rwEffector, context.scObject)
+
+    cmdArray = messaging.ArrayMotorTorqueMsgPayload()
+    cmdArray.motorTorque = [
+        0.01 * ((-1.0) ** wheelIndex) for wheelIndex in range(context.config.numberOfComponents)
+    ]  # [N*m]
+    cmdMsg = messaging.ArrayMotorTorqueMsg().write(cmdArray)
+    rwEffector.rwMotorCmdInMsg.subscribeTo(cmdMsg)
+    context.keepAlive.append(cmdMsg)
+    _add_task_model(context, rwEffector)
+
+
+def _setup_spherical_pendulum(context):
+    """Attach repeated spherical pendulum state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        sign = -1.0 if effectorIndex % 2 else 1.0
+        pendulum = sphericalPendulum.SphericalPendulum()
+        pendulum.ModelTag = f"sphericalPendulum{effectorIndex}"
+        pendulum.pendulumRadius = 0.3 + 0.02 * effectorIndex  # [m]
+        pendulum.d = [[0.1 * sign], [0.1], [0.1]]  # [m]
+        pendulum.D = [[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 0.1]]  # [N*s/m]
+        pendulum.phiDotInit = 0.01 * sign  # [rad/s]
+        pendulum.thetaDotInit = 0.05  # [rad/s]
+        pendulum.massInit = 20.0 + effectorIndex  # [kg]
+        pendulum.pHat_01 = _unit_vector((1.0, 0.0, 1.0))
+        pendulum.pHat_02 = [[0.0], [1.0], [0.0]]
+        pendulum.pHat_03 = _unit_vector((-1.0, 0.0, 1.0))
+        _add_state_effector(context, pendulum)
+
+
+def _make_spinning_body_ndof(bodyIndex):
+    """Create one body for a spinning body NDOF state effector."""
+
+    linkMassKg = 20.0  # [kg]
+    linkLengthM = 1.25  # [m]
+    linkRadiusM = 0.08  # [m]
+    linkCenterM = linkLengthM / 2.0  # [m]
+    jointStiffnessNmRad = 2.0  # [N*m/rad]
+    jointDampingNmSecRad = 0.05  # [N*m*s/rad]
+    initialThetaStepRad = 0.04  # [rad]
+    initialThetaDotStepRadSec = 0.01  # [rad/s]
+
+    if bodyIndex == 0:
+        parentOffsetM = 1.5  # [m]
+    else:
+        parentOffsetM = linkLengthM
+
+    transverseInertiaKgM2 = linkMassKg / 12.0 * (
+        3.0 * linkRadiusM**2 + linkLengthM**2
+    )  # [kg*m^2]
+    axialInertiaKgM2 = 0.5 * linkMassKg * linkRadiusM**2  # [kg*m^2]
+
+    sign = -1.0 if bodyIndex % 2 else 1.0
+    thetaInitRad = sign * (bodyIndex + 1) * initialThetaStepRad  # [rad]
+    thetaDotInitRadSec = sign * initialThetaDotStepRadSec  # [rad/s]
+
+    spinAxes = (
+        [[1.0], [0.0], [0.0]],
+        [[0.0], [0.0], [1.0]],
+        [[0.0], [1.0], [0.0]],
+    )
+
+    spinningBody = spinningBodyNDOFStateEffector.SpinningBody()
+    spinningBody.setMass(linkMassKg)
+    spinningBody.setISPntSc_S(
+        [
+            [transverseInertiaKgM2, 0.0, 0.0],
+            [0.0, axialInertiaKgM2, 0.0],
+            [0.0, 0.0, transverseInertiaKgM2],
+        ]
+    )  # [kg*m^2]
+    spinningBody.setDCM_S0P(_rotation_identity())
+    spinningBody.setR_ScS_S([[0.0], [linkCenterM], [0.0]])  # [m]
+    spinningBody.setR_SP_P([[0.0], [parentOffsetM], [0.0]])  # [m]
+    spinningBody.setSHat_S(spinAxes[bodyIndex % len(spinAxes)])
+    spinningBody.setThetaInit(thetaInitRad)
+    spinningBody.setThetaDotInit(thetaDotInitRadSec)
+    spinningBody.setK(jointStiffnessNmRad)
+    spinningBody.setC(jointDampingNmSecRad)
+
+    return spinningBody
+
+
+def _setup_spinning_body_ndof(context):
+    """Attach spinning body NDOF state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        effector = spinningBodyNDOFStateEffector.SpinningBodyNDOFStateEffector()
+        effector.ModelTag = f"spinningBodyNDOF{effectorIndex}"
+        for bodyIndex in range(context.config.numberOfSegments):
+            effector.addSpinningBody(_make_spinning_body_ndof(bodyIndex))
+        _add_state_effector(context, effector)
+
+
+def _make_spinning_body_one_dof(effectorIndex):
+    """Create one spinning body one-DOF state effector."""
+
+    sign = -1.0 if effectorIndex % 2 else 1.0
+    spinningBody = spinningBodyOneDOFStateEffector.SpinningBodyOneDOFStateEffector()
+    spinningBody.ModelTag = f"spinningBodyOneDOF{effectorIndex}"
+    spinningBody.mass = 50.0  # [kg]
+    spinningBody.IPntSc_S = [[50.0, 0.0, 0.0], [0.0, 30.0, 0.0], [0.0, 0.0, 40.0]]  # [kg*m^2]
+    spinningBody.dcm_S0B = [[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]]
+    spinningBody.r_ScS_S = [[1.0], [0.0], [-1.0]]  # [m]
+    spinningBody.r_SB_B = [[0.5 * sign], [-1.5], [-0.5]]  # [m]
+    spinningBody.sHat_S = [[0.0], [-1.0], [0.0]]
+    spinningBody.thetaInit = sign * 5.0 * macros.D2R  # [rad]
+    spinningBody.thetaDotInit = -sign * 1.0 * macros.D2R  # [rad/s]
+    spinningBody.k = 100.0  # [N*m/rad]
+    spinningBody.c = 0.2  # [N*m*s/rad]
+    return spinningBody
+
+
+def _setup_spinning_body_one_dof(context):
+    """Attach repeated spinning body one-DOF state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        _add_state_effector(context, _make_spinning_body_one_dof(effectorIndex))
+
+
+def _make_spinning_body_two_dof(effectorIndex):
+    """Create one spinning body two-DOF state effector."""
+
+    sign = -1.0 if effectorIndex % 2 else 1.0
+    spinningBody = spinningBodyTwoDOFStateEffector.SpinningBodyTwoDOFStateEffector()
+    spinningBody.ModelTag = f"spinningBodyTwoDOF{effectorIndex}"
+    spinningBody.mass1 = 100.0  # [kg]
+    spinningBody.mass2 = 50.0  # [kg]
+    spinningBody.IS1PntSc1_S1 = [[100.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]  # [kg*m^2]
+    spinningBody.IS2PntSc2_S2 = [[50.0, 0.0, 0.0], [0.0, 30.0, 0.0], [0.0, 0.0, 40.0]]  # [kg*m^2]
+    spinningBody.dcm_S10B = [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]]
+    spinningBody.dcm_S20S1 = [[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]]
+    spinningBody.r_Sc1S1_S1 = [[2.0], [-0.5], [0.0]]  # [m]
+    spinningBody.r_Sc2S2_S2 = [[1.0], [0.0], [-1.0]]  # [m]
+    spinningBody.r_S1B_B = [[-2.0 * sign], [0.5], [-1.0]]  # [m]
+    spinningBody.r_S2S1_S1 = [[0.5], [-1.5], [-0.5]]  # [m]
+    spinningBody.s1Hat_S1 = [[0.0], [0.0], [1.0]]
+    spinningBody.s2Hat_S2 = [[0.0], [-1.0], [0.0]]
+    spinningBody.theta1Init = sign * 2.0 * macros.D2R  # [rad]
+    spinningBody.theta2Init = sign * 5.0 * macros.D2R  # [rad]
+    spinningBody.theta1DotInit = 2.0 * macros.D2R  # [rad/s]
+    spinningBody.theta2DotInit = -1.0 * macros.D2R  # [rad/s]
+    spinningBody.k1 = 1000.0  # [N*m/rad]
+    spinningBody.k2 = 500.0  # [N*m/rad]
+    spinningBody.c1 = 0.2  # [N*m*s/rad]
+    spinningBody.c2 = 0.1  # [N*m*s/rad]
+    return spinningBody
+
+
+def _setup_spinning_body_two_dof(context):
+    """Attach repeated spinning body two-DOF state effectors."""
+
+    for effectorIndex in range(context.config.numberOfComponents):
+        _add_state_effector(context, _make_spinning_body_two_dof(effectorIndex))
+
+
+def _default_vscmg_payload():
+    """Create a VSCMG configuration payload with common defaults."""
+
+    vscmgConfig = messaging.VSCMGConfigMsgPayload()
+    vscmgConfig.rGB_B = [[0.0], [0.0], [0.0]]  # [m]
+    vscmgConfig.gsHat0_B = [[1.0], [0.0], [0.0]]
+    vscmgConfig.gtHat0_B = [[0.0], [1.0], [0.0]]
+    vscmgConfig.ggHat_B = [[0.0], [0.0], [1.0]]
+    vscmgConfig.u_s_max = -1.0  # [N*m]
+    vscmgConfig.u_s_min = -1.0  # [N*m]
+    vscmgConfig.u_s_f = 0.0  # [N*m]
+    vscmgConfig.wheelLinearFrictionRatio = -1.0
+    vscmgConfig.u_g_current = 0.0  # [N*m]
+    vscmgConfig.u_g_max = -1.0  # [N*m]
+    vscmgConfig.u_g_min = -1.0  # [N*m]
+    vscmgConfig.u_g_f = 0.0  # [N*m]
+    vscmgConfig.gimbalLinearFrictionRatio = -1.0
+    vscmgConfig.Omega = 0.0  # [rad/s]
+    vscmgConfig.gamma = 0.0  # [rad]
+    vscmgConfig.gammaDot = 0.0  # [rad/s]
+    vscmgConfig.Omega_max = 6000.0 * macros.RPM  # [rad/s]
+    vscmgConfig.gammaDot_max = -1.0  # [rad/s]
+    vscmgConfig.IW1 = 100.0 / vscmgConfig.Omega_max  # [kg*m^2]
+    vscmgConfig.IW2 = 0.5 * vscmgConfig.IW1  # [kg*m^2]
+    vscmgConfig.IW3 = 0.5 * vscmgConfig.IW1  # [kg*m^2]
+    vscmgConfig.IG1 = 0.1  # [kg*m^2]
+    vscmgConfig.IG2 = 0.2  # [kg*m^2]
+    vscmgConfig.IG3 = 0.3  # [kg*m^2]
+    vscmgConfig.U_s = 4.8e-06 * 1.0e4  # [kg*m]
+    vscmgConfig.U_d = 1.54e-06 * 1.0e4  # [kg*m]
+    vscmgConfig.l = 0.01  # [m]
+    vscmgConfig.L = 0.1  # [m]
+    vscmgConfig.rGcG_G = [[0.0001], [-0.02], [0.1]]  # [m]
+    vscmgConfig.massW = 6.0  # [kg]
+    vscmgConfig.massG = 6.0  # [kg]
+    vscmgConfig.VSCMGModel = 2
+    return vscmgConfig
+
+
+def _setup_vscmg(context):
+    """Attach a VSCMG state effector with repeated VSCMG devices."""
+
+    vscmgEffector = vscmgStateEffector.VSCMGStateEffector()
+    vscmgEffector.ModelTag = "vscmgBenchmark"
+    axes = (
+        ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
+        ((0.0, 1.0, 0.0), (0.7071067812, 0.0, -0.7071067812), (0.7071067812, 0.0, 0.7071067812)),
+        ((0.0, -1.0, 0.0), (-0.7071067812, 0.0, -0.7071067812), (-0.7071067812, 0.0, 0.7071067812)),
+    )
+
+    for vscmgIndex in range(context.config.numberOfComponents):
+        vscmgConfig = _default_vscmg_payload()
+        gsHat, gtHat, ggHat = axes[vscmgIndex % len(axes)]
+        vscmgConfig.gsHat0_B = _column(gsHat)
+        vscmgConfig.gtHat0_B = _column(gtHat)
+        vscmgConfig.ggHat_B = _column(ggHat)
+        vscmgConfig.Omega = (2000.0 - 150.0 * vscmgIndex) * macros.RPM  # [rad/s]
+        vscmgConfig.gamma = 0.01 * vscmgIndex  # [rad]
+        vscmgConfig.gammaDot = 0.005 * ((-1.0) ** vscmgIndex)  # [rad/s]
+        vscmgConfig.rGB_B = [[0.05 * vscmgIndex], [0.02 * (vscmgIndex % 2)], [-0.02]]  # [m]
+        vscmgEffector.AddVSCMG(vscmgConfig)
+
+    context.scObject.addStateEffector(vscmgEffector)
+
+    cmdArray = messaging.VSCMGArrayTorqueMsgPayload()
+    cmdArray.wheelTorque = [0.001 * ((-1.0) ** index) for index in range(context.config.numberOfComponents)]  # [N*m]
+    cmdArray.gimbalTorque = [
+        0.002 * ((-1.0) ** (index + 1)) for index in range(context.config.numberOfComponents)
+    ]  # [N*m]
+    cmdMsg = messaging.VSCMGArrayTorqueMsg().write(cmdArray)
+    vscmgEffector.cmdsInMsg.subscribeTo(cmdMsg)
+    context.keepAlive.append(cmdMsg)
+    _add_task_model(context, vscmgEffector)
+
+
+CASE_DEFINITIONS = {
+    "spacecraft": CaseDefinition("spacecraft", _setup_spacecraft_only),
+    "dual-hinged-rigid-body": CaseDefinition("dual-hinged-rigid-body", _setup_dual_hinged_rigid_body),
+    "gravity-gradient": CaseDefinition("gravity-gradient", _setup_gravity_gradient),
+    "hinged-rigid-body": CaseDefinition("hinged-rigid-body", _setup_hinged_rigid_body),
+    "linear-spring-mass-damper": CaseDefinition("linear-spring-mass-damper", _setup_linear_spring_mass_damper),
+    "linear-translation-ndof": CaseDefinition("linear-translation-ndof", _setup_linear_translation_ndof),
+    "linear-translation-one-dof": CaseDefinition("linear-translation-one-dof", _setup_linear_translation_one_dof),
+    "n-hinged-rigid-body": CaseDefinition("n-hinged-rigid-body", _setup_n_hinged_rigid_body),
+    "prescribed-motion": CaseDefinition("prescribed-motion", _setup_prescribed_motion),
+    "reaction-wheel": CaseDefinition("reaction-wheel", _setup_reaction_wheel),
+    "spherical-pendulum": CaseDefinition("spherical-pendulum", _setup_spherical_pendulum),
+    "spinning-body-ndof": CaseDefinition("spinning-body-ndof", _setup_spinning_body_ndof),
+    "spinning-body-one-dof": CaseDefinition("spinning-body-one-dof", _setup_spinning_body_one_dof),
+    "spinning-body-two-dof": CaseDefinition("spinning-body-two-dof", _setup_spinning_body_two_dof),
+    "vscmg": CaseDefinition("vscmg", _setup_vscmg),
+}
+
+
+CASE_ALIASES = {
+    "dualhingedrigidbody": "dual-hinged-rigid-body",
+    "dualhingedrigidbodystateeffector": "dual-hinged-rigid-body",
+    "gravitygradienteffector": "gravity-gradient",
+    "hingedrigidbodyeffector": "hinged-rigid-body",
+    "hingedrigidbodystateeffector": "hinged-rigid-body",
+    "linearspringmassdampereffector": "linear-spring-mass-damper",
+    "linearspringmassdamper": "linear-spring-mass-damper",
+    "lineartranslationndofstateeffector": "linear-translation-ndof",
+    "lineartranslationonedofstateeffector": "linear-translation-one-dof",
+    "nhingedrigidbodystateeffector": "n-hinged-rigid-body",
+    "prescribedmotionstateeffector": "prescribed-motion",
+    "reactionwheelstateeffector": "reaction-wheel",
+    "sphericalpendulum": "spherical-pendulum",
+    "spinningbodyndofstateeffector": "spinning-body-ndof",
+    "spinningbodyonedofstateeffector": "spinning-body-one-dof",
+    "spinningbodytwodofstateeffector": "spinning-body-two-dof",
+    "vscmgstateeffector": "vscmg",
+}
+
+
+def _case_key(caseName):
+    """Return a punctuation-insensitive lookup key for ``caseName``."""
+
+    return "".join(character for character in caseName.lower() if character.isalnum())
+
+
+def _canonical_case_name(caseName):
+    """Map a user-supplied case name to a benchmark case key."""
+
+    if caseName.lower() == "all":
+        return "all"
+
+    normalized = _case_key(caseName)
+    for canonicalName in CASE_DEFINITIONS:
+        if normalized == _case_key(canonicalName):
+            return canonicalName
+
+    if normalized in CASE_ALIASES:
+        return CASE_ALIASES[normalized]
+
+    validCases = ", ".join(["all"] + sorted(CASE_DEFINITIONS))
+    raise argparse.ArgumentTypeError(f"unknown case '{caseName}'. Valid cases: {validCases}")
+
+
+def _parse_args():
+    """Parse command-line options for the benchmark."""
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark selected Basilisk spacecraft dynamics effectors."
+    )
+    parser.add_argument(
+        "--case",
+        type=_canonical_case_name,
+        nargs="+",
+        default=("all",),
+        help="case name, exact effector class alias, or 'all'",
+    )
+    parser.add_argument(
+        "--list-cases",
+        action="store_true",
+        help="list available canonical case names and exit",
+    )
+    parser.add_argument(
+        "--steps",
+        type=_positive_int,
+        default=BenchmarkConfig(("all",)).numberOfSteps,
+        help="integration steps per measured trial",
+    )
+    parser.add_argument(
+        "--trials",
+        type=_positive_int,
+        default=BenchmarkConfig(("all",)).numberOfTrials,
+        help="number of measured trials",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=_nonnegative_int,
+        default=BenchmarkConfig(("all",)).numberOfWarmupSteps,
+        help="integration steps in the unreported warmup run",
+    )
+    parser.add_argument(
+        "--dt",
+        type=_positive_float,
+        default=BenchmarkConfig(("all",)).timeStepSec,
+        help="simulation time step in seconds",
+    )
+    parser.add_argument(
+        "--components",
+        type=_positive_int,
+        default=BenchmarkConfig(("all",)).numberOfComponents,
+        help="number of repeated devices or effectors in each benchmark case",
+    )
+    parser.add_argument(
+        "--segments",
+        type=_positive_int,
+        default=BenchmarkConfig(("all",)).numberOfSegments,
+        help="number of per-effector bodies in NDOF benchmark cases",
+    )
+
+    args = parser.parse_args()
+    if args.list_cases:
+        print("Available benchmark cases:")
+        for caseName in sorted(CASE_DEFINITIONS):
+            print(f"  {caseName}")
+        raise SystemExit(0)
+
+    selectedCases = tuple(args.case)
+    if "all" in selectedCases:
+        selectedCases = tuple(CASE_DEFINITIONS)
+
+    return BenchmarkConfig(
+        selectedCases=selectedCases,
+        numberOfSteps=args.steps,
+        numberOfTrials=args.trials,
+        numberOfWarmupSteps=args.warmup_steps,
+        timeStepSec=args.dt,
+        numberOfComponents=args.components,
+        numberOfSegments=args.segments,
+    )
+
+
+def _create_simulation(caseName, config):
+    """Build and initialize one benchmark simulation."""
+
+    processName = "dynamicsProcess"
+    taskName = "dynamicsTask"
+    processRateNs = macros.sec2nano(config.timeStepSec)  # [ns]
+
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess(processName)
+    dynProcess.addTask(scSim.CreateNewTask(taskName, processRateNs))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "dynamicsEffectorBenchmarkSpacecraft"
+    _set_hub_properties(scObject)
+    scSim.AddModelToTask(taskName, scObject)
+
+    context = BenchmarkContext(
+        scSim=scSim,
+        scObject=scObject,
+        taskName=taskName,
+        config=config,
+        keepAlive=[],
+    )
+    CASE_DEFINITIONS[caseName].setupFunction(context)
+    scSim.benchmarkKeepAlive = context.keepAlive
+    return scSim
+
+
+def _run_trial(caseName, config, numberOfSteps):
+    """Run one initialized benchmark simulation and return wall time."""
+
+    stopTimeSec = numberOfSteps * config.timeStepSec  # [s]
+    stopTimeNs = macros.sec2nano(stopTimeSec)  # [ns]
+
+    scSim = _create_simulation(caseName, config)
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(stopTimeNs)
+
+    startTimeSec = time.perf_counter()  # [s]
+    scSim.ExecuteSimulation()
+    elapsedTimeSec = time.perf_counter() - startTimeSec  # [s]
+
+    return elapsedTimeSec
+
+
+def _trial_metrics(elapsedTimeSec, numberOfSteps):
+    """Compute display metrics from one elapsed wall time."""
+
+    microsecondsPerStep = elapsedTimeSec * 1.0e6 / numberOfSteps  # [us/step]
+    return microsecondsPerStep
+
+
+def _print_header(config):
+    """Print the benchmark setup."""
+
+    stopTimeSec = config.numberOfSteps * config.timeStepSec  # [s]
+    requestedCases = "all" if len(config.selectedCases) == len(CASE_DEFINITIONS) else ", ".join(config.selectedCases)
+    print("Dynamics effector benchmark")
+    print(f"Cases: {requestedCases}")
+    print(f"Steps per trial: {config.numberOfSteps}")
+    print(f"Time step: {config.timeStepSec:.6f} s")
+    print(f"Simulated time per trial: {stopTimeSec:.3f} s")
+    print(f"Trials: {config.numberOfTrials}")
+    print(f"Warmup steps: {config.numberOfWarmupSteps}")
+    print(f"Components per case: {config.numberOfComponents}")
+    print(f"Segments per NDOF case: {config.numberOfSegments}")
+    print("Gravity: disabled except gravity-gradient case")
+    print("Recorders: disabled")
+    print("Spacecraft integrator: RK4 default")
+
+
+def _print_trial_row(label, elapsedTimeSec, numberOfSteps):
+    """Print one single-case trial row."""
+
+    microsecondsPerStep = _trial_metrics(elapsedTimeSec, numberOfSteps)
+    print(f"{label:<9}{elapsedTimeSec:12.6f}{microsecondsPerStep:17.3f}")
+
+
+def _print_summary_row(caseName, elapsedTimesSec, numberOfSteps):
+    """Print one all-case summary row."""
+
+    medianElapsedTimeSec = statistics.median(elapsedTimesSec)  # [s]
+    minElapsedTimeSec = min(elapsedTimesSec)  # [s]
+    medianMicrosecondsPerStep = _trial_metrics(medianElapsedTimeSec, numberOfSteps)  # [us/step]
+    minMicrosecondsPerStep = _trial_metrics(minElapsedTimeSec, numberOfSteps)  # [us/step]
+    print(
+        f"{caseName:<40}{medianElapsedTimeSec:12.6f}"
+        f"{medianMicrosecondsPerStep:17.3f}"
+        f"{minElapsedTimeSec:12.6f}"
+        f"{minMicrosecondsPerStep:15.3f}"
+    )
+
+
+def _run_case(caseName, config, showTrials):
+    """Run warmup and measured trials for ``caseName``."""
+
+    if config.numberOfWarmupSteps > 0:
+        _run_trial(caseName, config, config.numberOfWarmupSteps)
+
+    if showTrials:
+        print()
+        print(CASE_DEFINITIONS[caseName].displayName)
+        print("Trial          Wall [s]     us/step")
+
+    elapsedTimesSec = []  # [s]
+    for trialIndex in range(config.numberOfTrials):
+        elapsedTimeSec = _run_trial(caseName, config, config.numberOfSteps)  # [s]
+        elapsedTimesSec.append(elapsedTimeSec)
+        if showTrials:
+            _print_trial_row(str(trialIndex + 1), elapsedTimeSec, config.numberOfSteps)
+
+    if showTrials:
+        print()
+        _print_trial_row("median", statistics.median(elapsedTimesSec), config.numberOfSteps)
+        _print_trial_row("min", min(elapsedTimesSec), config.numberOfSteps)
+
+    return elapsedTimesSec
+
+
+def main():
+    """Run the dynamics effector benchmark."""
+
+    config = _parse_args()
+    showTrials = len(config.selectedCases) == 1
+    _print_header(config)
+
+    if not showTrials:
+        print()
+        print("Case                                      median [s]   median us/step      min [s]    min us/step")
+
+    for caseName in config.selectedCases:
+        elapsedTimesSec = _run_case(caseName, config, showTrials)
+        if not showTrials:
+            _print_summary_row(CASE_DEFINITIONS[caseName].displayName, elapsedTimesSec, config.numberOfSteps)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dynamics/benchmark_state_effectors.py
+++ b/benchmarks/dynamics/benchmark_state_effectors.py
@@ -63,6 +63,9 @@ The ``--case`` option accepts either the canonical benchmark names or the
 corresponding effector class-style aliases:
 
 - ``spacecraft``
+- ``spacecraft-point-mass``
+- ``spacecraft-orbit``
+- ``spacecraft-point-mass-orbit``
 - ``dual-hinged-rigid-body``
 - ``gravity-gradient``
 - ``hinged-rigid-body``
@@ -95,7 +98,7 @@ looks like:
    Warmup steps: 200
    Components per case: 4
    Segments per NDOF case: 4
-   Gravity: disabled except gravity-gradient case
+   Gravity: disabled except orbit and gravity-gradient cases
    Recorders: disabled
    Spacecraft integrator: RK4 default
 
@@ -147,7 +150,6 @@ _configure_headless_environment()
 from Basilisk.architecture import messaging
 from Basilisk.simulation import GravityGradientEffector
 from Basilisk.simulation import dualHingedRigidBodyStateEffector
-from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import hingedRigidBodyStateEffector
 from Basilisk.simulation import linearSpringMassDamper
 from Basilisk.simulation import linearTranslationNDOFStateEffector
@@ -163,6 +165,7 @@ from Basilisk.simulation import spinningBodyTwoDOFStateEffector
 from Basilisk.simulation import vscmgStateEffector
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
+from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import simIncludeRW
 
 
@@ -293,17 +296,43 @@ def _setup_spacecraft_only(context):
     """Run the baseline spacecraft dynamics case without extra effectors."""
 
 
+def _setup_spacecraft_point_mass(context):
+    """Run the translation-only point-mass spacecraft dynamics case."""
+
+    context.scObject.pointMassTranslationalOnly = True
+
+
+def _add_central_earth_gravity(context):
+    """Attach central-body Earth point-mass gravity."""
+
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    earth = gravFactory.createEarth()
+    earth.isCentralBody = True
+    context.keepAlive.extend([gravFactory, earth])
+    context.scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))
+    return earth
+
+
+def _setup_spacecraft_orbit(context):
+    """Run the baseline spacecraft dynamics case with central gravity."""
+
+    _set_hub_properties(context.scObject, useOrbitState=True)
+    _add_central_earth_gravity(context)
+
+
+def _setup_spacecraft_point_mass_orbit(context):
+    """Run the translation-only point-mass spacecraft dynamics case with central gravity."""
+
+    context.scObject.pointMassTranslationalOnly = True
+    _set_hub_properties(context.scObject, useOrbitState=True)
+    _add_central_earth_gravity(context)
+
+
 def _setup_gravity_gradient(context):
     """Attach gravity-gradient dynamic effectors."""
 
     _set_hub_properties(context.scObject, useOrbitState=True)
-
-    earthGravBody = gravityEffector.GravBodyData()
-    earthGravBody.planetName = "earth_planet_data"
-    earthGravBody.mu = 0.3986004415e15  # [m^3/s^2]
-    earthGravBody.isCentralBody = True
-    context.keepAlive.append(earthGravBody)
-    context.scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+    earthGravBody = _add_central_earth_gravity(context)
 
     for effectorIndex in range(context.config.numberOfComponents):
         ggEffector = GravityGradientEffector.GravityGradientEffector()
@@ -763,6 +792,11 @@ def _setup_vscmg(context):
 
 CASE_DEFINITIONS = {
     "spacecraft": CaseDefinition("spacecraft", _setup_spacecraft_only),
+    "spacecraft-point-mass": CaseDefinition("spacecraft-point-mass", _setup_spacecraft_point_mass),
+    "spacecraft-orbit": CaseDefinition("spacecraft-orbit", _setup_spacecraft_orbit),
+    "spacecraft-point-mass-orbit": CaseDefinition(
+        "spacecraft-point-mass-orbit", _setup_spacecraft_point_mass_orbit
+    ),
     "dual-hinged-rigid-body": CaseDefinition("dual-hinged-rigid-body", _setup_dual_hinged_rigid_body),
     "gravity-gradient": CaseDefinition("gravity-gradient", _setup_gravity_gradient),
     "hinged-rigid-body": CaseDefinition("hinged-rigid-body", _setup_hinged_rigid_body),
@@ -781,6 +815,10 @@ CASE_DEFINITIONS = {
 
 
 CASE_ALIASES = {
+    "pointmassspacecraft": "spacecraft-point-mass",
+    "spacecraftpointmass": "spacecraft-point-mass",
+    "pointmassorbit": "spacecraft-point-mass-orbit",
+    "spacecraftpointmassorbit": "spacecraft-point-mass-orbit",
     "dualhingedrigidbody": "dual-hinged-rigid-body",
     "dualhingedrigidbodystateeffector": "dual-hinged-rigid-body",
     "gravitygradienteffector": "gravity-gradient",
@@ -968,7 +1006,7 @@ def _print_header(config):
     print(f"Warmup steps: {config.numberOfWarmupSteps}")
     print(f"Components per case: {config.numberOfComponents}")
     print(f"Segments per NDOF case: {config.numberOfSegments}")
-    print("Gravity: disabled except gravity-gradient case")
+    print("Gravity: disabled except orbit and gravity-gradient cases")
     print("Recorders: disabled")
     print("Spacecraft integrator: RK4 default")
 

--- a/benchmarks/tests/test_benchmark_smoke.py
+++ b/benchmarks/tests/test_benchmark_smoke.py
@@ -34,16 +34,19 @@ SUBPROCESS_TIMEOUT_SEC = 180  # [s]
 def _run(command, env=None):
     """Run ``command`` from the repository root and require success."""
 
+    uses_shell = isinstance(command, str)
     completed = subprocess.run(
         command,
         cwd=REPO_ROOT,
         env=env,
         text=True,
         capture_output=True,
+        shell=uses_shell,
         timeout=SUBPROCESS_TIMEOUT_SEC,
     )
+    command_text = command if uses_shell else " ".join(str(item) for item in command)
     assert completed.returncode == 0, (
-        f"Command failed: {' '.join(str(item) for item in command)}\n"
+        f"Command failed: {command_text}\n"
         f"stdout:\n{completed.stdout}\n"
         f"stderr:\n{completed.stderr}"
     )
@@ -77,6 +80,70 @@ def _cmake_command():
     if cmake_path is None:
         pytest.skip("CMake is not available")
     return cmake_path
+
+
+def _visual_studio_dev_command():
+    """Return ``VsDevCmd.bat`` if Visual Studio can be found on Windows."""
+
+    if os.name != "nt":
+        return None
+
+    configured_path = os.environ.get("BASILISK_VSDEVCMD")
+    if configured_path and Path(configured_path).exists():
+        return configured_path
+
+    program_files_x86 = os.environ.get("ProgramFiles(x86)")
+    if program_files_x86 is None:
+        return None
+
+    vswhere_path = Path(program_files_x86) / "Microsoft Visual Studio" / "Installer" / "vswhere.exe"
+    if not vswhere_path.exists():
+        return None
+
+    completed = subprocess.run(
+        [
+            str(vswhere_path),
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=SUBPROCESS_TIMEOUT_SEC,
+    )
+    if completed.returncode != 0:
+        return None
+
+    install_paths = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    if not install_paths:
+        return None
+
+    vsdevcmd_path = Path(install_paths[0]) / "Common7" / "Tools" / "VsDevCmd.bat"
+    if not vsdevcmd_path.exists():
+        return None
+
+    return str(vsdevcmd_path)
+
+
+def _build_environment_command(command):
+    """Return ``command`` wrapped in a compiler environment when needed."""
+
+    if os.name != "nt":
+        return command
+    if os.environ.get("VCINSTALLDIR") and os.environ.get("INCLUDE"):
+        return command
+
+    vsdevcmd_path = _visual_studio_dev_command()
+    if vsdevcmd_path is None:
+        return command
+
+    command_text = subprocess.list2cmdline(command)
+    return f'call "{vsdevcmd_path}" -arch=amd64 -host_arch=amd64 >nul && {command_text}'
 
 
 def _cmake_target_is_available(cmake_command, build_directory, target_name):
@@ -151,15 +218,17 @@ def test_eigen_linear_algebra_benchmark_smoke():
         )
 
     completed = _run(
-        [
-            cmake_command,
-            "--build",
-            str(build_directory),
-            "--target",
-            target_name,
-            "--config",
-            "Release",
-        ]
+        _build_environment_command(
+            [
+                cmake_command,
+                "--build",
+                str(build_directory),
+                "--target",
+                target_name,
+                "--config",
+                "Release",
+            ]
+        )
     )
 
     assert "Smoke mode:" in completed.stdout

--- a/benchmarks/tests/test_benchmark_smoke.py
+++ b/benchmarks/tests/test_benchmark_smoke.py
@@ -1,0 +1,165 @@
+#
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+"""Smoke tests for optional benchmark entry points."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SUBPROCESS_TIMEOUT_SEC = 180  # [s]
+
+
+def _run(command, env=None):
+    """Run ``command`` from the repository root and require success."""
+
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=SUBPROCESS_TIMEOUT_SEC,
+    )
+    assert completed.returncode == 0, (
+        f"Command failed: {' '.join(str(item) for item in command)}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+    return completed
+
+
+def _python_environment():
+    """Return a subprocess environment suitable for running benchmark scripts."""
+
+    env = os.environ.copy()
+    python_path_entries = [str(REPO_ROOT / "dist3")]
+    if env.get("PYTHONPATH"):
+        python_path_entries.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(python_path_entries)
+    env.setdefault("MPLBACKEND", "Agg")
+    return env
+
+
+def _cmake_command():
+    """Return the configured CMake command or skip the test."""
+
+    candidate_names = ["cmake.exe"] if os.name == "nt" else ["cmake"]
+    venv_bin_directory = REPO_ROOT / ".venv" / ("Scripts" if os.name == "nt" else "bin")
+
+    for candidate_name in candidate_names:
+        candidate_path = venv_bin_directory / candidate_name
+        if candidate_path.exists():
+            return str(candidate_path)
+
+    cmake_path = shutil.which("cmake")
+    if cmake_path is None:
+        pytest.skip("CMake is not available")
+    return cmake_path
+
+
+def _cmake_target_is_available(cmake_command, build_directory, target_name):
+    """Return ``True`` if ``target_name`` is present in the configured build tree."""
+
+    target_directories = build_directory / "CMakeFiles" / "TargetDirectories.txt"
+    if target_directories.exists():
+        target_text = target_directories.read_text(encoding="utf-8", errors="ignore")
+        if target_name in target_text:
+            return True
+
+    completed = subprocess.run(
+        [
+            cmake_command,
+            "--build",
+            str(build_directory),
+            "--target",
+            "help",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=SUBPROCESS_TIMEOUT_SEC,
+    )
+    if completed.returncode != 0:
+        pytest.skip("CMake target list is not available from the configured 'dist3' build directory")
+
+    return target_name in completed.stdout or target_name in completed.stderr
+
+
+def test_dynamics_benchmark_smoke():
+    """Run each Python dynamics benchmark case with the smallest timing load."""
+
+    benchmark_script = REPO_ROOT / "benchmarks" / "dynamics" / "benchmark_state_effectors.py"
+    completed = _run(
+        [
+            sys.executable,
+            str(benchmark_script),
+            "--case",
+            "all",
+            "--steps",
+            "1",
+            "--trials",
+            "1",
+            "--warmup-steps",
+            "0",
+            "--components",
+            "1",
+            "--segments",
+            "1",
+        ],
+        env=_python_environment(),
+    )
+
+    assert "Dynamics effector benchmark" in completed.stdout
+    assert "spacecraft" in completed.stdout
+
+
+def test_eigen_linear_algebra_benchmark_smoke():
+    """Build and run the C++ Eigen versus linearAlgebra benchmark smoke target."""
+
+    build_directory = REPO_ROOT / "dist3"
+    if not (build_directory / "CMakeCache.txt").exists():
+        pytest.skip("Basilisk CMake build directory 'dist3' is not configured")
+
+    cmake_command = _cmake_command()
+    target_name = "benchmark_smoke_tests"
+    if not _cmake_target_is_available(cmake_command, build_directory, target_name):
+        pytest.skip(
+            "CMake build directory 'dist3' does not include benchmark targets; "
+            "re-run CMake configure before running this smoke test"
+        )
+
+    completed = _run(
+        [
+            cmake_command,
+            "--build",
+            str(build_directory),
+            "--target",
+            target_name,
+            "--config",
+            "Release",
+        ]
+    )
+
+    assert "Smoke mode:" in completed.stdout

--- a/benchmarks/utilities/CMakeLists.txt
+++ b/benchmarks/utilities/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(benchmark_eigen_linear_algebra EXCLUDE_FROM_ALL benchmark_eigen_linear_algebra.cpp)
+target_link_libraries(benchmark_eigen_linear_algebra ArchitectureUtilities)
+set_target_properties(benchmark_eigen_linear_algebra PROPERTIES FOLDER "benchmarks/utilities")
+
+add_custom_target(benchmark_eigen_linear_algebra_smoke
+    COMMAND benchmark_eigen_linear_algebra --smoke
+    DEPENDS benchmark_eigen_linear_algebra
+    COMMENT "Running Eigen versus linearAlgebra benchmark smoke test"
+    VERBATIM
+)
+add_dependencies(benchmark_smoke_tests benchmark_eigen_linear_algebra_smoke)

--- a/benchmarks/utilities/benchmark_eigen_linear_algebra.cpp
+++ b/benchmarks/utilities/benchmark_eigen_linear_algebra.cpp
@@ -1,0 +1,811 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+
+#include "architecture/utilities/linearAlgebra.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using Matrix6d = Eigen::Matrix<double, 6, 6>;
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+using LoopFunction = std::function<double(std::uint64_t)>;
+
+volatile double benchmarkSink = 0.0;
+volatile std::uint64_t perturbationSeed = 1;
+
+struct TimedRun
+{
+    double nanosecondsPerOperation;
+    double checksum;
+};
+
+struct BenchmarkResult
+{
+    std::string name;
+    std::uint64_t iterations;
+    double eigenNanoseconds;
+    double linearAlgebraNanoseconds;
+    double ratio;
+    double relativeChecksumDifference;
+};
+
+struct BenchmarkOptions
+{
+    std::uint64_t iterationScale = 1;
+    bool smokeMode = false;
+};
+
+void
+printUsage(const char* executableName)
+{
+    std::cout << "Usage: " << executableName << " [iterationScale] [--smoke]\n"
+              << "  iterationScale is a positive integer multiplier for the default loop counts.\n"
+              << "  --smoke caps each operation's iteration count to verify that the benchmark still executes.\n";
+}
+
+BenchmarkOptions
+parseOptions(int argc, char** argv)
+{
+    BenchmarkOptions options;
+    bool scaleWasProvided = false;
+
+    for (int argumentIndex = 1; argumentIndex < argc; ++argumentIndex) {
+        const std::string argument = argv[argumentIndex];
+        if (argument == "-h" || argument == "--help") {
+            printUsage(argv[0]);
+            std::exit(EXIT_SUCCESS);
+        }
+        if (argument == "--smoke") {
+            options.smokeMode = true;
+            continue;
+        }
+        if (!argument.empty() && argument.front() == '-') {
+            throw std::runtime_error("unknown option '" + argument + "'.");
+        }
+        if (scaleWasProvided) {
+            throw std::runtime_error("only one iterationScale argument is allowed.");
+        }
+
+        std::size_t parsedCharacters = 0;
+        const std::uint64_t scale = std::stoull(argument, &parsedCharacters);
+        if (parsedCharacters != argument.size() || scale == 0) {
+            throw std::runtime_error("iterationScale must be a positive integer.");
+        }
+        options.iterationScale = scale;
+        scaleWasProvided = true;
+    }
+
+    return options;
+}
+
+std::uint64_t
+scaledIterations(std::uint64_t baseIterations, std::uint64_t scale)
+{
+    if (baseIterations > std::numeric_limits<std::uint64_t>::max() / scale) {
+        throw std::overflow_error("iteration count overflow.");
+    }
+    return baseIterations * scale;
+}
+
+std::uint64_t
+benchmarkIterations(std::uint64_t baseIterations, const BenchmarkOptions& options)
+{
+    if (options.smokeMode) {
+        constexpr std::uint64_t smokeIterationCap = 1000;
+        return std::min(baseIterations, smokeIterationCap);
+    }
+    return scaledIterations(baseIterations, options.iterationScale);
+}
+
+double
+perturbation(std::uint64_t iteration)
+{
+    constexpr double perturbationStep = 1.0e-12;
+    constexpr std::uint64_t perturbationPeriod = 97;
+    return perturbationStep * static_cast<double>(((iteration + perturbationSeed) % perturbationPeriod) + 1);
+}
+
+std::uint64_t
+warmupIterations(std::uint64_t iterations)
+{
+    constexpr std::uint64_t warmupDivisor = 200;
+    constexpr std::uint64_t maxWarmupIterations = 2000;
+    return std::max<std::uint64_t>(1, std::min(iterations / warmupDivisor, maxWarmupIterations));
+}
+
+TimedRun
+timeLoop(const LoopFunction& loopFunction, std::uint64_t iterations)
+{
+    const auto start = Clock::now();
+    const double checksum = loopFunction(iterations);
+    const auto finish = Clock::now();
+    const double elapsedNanoseconds = std::chrono::duration<double, std::nano>(finish - start).count();
+
+    benchmarkSink += checksum;
+    return { elapsedNanoseconds / static_cast<double>(iterations), checksum };
+}
+
+double
+relativeDifference(double firstValue, double secondValue)
+{
+    const double scale = std::max({ std::abs(firstValue), std::abs(secondValue), 1.0 });
+    return std::abs(firstValue - secondValue) / scale;
+}
+
+BenchmarkResult
+runBenchmarkPair(const std::string& name,
+                 std::uint64_t iterations,
+                 const LoopFunction& eigenLoop,
+                 const LoopFunction& linearAlgebraLoop)
+{
+    const std::uint64_t warmup = warmupIterations(iterations);
+    benchmarkSink += eigenLoop(warmup);
+    benchmarkSink += linearAlgebraLoop(warmup);
+
+    const TimedRun eigenRun = timeLoop(eigenLoop, iterations);
+    const TimedRun linearAlgebraRun = timeLoop(linearAlgebraLoop, iterations);
+    return { name,
+             iterations,
+             eigenRun.nanosecondsPerOperation,
+             linearAlgebraRun.nanosecondsPerOperation,
+             linearAlgebraRun.nanosecondsPerOperation / eigenRun.nanosecondsPerOperation,
+             relativeDifference(eigenRun.checksum, linearAlgebraRun.checksum) };
+}
+
+double
+matrixValue(std::size_t row, std::size_t col, double diagonalBoost)
+{
+    const double baseValue = 0.05 * static_cast<double>((row + 1) * (col + 2));
+    if (row == col) {
+        return diagonalBoost + baseValue;
+    }
+    return baseValue / static_cast<double>(row + col + 2);
+}
+
+void
+fillMatrix3(double matrix[3][3], double diagonalBoost)
+{
+    for (std::size_t row = 0; row < 3; row++) {
+        for (std::size_t col = 0; col < 3; col++) {
+            matrix[row][col] = matrixValue(row, col, diagonalBoost);
+        }
+    }
+}
+
+Eigen::Matrix3d
+makeEigenMatrix3(double diagonalBoost)
+{
+    Eigen::Matrix3d matrix;
+    for (Eigen::Index row = 0; row < matrix.rows(); row++) {
+        for (Eigen::Index col = 0; col < matrix.cols(); col++) {
+            matrix(row, col) = matrixValue(static_cast<std::size_t>(row), static_cast<std::size_t>(col), diagonalBoost);
+        }
+    }
+    return matrix;
+}
+
+void
+fillMatrix4(double matrix[4][4], double diagonalBoost)
+{
+    for (std::size_t row = 0; row < 4; row++) {
+        for (std::size_t col = 0; col < 4; col++) {
+            matrix[row][col] = matrixValue(row, col, diagonalBoost);
+        }
+    }
+}
+
+Eigen::Matrix4d
+makeEigenMatrix4(double diagonalBoost)
+{
+    Eigen::Matrix4d matrix;
+    for (Eigen::Index row = 0; row < matrix.rows(); row++) {
+        for (Eigen::Index col = 0; col < matrix.cols(); col++) {
+            matrix(row, col) = matrixValue(static_cast<std::size_t>(row), static_cast<std::size_t>(col), diagonalBoost);
+        }
+    }
+    return matrix;
+}
+
+void
+fillMatrix6(double matrix[6][6], double diagonalBoost)
+{
+    for (std::size_t row = 0; row < 6; row++) {
+        for (std::size_t col = 0; col < 6; col++) {
+            matrix[row][col] = matrixValue(row, col, diagonalBoost);
+        }
+    }
+}
+
+Matrix6d
+makeEigenMatrix6(double diagonalBoost)
+{
+    Matrix6d matrix;
+    for (Eigen::Index row = 0; row < matrix.rows(); row++) {
+        for (Eigen::Index col = 0; col < matrix.cols(); col++) {
+            matrix(row, col) = matrixValue(static_cast<std::size_t>(row), static_cast<std::size_t>(col), diagonalBoost);
+        }
+    }
+    return matrix;
+}
+
+std::vector<double>
+makeLinearAlgebraMatrix(std::size_t dimension, double diagonalBoost)
+{
+    std::vector<double> matrix(dimension * dimension);
+    for (std::size_t row = 0; row < dimension; row++) {
+        for (std::size_t col = 0; col < dimension; col++) {
+            matrix[row * dimension + col] = matrixValue(row, col, diagonalBoost);
+        }
+    }
+    return matrix;
+}
+
+Eigen::MatrixXd
+makeEigenDynamicMatrix(std::size_t dimension, double diagonalBoost)
+{
+    Eigen::MatrixXd matrix(static_cast<Eigen::Index>(dimension), static_cast<Eigen::Index>(dimension));
+    for (Eigen::Index row = 0; row < matrix.rows(); row++) {
+        for (Eigen::Index col = 0; col < matrix.cols(); col++) {
+            matrix(row, col) = matrixValue(static_cast<std::size_t>(row), static_cast<std::size_t>(col), diagonalBoost);
+        }
+    }
+    return matrix;
+}
+
+double
+runEigenVector3Dot(std::uint64_t iterations)
+{
+    Eigen::Vector3d vectorA(1.1, -2.2, 3.3);
+    Eigen::Vector3d vectorB(-4.4, 5.5, -6.6);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        vectorA(0) += offset;
+        vectorB(2) -= offset;
+        checksum += vectorA.dot(vectorB);
+        vectorB(2) += offset;
+        vectorA(0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraVector3Dot(std::uint64_t iterations)
+{
+    double vectorA[3] = { 1.1, -2.2, 3.3 };
+    double vectorB[3] = { -4.4, 5.5, -6.6 };
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        vectorA[0] += offset;
+        vectorB[2] -= offset;
+        checksum += v3Dot(vectorA, vectorB);
+        vectorB[2] += offset;
+        vectorA[0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenVector3Cross(std::uint64_t iterations)
+{
+    Eigen::Vector3d vectorA(1.1, -2.2, 3.3);
+    Eigen::Vector3d vectorB(-4.4, 5.5, -6.6);
+    Eigen::Vector3d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        vectorA(1) += offset;
+        vectorB(0) -= offset;
+        result = vectorA.cross(vectorB);
+        checksum += result(0) + result(1) + result(2);
+        vectorB(0) += offset;
+        vectorA(1) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraVector3Cross(std::uint64_t iterations)
+{
+    double vectorA[3] = { 1.1, -2.2, 3.3 };
+    double vectorB[3] = { -4.4, 5.5, -6.6 };
+    double result[3];
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        vectorA[1] += offset;
+        vectorB[0] -= offset;
+        v3Cross(vectorA, vectorB, result);
+        checksum += result[0] + result[1] + result[2];
+        vectorB[0] += offset;
+        vectorA[1] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix3Multiply(std::uint64_t iterations)
+{
+    Eigen::Matrix3d matrixA = makeEigenMatrix3(4.0);
+    Eigen::Matrix3d matrixB = makeEigenMatrix3(1.0);
+    Eigen::Matrix3d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 0) += offset;
+        matrixB(2, 1) -= offset;
+        result.noalias() = matrixA * matrixB;
+        checksum += result(0, 0) + result(1, 2) + result(2, 1);
+        matrixB(2, 1) += offset;
+        matrixA(0, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix3Multiply(std::uint64_t iterations)
+{
+    double matrixA[3][3];
+    double matrixB[3][3];
+    double result[3][3];
+    fillMatrix3(matrixA, 4.0);
+    fillMatrix3(matrixB, 1.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0][0] += offset;
+        matrixB[2][1] -= offset;
+        m33MultM33(matrixA, matrixB, result);
+        checksum += result[0][0] + result[1][2] + result[2][1];
+        matrixB[2][1] += offset;
+        matrixA[0][0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix3TransposeMultiply(std::uint64_t iterations)
+{
+    Eigen::Matrix3d matrixA = makeEigenMatrix3(4.0);
+    Eigen::Matrix3d matrixB = makeEigenMatrix3(1.0);
+    Eigen::Matrix3d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(1, 0) += offset;
+        matrixB(2, 2) -= offset;
+        result.noalias() = matrixA.transpose() * matrixB;
+        checksum += result(0, 0) + result(1, 2) + result(2, 1);
+        matrixB(2, 2) += offset;
+        matrixA(1, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix3TransposeMultiply(std::uint64_t iterations)
+{
+    double matrixA[3][3];
+    double matrixB[3][3];
+    double result[3][3];
+    fillMatrix3(matrixA, 4.0);
+    fillMatrix3(matrixB, 1.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[1][0] += offset;
+        matrixB[2][2] -= offset;
+        m33tMultM33(matrixA, matrixB, result);
+        checksum += result[0][0] + result[1][2] + result[2][1];
+        matrixB[2][2] += offset;
+        matrixA[1][0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix3VectorMultiply(std::uint64_t iterations)
+{
+    Eigen::Matrix3d matrixA = makeEigenMatrix3(4.0);
+    Eigen::Vector3d vectorA(1.1, -2.2, 3.3);
+    Eigen::Vector3d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 1) += offset;
+        vectorA(2) -= offset;
+        result.noalias() = matrixA * vectorA;
+        checksum += result(0) + result(1) + result(2);
+        vectorA(2) += offset;
+        matrixA(0, 1) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix3VectorMultiply(std::uint64_t iterations)
+{
+    double matrixA[3][3];
+    double vectorA[3] = { 1.1, -2.2, 3.3 };
+    double result[3];
+    fillMatrix3(matrixA, 4.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0][1] += offset;
+        vectorA[2] -= offset;
+        m33MultV3(matrixA, vectorA, result);
+        checksum += result[0] + result[1] + result[2];
+        vectorA[2] += offset;
+        matrixA[0][1] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix3Inverse(std::uint64_t iterations)
+{
+    Eigen::Matrix3d matrixA = makeEigenMatrix3(5.0);
+    Eigen::Matrix3d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 0) += offset;
+        matrixA(2, 2) -= offset;
+        result = matrixA.inverse();
+        checksum += result(0, 0) + result(1, 2) + result(2, 1);
+        matrixA(2, 2) += offset;
+        matrixA(0, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix3Inverse(std::uint64_t iterations)
+{
+    double matrixA[3][3];
+    double result[3][3];
+    fillMatrix3(matrixA, 5.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0][0] += offset;
+        matrixA[2][2] -= offset;
+        m33Inverse(matrixA, result);
+        checksum += result[0][0] + result[1][2] + result[2][1];
+        matrixA[2][2] += offset;
+        matrixA[0][0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix4Inverse(std::uint64_t iterations)
+{
+    Eigen::Matrix4d matrixA = makeEigenMatrix4(6.0);
+    Eigen::Matrix4d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 0) += offset;
+        matrixA(3, 3) -= offset;
+        result = matrixA.inverse();
+        checksum += result(0, 0) + result(1, 3) + result(3, 1);
+        matrixA(3, 3) += offset;
+        matrixA(0, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix4Inverse(std::uint64_t iterations)
+{
+    double matrixA[4][4];
+    double result[4][4];
+    fillMatrix4(matrixA, 6.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0][0] += offset;
+        matrixA[3][3] -= offset;
+        m44Inverse(matrixA, result);
+        checksum += result[0][0] + result[1][3] + result[3][1];
+        matrixA[3][3] += offset;
+        matrixA[0][0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix6Multiply(std::uint64_t iterations)
+{
+    Matrix6d matrixA = makeEigenMatrix6(5.0);
+    Matrix6d matrixB = makeEigenMatrix6(2.0);
+    Matrix6d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 0) += offset;
+        matrixB(5, 2) -= offset;
+        result.noalias() = matrixA * matrixB;
+        checksum += result(0, 0) + result(3, 5) + result(5, 2);
+        matrixB(5, 2) += offset;
+        matrixA(0, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix6Multiply(std::uint64_t iterations)
+{
+    double matrixA[6][6];
+    double matrixB[6][6];
+    double result[6][6];
+    fillMatrix6(matrixA, 5.0);
+    fillMatrix6(matrixB, 2.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0][0] += offset;
+        matrixB[5][2] -= offset;
+        m66MultM66(matrixA, matrixB, result);
+        checksum += result[0][0] + result[3][5] + result[5][2];
+        matrixB[5][2] += offset;
+        matrixA[0][0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenMatrix6VectorMultiply(std::uint64_t iterations)
+{
+    Matrix6d matrixA = makeEigenMatrix6(5.0);
+    Vector6d vectorA;
+    vectorA << 1.1, -2.2, 3.3, -4.4, 5.5, -6.6;
+    Vector6d result;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 1) += offset;
+        vectorA(5) -= offset;
+        result.noalias() = matrixA * vectorA;
+        checksum += result(0) + result(3) + result(5);
+        vectorA(5) += offset;
+        matrixA(0, 1) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraMatrix6VectorMultiply(std::uint64_t iterations)
+{
+    double matrixA[6][6];
+    double vectorA[6] = { 1.1, -2.2, 3.3, -4.4, 5.5, -6.6 };
+    double result[6];
+    fillMatrix6(matrixA, 5.0);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0][1] += offset;
+        vectorA[5] -= offset;
+        m66MultV6(matrixA, vectorA, result);
+        checksum += result[0] + result[3] + result[5];
+        vectorA[5] += offset;
+        matrixA[0][1] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenDynamicMultiply(std::uint64_t iterations, std::size_t dimension)
+{
+    Eigen::MatrixXd matrixA = makeEigenDynamicMatrix(dimension, 5.0);
+    Eigen::MatrixXd matrixB = makeEigenDynamicMatrix(dimension, 2.0);
+    Eigen::MatrixXd result(static_cast<Eigen::Index>(dimension), static_cast<Eigen::Index>(dimension));
+    const Eigen::Index last = static_cast<Eigen::Index>(dimension - 1);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 0) += offset;
+        matrixB(last, 2) -= offset;
+        result.noalias() = matrixA * matrixB;
+        checksum += result(0, 0) + result(last / 2, last) + result(last, 2);
+        matrixB(last, 2) += offset;
+        matrixA(0, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraDynamicMultiply(std::uint64_t iterations, std::size_t dimension)
+{
+    std::vector<double> matrixA = makeLinearAlgebraMatrix(dimension, 5.0);
+    std::vector<double> matrixB = makeLinearAlgebraMatrix(dimension, 2.0);
+    std::vector<double> result(dimension * dimension);
+    const std::size_t last = dimension - 1;
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0] += offset;
+        matrixB[last * dimension + 2] -= offset;
+        mMultM(matrixA.data(), dimension, dimension, matrixB.data(), dimension, dimension, result.data());
+        checksum += result[0] + result[(last / 2) * dimension + last] + result[last * dimension + 2];
+        matrixB[last * dimension + 2] += offset;
+        matrixA[0] -= offset;
+    }
+    return checksum;
+}
+
+double
+runEigenGeneralMatrix6Inverse(std::uint64_t iterations)
+{
+    constexpr std::size_t dimension = 6;
+    Eigen::MatrixXd matrixA = makeEigenDynamicMatrix(dimension, 8.0);
+    Eigen::MatrixXd result(dimension, dimension);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA(0, 0) += offset;
+        matrixA(5, 5) -= offset;
+        result = matrixA.inverse();
+        checksum += result(0, 0) + result(2, 5) + result(5, 2);
+        matrixA(5, 5) += offset;
+        matrixA(0, 0) -= offset;
+    }
+    return checksum;
+}
+
+double
+runLinearAlgebraGeneralMatrix6Inverse(std::uint64_t iterations)
+{
+    constexpr std::size_t dimension = 6;
+    std::vector<double> matrixA = makeLinearAlgebraMatrix(dimension, 8.0);
+    std::vector<double> result(dimension * dimension);
+    double checksum = 0.0;
+
+    for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+        const double offset = perturbation(iteration);
+        matrixA[0] += offset;
+        matrixA[5 * dimension + 5] -= offset;
+        mInverse(matrixA.data(), dimension, result.data());
+        checksum += result[0] + result[2 * dimension + 5] + result[5 * dimension + 2];
+        matrixA[5 * dimension + 5] += offset;
+        matrixA[0] -= offset;
+    }
+    return checksum;
+}
+
+void
+printResults(const std::vector<BenchmarkResult>& results)
+{
+    std::cout << std::fixed << std::setprecision(3);
+    std::cout << "\n";
+    std::cout << std::left << std::setw(34) << "Operation" << std::right << std::setw(12) << "Iterations"
+              << std::setw(15) << "Eigen ns/op" << std::setw(20) << "linearAlg ns/op" << std::setw(18) << "linear/Eigen"
+              << std::setw(18) << "checksum diff"
+              << "\n";
+
+    for (const BenchmarkResult& result : results) {
+        std::cout << std::left << std::setw(34) << result.name << std::right << std::setw(12) << result.iterations
+                  << std::setw(15) << result.eigenNanoseconds << std::setw(20) << result.linearAlgebraNanoseconds
+                  << std::setw(18) << result.ratio << std::setw(18) << result.relativeChecksumDifference << "\n";
+    }
+}
+
+} // namespace
+
+int
+main(int argc, char** argv)
+{
+    try {
+        const BenchmarkOptions options = parseOptions(argc, argv);
+        std::vector<BenchmarkResult> results;
+
+        results.push_back(runBenchmarkPair(
+          "v3 dot", benchmarkIterations(20000000, options), runEigenVector3Dot, runLinearAlgebraVector3Dot));
+        results.push_back(runBenchmarkPair(
+          "v3 cross", benchmarkIterations(10000000, options), runEigenVector3Cross, runLinearAlgebraVector3Cross));
+        results.push_back(runBenchmarkPair(
+          "3x3 multiply", benchmarkIterations(5000000, options), runEigenMatrix3Multiply, runLinearAlgebraMatrix3Multiply));
+        results.push_back(runBenchmarkPair("3x3 transpose multiply",
+                                           benchmarkIterations(5000000, options),
+                                           runEigenMatrix3TransposeMultiply,
+                                           runLinearAlgebraMatrix3TransposeMultiply));
+        results.push_back(runBenchmarkPair("3x3 vector multiply",
+                                           benchmarkIterations(8000000, options),
+                                           runEigenMatrix3VectorMultiply,
+                                           runLinearAlgebraMatrix3VectorMultiply));
+        results.push_back(runBenchmarkPair(
+          "3x3 inverse", benchmarkIterations(1000000, options), runEigenMatrix3Inverse, runLinearAlgebraMatrix3Inverse));
+        results.push_back(runBenchmarkPair(
+          "4x4 inverse", benchmarkIterations(200000, options), runEigenMatrix4Inverse, runLinearAlgebraMatrix4Inverse));
+        results.push_back(runBenchmarkPair(
+          "6x6 multiply", benchmarkIterations(800000, options), runEigenMatrix6Multiply, runLinearAlgebraMatrix6Multiply));
+        results.push_back(runBenchmarkPair("6x6 vector multiply",
+                                           benchmarkIterations(2000000, options),
+                                           runEigenMatrix6VectorMultiply,
+                                           runLinearAlgebraMatrix6VectorMultiply));
+        results.push_back(runBenchmarkPair(
+          "dynamic 6x6 multiply",
+          benchmarkIterations(500000, options),
+          [](std::uint64_t iterations) { return runEigenDynamicMultiply(iterations, 6); },
+          [](std::uint64_t iterations) { return runLinearAlgebraDynamicMultiply(iterations, 6); }));
+        results.push_back(runBenchmarkPair(
+          "dynamic 12x12 multiply",
+          benchmarkIterations(100000, options),
+          [](std::uint64_t iterations) { return runEigenDynamicMultiply(iterations, 12); },
+          [](std::uint64_t iterations) { return runLinearAlgebraDynamicMultiply(iterations, 12); }));
+        results.push_back(runBenchmarkPair("generic 6x6 inverse",
+                                           benchmarkIterations(200, options),
+                                           runEigenGeneralMatrix6Inverse,
+                                           runLinearAlgebraGeneralMatrix6Inverse));
+
+        std::cout << "Eigen versus linearAlgebra benchmark\n"
+                  << "Build and run this benchmark target in Release mode for meaningful timings.\n"
+                  << "The ratio column is linearAlgebra time divided by Eigen time.\n";
+        if (options.smokeMode) {
+            std::cout << "Smoke mode: each operation uses a capped iteration count.\n";
+        }
+        printResults(results);
+        std::cout << "\nchecksum sink: " << benchmarkSink << "\n";
+    } catch (const std::exception& error) {
+        std::cerr << "benchmark_eigen_linear_algebra: " << error.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/docs/source/Support/Developer.rst
+++ b/docs/source/Support/Developer.rst
@@ -18,6 +18,7 @@ The following support files help with writing Basilisk modules.
    Developer/UnderstandingBasilisk
    Developer/migratingBskModuleToBsk2
    Developer/MigratingToPython3
+   Developer/performanceBenchmarks
    Developer/addSupportData
    Developer/bskReleaseGuide
    Developer/bskSdkReleaseGuide

--- a/docs/source/Support/Developer/CodingGuidlines.rst
+++ b/docs/source/Support/Developer/CodingGuidlines.rst
@@ -248,6 +248,12 @@ This will execute ``pytest`` and ``gtest`` checks.  All tests should pass.  If n
 Basilisk modules are built (i.e. the build process turned off ``opNav`` option), then
 some tests will show up as skipped.
 
+Optional developer performance benchmarks are documented separately in
+:ref:`performanceBenchmarks`.  Benchmark timing runs are opt-in speed
+investigations.  The lightweight benchmark smoke tests only check that benchmark
+entry points still execute, and may be included in the default ``pytest``
+collection paths.
+
 If you want to use ``pytest`` to generate a validation HTML report,
 then the ``pytest-html`` package is used. In a terminal window, make your
 working directory ``basilisk/src``.  Next, run ``pytest`` by adding the ``--html`` argument

--- a/docs/source/Support/Developer/performanceBenchmarks.rst
+++ b/docs/source/Support/Developer/performanceBenchmarks.rst
@@ -1,0 +1,162 @@
+.. _performanceBenchmarks:
+
+Optional Performance Benchmarks
+===============================
+
+Basilisk performance benchmarks are developer utilities for measuring selected
+implementation choices.  They are not numerical validation tests.  Run them when
+investigating execution speed, comparing algorithms, or checking whether a local
+change affects a performance-sensitive code path.
+
+Benchmark timing depends on the processor, compiler, build type, system load, and
+power management state.  Use a release build, run the benchmark several times from a
+quiet terminal, and compare results from the same machine and build configuration.
+
+Dynamics Effector Benchmark
+---------------------------
+
+The dynamics effector benchmark measures selected spacecraft, state effector, and
+dynamic effector execution speed with a shared benchmark harness, including the
+NDOF spinning-body BSM multi-body dynamics case.
+
+Source script: :download:`benchmark_state_effectors.py <../../../../benchmarks/dynamics/benchmark_state_effectors.py>`
+
+.. _benchmark_state_effectors:
+
+.. automodule:: benchmark_state_effectors
+
+Eigen and ``linearAlgebra`` Benchmark
+-------------------------------------
+
+The ``benchmark_eigen_linear_algebra`` executable compares common Eigen vector and
+matrix operations against the Basilisk ``linearAlgebra.c/h`` utility functions.  It
+includes dot products, cross products, fixed-size matrix-vector products, fixed-size
+matrix-matrix products, dynamic matrix products, and inverse operations.
+
+Source file: :download:`benchmark_eigen_linear_algebra.cpp <../../../../benchmarks/utilities/benchmark_eigen_linear_algebra.cpp>`
+
+This benchmark is excluded from the normal build with ``EXCLUDE_FROM_ALL``.  Build it
+explicitly from the Basilisk repository root directory:
+
+.. code-block:: bash
+
+   cd /path/to/basilisk
+   .venv/bin/cmake -S src -B dist3
+   .venv/bin/cmake --build dist3 --target benchmark_eigen_linear_algebra --config Release
+
+Then run the benchmark executable:
+
+.. code-block:: bash
+
+   dist3/benchmarks/utilities/benchmark_eigen_linear_algebra
+
+To run a longer benchmark, pass a positive integer scale factor.  For example, the
+following command multiplies the default loop counts by ``5``:
+
+.. code-block:: bash
+
+   dist3/benchmarks/utilities/benchmark_eigen_linear_algebra 5
+
+To run only a brief executable smoke check, use ``--smoke``:
+
+.. code-block:: bash
+
+   dist3/benchmarks/utilities/benchmark_eigen_linear_algebra --smoke
+
+Expected Terminal Output
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The exact timings will vary by machine.  A representative run looks like:
+
+.. code-block:: text
+
+   Eigen versus linearAlgebra benchmark
+   Build and run this benchmark target in Release mode for meaningful timings.
+   The ratio column is linearAlgebra time divided by Eigen time.
+
+   Operation                           Iterations    Eigen ns/op     linearAlg ns/op      linear/Eigen     checksum diff
+   v3 dot                                20000000          2.512               2.623             1.044             0.000
+   v3 cross                              10000000          1.701               3.458             2.032             0.000
+   3x3 multiply                           5000000          2.386               3.538             1.483             0.000
+   3x3 transpose multiply                 5000000          2.761               4.241             1.536             0.000
+   3x3 vector multiply                    8000000          2.213               4.164             1.881             0.000
+   3x3 inverse                            1000000          2.475               4.849             1.959             0.000
+   4x4 inverse                             200000          4.401              22.896             5.202             0.000
+   6x6 multiply                            800000          8.622              13.384             1.552             0.000
+   6x6 vector multiply                    2000000          2.387               5.347             2.240             0.000
+   dynamic 6x6 multiply                    500000         68.503              50.585             0.738             0.000
+   dynamic 12x12 multiply                  100000        154.105             650.041             4.218             0.000
+   generic 6x6 inverse                        200        573.330           54896.460            95.750             0.000
+
+   checksum sink: -1791071704.319
+
+Interpreting the Columns
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Eigen ns/op``
+   Average Eigen execution time for the listed operation, in nanoseconds per
+   operation.
+
+``linearAlg ns/op``
+   Average ``linearAlgebra`` execution time for the same operation, in nanoseconds
+   per operation.
+
+``linear/Eigen``
+   Ratio of ``linearAlg ns/op`` divided by ``Eigen ns/op``.  Values greater than
+   ``1.0`` mean ``linearAlgebra`` was slower for that operation.  Values less than
+   ``1.0`` mean ``linearAlgebra`` was faster.
+
+``checksum diff``
+   Relative difference between the Eigen and ``linearAlgebra`` checksums.  This is a
+   basic guard that both loops performed comparable numerical work; it is not a
+   replacement for a unit test.
+
+Benchmark Smoke Tests
+---------------------
+
+The benchmark smoke tests are pass/fail freshness checks.  They do not evaluate
+performance; they only verify that the benchmark entry points still build or run with
+a minimal workload.
+
+Source test: :download:`test_benchmark_smoke.py <../../../../benchmarks/tests/test_benchmark_smoke.py>`
+
+The benchmark smoke tests are included in the default ``pytest`` collection paths,
+so they run when a developer invokes ``pytest`` from the Basilisk repository root
+directory or from the ``src`` directory.  To run only the benchmark smoke tests from
+the repository root directory:
+
+.. code-block:: bash
+
+   .venv/bin/pytest -q benchmarks/tests
+
+Or from the ``src`` directory:
+
+.. code-block:: bash
+
+   ../.venv/bin/pytest -q ../benchmarks/tests
+
+The Python smoke test runs the dynamics benchmark with one integration step, one
+trial, no warmup, one component, and one segment.  The C++ smoke test builds and runs
+the ``benchmark_smoke_tests`` CMake target, which executes the Eigen versus
+``linearAlgebra`` benchmark in ``--smoke`` mode with capped iteration counts.  The
+C++ smoke test requires an already configured ``dist3`` build directory that includes
+the benchmark targets; otherwise it is skipped with a reconfigure hint.
+
+Developers can also run the C++ smoke target directly:
+
+.. code-block:: bash
+
+   .venv/bin/cmake --build dist3 --target benchmark_smoke_tests --config Release
+
+Guidelines for Future Benchmarks
+--------------------------------
+
+Keep performance benchmarks opt-in unless there is a specific reason to run them in
+CI.  New benchmarks should document:
+
+- The target name and source file.
+- The build configuration used for meaningful results.
+- The command used to run the benchmark.
+- Representative terminal output.
+- How to interpret each reported metric.
+- Any known limitations that affect comparison quality.

--- a/docs/source/Support/bskReleaseNotesSnippets/dynamics-effector-benchmark.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/dynamics-effector-benchmark.rst
@@ -1,0 +1,3 @@
+- Added optional performance benchmarks for Eigen versus ``linearAlgebra`` and dynamics effectors, with smoke tests to keep benchmark entry points fresh.
+- Improved selected dynamics effector performance by replacing hot-path skew-matrix vector products with equivalent Eigen ``cross()`` operations.
+- Added point mass and single rigid body modes to spacecraft to speed up dynamics evaluation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,12 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath("_ext"))
 
+benchmarkSourceRoot = os.path.abspath("../../benchmarks")
+if os.path.isdir(benchmarkSourceRoot):
+    for dirPath, _, fileNames in os.walk(benchmarkSourceRoot):
+        if any(fileName.endswith(".py") for fileName in fileNames):
+            sys.path.insert(0, dirPath)
+
 import numpy as np
 
 from docutils import nodes
@@ -401,6 +407,7 @@ class fileCrawler():
                     "_VizFiles" in dirs_in_dir[i] or \
                     "Support" in dirs_in_dir[i] or \
                     "cmake" in dirs_in_dir[i] or \
+                    "benchmarks" in dirs_in_dir[i] or \
                     "topLevelModules" in dirs_in_dir[i] or \
                     "outputFiles" in dirs_in_dir[i] or \
                     "msgAutoSource" in dirs_in_dir[i] or \
@@ -518,10 +525,6 @@ class fileCrawler():
             if name.startswith("_"):
                 pathToFolder = index_path.split("/"+name)[0]
                 lines += ".. " + name + pathToFolder.split("/")[-1] + ":\n\n"
-            elif "/benchmarks/" in normalizedIndexPath:
-                benchmarkPath = normalizedIndexPath.split("/benchmarks/", 1)[1]
-                benchmarkLabel = benchmarkPath.replace("/", "_")
-                lines += ".. _Folder_benchmarks_" + benchmarkLabel + ":\n\n"
             elif name == 'utilities':
                 pathToFolder = index_path.split("/" + name)[0]
                 lines += ".. _Folder_" + name + pathToFolder.split("/")[-1] + ":\n\n"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -514,9 +514,14 @@ class fileCrawler():
 
         except: # Auto-generate the index.rst file
             # add page tag
+            normalizedIndexPath = index_path.replace(os.sep, "/").rstrip("/")
             if name.startswith("_"):
                 pathToFolder = index_path.split("/"+name)[0]
                 lines += ".. " + name + pathToFolder.split("/")[-1] + ":\n\n"
+            elif "/benchmarks/" in normalizedIndexPath:
+                benchmarkPath = normalizedIndexPath.split("/benchmarks/", 1)[1]
+                benchmarkLabel = benchmarkPath.replace("/", "_")
+                lines += ".. _Folder_benchmarks_" + benchmarkLabel + ":\n\n"
             elif name == 'utilities':
                 pathToFolder = index_path.split("/" + name)[0]
                 lines += ".. _Folder_" + name + pathToFolder.split("/")[-1] + ":\n\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,10 @@ manylinux-aarch64-image = "manylinux_2_28"
 environment-pass = ["CONAN_ARGS", "CMAKE_C_COMPILER_LAUNCHER", "CMAKE_CXX_COMPILER_LAUNCHER"]
 
 [tool.pytest.ini_options]
+testpaths = [
+  "src",
+  "benchmarks/tests",
+]
 markers = [
   "slowtest: mark a test as a slow unit test.",
   "scenarioTest: mark a test as a tutorial scenario test.",

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -759,5 +759,8 @@ file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/Basilisk/supportData")
 file(GLOB dataFiles "${CMAKE_SOURCE_DIR}/../supportData/*")
 create_symlinks("${CMAKE_BINARY_DIR}/Basilisk/supportData" ${dataFiles})
 
+# Optional performance benchmark targets
+add_subdirectory("${CMAKE_SOURCE_DIR}/../benchmarks" "${CMAKE_BINARY_DIR}/benchmarks")
+
 # Tests targets
 add_subdirectory("architecture/utilities/tests")

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,5 +1,8 @@
 # content of pytest.ini
 [pytest]
+testpaths =
+    .
+    ../benchmarks/tests
 markers =
     slowtest: mark a test as a slow unit test.
     scenarioTest: mark a test as a tutorial scenario test.

--- a/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.cpp
+++ b/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.cpp
@@ -104,7 +104,7 @@ void GravityGradientEffector::computeForceTorque(double integTime, double timeSt
 
     /* compute DCN [BN] */
     Eigen::MRPd sigmaBN;
-    sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
+    sigmaBN = (Eigen::Vector3d)this->hubSigma->getStateReference();
     Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
     /* evaluate inertia tensor about center of mass */
@@ -119,7 +119,7 @@ void GravityGradientEffector::computeForceTorque(double integTime, double timeSt
         double mu = (*this->muPlanet[c])(0,0);  /* in m^3/s^2 */
 
         /* determine spacecraft CM position relative to planet */
-        Eigen::Vector3d r_CP_N = this->r_BN_N->getState() + dcm_BN.transpose()*(*this->c_B) - *(this->r_PN_N[c]);
+        Eigen::Vector3d r_CP_N = this->r_BN_N->getStateReference() + dcm_BN.transpose()*(*this->c_B) - *(this->r_PN_N[c]);
 
         /* find orbit radius */
         double rMag = r_CP_N.norm();

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -250,8 +250,6 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     this->omega_BN_B = omega_BN_B;
     this->omegaLoc_PN_P = this->omega_BN_B;
     this->omega_PN_S = this->dcm_SP*this->omegaLoc_PN_P;
-    // - Define omegaTildeLoc_BN_B
-    this->omegaTildeLoc_PN_P = eigenTilde(this->omegaLoc_PN_P);
 
     // - Define aTheta
     this->aTheta = -this->mass*this->d/(this->IPntS_S(1,1) + this->mass*this->d*this->d)*this->sHat3_P;
@@ -259,7 +257,8 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     // - Define bTheta
     this->rTilde_HP_P = eigenTilde(this->r_HP_P);
     this->bTheta = -1.0/(this->IPntS_S(1,1) + this->mass*this->d*this->d)*((this->IPntS_S(1,1)
-                      + this->mass*this->d*this->d)*this->sHat2_P + this->mass*this->d*this->rTilde_HP_P*this->sHat3_P);
+                      + this->mass*this->d*this->d)*this->sHat2_P
+                      + this->mass*this->d*this->r_HP_P.cross(this->sHat3_P));
 
     // - Define cTheta
     Eigen::Vector3d gravityTorquePntH_P;
@@ -267,7 +266,7 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     this->cTheta = 1.0/(this->IPntS_S(1,1) + this->mass*this->d*this->d)*(this->u -this->k*(this->theta-this->thetaRef) - this->c*(this->thetaDot-this->thetaDotRef)
                     + this->sHat2_P.dot(gravityTorquePntH_P + this->dcm_SP.transpose() * attBodyTorquePntS_S) + (this->IPntS_S(2,2) - this->IPntS_S(0,0)
                      + this->mass*this->d*this->d)*this->omega_PN_S(2)*this->omega_PN_S(0) - this->mass*this->d*
-                              this->sHat3_P.transpose()*this->omegaTildeLoc_PN_P*this->omegaTildeLoc_PN_P*this->r_HP_P);
+                              this->sHat3_P.dot(this->omegaLoc_PN_P.cross(this->omegaLoc_PN_P.cross(this->r_HP_P))));
 
     // - Start defining them good old contributions - start with translation
     // - For documentation on contributions see Allard, Diaz, Schaub flex/slosh paper
@@ -278,15 +277,15 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
                               + this->dcm_SP.transpose() * attBodyForce_S;
 
     // - Define rotational matrice contributions
-    backSubContr.matrixC = (this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*this->rTilde_SP_P*this->sHat3_P)
-                                                                                              *this->aTheta.transpose();
-    backSubContr.matrixD = (this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*this->rTilde_SP_P*this->sHat3_P)
-                                                                                              *this->bTheta.transpose();
-    Eigen::Matrix3d intermediateMatrix;
-    backSubContr.vecRot = -((this->thetaDot*this->omegaTildeLoc_PN_P + this->cTheta*intermediateMatrix.Identity())
-                    *(this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*this->rTilde_SP_P*this->sHat3_P)
-                                    + this->mass*this->d*this->thetaDot*this->thetaDot*this->rTilde_SP_P*this->sHat1_P)
-                                    + (this->dcm_SP.transpose() * attBodyTorquePntS_S) + eigenTilde(this->r_HP_P) * (this->dcm_SP.transpose() * attBodyForce_S);
+    Eigen::Vector3d rotThetaFactor_P = this->IPntS_S(1,1)*this->sHat2_P
+                                       + this->mass*this->d*this->r_SP_P.cross(this->sHat3_P);
+    backSubContr.matrixC = rotThetaFactor_P * this->aTheta.transpose();
+    backSubContr.matrixD = rotThetaFactor_P * this->bTheta.transpose();
+    backSubContr.vecRot = -(this->thetaDot*this->omegaLoc_PN_P.cross(rotThetaFactor_P)
+                            + this->cTheta*rotThetaFactor_P
+                            + this->mass*this->d*this->thetaDot*this->thetaDot*this->r_SP_P.cross(this->sHat1_P))
+                          + (this->dcm_SP.transpose() * attBodyTorquePntS_S)
+                          + this->r_HP_P.cross(this->dcm_SP.transpose() * attBodyForce_S);
 
     return;
 }
@@ -375,8 +374,6 @@ void HingedRigidBodyStateEffector::calcForceTorqueOnBody(double integTime, Eigen
 
     // - Get the current omega state
     Eigen::Vector3d omegaLocal_PN_P = omega_BN_B;
-    Eigen::Matrix3d omegaLocalTilde_PN_P;
-    omegaLocalTilde_PN_P = eigenTilde(omegaLoc_PN_P);
 
     // - Get thetaDDot from last integrator call
     double thetaDDotLocal;
@@ -384,32 +381,34 @@ void HingedRigidBodyStateEffector::calcForceTorqueOnBody(double integTime, Eigen
 
     // - Calculate force that the HRB is applying to the spacecraft
     this->forceOnBody_B = -(this->mass*this->d*this->sHat3_P*thetaDDotLocal + this->mass*this->d*this->thetaDot
-                            *this->thetaDot*this->sHat1_P + 2.0*omegaLocalTilde_PN_P*this->mass*this->d*this->thetaDot
-                            *this->sHat3_P);
+                            *this->thetaDot*this->sHat1_P + 2.0*this->mass*this->d*this->thetaDot
+                            *this->omegaLoc_PN_P.cross(this->sHat3_P));
 
     // - Calculate torque that the HRB is applying about point B
-    this->torqueOnBodyPntB_B = -((this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*this->rTilde_SP_P*this->sHat3_P)
-                                 *thetaDDotLocal + (this->ISPrimePntS_P - this->mass*(this->rPrimeTilde_SP_P*rTilde_SP_P
-                                                                                      + this->rTilde_SP_P*this->rPrimeTilde_SP_P))*omegaLocal_PN_P + this->thetaDot
-                                 *omegaLocalTilde_PN_P*(this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d
-                                 *this->rTilde_SP_P*this->sHat3_P) + this->mass*this->d*this->thetaDot*this->thetaDot
-                                 *this->rTilde_SP_P*this->sHat1_P);
+    Eigen::Vector3d torqueFactorPntB_P = this->IPntS_S(1,1)*this->sHat2_P
+                                         + this->mass*this->d*this->r_SP_P.cross(this->sHat3_P);
+    Eigen::Vector3d inertiaPrimeOmegaPntB_P = this->ISPrimePntS_P*omegaLocal_PN_P
+                                              - this->mass*(this->rPrime_SP_P.cross(this->r_SP_P.cross(omegaLocal_PN_P))
+                                                            + this->r_SP_P.cross(this->rPrime_SP_P.cross(omegaLocal_PN_P)));
+    this->torqueOnBodyPntB_B = -(torqueFactorPntB_P*thetaDDotLocal + inertiaPrimeOmegaPntB_P
+                                 + this->thetaDot*this->omegaLoc_PN_P.cross(torqueFactorPntB_P)
+                                 + this->mass*this->d*this->thetaDot*this->thetaDot*this->r_SP_P.cross(this->sHat1_P));
 
     // - Define values needed to get the torque about point C
     Eigen::Vector3d cLocal_B = *this->c_B;
     Eigen::Vector3d cPrimeLocal_B = *cPrime_B;
     Eigen::Vector3d r_SC_B = this->r_SP_P - cLocal_B;
     Eigen::Vector3d rPrime_SC_B = this->rPrime_SP_P - cPrimeLocal_B;
-    Eigen::Matrix3d rTilde_SC_B = eigenTilde(r_SC_B);
-    Eigen::Matrix3d rPrimeTilde_SC_B = eigenTilde(rPrime_SC_B);
 
     // - Calculate the torque about point C
-    this->torqueOnBodyPntC_B = -((this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d*rTilde_SC_B*this->sHat3_P)
-                                 *thetaDDotLocal + (this->ISPrimePntS_P - this->mass*(rPrimeTilde_SC_B*rTilde_SC_B
-                                 + rTilde_SC_B*rPrimeTilde_SC_B))*omegaLocal_PN_P + this->thetaDot
-                                 *omegaLocalTilde_PN_P*(this->IPntS_S(1,1)*this->sHat2_P + this->mass*this->d
-                                 *rTilde_SC_B*this->sHat3_P) + this->mass*this->d*this->thetaDot*this->thetaDot
-                                 *rTilde_SC_B*this->sHat1_P);
+    Eigen::Vector3d torqueFactorPntC_P = this->IPntS_S(1,1)*this->sHat2_P
+                                         + this->mass*this->d*r_SC_B.cross(this->sHat3_P);
+    Eigen::Vector3d inertiaPrimeOmegaPntC_P = this->ISPrimePntS_P*omegaLocal_PN_P
+                                              - this->mass*(rPrime_SC_B.cross(r_SC_B.cross(omegaLocal_PN_P))
+                                                            + r_SC_B.cross(rPrime_SC_B.cross(omegaLocal_PN_P)));
+    this->torqueOnBodyPntC_B = -(torqueFactorPntC_P*thetaDDotLocal + inertiaPrimeOmegaPntC_P
+                                 + this->thetaDot*this->omegaLoc_PN_P.cross(torqueFactorPntC_P)
+                                 + this->mass*this->d*this->thetaDot*this->thetaDot*r_SC_B.cross(this->sHat1_P));
 
     return;
 }

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -181,8 +181,8 @@ void HingedRigidBodyStateEffector::updateEffectorMassProps(double integTime)
 
     // - Find hinged rigid bodies' position with respect to point B
     // - First need to grab current states
-    this->theta = this->thetaState->getState()(0, 0);
-    this->thetaDot = this->thetaDotState->getState()(0, 0);
+    this->theta = this->thetaState->getStateReference()(0, 0);
+    this->thetaDot = this->thetaDotState->getStateReference()(0, 0);
     // - Next find the sHat unit vectors
     this->dcm_SH = eigenM2(this->theta);
     this->dcm_SP = this->dcm_SH*this->dcm_HP;
@@ -308,7 +308,7 @@ void HingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::V
 
     // - Compute Derivatives
     // - First is trivial
-    this->thetaState->setDerivative(thetaDotState->getState());
+    this->thetaState->setDerivative(thetaDotState->getStateReference());
     // - Second, a little more involved
     Eigen::MatrixXd thetaDDot(1,1);
     thetaDDot(0,0) = this->aTheta.dot(rDDotLoc_PN_P) + this->bTheta.dot(omegaDot_BN_B) + this->cTheta;
@@ -377,7 +377,7 @@ void HingedRigidBodyStateEffector::calcForceTorqueOnBody(double integTime, Eigen
 
     // - Get thetaDDot from last integrator call
     double thetaDDotLocal;
-    thetaDDotLocal = thetaDotState->getStateDeriv()(0, 0);
+    thetaDDotLocal = thetaDotState->getStateDerivReference()(0, 0);
 
     // - Calculate force that the HRB is applying to the spacecraft
     this->forceOnBody_B = -(this->mass*this->d*this->sHat3_P*thetaDDotLocal + this->mass*this->d*this->thetaDot

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
@@ -95,9 +95,9 @@ void LinearSpringMassDamper::registerStates(DynParamManager& states)
 void LinearSpringMassDamper::updateEffectorMassProps(double integTime)
 {
 	// - Grab rho from state manager and define r_PcB_B
-	this->rho = this->rhoState->getState()(0,0);
+	this->rho = this->rhoState->getStateReference()(0,0);
 	this->r_PcB_B = this->rho * this->pHat_B + this->r_PB_B;
-	this->massSMD = this->massState->getState()(0, 0);
+	this->massSMD = this->massState->getStateReference()(0, 0);
 
 	// - Update the effectors mass
 	this->effProps.mEff = this->massSMD;
@@ -108,7 +108,7 @@ void LinearSpringMassDamper::updateEffectorMassProps(double integTime)
 	this->effProps.IEffPntB_B = this->massSMD * this->rTilde_PcB_B * this->rTilde_PcB_B.transpose();
 
 	// - Grab rhoDot from the stateManager and define rPrime_PcB_B
-	this->rhoDot = this->rhoDotState->getState()(0, 0);
+	this->rhoDot = this->rhoDotState->getStateReference()(0, 0);
 	this->rPrime_PcB_B = this->rhoDot * this->pHat_B;
 	this->effProps.rEffPrime_CB_B = this->rPrime_PcB_B;
 
@@ -181,7 +181,7 @@ void LinearSpringMassDamper::computeDerivatives(double integTime, Eigen::Vector3
 	dcm_BN = (sigmaLocal_BN.toRotationMatrix()).transpose();
 
 	// - Set the derivative of rho to rhoDot
-	this->rhoState->setDerivative(this->rhoDotState->getState());
+	this->rhoState->setDerivative(this->rhoDotState->getStateReference());
 
 	// - Compute rhoDDot
 	Eigen::MatrixXd conv(1,1);
@@ -225,7 +225,7 @@ void LinearSpringMassDamper::calcForceTorqueOnBody(double integTime, Eigen::Vect
 
     // - Get rhoDDot from last integrator call
     double rhoDDotLocal;
-    rhoDDotLocal = rhoDotState->getStateDeriv()(0, 0);
+    rhoDDotLocal = rhoDotState->getStateDerivReference()(0, 0);
 
     // - Calculate force that the FSP is applying to the spacecraft
     this->forceOnBody_B = -(this->massSMD*this->pHat_B*rhoDDotLocal + 2*this->massSMD

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
@@ -150,24 +150,22 @@ void LinearSpringMassDamper::updateContributions(double integTime, BackSubMatric
     this->aRho = -this->pHat_B;
 
     // - Define bRho
-    this->bRho = -this->rTilde_PcB_B*this->pHat_B;
+    this->bRho = this->pHat_B.cross(this->r_PcB_B);
 
     // - Define cRho
     Eigen::Vector3d omega_BN_B_local = omega_BN_B;
-    Eigen::Matrix3d omegaTilde_BN_B_local;
-    omegaTilde_BN_B_local = eigenTilde(omega_BN_B_local);
 	cRho = 1.0/(this->massSMD)*(this->pHat_B.dot(this->massSMD * g_B) - this->k*this->rho - this->c*this->rhoDot
-		         - 2 * this->massSMD*this->pHat_B.dot(omegaTilde_BN_B_local * this->rPrime_PcB_B)
-		                   - this->massSMD*this->pHat_B.dot(omegaTilde_BN_B_local*omegaTilde_BN_B_local*this->r_PcB_B));
+		         - 2 * this->massSMD*this->pHat_B.dot(omega_BN_B_local.cross(this->rPrime_PcB_B))
+		                   - this->massSMD*this->pHat_B.dot(omega_BN_B_local.cross(omega_BN_B_local.cross(this->r_PcB_B))));
 
 	// - Compute matrix/vector contributions
 	backSubContr.matrixA = this->massSMD*this->pHat_B*this->aRho.transpose();
     backSubContr.matrixB = this->massSMD*this->pHat_B*this->bRho.transpose();
-    backSubContr.matrixC = this->massSMD*this->rTilde_PcB_B*this->pHat_B*this->aRho.transpose();
-	backSubContr.matrixD = this->massSMD*this->rTilde_PcB_B*this->pHat_B*this->bRho.transpose();
+    backSubContr.matrixC = -this->massSMD*this->bRho*this->aRho.transpose();
+	backSubContr.matrixD = -this->massSMD*this->bRho*this->bRho.transpose();
 	backSubContr.vecTrans = -this->massSMD*this->cRho*this->pHat_B;
-	backSubContr.vecRot = -this->massSMD*omegaTilde_BN_B_local * this->rTilde_PcB_B *this->rPrime_PcB_B -
-                                                             this->massSMD*this->cRho*this->rTilde_PcB_B * this->pHat_B;
+	backSubContr.vecRot = -this->massSMD*omega_BN_B_local.cross(this->r_PcB_B.cross(this->rPrime_PcB_B)) +
+	                                                             this->massSMD*this->cRho*this->bRho;
     return;
 }
 
@@ -224,30 +222,32 @@ void LinearSpringMassDamper::calcForceTorqueOnBody(double integTime, Eigen::Vect
     // - Get the current omega state
     Eigen::Vector3d omegaLocal_BN_B;
     omegaLocal_BN_B = omega_BN_B;
-    Eigen::Matrix3d omegaLocalTilde_BN_B;
-    omegaLocalTilde_BN_B = eigenTilde(omegaLocal_BN_B);
 
     // - Get rhoDDot from last integrator call
     double rhoDDotLocal;
     rhoDDotLocal = rhoDotState->getStateDeriv()(0, 0);
 
     // - Calculate force that the FSP is applying to the spacecraft
-    this->forceOnBody_B = -(this->massSMD*this->pHat_B*rhoDDotLocal + 2*omegaLocalTilde_BN_B*this->massSMD
-                            *this->rhoDot*this->pHat_B);
+    this->forceOnBody_B = -(this->massSMD*this->pHat_B*rhoDDotLocal + 2*this->massSMD
+                            *this->rhoDot*omegaLocal_BN_B.cross(this->pHat_B));
 
     // - Calculate torque that the FSP is applying about point B
-    this->torqueOnBodyPntB_B = -(this->massSMD*this->rTilde_PcB_B*this->pHat_B*rhoDDotLocal + this->massSMD*omegaLocalTilde_BN_B*this->rTilde_PcB_B*this->rPrime_PcB_B - this->massSMD*(this->rPrimeTilde_PcB_B*this->rTilde_PcB_B + this->rTilde_PcB_B*this->rPrimeTilde_PcB_B)*omegaLocal_BN_B);
+    this->torqueOnBodyPntB_B = -(this->massSMD*this->r_PcB_B.cross(this->pHat_B)*rhoDDotLocal
+                                 + this->massSMD*omegaLocal_BN_B.cross(this->r_PcB_B.cross(this->rPrime_PcB_B))
+                                 - this->massSMD*(this->rPrime_PcB_B.cross(this->r_PcB_B.cross(omegaLocal_BN_B))
+                                                   + this->r_PcB_B.cross(this->rPrime_PcB_B.cross(omegaLocal_BN_B))));
 
     // - Define values needed to get the torque about point C
     Eigen::Vector3d cLocal_B = *this->c_B;
     Eigen::Vector3d cPrimeLocal_B = *this->cPrime_B;
     Eigen::Vector3d r_PcC_B = this->r_PcB_B - cLocal_B;
     Eigen::Vector3d rPrime_PcC_B = this->rPrime_PcB_B - cPrimeLocal_B;
-    Eigen::Matrix3d rTilde_PcC_B = eigenTilde(r_PcC_B);
-    Eigen::Matrix3d rPrimeTilde_PcC_B = eigenTilde(rPrime_PcC_B);
 
     // - Calculate the torque about point C
-    this->torqueOnBodyPntC_B = -(this->massSMD*rTilde_PcC_B*this->pHat_B*rhoDDotLocal + this->massSMD*omegaLocalTilde_BN_B*rTilde_PcC_B*rPrime_PcC_B - this->massSMD*(rPrimeTilde_PcC_B*rTilde_PcC_B + rTilde_PcC_B*rPrimeTilde_PcC_B)*omegaLocal_BN_B);
+    this->torqueOnBodyPntC_B = -(this->massSMD*r_PcC_B.cross(this->pHat_B)*rhoDDotLocal
+                                 + this->massSMD*omegaLocal_BN_B.cross(r_PcC_B.cross(rPrime_PcC_B))
+                                 - this->massSMD*(rPrime_PcC_B.cross(r_PcC_B.cross(omegaLocal_BN_B))
+                                                   + r_PcC_B.cross(rPrime_PcC_B.cross(omegaLocal_BN_B))));
 
     return;
 }

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -120,14 +120,16 @@ void NHingedRigidBodyStateEffector::updateEffectorMassProps(double integTime)
     Eigen::Vector3d sum_rPrimeH;
     sum_rPrimeH.setZero();
 
+    const Eigen::MatrixXd& thetaVector = this->thetaState->getStateReference();
+    const Eigen::MatrixXd& thetaDotVector = this->thetaDotState->getStateReference();
     std::vector<HingedPanel>::iterator PanelIt;
     int it = 0;
     for(PanelIt=this->PanelVec.begin(); PanelIt!=this->PanelVec.end(); PanelIt++){
 
         // - Find hinged rigid bodies' position with respect to point B
         // - First need to grab current states
-        PanelIt->theta = this->thetaState->getState()(it, 0);
-        PanelIt->thetaDot = this->thetaDotState->getState()(it, 0);
+        PanelIt->theta = thetaVector(it, 0);
+        PanelIt->thetaDot = thetaDotVector(it, 0);
         // - Next find the sHat unit vectors
         sum_Theta += PanelIt->theta;
         PanelIt->dcm_SS_prev = eigenM2(PanelIt->theta);
@@ -466,7 +468,7 @@ void NHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::
         i += 1;
     }
     // - First is trivial
-    this->thetaState->setDerivative(this->thetaDotState->getState());
+    this->thetaState->setDerivative(this->thetaDotState->getStateReference());
     // - Second, a little more involved
     this->thetaDotState->setDerivative(thetaDDot);
 

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -226,8 +226,6 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
     for(PanelIt=this->PanelVec.begin(); PanelIt!=this->PanelVec.end(); PanelIt++){
         PanelIt->omega_BN_S = PanelIt->dcm_SB*this->omegaLoc_BN_B;
     }
-    // - Define omegaTildeLoc_BN_B
-    this->omegaTildeLoc_BN_B = eigenTilde(this->omegaLoc_BN_B);
 
     // - Define A matrix for the panel equations
     std::vector<HingedPanel>::iterator PanelIt2;
@@ -287,12 +285,12 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
             PanelIt2 = PanelIt;
             std::advance(PanelIt2, 1);
             for(int i = j+1; i<=(int) this->PanelVec.size();i++){
-                sumTerm2 += (2*PanelIt->mass*PanelIt->d*PanelIt->sHat3_B.transpose()*PanelIt2->rTilde_SB_B).transpose();
+                sumTerm2 += 2*PanelIt->mass*PanelIt->d*PanelIt->sHat3_B.cross(PanelIt2->r_SB_B);
                 std::advance(PanelIt2, 1);
             }
         }
-        sumTerm1 = -(PanelIt->IPntS_S(1,1)*PanelIt->sHat2_B.transpose()-PanelIt->mass*PanelIt->d
-                     *PanelIt->sHat3_B.transpose()*PanelIt->rTilde_SB_B - sumTerm2.transpose());
+        sumTerm1 = -(PanelIt->IPntS_S(1,1)*PanelIt->sHat2_B - PanelIt->mass*PanelIt->d
+                     *PanelIt->sHat3_B.cross(PanelIt->r_SB_B) - sumTerm2);
         this->matrixGDHRB(j-1,0) = sumTerm1[0];
         this->matrixGDHRB(j-1,1) = sumTerm1[1];
         this->matrixGDHRB(j-1,2) = sumTerm1[2];
@@ -325,8 +323,8 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
             PanelIt3 = PanelIt;
             std::advance(PanelIt3, 1);
             for(int i = j+1; i <= (int) this->PanelVec.size(); i++){
-                sumTerm2 += 4*this->omegaTildeLoc_BN_B*PanelIt3->rPrime_SB_B
-                +2*this->omegaTildeLoc_BN_B*this->omegaTildeLoc_BN_B*PanelIt3->r_SB_B;
+                sumTerm2 += 4*this->omegaLoc_BN_B.cross(PanelIt3->rPrime_SB_B)
+                +2*this->omegaLoc_BN_B.cross(this->omegaLoc_BN_B.cross(PanelIt3->r_SB_B));
                 std::advance(PanelIt3, 1);
             }
         }
@@ -345,8 +343,8 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
         }
         sumTerm3 -= pow(sumThetaDot, 2)*PanelIt->d*PanelIt->sHat1_B;
         sumTerm1 = springTerm -(PanelIt->IPntS_S(0,0) - PanelIt->IPntS_S(2,2))*PanelIt->omega_BN_S(2)
-        *PanelIt->omega_BN_S(0) - PanelIt->mass*PanelIt->d*PanelIt->sHat3_B.transpose()*(2*this->omegaTildeLoc_BN_B
-             *PanelIt->rPrime_SB_B+this->omegaTildeLoc_BN_B*this->omegaTildeLoc_BN_B*PanelIt->r_SB_B+sumTerm2+sumTerm3);
+        *PanelIt->omega_BN_S(0) - PanelIt->mass*PanelIt->d*PanelIt->sHat3_B.dot(2*this->omegaLoc_BN_B.cross(PanelIt->rPrime_SB_B)
+             +this->omegaLoc_BN_B.cross(this->omegaLoc_BN_B.cross(PanelIt->r_SB_B))+sumTerm2+sumTerm3);
         // Add gravity torque to this sumTerm
         Eigen::Vector3d gravTorqueCurPanel;
         gravTorqueCurPanel = -PanelIt->d*PanelIt->sHat1_B.cross(PanelIt->mass*g_B);
@@ -398,7 +396,7 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
     backSubContr.vecRot.setZero();
     sumThetaDot = 0;
     sumTerm2.setZero();
-    Eigen::Matrix3d sumTerm3;
+    Eigen::Vector3d sumTerm3;
     j = 1;
     for(PanelIt=this->PanelVec.begin(); PanelIt!=this->PanelVec.end(); PanelIt++){
         Eigen::Vector3d sumTerm1;
@@ -411,12 +409,12 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
                 PanelIt3 = PanelIt2;
                 std::advance(PanelIt3, 1);
                 for(int n = k+1; n <= (int) this->PanelVec.size();n++){
-                    sumTerm3 += 2*PanelIt3->rTilde_SB_B;
+                    sumTerm3 += 2*PanelIt3->r_SB_B.cross(PanelIt2->sHat3_B);
                     std::advance(PanelIt3, 1);
                 }
             }
             sumTerm1 += PanelIt2->IPntS_S(1,1)*PanelIt2->sHat2_B
-            +(PanelIt2->rTilde_SB_B+sumTerm3)*PanelIt2->mass*PanelIt2->d*PanelIt2->sHat3_B;
+            + PanelIt2->mass*PanelIt2->d*(PanelIt2->r_SB_B.cross(PanelIt2->sHat3_B) + sumTerm3);
             std::advance(PanelIt2, 1);
         }
         sumTerm3.setZero();
@@ -424,13 +422,13 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
             PanelIt3 = PanelIt;
             std::advance(PanelIt3, 1);
             for(int n = j+1; n <= (int) this->PanelVec.size();n++){
-                sumTerm3 += 2*PanelIt3->rTilde_SB_B;
+                sumTerm3 += 2*PanelIt3->r_SB_B.cross(PanelIt->sHat1_B);
                 std::advance(PanelIt3, 1);
             }
         }
-        sumTerm2 = PanelIt->mass*this->omegaTildeLoc_BN_B*PanelIt->rTilde_SB_B*PanelIt->rPrime_SB_B
-        + pow(sumThetaDot,2)*(PanelIt->rTilde_SB_B+sumTerm3)*PanelIt->mass*PanelIt->d*PanelIt->sHat1_B
-        + PanelIt->IPntS_S(1,1)*sumThetaDot*this->omegaTildeLoc_BN_B*PanelIt->sHat2_B;
+        sumTerm2 = PanelIt->mass*this->omegaLoc_BN_B.cross(PanelIt->r_SB_B.cross(PanelIt->rPrime_SB_B))
+        + pow(sumThetaDot,2)*PanelIt->mass*PanelIt->d*(PanelIt->r_SB_B.cross(PanelIt->sHat1_B) + sumTerm3)
+        + PanelIt->IPntS_S(1,1)*sumThetaDot*this->omegaLoc_BN_B.cross(PanelIt->sHat2_B);
         backSubContr.matrixC += sumTerm1*this->matrixEDHRB.row(j-1)*this->matrixFDHRB;
         backSubContr.matrixD += sumTerm1*this->matrixEDHRB.row(j-1)*this->matrixGDHRB;
         backSubContr.vecRot += -sumTerm2 - sumTerm1*this->matrixEDHRB.row(j-1)*this->vectorVDHRB;

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -84,7 +84,6 @@ private:
     Eigen::Vector3d aTheta;         //!< -- term needed for back substitution
     Eigen::Vector3d bTheta;         //!< -- term needed for back substitution
     Eigen::Vector3d omegaLoc_BN_B;  //!< [rad/s] local copy of omegaBN
-    Eigen::Matrix3d omegaTildeLoc_BN_B; //!< -- tilde matrix of omegaBN
     Eigen::MatrixXd *g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
     static uint64_t effectorID;        //!< [] ID number of this panel
 

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -262,7 +262,6 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 	double omegas;
 	double omegat;
 	double OmegaSquared;
-	Eigen::Matrix3d omegaTilde;
     Eigen::MRPd sigmaBNLocal;
     Eigen::Matrix3d dcm_BN;                        /* direction cosine matrix from N to B */
     Eigen::Matrix3d dcm_NB;                        /* direction cosine matrix from B to N */
@@ -294,7 +293,6 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 	for(it=VSCMGData.begin(); it!=VSCMGData.end(); it++)
 	{
 		OmegaSquared = it->Omega * it->Omega;
-		omegaTilde = eigenTilde(omegaLoc_BN_B);
 		omega_WB_B = it->gammaDot*it->ggHat_B+it->Omega*it->gsHat_B;
 		omegas = it->gsHat_B.transpose()*omegaLoc_BN_B;
 		omegat = it->gtHat_B.transpose()*omegaLoc_BN_B;
@@ -302,7 +300,7 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 		if (it->VSCMGModel == vscmgBalancedWheels || it->VSCMGModel == vscmgJitterSimple) {
 			backSubContr.matrixD -= it->IV3 * it->ggHat_B * it->ggHat_B.transpose() + it->IW1 * it->gsHat_B * it->gsHat_B.transpose();
 			backSubContr.vecRot -= (it->u_s_current-it->IW1*omegat*it->gammaDot)*it->gsHat_B + it->IW1*it->Omega*it->gammaDot*it->gtHat_B + (it->u_g_current+(it->IV1-it->IV2)*omegas*omegat+it->IW1*it->Omega*omegat)*it->ggHat_B
-			+ omegaTilde*it->IGPntGc_B*it->gammaDot*it->ggHat_B + omegaTilde*it->IWPntWc_B*omega_WB_B;
+			+ omegaLoc_BN_B.cross(it->IGPntGc_B*it->gammaDot*it->ggHat_B) + omegaLoc_BN_B.cross(it->IWPntWc_B*omega_WB_B);
 			if (it->VSCMGModel == vscmgJitterSimple) {
 				/* static imbalance force: Fs = Us * Omega^2 */
 				tempF = it->U_s * OmegaSquared * it->w2Hat_B;
@@ -320,16 +318,12 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 
 			double dSquared = it->d * it->d;
 			double gammaDotSquared = it->gammaDot * it->gammaDot;
-			Eigen::Matrix3d omegaTildeSquared = omegaTilde*omegaTilde;
-			Eigen::Matrix3d ggHatTilde_B = eigenTilde(it->ggHat_B);
-			Eigen::Matrix3d w2HatTilde_B = eigenTilde(it->w2Hat_B);
 			Eigen::Vector3d omega_GN_B = omegaLoc_BN_B + it->gammaDot*it->ggHat_B;
 			Eigen::Vector3d omega_WN_B = omega_GN_B + it->Omega*it->gsHat_B;
 
 			Eigen::Vector3d rVcG_B = 1.0/it->massV*(it->massG*it->rGcG_B + it->massW*it->rWcG_B);
 			Eigen::Vector3d rVcB_B = rVcG_B + it->rGB_B;
 			Eigen::Matrix3d rTildeVcG_B = eigenTilde(rVcG_B);
-			Eigen::Matrix3d rTildeVcB_B = eigenTilde(rVcG_B + it->rGB_B);
 			Eigen::Vector3d rGcVc_B = it->rGcG_B - rVcG_B;
 			Eigen::Vector3d rWcVc_B = it->rWcG_B - rVcG_B;
 			Eigen::Matrix3d rTildeGcVc_B = eigenTilde(rGcVc_B);
@@ -346,38 +340,38 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 			Eigen::Matrix3d P = it->massW*it->rhoG*rTildeWcVc_B - it->massG*it->rhoW*rTildeGcVc_B + it->massW*rTildeVcG_B;
 			Eigen::Matrix3d Q = it->massG*it->rhoW*rTildeGcVc_B - it->massW*it->rhoG*rTildeWcVc_B + it->massG*rTildeVcG_B;
 
-			it->egamma = it->ggHat_B.dot(it->IGPntGc_B*it->ggHat_B+it->IWPntWc_B*it->ggHat_B+P*(it->l*it->gtHat_B-it->d*cos(it->theta)*it->gsHat_B)+Q*ggHatTilde_B*it->rGcG_B);
-			it->agamma = 1.0/it->egamma*it->massV*rTildeVcG_B*it->ggHat_B;
-			it->bgamma = -1.0/it->egamma*(IVPntVc_B.transpose()*it->ggHat_B-it->massV*rTildeVcB_B*rTildeVcG_B*it->ggHat_B);
+			it->egamma = it->ggHat_B.dot(it->IGPntGc_B*it->ggHat_B+it->IWPntWc_B*it->ggHat_B+P*(it->l*it->gtHat_B-it->d*cos(it->theta)*it->gsHat_B)+Q*it->ggHat_B.cross(it->rGcG_B));
+			it->agamma = 1.0/it->egamma*it->massV*rVcG_B.cross(it->ggHat_B);
+			it->bgamma = -1.0/it->egamma*(IVPntVc_B*it->ggHat_B-it->massV*rVcB_B.cross(rVcG_B.cross(it->ggHat_B)));
 			it->cgamma = -1.0/it->egamma*(it->ggHat_B.dot(it->IWPntWc_B*it->gsHat_B) + it->d*it->ggHat_B.dot(P*it->w3Hat_B));
-			it->dgamma = -1.0/it->egamma*it->ggHat_B.dot( it->gammaDot*Q*ggHatTilde_B*rPrimeGcG_B + P*((2.0*it->d*it->gammaDot*it->Omega*sin(it->theta)-it->l*gammaDotSquared)*it->gsHat_B-it->d*gammaDotSquared*cos(it->theta)*it->gtHat_B-it->d*OmegaSquared*it->w2Hat_B)
-							+ it->IPrimeGPntGc_B*omega_GN_B + omegaTilde*it->IGPntGc_B*omega_GN_B + it->IWPntWc_B*it->Omega*it->gammaDot*it->gtHat_B + it->IPrimeWPntWc_B*omega_WN_B + omegaTilde*it->IWPntWc_B*omega_WN_B
-							+ it->massG*rTildeGcVc_B*(2.0*omegaTilde*rPrimeGcVc_B+omegaTilde*omegaTilde*rGcVc_B) + it->massW*rTildeWcVc_B*(2.0*omegaTilde*rPrimeWcVc_B+omegaTildeSquared*rWcVc_B)
-							+ it->massV*rTildeVcG_B*(2.0*omegaTilde*rPrimeVcB_B+omegaTildeSquared*rVcB_B) )
+			it->dgamma = -1.0/it->egamma*it->ggHat_B.dot( it->gammaDot*Q*it->ggHat_B.cross(rPrimeGcG_B) + P*((2.0*it->d*it->gammaDot*it->Omega*sin(it->theta)-it->l*gammaDotSquared)*it->gsHat_B-it->d*gammaDotSquared*cos(it->theta)*it->gtHat_B-it->d*OmegaSquared*it->w2Hat_B)
+							+ it->IPrimeGPntGc_B*omega_GN_B + omegaLoc_BN_B.cross(it->IGPntGc_B*omega_GN_B) + it->IWPntWc_B*it->Omega*it->gammaDot*it->gtHat_B + it->IPrimeWPntWc_B*omega_WN_B + omegaLoc_BN_B.cross(it->IWPntWc_B*omega_WN_B)
+							+ it->massG*rGcVc_B.cross(2.0*omegaLoc_BN_B.cross(rPrimeGcVc_B)+omegaLoc_BN_B.cross(omegaLoc_BN_B.cross(rGcVc_B))) + it->massW*rWcVc_B.cross(2.0*omegaLoc_BN_B.cross(rPrimeWcVc_B)+omegaLoc_BN_B.cross(omegaLoc_BN_B.cross(rWcVc_B)))
+							+ it->massV*rVcG_B.cross(2.0*omegaLoc_BN_B.cross(rPrimeVcB_B)+omegaLoc_BN_B.cross(omegaLoc_BN_B.cross(rVcB_B))) )
 							+ 1.0/it->egamma*(it->u_g_current + it->gravityTorqueGimbal_g);
 
 			it->eOmega = it->IW1 + it->massW*dSquared;
 			it->aOmega = -1.0/it->eOmega*it->massW*it->d*it->w3Hat_B;
-			it->bOmega = -1.0/it->eOmega*(it->IWPntWc_B.transpose()*it->gsHat_B - it->massW*it->d*it->rTildeWcB_B*w2HatTilde_B*it->gsHat_B);
+			it->bOmega = -1.0/it->eOmega*(it->IWPntWc_B*it->gsHat_B - it->massW*it->d*it->rWcB_B.cross(it->w2Hat_B.cross(it->gsHat_B)));
 			it->cOmega = -1.0/it->eOmega*(it->IW13*cos(it->theta)-it->massW*it->d*it->l*sin(it->theta));
 			it->dOmega = -1.0/it->eOmega*(it->gsHat_B.dot(it->IPrimeWPntWc_B*omega_WN_B)
-										  + it->gsHat_B.transpose()*omegaTilde*it->IWPntWc_B*omega_WN_B
-										  + it->massW*it->d*it->gsHat_B.transpose()*w2HatTilde_B*(2.0*it->rPrimeTildeWcB_B.transpose()*omegaLoc_BN_B+omegaTilde*omegaTilde*it->rWcB_B))
+										  + it->gsHat_B.dot(omegaLoc_BN_B.cross(it->IWPntWc_B*omega_WN_B))
+										  + it->massW*it->d*it->gsHat_B.dot(it->w2Hat_B.cross(2.0*omegaLoc_BN_B.cross(it->rPrimeWcB_B)+omegaLoc_BN_B.cross(omegaLoc_BN_B.cross(it->rWcB_B)))))
 										  + (1.0/it->eOmega)*(it->IW13*sin(it->theta)*it->Omega*it->gammaDot - it->massW*dSquared*gammaDotSquared*cos(it->theta)*sin(it->theta) + it->u_s_current + it->gravityTorqueWheel_s);
 
 			it->p = (it->aOmega+it->cOmega*it->agamma)/(1.0-it->cOmega*it->cgamma);
 			it->q = (it->bOmega+it->cOmega*it->bgamma)/(1.0-it->cOmega*it->cgamma);
 			it->s = (it->dOmega+it->cOmega*it->dgamma)/(1.0-it->cOmega*it->cgamma);
 
-			ur = it->massG*ggHatTilde_B*it->rGcG_B - it->massW*it->d*cos(it->theta)*it->gsHat_B + it->massW*it->l*it->gtHat_B;
+			ur = it->massG*it->ggHat_B.cross(it->rGcG_B) - it->massW*it->d*cos(it->theta)*it->gsHat_B + it->massW*it->l*it->gtHat_B;
 			vr = it->massW*it->d*it->w3Hat_B;
-			kr = it->massG*it->gammaDot*ggHatTilde_B*it->rPrimeGcB_B + it->massW*((2.0*it->d*it->gammaDot*it->Omega*sin(it->theta)-it->l*gammaDotSquared)*it->gsHat_B-it->d*gammaDotSquared*cos(it->theta)*it->gtHat_B-it->d*OmegaSquared*it->w2Hat_B);
+			kr = it->massG*it->gammaDot*it->ggHat_B.cross(it->rPrimeGcB_B) + it->massW*((2.0*it->d*it->gammaDot*it->Omega*sin(it->theta)-it->l*gammaDotSquared)*it->gsHat_B-it->d*gammaDotSquared*cos(it->theta)*it->gtHat_B-it->d*OmegaSquared*it->w2Hat_B);
 
-			uomega = it->IGPntGc_B*it->ggHat_B + it->massG*it->rTildeGcB_B*ggHatTilde_B*it->rGcG_B + it->IWPntWc_B*it->ggHat_B + it->massW*it->rTildeWcB_B*(it->l*it->gtHat_B-it->d*cos(it->theta)*it->gsHat_B);
-			vomega = it->IWPntWc_B*it->gsHat_B + it->massW*it->d*it->rTildeWcB_B*it->w3Hat_B;
-			komega = it->IPrimeGPntGc_B*it->gammaDot*it->ggHat_B + omegaTilde*it->IGPntGc_B*it->gammaDot*it->ggHat_B + it->massG*omegaTilde*it->rTildeGcB_B*it->rPrimeGcB_B + it->massG*it->gammaDot*it->rTildeGcB_B*ggHatTilde_B*rPrimeGcG_B
-						+ it->IWPntWc_B*it->Omega*it->gammaDot*it->gtHat_B + it->IPrimeWPntWc_B*omega_WB_B + omegaTilde*it->IWPntWc_B*omega_WB_B + it->massW*omegaTilde*it->rTildeWcB_B*it->rPrimeWcB_B
-						+ it->massW*it->rTildeWcB_B*((2.0*it->d*it->gammaDot*it->Omega*sin(it->theta)-it->l*gammaDotSquared)*it->gsHat_B-it->d*gammaDotSquared*cos(it->theta)*it->gtHat_B-it->d*OmegaSquared*it->w2Hat_B);
+			uomega = it->IGPntGc_B*it->ggHat_B + it->massG*it->rGcB_B.cross(it->ggHat_B.cross(it->rGcG_B)) + it->IWPntWc_B*it->ggHat_B + it->massW*it->rWcB_B.cross(it->l*it->gtHat_B-it->d*cos(it->theta)*it->gsHat_B);
+			vomega = it->IWPntWc_B*it->gsHat_B + it->massW*it->d*it->rWcB_B.cross(it->w3Hat_B);
+			komega = it->IPrimeGPntGc_B*it->gammaDot*it->ggHat_B + omegaLoc_BN_B.cross(it->IGPntGc_B*it->gammaDot*it->ggHat_B) + it->massG*omegaLoc_BN_B.cross(it->rGcB_B.cross(it->rPrimeGcB_B)) + it->massG*it->gammaDot*it->rGcB_B.cross(it->ggHat_B.cross(rPrimeGcG_B))
+						+ it->IWPntWc_B*it->Omega*it->gammaDot*it->gtHat_B + it->IPrimeWPntWc_B*omega_WB_B + omegaLoc_BN_B.cross(it->IWPntWc_B*omega_WB_B) + it->massW*omegaLoc_BN_B.cross(it->rWcB_B.cross(it->rPrimeWcB_B))
+						+ it->massW*it->rWcB_B.cross((2.0*it->d*it->gammaDot*it->Omega*sin(it->theta)-it->l*gammaDotSquared)*it->gsHat_B-it->d*gammaDotSquared*cos(it->theta)*it->gtHat_B-it->d*OmegaSquared*it->w2Hat_B);
 
 			backSubContr.matrixA += ur*it->agamma.transpose() + (vr+ur*it->cgamma)*it->p.transpose();
 			backSubContr.matrixB += ur*it->bgamma.transpose() + (vr+ur*it->cgamma)*it->q.transpose();

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -107,15 +107,20 @@ void VSCMGStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.rEffPrime_CB_B.setZero();
     this->effProps.IEffPrimePntB_B.setZero();
 
+    const Eigen::MatrixXd& omegasVector = this->OmegasState->getStateReference();
+    const Eigen::MatrixXd& gammasVector = this->gammasState->getStateReference();
+    const Eigen::MatrixXd& gammaDotsVector = this->gammaDotsState->getStateReference();
+    const Eigen::MatrixXd* thetaVector = this->numVSCMGJitter > 0 ? &this->thetasState->getStateReference() : nullptr;
     int thetaCount = 0;
     std::vector<VSCMGConfigMsgPayload>::iterator it;
 	for(it=VSCMGData.begin(); it!=VSCMGData.end(); it++)
 	{
-		it->Omega = this->OmegasState->getState()(it - VSCMGData.begin(), 0);
-		it->gamma = this->gammasState->getState()(it - VSCMGData.begin(), 0);
-		it->gammaDot = this->gammaDotsState->getState()(it - VSCMGData.begin(), 0);
+        std::size_t vscmgIndex = it - VSCMGData.begin();
+		it->Omega = omegasVector(vscmgIndex, 0);
+		it->gamma = gammasVector(vscmgIndex, 0);
+		it->gammaDot = gammaDotsVector(vscmgIndex, 0);
 		if (it->VSCMGModel == vscmgJitterFullyCoupled || it->VSCMGModel == vscmgJitterSimple) {
-			it->theta = this->thetasState->getState()(thetaCount, 0);
+			it->theta = (*thetaVector)(thetaCount, 0);
 			thetaCount++;
 		}
 
@@ -405,7 +410,7 @@ void VSCMGStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rD
 
 	//! Grab necessarry values from manager
 	omegaDotBNLoc_B = omegaDot_BN_B;
-	omegaLoc_BN_B = this->hubOmega->getState();
+	omegaLoc_BN_B = this->hubOmega->getStateReference();
 	rDDotBNLoc_N = rDDot_BN_N;
 	sigmaBNLocal = (Eigen::Vector3d ) sigma_BN;
 	dcm_NB = sigmaBNLocal.toRotationMatrix();
@@ -448,7 +453,7 @@ void VSCMGStateEffector::updateEnergyMomContributions(double integTime, Eigen::V
 	Eigen::MRPd sigmaBNLocal;
 	Eigen::Matrix3d dcm_BN;                        /* direction cosine matrix from N to B */
 	Eigen::Matrix3d dcm_NB;                        /* direction cosine matrix from B to N */
-	Eigen::Vector3d omegaLoc_BN_B = hubOmega->getState();
+	Eigen::Vector3d omegaLoc_BN_B = hubOmega->getStateReference();
 
     //! - Compute energy and momentum contribution of each wheel
     rotAngMomPntCContr_B.setZero();
@@ -535,23 +540,28 @@ void VSCMGStateEffector::WriteOutputMessages(uint64_t CurrentClock)
 {
     this->outputStates = this->speedOutMsg.zeroMsgPayload;
 	VSCMGConfigMsgPayload tmpVSCMG;
+    const Eigen::MatrixXd& omegasVector = this->OmegasState->getStateReference();
+    const Eigen::MatrixXd& gammasVector = this->gammasState->getStateReference();
+    const Eigen::MatrixXd& gammaDotsVector = this->gammaDotsState->getStateReference();
+    const Eigen::MatrixXd* thetaVector = this->numVSCMGJitter > 0 ? &this->thetasState->getStateReference() : nullptr;
 	std::vector<VSCMGConfigMsgPayload>::iterator it;
 	for (it = VSCMGData.begin(); it != VSCMGData.end(); it++)
 	{
+        std::size_t vscmgIndex = it - VSCMGData.begin();
         tmpVSCMG = this->vscmgOutMsgs[0]->zeroMsgPayload;
         if (numVSCMGJitter > 0) {
-            double thetaCurrent = this->thetasState->getState()(it - VSCMGData.begin(), 0);
+            double thetaCurrent = (*thetaVector)(vscmgIndex, 0);
             it->theta = thetaCurrent;
         }
-        double omegaCurrent = this->OmegasState->getState()(it - VSCMGData.begin(), 0);
+        double omegaCurrent = omegasVector(vscmgIndex, 0);
         it->Omega = omegaCurrent;
-		this->outputStates.wheelSpeeds[it - VSCMGData.begin()] = it->Omega;
-		double gammaCurrent = this->gammasState->getState()(it - VSCMGData.begin(), 0);
+		this->outputStates.wheelSpeeds[vscmgIndex] = it->Omega;
+		double gammaCurrent = gammasVector(vscmgIndex, 0);
 		it->gamma = gammaCurrent;
-		this->outputStates.gimbalAngles[it - VSCMGData.begin()] = it->gamma;
-		double gammaDotCurrent = this->gammaDotsState->getState()(it - VSCMGData.begin(), 0);
+		this->outputStates.gimbalAngles[vscmgIndex] = it->gamma;
+		double gammaDotCurrent = gammaDotsVector(vscmgIndex, 0);
 		it->gammaDot = gammaDotCurrent;
-		this->outputStates.gimbalRates[it - VSCMGData.begin()] = it->gammaDot;
+		this->outputStates.gimbalRates[vscmgIndex] = it->gammaDot;
 
 		tmpVSCMG.u_s_current = it->u_s_current;
 		tmpVSCMG.u_s_max = it->u_s_max;

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.cpp
@@ -41,7 +41,7 @@ void StateVector::setStates(const StateVector& operand)
     for (auto [it1, it2] = std::tuple{std::begin(this->stateMap), std::begin(operand.stateMap)};
          it1 != std::end(this->stateMap) && it2 != std::end(operand.stateMap);
          ++it1, ++it2) {
-        it1->second->setState(it2->second->getState());
+        it1->second->setState(it2->second->getStateReference());
     }
 }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.i
+++ b/src/simulation/dynamics/_GeneralModuleFiles/dynParamManager.i
@@ -33,6 +33,10 @@
 // Uses unique_ptr, don't need it at the Python level
 %ignore StateData::clone;
 
+// These accessors expose internal Eigen storage and are intended for C++ use only.
+%ignore StateData::getStateReference;
+%ignore StateData::getStateDerivReference;
+
 %include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 
 // Current limitation of SWIG for complex templated types like

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
@@ -174,9 +174,9 @@ void HubEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_
     Eigen::Vector3d cLocal_B;
     Eigen::Vector3d cPrimeLocal_B;
     Eigen::Vector3d gLocal_N;
-    rDotLocal_BN_N = velocityState->getState();
-    sigmaLocal_BN = (Eigen::Vector3d )sigmaState->getState();
-    omegaLocal_BN_B = omegaState->getState();
+    rDotLocal_BN_N = velocityState->getStateReference();
+    sigmaLocal_BN = (Eigen::Vector3d )sigmaState->getStateReference();
+    omegaLocal_BN_B = omegaState->getStateReference();
     gLocal_N = *this->g_N;
 
     // - Set kinematic derivative
@@ -216,10 +216,10 @@ void HubEffector::computeHubOnlyDerivatives(const Eigen::Vector3d& forceExternal
                                             const Eigen::Vector3d& forceExternal_B,
                                             const Eigen::Vector3d& torquePntB_B)
 {
-    Eigen::Vector3d rDotLocal_BN_N = this->velocityState->getState();
+    Eigen::Vector3d rDotLocal_BN_N = this->velocityState->getStateReference();
     Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d) this->sigmaState->getState();
-    Eigen::Vector3d omegaLocal_BN_B = this->omegaState->getState();
+    sigmaLocal_BN = (Eigen::Vector3d) this->sigmaState->getStateReference();
+    Eigen::Vector3d omegaLocal_BN_B = this->omegaState->getStateReference();
     Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
 
     Eigen::Vector3d translationalAccel_N =
@@ -245,7 +245,7 @@ void HubEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d
 {
     // - Get variables needed for energy momentum calcs
     Eigen::Vector3d omegaLocal_BN_B;
-    omegaLocal_BN_B = omegaState->getState();
+    omegaLocal_BN_B = omegaState->getStateReference();
 
     //  - Find rotational angular momentum contribution from hub
     Eigen::Vector3d rDot_BcB_B;
@@ -263,7 +263,7 @@ void HubEffector::modifyStates(double integTime)
 {
     // Lets switch those MRPs!!
     Eigen::Vector3d sigmaBNLoc;
-    sigmaBNLoc = (Eigen::Vector3d) this->sigmaState->getState();
+    sigmaBNLoc = (Eigen::Vector3d) this->sigmaState->getStateReference();
     if (sigmaBNLoc.norm() > 1) {
         sigmaBNLoc = -sigmaBNLoc/(sigmaBNLoc.dot(sigmaBNLoc));
         this->sigmaState->setState(sigmaBNLoc);
@@ -275,6 +275,6 @@ void HubEffector::modifyStates(double integTime)
 /*! This method is used to set the gravitational velocity state equal to the base velocity state */
 void HubEffector::matchGravitytoVelocityState(Eigen::Vector3d v_CN_N)
 {
-    this->gravVelocityState->setState(this->velocityState->getState());
+    this->gravVelocityState->setState(this->velocityState->getStateReference());
     this->gravVelocityBcState->setState(v_CN_N);
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
@@ -210,6 +210,35 @@ void HubEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_
     return;
 }
 
+/*! This method computes direct derivatives for a fixed-mass hub-only spacecraft whose body
+ frame origin is at the hub center of mass. */
+void HubEffector::computeHubOnlyDerivatives(const Eigen::Vector3d& forceExternal_N,
+                                            const Eigen::Vector3d& forceExternal_B,
+                                            const Eigen::Vector3d& torquePntB_B)
+{
+    Eigen::Vector3d rDotLocal_BN_N = this->velocityState->getState();
+    Eigen::MRPd sigmaLocal_BN;
+    sigmaLocal_BN = (Eigen::Vector3d) this->sigmaState->getState();
+    Eigen::Vector3d omegaLocal_BN_B = this->omegaState->getState();
+    Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
+
+    Eigen::Vector3d translationalAccel_N =
+        *this->g_N + (forceExternal_N + dcm_NB*forceExternal_B)/this->effProps.mEff;
+
+    Eigen::Vector3d rotAngularMomentumPntB_B = this->effProps.IEffPntB_B*omegaLocal_BN_B;
+    Eigen::Vector3d omegaDotLocal_BN_B =
+        this->effProps.IEffPntB_B.ldlt().solve(torquePntB_B - omegaLocal_BN_B.cross(rotAngularMomentumPntB_B));
+
+    this->posState->setDerivative(rDotLocal_BN_N);
+    this->velocityState->setDerivative(translationalAccel_N);
+    this->sigmaState->setDerivative(1.0/4.0*sigmaLocal_BN.Bmat()*omegaLocal_BN_B);
+    this->omegaState->setDerivative(omegaDotLocal_BN_B);
+    this->gravVelocityState->setDerivative(*this->g_N);
+    this->gravVelocityBcState->setDerivative(*this->g_N);
+
+    return;
+}
+
 /*! This method is for computing the energy and momentum contributions from the hub */
 void HubEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                                double & rotEnergyContr, Eigen::Vector3d omega_BN_B)

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
@@ -114,6 +114,31 @@ void HubEffector::registerStates(DynParamManager& states)
     return;
 }
 
+/*! This method allows the hub to register only translational states: r_BN_N and v_BN_N */
+void HubEffector::registerTranslationalStates(DynParamManager& states)
+{
+    // - Register the hub translational states and set with initial values
+    this->posState = states.registerState(3, 1, this->nameOfHubPosition);
+    this->velocityState = states.registerState(3, 1, this->nameOfHubVelocity);
+
+    this->posState->setState(this->r_CN_NInit);
+    this->velocityState->setState(this->v_CN_NInit);
+
+    return;
+}
+
+/*! This method allows the hub to register fixed attitude states for point-mass dynamics with dynamic effectors */
+void HubEffector::registerAttitudeStates(DynParamManager& states)
+{
+    this->sigmaState = states.registerState(3, 1, this->nameOfHubSigma);
+    this->omegaState = states.registerState(3, 1, this->nameOfHubOmega);
+
+    this->sigmaState->setState(this->sigma_BNInit);
+    this->omegaState->setState(this->omega_BN_BInit);
+
+    return;
+}
+
 /*! This method allows the hub to give its mass properties to the spacecraft */
 void HubEffector::updateEffectorMassProps(double integTime)
 {

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
@@ -55,6 +55,9 @@ public:
     void registerAttitudeStates(DynParamManager& states);       //!< -- Register constant attitude hub states
     void updateEffectorMassProps(double integTime);  //!< -- Method for the hub to update its mass props for the s/c
     void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for the hub to compute it's derivatives
+    void computeHubOnlyDerivatives(const Eigen::Vector3d& forceExternal_N,
+                                   const Eigen::Vector3d& forceExternal_B,
+                                   const Eigen::Vector3d& torquePntB_B);  //!< -- Compute direct hub derivatives
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                       double & rotEnergyContr, Eigen::Vector3d omega_BN_B); //!< -- Add contributions to energy and momentum
     void modifyStates(double integTime); //!< -- Method to switch MRPs

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
@@ -51,6 +51,8 @@ public:
     ~HubEffector();                      //!< -- Destructor
     void linkInStates(DynParamManager& statesIn);  //!< -- Method to give the hub access to states
     void registerStates(DynParamManager& states);  //!< -- Method for the hub to register some states
+    void registerTranslationalStates(DynParamManager& states);  //!< -- Register only translational hub states
+    void registerAttitudeStates(DynParamManager& states);       //!< -- Register constant attitude hub states
     void updateEffectorMassProps(double integTime);  //!< -- Method for the hub to update its mass props for the s/c
     void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for the hub to compute it's derivatives
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateData.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateData.h
@@ -115,8 +115,26 @@ public:
     /** Retrieves a copy of the current state */
     Eigen::MatrixXd getState() const { return state; }
 
+    /** Retrieves a constant reference to the current state.
+     *
+     * Unlike getState(), this method does not create a copy. Subsequent state updates
+     * are visible through the returned reference, which must not outlive this object.
+     *
+     * @return Constant reference to the current state
+     */
+    const Eigen::MatrixXd& getStateReference() const { return state; }
+
     /** Retrieves a copy of the current state derivative */
     Eigen::MatrixXd getStateDeriv() const { return stateDeriv; }
+
+    /** Retrieves a constant reference to the current state derivative.
+     *
+     * Unlike getStateDeriv(), this method does not create a copy. Subsequent derivative
+     * updates are visible through the returned reference, which must not outlive this object.
+     *
+     * @return Constant reference to the current state derivative
+     */
+    const Eigen::MatrixXd& getStateDerivReference() const { return stateDeriv; }
 
     /** Retrieves a copy of the current state diffusion
      *

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -157,10 +157,10 @@ void DualHingedRigidBodyStateEffector::updateEffectorMassProps(double integTime)
 
     // - find hinged rigid bodies' position with respect to point B
     // - First need to grab current states
-    this->theta1 = this->theta1State->getState()(0, 0);
-    this->theta1Dot = this->theta1DotState->getState()(0, 0);
-    this->theta2 = this->theta2State->getState()(0, 0);
-    this->theta2Dot = this->theta2DotState->getState()(0, 0);
+    this->theta1 = this->theta1State->getStateReference()(0, 0);
+    this->theta1Dot = this->theta1DotState->getStateReference()(0, 0);
+    this->theta2 = this->theta2State->getStateReference()(0, 0);
+    this->theta2Dot = this->theta2DotState->getStateReference()(0, 0);
     // - Next find the sHat unit vectors
     Eigen::Matrix3d dcmS1H1;
     dcmS1H1 = eigenM2(this->theta1);
@@ -314,7 +314,7 @@ void DualHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eige
     Eigen::Vector3d omegaDotBNLoc_B;              /* time derivative of omegaBN in B frame */
 
     // Grab necessarry values from manager (these have been previously computed in hubEffector)
-    rDDotBNLoc_N = this->v_BN_NState->getStateDeriv();
+    rDDotBNLoc_N = this->v_BN_NState->getStateDerivReference();
     this->sigma_BN = sigma_BN;
     sigmaBNLocal = this->sigma_BN;
     omegaDotBNLoc_B = omegaDot_BN_B;
@@ -324,11 +324,11 @@ void DualHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eige
 
     // - Compute Derivatives
     // - First is trivial
-    this->theta1State->setDerivative(theta1DotState->getState());
+    this->theta1State->setDerivative(theta1DotState->getStateReference());
     // - Second, a little more involved - see Allard, Diaz, Schaub flex/slosh paper
     theta1DDot(0,0) = this->matrixEDHRB.row(0).dot(this->matrixFDHRB*rDDotBNLoc_B) + this->matrixEDHRB.row(0)*this->matrixGDHRB*omegaDotBNLoc_B + this->matrixEDHRB.row(0)*this->vectorVDHRB;
     this->theta1DotState->setDerivative(theta1DDot);
-    this->theta2State->setDerivative(theta2DotState->getState());
+    this->theta2State->setDerivative(theta2DotState->getStateReference());
     theta2DDot(0,0) = this->matrixEDHRB.row(1)*(this->matrixFDHRB*rDDotBNLoc_B) + this->matrixEDHRB.row(1).dot(this->matrixGDHRB*omegaDotBNLoc_B) + this->matrixEDHRB.row(1)*this->vectorVDHRB;
     this->theta2DotState->setDerivative(theta2DDot);
 

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -235,8 +235,7 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime, Bac
     this->omega_PNLoc_P = this->omega_BN_B;
     this->omega_PN_S1 = this->dcm_S1P*this->omega_PNLoc_P;
     this->omega_PN_S2 = this->dcm_S2P*this->omega_PNLoc_P;
-    // - Define omegaTildeBNLoc_B
-    this->omegaTildePNLoc_P = eigenTilde(this->omega_PNLoc_P);
+
     // - Define matrices needed for back substitution
     //gravityTorquePntH1_B = -this->d1*this->sHat11_B.cross(this->mass1*g_B); //Need to review these equations and implement them - SJKC
     //gravityTorquePntH2_B = -this->d2*this->sHat21_B.cross(this->mass2*g_B); //Need to review these equations and implement them - SJKC
@@ -248,16 +247,24 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime, Bac
     this->matrixFDHRB.row(0) = -(this->mass2*this->l1 + this->mass1*this->d1)*this->sHat13_P.transpose();
     this->matrixFDHRB.row(1) = -this->mass2*this->d2*this->sHat23_P.transpose();
 
-    this->matrixGDHRB.row(0) = -(this->IPntS1_S1(1,1)*this->sHat12_P.transpose() - this->mass1*this->d1*this->sHat13_P.transpose()*this->rTildeS1P_P - this->mass2*this->l1*this->sHat13_P.transpose()*this->rTildeS2P_P);
-    this->matrixGDHRB.row(1) = -(this->IPntS2_S2(1,1)*this->sHat22_P.transpose() - this->mass2*this->d2*this->sHat23_P.transpose()*this->rTildeS2P_P);
+    this->matrixGDHRB.row(0) = -(this->IPntS1_S1(1,1)*this->sHat12_P.transpose()
+                                 - this->mass1*this->d1*this->sHat13_P.cross(this->r_S1P_P).transpose()
+                                 - this->mass2*this->l1*this->sHat13_P.cross(this->r_S2P_P).transpose());
+    this->matrixGDHRB.row(1) = -(this->IPntS2_S2(1,1)*this->sHat22_P.transpose()
+                                 - this->mass2*this->d2*this->sHat23_P.cross(this->r_S2P_P).transpose());
 
     this->vectorVDHRB(0) =  -(this->IPntS1_S1(0,0) - this->IPntS1_S1(2,2))*this->omega_PN_S1(2)*this->omega_PN_S1(0)
                             + this->u1 - this->k1*this->theta1 - this->c1*this->theta1Dot + this->k2*this->theta2 + this->c2*this->theta2Dot + this->sHat12_P.dot(gravTorquePan1PntH1) + this->l1*this->sHat13_P.dot(gravForcePan2) -
-                            this->mass1*this->d1*this->sHat13_P.transpose()*(2*this->omegaTildePNLoc_P*this->rPrimeS1P_P + this->omegaTildePNLoc_P*this->omegaTildePNLoc_P*this->r_S1P_P)
-                            - this->mass2*this->l1*this->sHat13_P.transpose()*(2*this->omegaTildePNLoc_P*this->rPrimeS2P_P + this->omegaTildePNLoc_P*this->omegaTildePNLoc_P*this->r_S2P_P + this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P + this->d2*(this->theta1Dot + this->theta2Dot)*(this->theta1Dot + this->theta2Dot)*this->sHat21_P); //still missing torque and force terms - SJKC
+                            this->mass1*this->d1*this->sHat13_P.dot(2*this->omega_PNLoc_P.cross(this->rPrimeS1P_P)
+                            + this->omega_PNLoc_P.cross(this->omega_PNLoc_P.cross(this->r_S1P_P)))
+                            - this->mass2*this->l1*this->sHat13_P.dot(2*this->omega_PNLoc_P.cross(this->rPrimeS2P_P)
+                            + this->omega_PNLoc_P.cross(this->omega_PNLoc_P.cross(this->r_S2P_P))
+                            + this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P
+                            + this->d2*(this->theta1Dot + this->theta2Dot)*(this->theta1Dot + this->theta2Dot)*this->sHat21_P); //still missing torque and force terms - SJKC
 
     this->vectorVDHRB(1) =  -(this->IPntS2_S2(0,0) - this->IPntS2_S2(2,2))*this->omega_PN_S2(2)*this->omega_PN_S2(0)
-                            + this->u2 - this->k2*this->theta2 - this->c2*this->theta2Dot + this->sHat22_P.dot(gravTorquePan2PntH2) - this->mass2*this->d2*this->sHat23_P.transpose()*(2*this->omegaTildePNLoc_P*this->rPrimeS2P_P + this->omegaTildePNLoc_P*this->omegaTildePNLoc_P*this->r_S2P_P + this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P); // still missing torque term. - SJKC
+                            + this->u2 - this->k2*this->theta2 - this->c2*this->theta2Dot + this->sHat22_P.dot(gravTorquePan2PntH2) - this->mass2*this->d2*this->sHat23_P.dot(2*this->omega_PNLoc_P.cross(this->rPrimeS2P_P)
+                            + this->omega_PNLoc_P.cross(this->omega_PNLoc_P.cross(this->r_S2P_P)) + this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P); // still missing torque term. - SJKC
 
     // - Start defining them good old contributions - start with translation
     // - For documentation on contributions see Allard, Diaz, Schaub flex/slosh paper
@@ -268,16 +275,28 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime, Bac
 
     // - Define rotational matrice contributions (Eq 96 in paper)
 
-    backSubContr.matrixC = (this->IPntS1_S1(1,1)*this->sHat12_P + this->mass1*this->d1*this->rTildeS1P_P*this->sHat13_P + this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->l1*this->rTildeS2P_P*this->sHat13_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(0)*this->matrixFDHRB
-                    + (this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(1)*this->matrixFDHRB;
+    Eigen::Vector3d rotFactor0_P = this->IPntS1_S1(1,1)*this->sHat12_P
+                                   + this->mass1*this->d1*this->r_S1P_P.cross(this->sHat13_P)
+                                   + this->IPntS2_S2(1,1)*this->sHat22_P
+                                   + this->mass2*this->l1*this->r_S2P_P.cross(this->sHat13_P)
+                                   + this->mass2*this->d2*this->r_S2P_P.cross(this->sHat23_P);
+    Eigen::Vector3d rotFactor1_P = this->IPntS2_S2(1,1)*this->sHat22_P
+                                   + this->mass2*this->d2*this->r_S2P_P.cross(this->sHat23_P);
+    backSubContr.matrixC = rotFactor0_P*this->matrixEDHRB.row(0)*this->matrixFDHRB
+                    + rotFactor1_P*this->matrixEDHRB.row(1)*this->matrixFDHRB;
 
-    backSubContr.matrixD = (this->IPntS1_S1(1,1)*this->sHat12_P + this->mass1*this->d1*this->rTildeS1P_P*this->sHat13_P + this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->l1*this->rTildeS2P_P*this->sHat13_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(0)*this->matrixGDHRB
-                    +(this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(1)*this->matrixGDHRB;
+    backSubContr.matrixD = rotFactor0_P*this->matrixEDHRB.row(0)*this->matrixGDHRB
+                    + rotFactor1_P*this->matrixEDHRB.row(1)*this->matrixGDHRB;
 
-    backSubContr.vecRot = -(this->theta1Dot*this->IPntS1_S1(1,1)*this->omegaTildePNLoc_P*this->sHat12_P
-                    + this->mass1*this->omegaTildePNLoc_P*this->rTildeS1P_P*this->rPrimeS1P_P + this->mass1*this->d1*this->theta1Dot*this->theta1Dot*this->rTildeS1P_P*this->sHat11_P + (this->theta1Dot+this->theta2Dot)*this->IPntS2_S2(1,1)*this->omegaTildePNLoc_P*this->sHat22_P + this->mass2*this->omegaTildePNLoc_P*this->rTildeS2P_P*this->rPrimeS2P_P
-                    + this->mass2*this->rTildeS2P_P*(this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P + this->d2*(this->theta1Dot+this->theta2Dot)*(this->theta1Dot+this->theta2Dot)*this->sHat21_P) + (this->IPntS1_S1(1,1)*this->sHat12_P + this->mass1*this->d1*this->rTildeS1P_P*this->sHat13_P + this->IPntS2_S2(1,1)*this->sHat22_P
-                    + this->mass2*this->l1*this->rTildeS2P_P*this->sHat13_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(0)*this->vectorVDHRB + (this->IPntS2_S2(1,1)*this->sHat22_P + this->mass2*this->d2*this->rTildeS2P_P*this->sHat23_P)*this->matrixEDHRB.row(1)*this->vectorVDHRB);
+    backSubContr.vecRot = -(this->theta1Dot*this->IPntS1_S1(1,1)*this->omega_PNLoc_P.cross(this->sHat12_P)
+                    + this->mass1*this->omega_PNLoc_P.cross(this->r_S1P_P.cross(this->rPrimeS1P_P))
+                    + this->mass1*this->d1*this->theta1Dot*this->theta1Dot*this->r_S1P_P.cross(this->sHat11_P)
+                    + (this->theta1Dot+this->theta2Dot)*this->IPntS2_S2(1,1)*this->omega_PNLoc_P.cross(this->sHat22_P)
+                    + this->mass2*this->omega_PNLoc_P.cross(this->r_S2P_P.cross(this->rPrimeS2P_P))
+                    + this->mass2*this->r_S2P_P.cross(this->l1*this->theta1Dot*this->theta1Dot*this->sHat11_P
+                    + this->d2*(this->theta1Dot+this->theta2Dot)*(this->theta1Dot+this->theta2Dot)*this->sHat21_P)
+                    + rotFactor0_P*this->matrixEDHRB.row(0)*this->vectorVDHRB
+                    + rotFactor1_P*this->matrixEDHRB.row(1)*this->vectorVDHRB);
 
     return;
 }

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -235,8 +235,8 @@ void LinearTranslationNDOFStateEffector::updateEffectorMassProps(double integTim
         this->effProps.mEff += translatingBody->mass;
 
         // Grab current states
-        translatingBody->rho = this->rhoState->getState()(i, 0);
-        translatingBody->rhoDot = this->rhoDotState->getState()(i, 0);
+        translatingBody->rho = this->rhoState->getStateReference()(i, 0);
+        translatingBody->rhoDot = this->rhoDotState->getStateReference()(i, 0);
 
         // Write the translating axis in B frame
         if (i == 0) {
@@ -423,7 +423,7 @@ void LinearTranslationNDOFStateEffector::computeDerivatives(double integTime, Ei
 
     // Compute rho and rhoDot derivatives
     Eigen::VectorXd rhoDDot = this->ARho * rDDotLocal_BN_B + this->BRho * omegaDot_BN_B + this->CRho;
-    this->rhoState->setDerivative(this->rhoDotState->getState());
+    this->rhoState->setDerivative(this->rhoDotState->getStateReference());
     this->rhoDotState->setDerivative(rhoDDot);
 }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -354,9 +354,9 @@ void LinearTranslationNDOFStateEffector::computeBRhoStar(Eigen::MatrixXd& BRhoSt
             continue;
         for (int i = n; i<this->N; i++) {
             Eigen::Vector3d r_FciB_B = this->translatingBodyVec[i]->r_FcB_B;
-            Eigen::Matrix3d rTilde_FciB_B = eigenTilde(r_FciB_B);
 
-            BRhoStar.row(n) += this->translatingBodyVec[n]->fHat_B.transpose() * this->translatingBodyVec[i]->mass * rTilde_FciB_B;
+            BRhoStar.row(n) += this->translatingBodyVec[i]->mass
+                                * this->translatingBodyVec[n]->fHat_B.cross(r_FciB_B).transpose();
         }
     }
 }
@@ -365,8 +365,6 @@ void LinearTranslationNDOFStateEffector::computeBRhoStar(Eigen::MatrixXd& BRhoSt
 void LinearTranslationNDOFStateEffector::computeCRhoStar(Eigen::VectorXd& CRhoStar,
                                                       const Eigen::Vector3d& g_N)
 {
-    Eigen::Matrix3d omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
-
     // Map gravity to body frame
     Eigen::Vector3d g_B;
     g_B = this->dcm_BN * g_N;
@@ -385,7 +383,8 @@ void LinearTranslationNDOFStateEffector::computeCRhoStar(Eigen::VectorXd& CRhoSt
 
             F_g = this->translatingBodyVec[i]->mass * g_B;
             CRhoStar(n, 0) += this->translatingBodyVec[n]->fHat_B.transpose() * (F_g - this->translatingBodyVec[i]->mass *
-                              (omegaTilde_BN_B * omegaTilde_BN_B * r_FciB_B + 2 * omegaTilde_BN_B * rPrime_FciB_B));
+                              (this->omega_BN_B.cross(this->omega_BN_B.cross(r_FciB_B))
+                               + 2 * this->omega_BN_B.cross(rPrime_FciB_B)));
         }
     }
 }
@@ -393,14 +392,14 @@ void LinearTranslationNDOFStateEffector::computeCRhoStar(Eigen::VectorXd& CRhoSt
 /*! This method computes the back-sub contributions of the system */
 void LinearTranslationNDOFStateEffector::computeBackSubContributions(BackSubMatrices& backSubContr) const
 {
-    Eigen::Matrix3d omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
-
     for (int i = 0; i<this->N; i++) {
-    Eigen::Matrix3d rTilde_FciB_B = eigenTilde(this->translatingBodyVec[i]->r_FcB_B);
-    Eigen::Vector3d rPrime_FciB_B = this->translatingBodyVec[i]->rPrime_FcB_B;
-    backSubContr.vecRot -= this->translatingBodyVec[i]->mass * omegaTilde_BN_B * rTilde_FciB_B * rPrime_FciB_B;
+        Eigen::Vector3d r_FciB_B = this->translatingBodyVec[i]->r_FcB_B;
+        Eigen::Vector3d rPrime_FciB_B = this->translatingBodyVec[i]->rPrime_FcB_B;
+        backSubContr.vecRot -= this->translatingBodyVec[i]->mass
+                               * this->omega_BN_B.cross(r_FciB_B.cross(rPrime_FciB_B));
         for (int j = i; j < this->N; j++) {
-            Eigen::Matrix3d rTilde_FcjB_B = eigenTilde(this->translatingBodyVec[j]->r_FcB_B);
+            Eigen::Vector3d rCrossFHat_B = this->translatingBodyVec[j]->r_FcB_B.cross(
+                this->translatingBodyVec[i]->fHat_B);
 
             // Translation contributions
             backSubContr.matrixA += this->translatingBodyVec[j]->mass *  this->translatingBodyVec[i]->fHat_B * this->ARho.row(i);
@@ -408,9 +407,9 @@ void LinearTranslationNDOFStateEffector::computeBackSubContributions(BackSubMatr
             backSubContr.vecTrans -= this->translatingBodyVec[j]->mass * this->translatingBodyVec[i]->fHat_B * this->CRho.row(i);
 
             // Rotation contributions
-            backSubContr.matrixC += this->translatingBodyVec[j]->mass * rTilde_FcjB_B * this->translatingBodyVec[i]->fHat_B * this->ARho.row(i);
-            backSubContr.matrixD += this->translatingBodyVec[j]->mass * rTilde_FcjB_B * this->translatingBodyVec[i]->fHat_B * this->BRho.row(i);
-            backSubContr.vecRot -= this->translatingBodyVec[j]->mass * rTilde_FcjB_B * this->translatingBodyVec[i]->fHat_B * this->CRho.row(i);
+            backSubContr.matrixC += this->translatingBodyVec[j]->mass * rCrossFHat_B * this->ARho.row(i);
+            backSubContr.matrixD += this->translatingBodyVec[j]->mass * rCrossFHat_B * this->BRho.row(i);
+            backSubContr.vecRot -= this->translatingBodyVec[j]->mass * rCrossFHat_B * this->CRho.row(i);
         }
     }
 }
@@ -435,7 +434,6 @@ void LinearTranslationNDOFStateEffector::updateEnergyMomContributions(double int
                                                                       Eigen::Vector3d omega_BN_B)
 {
     this->omega_BN_B = omega_BN_B;
-    Eigen::Matrix3d omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
 
     rotAngMomPntCContr_B = Eigen::Vector3d::Zero();
     rotEnergyContr = 0.0;
@@ -445,10 +443,12 @@ void LinearTranslationNDOFStateEffector::updateEnergyMomContributions(double int
         translatingBody->omega_FN_B = this->omega_BN_B;
 
         // Compute rDot_FcB_B
-        translatingBody->rDot_FcB_B = translatingBody->rPrime_FcB_B + omegaTilde_BN_B * translatingBody->r_FcB_B;
+        translatingBody->rDot_FcB_B = translatingBody->rPrime_FcB_B
+                                      + this->omega_BN_B.cross(translatingBody->r_FcB_B);
 
         // Find rotational angular momentum contribution from hub
-        rotAngMomPntCContr_B += translatingBody->IPntFc_B * translatingBody->omega_FN_B + translatingBody->mass * translatingBody->rTilde_FcB_B * translatingBody->rDot_FcB_B;
+        rotAngMomPntCContr_B += translatingBody->IPntFc_B * translatingBody->omega_FN_B
+                                + translatingBody->mass * translatingBody->r_FcB_B.cross(translatingBody->rDot_FcB_B);
 
         // Find rotational energy contribution from the hub
         rotEnergyContr += 1.0 / 2.0 * translatingBody->omega_FN_B.dot(translatingBody->IPntFc_B * translatingBody->omega_FN_B)

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -227,7 +227,6 @@ void LinearTranslationOneDOFStateEffector::updateContributions(double integTime,
     sigmaLocal_BN = sigma_BN;
     this->dcm_BN = sigmaLocal_BN.toRotationMatrix().transpose();
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(omega_BN_B);
 
     Eigen::Vector3d gLocal_N = *this->g_N;
     Eigen::Vector3d g_B = dcm_BN * gLocal_N;
@@ -261,29 +260,31 @@ void LinearTranslationOneDOFStateEffector::computeBackSubContributions(BackSubMa
 
         backSubContr.vecTrans = this->dcm_FB.transpose() * attBodyForce_F;
         backSubContr.vecRot = this->dcm_FB.transpose() * attBodyTorquePntF_F +
-                              eigenTilde(this->r_F0B_B + this->rho * this->fHat_B) *
-                              (this->dcm_FB.transpose() * attBodyForce_F);
+                              (this->r_F0B_B + this->rho * this->fHat_B).cross(
+                                  this->dcm_FB.transpose() * attBodyForce_F);
         return;
     }
 
     this->aRho = -this->fHat_B.transpose();
-    this->bRho = this->fHat_B.transpose() * this->rTilde_FcB_B;
+    this->bRho = this->fHat_B.cross(this->r_FcB_B);
     this->cRho = 1.0 / this->mass * (this->motorForce - this->k * (this->rho - this->rhoRef)
                  - this->c * (this->rhoDot - this->rhoDotRef)
                  + this->fHat_B.transpose() * (F_g + this->dcm_FB.transpose() * attBodyForce_F
-                 - this->mass * (2 * this->omegaTilde_BN_B * this->rPrime_FcB_B
-                 + this->omegaTilde_BN_B*this->omegaTilde_BN_B*this->r_FcB_B)));
+                 - this->mass * (2 * this->omega_BN_B.cross(this->rPrime_FcB_B)
+                 + this->omega_BN_B.cross(this->omega_BN_B.cross(this->r_FcB_B)))));
 
+    Eigen::Vector3d rCrossFHat_B = this->r_FcB_B.cross(this->fHat_B);
     backSubContr.matrixA = this->mass * this->fHat_B * this->aRho.transpose();
     backSubContr.matrixB = this->mass * this->fHat_B * this->bRho.transpose();
-    backSubContr.matrixC = this->mass * this->rTilde_FcB_B * this->fHat_B * this->aRho.transpose();
-	backSubContr.matrixD = this->mass * this->rTilde_FcB_B * this->fHat_B * this->bRho.transpose();
+    backSubContr.matrixC = this->mass * rCrossFHat_B * this->aRho.transpose();
+	backSubContr.matrixD = this->mass * rCrossFHat_B * this->bRho.transpose();
 	backSubContr.vecTrans = - this->mass * this->cRho * this->fHat_B
                             + this->dcm_FB.transpose() * attBodyForce_F;
-	backSubContr.vecRot = - this->mass * this->omegaTilde_BN_B * this->rTilde_FcB_B * this->rPrime_FcB_B
-                          - this->mass * this->cRho * this->rTilde_FcB_B * this->fHat_B
-                          + this->dcm_FB.transpose() * attBodyTorquePntF_F + eigenTilde(this->r_F0B_B +
-                          this->rho * this->fHat_B) * (this->dcm_FB.transpose() * attBodyForce_F);
+	backSubContr.vecRot = - this->mass * this->omega_BN_B.cross(this->r_FcB_B.cross(this->rPrime_FcB_B))
+                          - this->mass * this->cRho * rCrossFHat_B
+                          + this->dcm_FB.transpose() * attBodyTorquePntF_F
+                          + (this->r_F0B_B + this->rho * this->fHat_B).cross(
+                              this->dcm_FB.transpose() * attBodyForce_F);
 }
 
 void LinearTranslationOneDOFStateEffector::addPrescribedMotionCouplingContributions(BackSubMatrices & backSubContr) {
@@ -376,11 +377,10 @@ void LinearTranslationOneDOFStateEffector::updateEnergyMomContributions(double i
 {
     // Update omega_BN_B and omega_FN_B
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
     Eigen::Vector3d omega_FN_B = this->omega_BN_B;
 
     // Compute rDot_FcB_B
-    Eigen::Vector3d rDot_FcB_B = this->rPrime_FcB_B + this->omegaTilde_BN_B * this->r_FcB_B;
+    Eigen::Vector3d rDot_FcB_B = this->rPrime_FcB_B + this->omega_BN_B.cross(this->r_FcB_B);
 
     // Find rotational angular momentum contribution
     rotAngMomPntCContr_B = this->IPntFc_B * omega_FN_B + this->mass * this->r_FcB_B.cross(rDot_FcB_B);
@@ -399,10 +399,10 @@ void LinearTranslationOneDOFStateEffector::computeTranslatingBodyInertialStates(
 
     this->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * this->r_FcB_B;
     *this->r_FN_N = this->r_FcN_N - dcm_FN.transpose() * this->r_FcF_F;
-    Eigen::Vector3d rDot_FcB_B = this->rPrime_FcB_B + this->omegaTilde_BN_B * this->r_FcB_B;
+    Eigen::Vector3d rDot_FcB_B = this->rPrime_FcB_B + this->omega_BN_B.cross(this->r_FcB_B);
     this->v_FcN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * rDot_FcB_B;
-    *this->v_FN_N = this->dcm_BN.transpose() * (this->rPrime_FcB_B + this->omegaTilde_BN_B *
-                    (this->r_FcB_B - this->dcm_FB.transpose() * this->r_FcF_F));
+    *this->v_FN_N = this->dcm_BN.transpose() * (this->rPrime_FcB_B + this->omega_BN_B.cross(
+                    this->r_FcB_B - this->dcm_FB.transpose() * this->r_FcF_F));
 }
 
 void LinearTranslationOneDOFStateEffector::UpdateState(uint64_t currentSimNanos)

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -194,8 +194,8 @@ void LinearTranslationOneDOFStateEffector::writeOutputStateMessages(uint64_t cur
 
 void LinearTranslationOneDOFStateEffector::updateEffectorMassProps(double integTime)
 {
-	this->rho = this->rhoState->getState()(0,0);
-    this->rhoDot = this->rhoDotState->getState()(0, 0);
+	this->rho = this->rhoState->getStateReference()(0,0);
+    this->rhoDot = this->rhoDotState->getStateReference()(0, 0);
 
     if (this->isAxisLocked)
     {
@@ -300,7 +300,7 @@ void LinearTranslationOneDOFStateEffector::addPrescribedMotionCouplingContributi
     Eigen::Matrix3d dcm_PB = sigma_PB.toRotationMatrix().transpose();
 
     // Collect hub states
-    Eigen::Vector3d omega_BN_B = this->hubOmega->getState();
+    Eigen::Vector3d omega_BN_B = this->hubOmega->getStateReference();
     Eigen::Vector3d omega_BN_P = dcm_PB * omega_BN_B;
 
     // Prescribed motion translation coupling contributions
@@ -367,7 +367,7 @@ void LinearTranslationOneDOFStateEffector::computeDerivatives(double integTime,
 	Eigen::Vector3d rDDot_BN_B = dcm_BN * rDDot_BN_N;
     rhoDDot(0,0) = this->aRho.dot(rDDot_BN_B) + this->bRho.dot(omegaDot_BN_B) + this->cRho;
 	this->rhoDotState->setDerivative(rhoDDot);
-    this->rhoState->setDerivative(this->rhoDotState->getState());
+    this->rhoState->setDerivative(this->rhoDotState->getStateReference());
 }
 
 void LinearTranslationOneDOFStateEffector::updateEnergyMomContributions(double integTime,

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
@@ -126,7 +126,6 @@ private:
 	Eigen::Matrix3d IPntFc_B = Eigen::Matrix3d::Identity();       //!< [kg-m^2] Inertia of Fc about point B in B frame components
 	Eigen::Matrix3d dcm_BN = Eigen::Matrix3d::Identity();         //!< DCM from the B frame to the N frame
     Eigen::Vector3d omega_BN_B = Eigen::Vector3d::Zero();         //!< [rad/s] angular velocity of the B frame wrt the N frame in B frame components.
-    Eigen::Matrix3d omegaTilde_BN_B = Eigen::Matrix3d::Zero();    //!< [rad/s] tilde matrix of omega_BN_B
 
     Eigen::Vector3d aRho = Eigen::Vector3d::Zero();          //!< Term needed for back-sub method
     Eigen::Vector3d bRho = Eigen::Vector3d::Zero();          //!< Term needed for back-sub method

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -201,7 +201,7 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
     this->r_PM_M = this->rEpoch_PM_M + (this->rPrimeEpoch_PM_M * dt) + (0.5 * this->rPrimePrime_PM_M * dt * dt);
     this->rPrime_PM_M = this->rPrimeEpoch_PM_M + (this->rPrimePrime_PM_M * dt);
     this->omega_PM_P = this->omegaEpoch_PM_P + (this->omegaPrime_PM_P * dt);
-    this->sigma_PM = (Eigen::Vector3d)this->sigma_PMState->getState();
+    this->sigma_PM = (Eigen::Vector3d)this->sigma_PMState->getStateReference();
 
     // Give the mass of the prescribed body to the effProps mass
     this->effProps.mEff = this->mass;
@@ -411,7 +411,7 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime,
                                                        Eigen::Vector3d sigma_BN)
 {
     Eigen::MRPd sigma_PM_loc;
-    sigma_PM_loc = (Eigen::Vector3d)this->sigma_PMState->getState();
+    sigma_PM_loc = (Eigen::Vector3d)this->sigma_PMState->getStateReference();
     this->sigma_PMState->setDerivative(0.25*sigma_PM_loc.Bmat()*this->omega_PM_P);
 
     // Loop through attached state effectors for compute derivatives

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -244,7 +244,7 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.IEffPntB_B = this->IPntPc_B - this->mass * this->rTilde_PcB_B * this->rTilde_PcB_B;
 
     // Find the B frame time derivative of r_PcB_B
-    this->rPrime_PcB_B = this->omegaTilde_PB_B * this->r_PcP_B + this->rPrime_PM_B;
+    this->rPrime_PcB_B = this->omega_PB_B.cross(this->r_PcP_B) + this->rPrime_PM_B;
 
     if (this->stateEffectors.empty()) {
         this->effProps.rEff_CB_B = this->r_PcB_B;
@@ -276,7 +276,7 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
         this->effProps.rEff_CB_B += (*it)->effProps.mEff * r_EcB_B;
 
         Eigen::Vector3d rPPrime_EcP_P = (*it)->effProps.rEffPrime_CB_B;
-        Eigen::Vector3d rPrime_EcP_B = this->dcm_BP * rPPrime_EcP_P + this->omegaTilde_PB_B * r_EcP_B;
+        Eigen::Vector3d rPrime_EcP_B = this->dcm_BP * rPPrime_EcP_P + this->omega_PB_B.cross(r_EcP_B);
         *this->rPrime_PB_B = this->rPrime_PM_B;
         Eigen::Vector3d rPrime_EcB_B = rPrime_EcP_B + *this->rPrime_PB_B;
         this->effProps.rEffPrime_CB_B += (*it)->effProps.mEff * rPrime_EcB_B;
@@ -381,18 +381,19 @@ void PrescribedMotionStateEffector::updateContributions(double integTime,
     backSubContr.vecRot = totVecRot;
 
     // Prescribed motion translation contributions
-    Eigen::Matrix3d omegaPrimeTilde_PB_B = eigenTilde(this->omegaPrime_PB_B);
-    this->rPrimePrime_PcB_B = (omegaPrimeTilde_PB_B + this->omegaTilde_PB_B * this->omegaTilde_PB_B) * this->r_PcP_B +
-                              this->rPrimePrime_PM_B;
+    this->rPrimePrime_PcB_B = this->omegaPrime_PB_B.cross(this->r_PcP_B)
+                              + this->omega_PB_B.cross(this->omega_PB_B.cross(this->r_PcP_B))
+                              + this->rPrimePrime_PM_B;
     backSubContr.vecTrans += -this->mass * this->rPrimePrime_PcB_B;
 
     // Prescribed motion rotation contributions
     Eigen::Matrix3d IPrimePntPc_B;
     IPrimePntPc_B = this->omegaTilde_PB_B * this->IPntPc_B - this->IPntPc_B * this->omegaTilde_PB_B;
-    backSubContr.vecRot += -(this->mass * this->rTilde_PcB_B * this->rPrimePrime_PcB_B)
-                          - (IPrimePntPc_B + this->omegaTilde_BN_B * this->IPntPc_B) * this->omega_PB_B
+    backSubContr.vecRot += -(this->mass * this->r_PcB_B.cross(this->rPrimePrime_PcB_B))
+                          - IPrimePntPc_B * this->omega_PB_B
+                          - this->omega_BN_B.cross(this->IPntPc_B * this->omega_PB_B)
                           - this->IPntPc_B * this->omegaPrime_PB_B
-                          - this->mass * this->omegaTilde_BN_B * rTilde_PcB_B * this->rPrime_PcB_B;
+                          - this->mass * this->omega_BN_B.cross(this->r_PcB_B.cross(this->rPrime_PcB_B));
 }
 
 /*! This method is for defining the state effector's MRP state derivative
@@ -424,14 +425,14 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime,
         *this->sigma_PN = eigenMRPd2Vector3d(eigenC2MRP(dcm_PN));
 
         // Compute omegaDot_PN_P
-        Eigen::Vector3d omegaDot_PN_B = this->omegaPrime_PM_B + this->omegaTilde_BN_B * this->omega_PM_B + omegaDot_BN_B;
+        Eigen::Vector3d omegaDot_PN_B = this->omegaPrime_PM_B + this->omega_BN_B.cross(this->omega_PM_B) + omegaDot_BN_B;
         Eigen::Vector3d omegaDot_PN_P = this->dcm_BP.transpose() * omegaDot_PN_B;
 
         // Compute rDDot_PN_N
-        Eigen::Matrix3d omegaDotTilde_BN_B = eigenTilde(omegaDot_BN_B);
-        Eigen::Vector3d rDDot_PB_B = this->rPrimePrime_PM_B + 2 * this->omegaTilde_BN_B * this->rPrime_PM_B
-                                     + omegaDotTilde_BN_B * (*this->r_PB_B)
-                                     + this->omegaTilde_BN_B * this->omegaTilde_BN_B * (*this->r_PB_B);
+        Eigen::Vector3d r_PB_B = *this->r_PB_B;
+        Eigen::Vector3d rDDot_PB_B = this->rPrimePrime_PM_B + 2 * this->omega_BN_B.cross(this->rPrime_PM_B)
+                                     + omegaDot_BN_B.cross(r_PB_B)
+                                     + this->omega_BN_B.cross(this->omega_BN_B.cross(r_PB_B));
         Eigen::Vector3d rDDot_PN_N = this->dcm_BN.transpose() * rDDot_PB_B + rDDot_BN_N;
 
         std::vector<StateEffector*>::iterator it;
@@ -474,15 +475,13 @@ void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTim
 
         // Additional terms for rotational angular momentum
         Eigen::Vector3d r_EcP_B = this->dcm_BP * (*it)->effProps.rEff_CB_B;
-        Eigen::Matrix3d rTilde_EcP_B = eigenTilde(r_EcP_B);
-        Eigen::Vector3d rDot_PB_B = *this->rPrime_PB_B + this->omegaTilde_BN_B * *this->r_PB_B;
-        Eigen::Matrix3d rTilde_PB_B = eigenTilde(*this->r_PB_B);
-        Eigen::Matrix3d omegaTilde_PN_B = eigenTilde(this->omega_PN_B);
-        Eigen::Vector3d rDot_EcP_B = this->dcm_BP * (*it)->effProps.rEffPrime_CB_B + omegaTilde_PN_B * r_EcP_B;
+        Eigen::Vector3d r_PB_B = *this->r_PB_B;
+        Eigen::Vector3d rDot_PB_B = (Eigen::Vector3d)*this->rPrime_PB_B + this->omega_BN_B.cross(r_PB_B);
+        Eigen::Vector3d rDot_EcP_B = this->dcm_BP * (*it)->effProps.rEffPrime_CB_B + this->omega_PN_B.cross(r_EcP_B);
         totRotAngMomPntC_B += this->dcm_BP * rotAngMomPntCContr_B
-                                + (*it)->effProps.mEff * rTilde_EcP_B * rDot_PB_B
-                                + (*it)->effProps.mEff * rTilde_PB_B * rDot_EcP_B
-                                + (*it)->effProps.mEff * rTilde_PB_B * rDot_PB_B;
+                                + (*it)->effProps.mEff * r_EcP_B.cross(rDot_PB_B)
+                                + (*it)->effProps.mEff * r_PB_B.cross(rDot_EcP_B)
+                                + (*it)->effProps.mEff * r_PB_B.cross(rDot_PB_B);
 
         // Additional terms for rotational energy
         totRotEnergy += rotEnergyContr
@@ -494,8 +493,8 @@ void PrescribedMotionStateEffector::updateEnergyMomContributions(double integTim
     rotEnergyContr = totRotEnergy;
 
     // Prescribed motion rotational angular momentum contribution
-    this->rDot_PcB_B = this->rPrime_PcB_B + this->omegaTilde_BN_B * this->r_PcB_B;
-    rotAngMomPntCContr_B += this->IPntPc_B * this->omega_PN_B + this->mass * this->rTilde_PcB_B * this->rDot_PcB_B;
+    this->rDot_PcB_B = this->rPrime_PcB_B + this->omega_BN_B.cross(this->r_PcB_B);
+    rotAngMomPntCContr_B += this->IPntPc_B * this->omega_PN_B + this->mass * this->r_PcB_B.cross(this->rDot_PcB_B);
 
     // Prescribed motion rotational energy contribution
     rotEnergyContr += 0.5 * this->omega_PN_B.dot(this->IPntPc_B * this->omega_PN_B)
@@ -520,8 +519,8 @@ void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
 
     // Compute the effector's inertial velocity vectors
     this->v_PcN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * this->rDot_PcB_B;
-    *this->v_PN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * (*this->rPrime_PB_B +
-            this->omegaTilde_BN_B * *this->r_PB_B);
+    *this->v_PN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * (
+            (Eigen::Vector3d)*this->rPrime_PB_B + this->omega_BN_B.cross((Eigen::Vector3d)*this->r_PB_B));
 }
 
 /*! This method updates the effector state at the dynamics frequency.

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -98,14 +98,16 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
     this->effProps.rEffPrime_CB_B.setZero();
     this->effProps.IEffPrimePntB_B.setZero();
 
+    const Eigen::MatrixXd& omegasVector = this->OmegasState->getStateReference();
+    const Eigen::MatrixXd* thetaVector = this->numRWJitter > 0 ? &this->thetasState->getStateReference() : nullptr;
     int thetaCount = 0;
     for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
-		rw.Omega = this->OmegasState->getState()(i, 0);
+		rw.Omega = omegasVector(i, 0);
 
 		if (rw.RWModel == JitterFullyCoupled) {
-			rw.theta = this->thetasState->getState()(thetaCount, 0);
+			rw.theta = (*thetaVector)(thetaCount, 0);
 			Eigen::Matrix3d dcm_WW0 = eigenM1(rw.theta);
 			Eigen::Matrix3d dcm_BW0;
 			dcm_BW0.col(0) = rw.gsHat_B;
@@ -144,7 +146,7 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
 			this->effProps.IEffPrimePntB_B += rw.IPrimeRWPntWc_B + rw.mass*rPrimeTildeWcB_B*rw.rTildeWcB_B.transpose() + rw.mass*rw.rTildeWcB_B*rPrimeTildeWcB_B.transpose();
             thetaCount++;
 		} else if (rw.RWModel == JitterSimple) {
-			rw.theta = this->thetasState->getState()(thetaCount, 0);
+			rw.theta = (*thetaVector)(thetaCount, 0);
 			Eigen::Matrix3d dcm_WW0 = eigenM1(rw.theta);
 			Eigen::Matrix3d dcm_BW0;
 			dcm_BW0.col(0) = rw.gsHat_B;
@@ -407,15 +409,17 @@ void ReactionWheelStateEffector::Reset(uint64_t CurrenSimNanos)
  */
 void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
 {
+    const Eigen::MatrixXd& omegasVector = this->OmegasState->getStateReference();
+    const Eigen::MatrixXd* thetaVector = this->numRWJitter > 0 ? &this->thetasState->getStateReference() : nullptr;
     int thetaCount=0;
     for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
         if (rw.RWModel == JitterSimple || rw.RWModel == JitterFullyCoupled) {
-            rw.theta = this->thetasState->getState()(thetaCount, 0);
+            rw.theta = (*thetaVector)(thetaCount, 0);
             thetaCount++;
         }
-        rw.Omega = this->OmegasState->getState()(i, 0);
+        rw.Omega = omegasVector(i, 0);
 
         RWConfigLogMsgPayload tmpRW = this->rwOutMsgs[i]->zeroMsgPayload;
 		tmpRW.theta = rw.theta;
@@ -445,16 +449,18 @@ void ReactionWheelStateEffector::WriteOutputMessages(uint64_t CurrentClock)
  */
 void ReactionWheelStateEffector::writeOutputStateMessages(uint64_t integTimeNanos)
 {
+    const Eigen::MatrixXd& omegasVector = this->OmegasState->getStateReference();
+    const Eigen::MatrixXd* thetaVector = this->numRWJitter > 0 ? &this->thetasState->getStateReference() : nullptr;
     int thetaCount = 0;
     for (std::size_t i = 0; i < ReactionWheelData.size(); ++i)
     {
         auto& rw = *ReactionWheelData[i];
         if (rw.RWModel == JitterSimple || rw.RWModel == JitterFullyCoupled) {
-            rw.theta = this->thetasState->getState()(thetaCount, 0);
+            rw.theta = (*thetaVector)(thetaCount, 0);
             this->rwSpeedMsgBuffer.wheelThetas[i] = rw.theta;
             thetaCount++;
         }
-        rw.Omega = this->OmegasState->getState()(i, 0);
+        rw.Omega = omegasVector(i, 0);
         this->rwSpeedMsgBuffer.wheelSpeeds[i] = rw.Omega;
     }
 

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftHubOnlyFastPath.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftHubOnlyFastPath.py
@@ -1,0 +1,99 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Unit tests for the automatic hub-only spacecraft dynamics fast path.
+
+When no state effectors are attached and point :math:`B` is colocated with the
+hub center of mass, ``Spacecraft`` can bypass the general back-substitution
+matrix assembly and ask ``HubEffector`` to compute direct rigid-body
+derivatives.  This test validates the resulting translational and rotational
+dynamics against a simple analytic case.
+"""
+
+import numpy as np
+
+from Basilisk.simulation import extForceTorque
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+
+
+TASK_PERIOD = 0.01  # [s]
+STOP_TIME = 0.5  # [s]
+
+
+def test_spacecraftHubOnlyFastPath_matchesAnalyticForceTorque():
+    """Hub-only fast path must reproduce direct rigid-body force/torque motion."""
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTaskName = "unitTask"
+    unitProcessName = "testProcess"
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, macros.sec2nano(TASK_PERIOD)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+
+    mass = 20.0  # [kg]
+    inertia = np.diag([4.0, 5.0, 6.0])  # [kg*m^2]
+    initialPosition_N = np.array([10.0, -20.0, 30.0])  # [m]
+    initialVelocity_N = np.array([1.0, -2.0, 0.5])  # [m/s]
+    inertialForce_N = np.array([10.0, -4.0, 6.0])  # [N]
+    bodyTorque_B = np.array([0.0, 2.0, 0.0])  # [N*m]
+
+    scObject.hub.mHub = mass
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    scObject.hub.IHubPntBc_B = inertia.tolist()
+    scObject.hub.r_CN_NInit = initialPosition_N.reshape(3, 1).tolist()
+    scObject.hub.v_CN_NInit = initialVelocity_N.reshape(3, 1).tolist()
+    scObject.hub.sigma_BNInit = [[0.0], [0.0], [0.0]]  # [-]
+    scObject.hub.omega_BN_BInit = [[0.0], [0.0], [0.0]]  # [rad/s]
+
+    forceTorqueEffector = extForceTorque.ExtForceTorque()
+    forceTorqueEffector.ModelTag = "forceTorque"
+    forceTorqueEffector.extForce_N = inertialForce_N.reshape(3, 1).tolist()
+    forceTorqueEffector.extTorquePntB_B = bodyTorque_B.reshape(3, 1).tolist()
+    scObject.addDynamicEffector(forceTorqueEffector)
+
+    dataLog = scObject.scStateOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+    unitTestSim.AddModelToTask(unitTaskName, forceTorqueEffector)
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(STOP_TIME))
+    unitTestSim.ExecuteSimulation()
+
+    finalTime = dataLog.times()[-1] * macros.NANO2SEC  # [s]
+    translationalAcceleration_N = inertialForce_N / mass  # [m/s^2]
+    angularAcceleration_B = bodyTorque_B[1] / inertia[1, 1]  # [rad/s^2]
+
+    expectedPosition_N = (initialPosition_N + initialVelocity_N*finalTime
+                          + 0.5*translationalAcceleration_N*finalTime*finalTime)  # [m]
+    expectedVelocity_N = initialVelocity_N + translationalAcceleration_N*finalTime  # [m/s]
+    expectedOmega_BN_B = np.array([0.0, angularAcceleration_B*finalTime, 0.0])  # [rad/s]
+    expectedRotationAngle = 0.5*angularAcceleration_B*finalTime*finalTime  # [rad]
+    expectedSigma_BN = np.array([0.0, np.tan(expectedRotationAngle/4.0), 0.0])  # [-]
+
+    np.testing.assert_allclose(dataLog.r_BN_N[-1], expectedPosition_N, rtol=1e-13, atol=1e-12)
+    np.testing.assert_allclose(dataLog.v_BN_N[-1], expectedVelocity_N, rtol=1e-13, atol=1e-12)
+    np.testing.assert_allclose(dataLog.omega_BN_B[-1], expectedOmega_BN_B, rtol=1e-13, atol=1e-12)
+    np.testing.assert_allclose(dataLog.sigma_BN[-1], expectedSigma_BN, rtol=1e-10, atol=1e-12)
+
+
+if __name__ == "__main__":
+    test_spacecraftHubOnlyFastPath_matchesAnalyticForceTorque()

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftPointMass.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftPointMass.py
@@ -1,0 +1,163 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Unit tests for the ``Spacecraft.pointMassTranslationalOnly`` option.
+
+The point-mass mode should reproduce the normal ``spacecraft`` translational
+motion when no state effectors are attached, while omitting rotational dynamics
+from the integrated equations of motion.
+"""
+
+import numpy as np
+import pytest
+
+from Basilisk.architecture.bskLogging import BasiliskError
+from Basilisk.simulation import GravityGradientEffector
+from Basilisk.simulation import extForceTorque
+from Basilisk.simulation import hingedRigidBodyStateEffector
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+from Basilisk.utilities import simIncludeGravBody
+
+
+TEST_TASK_PERIOD = 0.1  # [s]
+STOP_TIME = 1.0  # [s]
+
+
+def _configureHub(scObject):
+    """Configure a hub state used by both full and point-mass spacecraft."""
+
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    scObject.hub.IHubPntBc_B = [  # [kg*m^2]
+        [900.0, 0.0, 0.0],
+        [0.0, 800.0, 0.0],
+        [0.0, 0.0, 600.0],
+    ]
+    scObject.hub.r_CN_NInit = [[7000.0e3], [0.0], [0.0]]  # [m]
+    scObject.hub.v_CN_NInit = [[0.0], [7500.0], [100.0]]  # [m/s]
+    scObject.hub.sigma_BNInit = [[0.1], [-0.2], [0.05]]  # [-]
+    scObject.hub.omega_BN_BInit = [[0.01], [0.02], [-0.03]]  # [rad/s]
+
+
+def _runSpacecraft(pointMassMode=False, addExternalForce=False, addGravityGradient=False):
+    """Run a short spacecraft simulation and return the state recorder."""
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTaskName = "unitTask"
+    unitProcessName = "testProcess"
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, macros.sec2nano(TEST_TASK_PERIOD)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.pointMassTranslationalOnly = pointMassMode
+    _configureHub(scObject)
+
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    earth = gravFactory.createEarth()
+    earth.isCentralBody = True
+    scObject.gravField.gravBodies = spacecraft.GravBodyVector(list(gravFactory.gravBodies.values()))
+
+    dynamicEffectors = []
+    if addExternalForce:
+        forceEffector = extForceTorque.ExtForceTorque()
+        forceEffector.ModelTag = "inertialForce"
+        forceEffector.extForce_N = [[12.0], [-7.0], [3.0]]  # [N]
+        scObject.addDynamicEffector(forceEffector)
+        dynamicEffectors.append(forceEffector)
+
+    if addGravityGradient:
+        gravityGradientEffector = GravityGradientEffector.GravityGradientEffector()
+        gravityGradientEffector.ModelTag = "gravityGradient"
+        gravityGradientEffector.addPlanetName(earth.planetName)
+        scObject.addDynamicEffector(gravityGradientEffector)
+        dynamicEffectors.append(gravityGradientEffector)
+
+    dataLog = scObject.scStateOutMsg.recorder()
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+    for effector in dynamicEffectors:
+        unitTestSim.AddModelToTask(unitTaskName, effector)
+    unitTestSim.AddModelToTask(unitTaskName, dataLog)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(STOP_TIME))
+    unitTestSim.ExecuteSimulation()
+
+    return dataLog
+
+
+def test_spacecraftPointMass_matchesStandardSpacecraftTranslation():
+    """Point-mass mode must match normal spacecraft translational motion."""
+
+    fullSpacecraftLog = _runSpacecraft(pointMassMode=False)
+    pointMassLog = _runSpacecraft(pointMassMode=True)
+
+    np.testing.assert_allclose(pointMassLog.r_BN_N, fullSpacecraftLog.r_BN_N, rtol=1e-12, atol=1e-6)
+    np.testing.assert_allclose(pointMassLog.v_BN_N, fullSpacecraftLog.v_BN_N, rtol=1e-12, atol=1e-9)
+
+
+def test_spacecraftPointMass_matchesStandardSpacecraftWithDynamicForce():
+    """Point-mass mode must include translational dynamic-effector forces."""
+
+    fullSpacecraftLog = _runSpacecraft(pointMassMode=False, addExternalForce=True)
+    pointMassLog = _runSpacecraft(pointMassMode=True, addExternalForce=True)
+
+    np.testing.assert_allclose(pointMassLog.r_BN_N, fullSpacecraftLog.r_BN_N, rtol=1e-12, atol=1e-6)
+    np.testing.assert_allclose(pointMassLog.v_BN_N, fullSpacecraftLog.v_BN_N, rtol=1e-12, atol=1e-9)
+
+
+def test_spacecraftPointMass_allowsAttitudeDependentDynamicEffector():
+    """Point-mass mode must expose fixed attitude states for dynamic effectors."""
+
+    pointMassLog = _runSpacecraft(pointMassMode=True)
+    pointMassWithGravityGradientLog = _runSpacecraft(pointMassMode=True, addGravityGradient=True)
+
+    np.testing.assert_allclose(pointMassWithGravityGradientLog.r_BN_N, pointMassLog.r_BN_N, rtol=1e-12, atol=1e-6)
+    np.testing.assert_allclose(pointMassWithGravityGradientLog.v_BN_N, pointMassLog.v_BN_N, rtol=1e-12, atol=1e-9)
+    np.testing.assert_allclose(pointMassWithGravityGradientLog.sigma_BN[-1],
+                               pointMassWithGravityGradientLog.sigma_BN[0])
+    np.testing.assert_allclose(pointMassWithGravityGradientLog.omega_BN_B[-1],
+                               pointMassWithGravityGradientLog.omega_BN_B[0])
+
+
+def test_spacecraftPointMass_rejectsStateEffectors():
+    """Point-mass mode must reject state effectors because they add internal states."""
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTaskName = "unitTask"
+    unitProcessName = "testProcess"
+    testProc = unitTestSim.CreateNewProcess(unitProcessName)
+    testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, macros.sec2nano(TEST_TASK_PERIOD)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.pointMassTranslationalOnly = True
+    _configureHub(scObject)
+    scObject.addStateEffector(hingedRigidBodyStateEffector.HingedRigidBodyStateEffector())
+    unitTestSim.AddModelToTask(unitTaskName, scObject)
+
+    with pytest.raises(BasiliskError, match="state effectors"):
+        unitTestSim.InitializeSimulation()
+
+
+if __name__ == "__main__":
+    test_spacecraftPointMass_matchesStandardSpacecraftTranslation()
+    test_spacecraftPointMass_matchesStandardSpacecraftWithDynamicForce()
+    test_spacecraftPointMass_allowsAttitudeDependentDynamicEffector()
+    test_spacecraftPointMass_rejectsStateEffectors()

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -59,7 +59,19 @@ Spacecraft::~Spacecraft()
 void Spacecraft::Reset(uint64_t CurrentSimNanos)
 {
     // - Verify the user-supplied hub configuration before the dynamics are initialized
-    this->hub.validateConfiguration();
+    if (this->pointMassTranslationalOnly) {
+        if (this->hub.mHub <= 0.0) {
+            bskLogger.bskError("spacecraft: pointMassTranslationalOnly requires mHub to be greater than 0.");
+        }
+        if (!this->states.empty()) {
+            bskLogger.bskError("spacecraft: pointMassTranslationalOnly does not support attached state effectors.");
+        }
+        if (this->hub.r_BcB_B.norm() > 0.0) {
+            bskLogger.bskError("spacecraft: pointMassTranslationalOnly requires r_BcB_B to be zero.");
+        }
+    } else {
+        this->hub.validateConfiguration();
+    }
 
     this->gravField.Reset(CurrentSimNanos);
     // - Call method for initializing the dynamics of spacecraft
@@ -106,14 +118,23 @@ void Spacecraft::writeOutputStateMessages(uint64_t clockTime)
     eigenMatrixXd2CArray(*this->inertialPositionProperty, stateOut.r_BN_N);
     eigenMatrixXd2CArray(*this->inertialVelocityProperty, stateOut.v_BN_N);
     Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getState();
+    if (this->pointMassTranslationalOnly && this->hubSigma == nullptr) {
+        sigmaLocal_BN = this->hub.sigma_BNInit;
+    } else {
+        sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getState();
+    }
     Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
     Eigen::Vector3d rLocal_CN_N = (*this->inertialPositionProperty) + dcm_NB*(*this->c_B);
     Eigen::Vector3d vLocal_CN_N = (*this->inertialVelocityProperty) + dcm_NB*(*this->cDot_B);
     eigenVector3d2CArray(rLocal_CN_N, stateOut.r_CN_N);
     eigenVector3d2CArray(vLocal_CN_N, stateOut.v_CN_N);
-    eigenMatrixXd2CArray(this->hubSigma->getState(), stateOut.sigma_BN);
-    eigenMatrixXd2CArray(this->hubOmega_BN_B->getState(), stateOut.omega_BN_B);
+    if (this->pointMassTranslationalOnly && this->hubSigma == nullptr) {
+        eigenVector3d2CArray(this->hub.sigma_BNInit, stateOut.sigma_BN);
+        eigenVector3d2CArray(this->hub.omega_BN_BInit, stateOut.omega_BN_B);
+    } else {
+        eigenMatrixXd2CArray(this->hubSigma->getState(), stateOut.sigma_BN);
+        eigenMatrixXd2CArray(this->hubOmega_BN_B->getState(), stateOut.omega_BN_B);
+    }
     eigenMatrixXd2CArray(this->dvAccum_CN_B, stateOut.TotalAccumDVBdy);
     stateOut.MRPSwitchCount = this->hub.MRPSwitchCount;
     eigenMatrixXd2CArray(this->dvAccum_BN_B, stateOut.TotalAccumDV_BN_B);
@@ -135,6 +156,10 @@ void Spacecraft::writeOutputStateMessages(uint64_t clockTime)
 void Spacecraft::readOptionalRefMsg()
 {
     if (this->attRefInMsg.isLinked()) {
+        if (this->pointMassTranslationalOnly) {
+            bskLogger.bskError(
+                "spacecraft: pointMassTranslationalOnly does not support attitude reference input messages.");
+        }
         Eigen::Vector3d omega_BN_B;
         AttRefMsgPayload attRefMsgBuffer;
         attRefMsgBuffer = this->attRefInMsg();
@@ -195,10 +220,22 @@ void Spacecraft::linkInStates(DynParamManager& statesIn)
     // - Get access to all hub states
     this->hubR_N = statesIn.getStateObject(this->hub.nameOfHubPosition);
     this->hubV_N = statesIn.getStateObject(this->hub.nameOfHubVelocity);
-    this->hubSigma = statesIn.getStateObject(this->hub.nameOfHubSigma);   /* Need sigmaBN for MRP switching */
-    this->hubOmega_BN_B = statesIn.getStateObject(this->hub.nameOfHubOmega);
-    this->hubGravVelocity = statesIn.getStateObject(this->hub.nameOfHubGravVelocity);
-    this->BcGravVelocity = statesIn.getStateObject(this->hub.nameOfBcGravVelocity);
+    if (this->pointMassTranslationalOnly) {
+        if (this->dynEffectors.empty()) {
+            this->hubSigma = nullptr;
+            this->hubOmega_BN_B = nullptr;
+        } else {
+            this->hubSigma = statesIn.getStateObject(this->hub.nameOfHubSigma);
+            this->hubOmega_BN_B = statesIn.getStateObject(this->hub.nameOfHubOmega);
+        }
+        this->hubGravVelocity = nullptr;
+        this->BcGravVelocity = nullptr;
+    } else {
+        this->hubSigma = statesIn.getStateObject(this->hub.nameOfHubSigma);   /* Need sigmaBN for MRP switching */
+        this->hubOmega_BN_B = statesIn.getStateObject(this->hub.nameOfHubOmega);
+        this->hubGravVelocity = statesIn.getStateObject(this->hub.nameOfHubGravVelocity);
+        this->BcGravVelocity = statesIn.getStateObject(this->hub.nameOfBcGravVelocity);
+    }
 
     // - Get access to the hubs position and velocity in the property manager
     this->inertialPositionProperty = statesIn.getPropertyReference(this->gravField.inertialPositionPropName);
@@ -220,6 +257,13 @@ void Spacecraft::initializeDynamics()
     Eigen::MatrixXd initCDot_B(3,1);
     Eigen::MatrixXd initISCPntBPrime_B(3,3);
     Eigen::MatrixXd systemTime(2,1);
+    initM_SC.setZero();
+    initMDot_SC.setZero();
+    initC_B.setZero();
+    initISCPntB_B.setZero();
+    initCPrime_B.setZero();
+    initCDot_B.setZero();
+    initISCPntBPrime_B.setZero();
     systemTime.setZero();
     // - Create the properties
     this->m_SC = this->dynManager.createProperty(this->propName_m_SC, initM_SC);
@@ -235,7 +279,14 @@ void Spacecraft::initializeDynamics()
     this->gravField.registerProperties(this->dynManager);
 
     // - Register the hub states
-    this->hub.registerStates(this->dynManager);
+    if (this->pointMassTranslationalOnly) {
+        this->hub.registerTranslationalStates(this->dynManager);
+        if (!this->dynEffectors.empty()) {
+            this->hub.registerAttitudeStates(this->dynManager);
+        }
+    } else {
+        this->hub.registerStates(this->dynManager);
+    }
 
     // - Loop through stateEffectors to register their states
     std::vector<StateEffector*>::iterator stateIt;
@@ -250,22 +301,29 @@ void Spacecraft::initializeDynamics()
     this->hub.linkInStates(this->dynManager);
 
     // - Update the mass properties of the spacecraft to retrieve c_B and cDot_B to update r_BN_N and v_BN_N
-    this->updateSCMassProps(0.0);
+    if (this->pointMassTranslationalOnly) {
+        (*this->m_SC)(0,0) = this->hub.mHub;
+        (*this->ISCPntB_B) = this->hub.IHubPntBc_B;
+    } else {
+        this->updateSCMassProps(0.0);
+    }
 
-    // - Edit r_BN_N and v_BN_N to take into account that point B and point C are not coincident
-    // - Pulling the state from the hub at this time gives us r_CN_N
-    Eigen::Vector3d rInit_BN_N = this->hubR_N->getState();
-    Eigen::MRPd sigma_BN;
-    sigma_BN = (Eigen::Vector3d) this->hubSigma->getState();
-    Eigen::Matrix3d dcm_NB = sigma_BN.toRotationMatrix();
-    // - Substract off the center mass to leave r_BN_N
-    rInit_BN_N -= dcm_NB*(*this->c_B);
-    // - Subtract off cDot_B to get v_BN_N
-    Eigen::Vector3d vInit_BN_N = this->hubV_N->getState();
-    vInit_BN_N -= dcm_NB*(*this->cDot_B);
-    // - Finally set the translational states r_BN_N and v_BN_N with the corrections
-    this->hubR_N->setState(rInit_BN_N);
-    this->hubV_N->setState(vInit_BN_N);
+    if (!this->pointMassTranslationalOnly) {
+        // - Edit r_BN_N and v_BN_N to take into account that point B and point C are not coincident
+        // - Pulling the state from the hub at this time gives us r_CN_N
+        Eigen::Vector3d rInit_BN_N = this->hubR_N->getState();
+        Eigen::MRPd sigma_BN;
+        sigma_BN = (Eigen::Vector3d) this->hubSigma->getState();
+        Eigen::Matrix3d dcm_NB = sigma_BN.toRotationMatrix();
+        // - Substract off the center mass to leave r_BN_N
+        rInit_BN_N -= dcm_NB*(*this->c_B);
+        // - Subtract off cDot_B to get v_BN_N
+        Eigen::Vector3d vInit_BN_N = this->hubV_N->getState();
+        vInit_BN_N -= dcm_NB*(*this->cDot_B);
+        // - Finally set the translational states r_BN_N and v_BN_N with the corrections
+        this->hubR_N->setState(rInit_BN_N);
+        this->hubV_N->setState(vInit_BN_N);
+    }
 
     // - Loop through the stateEffectros to link in the states needed
     for(stateIt = this->states.begin(); stateIt != this->states.end(); stateIt++)
@@ -339,6 +397,40 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     uint64_t integTimeNanos = secToNano(integTimeSeconds);
 
     (*this->sysTime) << (double) integTimeNanos, integTimeSeconds;
+
+    if (this->pointMassTranslationalOnly) {
+        Eigen::Vector3d rLocal_BN_N = this->hubR_N->getState();
+        Eigen::Vector3d vLocal_BN_N = this->hubV_N->getState();
+
+        this->gravField.computeGravityField(rLocal_BN_N, vLocal_BN_N);
+
+        this->sumForceExternal_N.setZero();
+        this->sumForceExternal_B.setZero();
+        std::vector<DynamicEffector*>::iterator dynIt;
+        for(dynIt = this->dynEffectors.begin(); dynIt != this->dynEffectors.end(); dynIt++)
+        {
+            (*dynIt)->computeForceTorque(integTimeSeconds, timeStep);
+            this->sumForceExternal_N += (*dynIt)->forceExternal_N;
+            this->sumForceExternal_B += (*dynIt)->forceExternal_B;
+        }
+
+        Eigen::MRPd sigmaLocal_BN;
+        sigmaLocal_BN = this->hub.sigma_BNInit;
+        if (this->hubSigma != nullptr) {
+            sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getState();
+            this->hubSigma->setDerivative(Eigen::Vector3d::Zero());
+        }
+        if (this->hubOmega_BN_B != nullptr) {
+            this->hubOmega_BN_B->setDerivative(Eigen::Vector3d::Zero());
+        }
+        Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
+        Eigen::Vector3d nonConservativeAccel_N =
+            (this->sumForceExternal_N + dcm_NB*this->sumForceExternal_B)/(*this->m_SC)(0,0);
+
+        this->hubR_N->setDerivative(vLocal_BN_N);
+        this->hubV_N->setDerivative(*this->g_N + nonConservativeAccel_N);
+        return;
+    }
 
     // - Zero all Matrices and vectors for back-sub and the dynamics
     this->hub.hubBackSubMatrices.matrixA.setZero();
@@ -459,6 +551,9 @@ void Spacecraft::equationsOfMotionDiffusion(double integTimeSeconds, double time
  */
 void Spacecraft::preIntegration(uint64_t integrateToThisTimeNanos) {
     this->timeStep = diffNanoToSec(integrateToThisTimeNanos, this->timeBeforeNanos); // - Find the time step in seconds
+    if (this->pointMassTranslationalOnly) {
+        return;
+    }
 
     // - Find v_CN_N before integration for accumulated DV
     Eigen::Vector3d oldV_BN_N = this->hubV_N->getState();  // - V_BN_N before integration
@@ -483,6 +578,10 @@ void Spacecraft::preIntegration(uint64_t integrateToThisTimeNanos) {
 void Spacecraft::postIntegration(uint64_t integrateToThisTimeNanos) {
     this->timeBeforeNanos = integrateToThisTimeNanos;     // - copy the current time into previous time for next integrate state call
     this->timeBefore = integrateToThisTimeNanos*NANO2SEC;
+    if (this->pointMassTranslationalOnly) {
+        return;
+    }
+
     double integrateToThisTime = integrateToThisTimeNanos*NANO2SEC; // - convert to seconds
 
     // - Call mass properties to get current info on the mass props of the spacecraft

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -387,6 +387,13 @@ void Spacecraft::updateSCMassProps(double time)
     (*this->cDot_B) = (*this->cPrime_B) + omegaLocal_BN_B.cross(cLocal_B);
 }
 
+/*! Return true if the spacecraft can use direct rigid-hub equations instead of
+ the full back-substitution path. */
+bool Spacecraft::useHubOnlyFastPath() const
+{
+    return this->states.empty() && this->hub.r_BcB_B.isZero();
+}
+
 /*! This method is solving Xdot = F(X,t) for the system. The hub needs to calculate its derivatives, along with all of
  the stateEffectors. The hub also has gravity and dynamicEffectors acting on it and these relationships are controlled
  in this method. At the end of this method all of the states will have their corresponding state derivatives set in the
@@ -429,6 +436,31 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
 
         this->hubR_N->setDerivative(vLocal_BN_N);
         this->hubV_N->setDerivative(*this->g_N + nonConservativeAccel_N);
+        return;
+    }
+
+    if (this->useHubOnlyFastPath()) {
+        Eigen::Vector3d rLocal_BN_N = this->hubR_N->getState();
+        Eigen::Vector3d vLocal_BN_N = this->hubV_N->getState();
+
+        this->gravField.computeGravityField(rLocal_BN_N, vLocal_BN_N);
+
+        this->sumForceExternal_B.setZero();
+        this->sumForceExternal_N.setZero();
+        this->sumTorquePntB_B.setZero();
+
+        std::vector<DynamicEffector*>::iterator dynIt;
+        for(dynIt = this->dynEffectors.begin(); dynIt != this->dynEffectors.end(); dynIt++)
+        {
+            (*dynIt)->computeForceTorque(integTimeSeconds, timeStep);
+            this->sumForceExternal_N += (*dynIt)->forceExternal_N;
+            this->sumForceExternal_B += (*dynIt)->forceExternal_B;
+            this->sumTorquePntB_B += (*dynIt)->torqueExternalPntB_B;
+        }
+
+        this->hub.computeHubOnlyDerivatives(this->sumForceExternal_N,
+                                            this->sumForceExternal_B,
+                                            this->sumTorquePntB_B);
         return;
     }
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -78,7 +78,7 @@ void Spacecraft::Reset(uint64_t CurrentSimNanos)
     this->initializeDynamics();
 
     // compute initial spacecraft states relative to inertial frame, taking into account initial sc states might be defined relative to a planet
-    this->gravField.updateInertialPosAndVel(this->hubR_N->getState(), this->hubV_N->getState());
+    this->gravField.updateInertialPosAndVel(this->hubR_N->getStateReference(), this->hubV_N->getStateReference());
     this->writeOutputStateMessages(CurrentSimNanos);
     // - Loop over stateEffectors to call writeOutputStateMessages and write initial state output messages
     std::vector<StateEffector*>::iterator it;
@@ -121,7 +121,7 @@ void Spacecraft::writeOutputStateMessages(uint64_t clockTime)
     if (this->pointMassTranslationalOnly && this->hubSigma == nullptr) {
         sigmaLocal_BN = this->hub.sigma_BNInit;
     } else {
-        sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getState();
+        sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
     }
     Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
     Eigen::Vector3d rLocal_CN_N = (*this->inertialPositionProperty) + dcm_NB*(*this->c_B);
@@ -132,8 +132,8 @@ void Spacecraft::writeOutputStateMessages(uint64_t clockTime)
         eigenVector3d2CArray(this->hub.sigma_BNInit, stateOut.sigma_BN);
         eigenVector3d2CArray(this->hub.omega_BN_BInit, stateOut.omega_BN_B);
     } else {
-        eigenMatrixXd2CArray(this->hubSigma->getState(), stateOut.sigma_BN);
-        eigenMatrixXd2CArray(this->hubOmega_BN_B->getState(), stateOut.omega_BN_B);
+        eigenMatrixXd2CArray(this->hubSigma->getStateReference(), stateOut.sigma_BN);
+        eigenMatrixXd2CArray(this->hubOmega_BN_B->getStateReference(), stateOut.omega_BN_B);
     }
     eigenMatrixXd2CArray(this->dvAccum_CN_B, stateOut.TotalAccumDVBdy);
     stateOut.MRPSwitchCount = this->hub.MRPSwitchCount;
@@ -198,8 +198,8 @@ void Spacecraft::UpdateState(uint64_t CurrentSimNanos)
     // If set, read in and prescribe attitude reference motion
     readOptionalRefMsg();
 
-    Eigen::Vector3d rLocal_BN_N = this->hubR_N->getState();
-    Eigen::Vector3d vLocal_BN_N = this->hubV_N->getState();
+    Eigen::Vector3d rLocal_BN_N = this->hubR_N->getStateReference();
+    Eigen::Vector3d vLocal_BN_N = this->hubV_N->getStateReference();
     this->gravField.updateInertialPosAndVel(rLocal_BN_N, vLocal_BN_N);
 
     // - Write the state of the vehicle into messages
@@ -311,14 +311,14 @@ void Spacecraft::initializeDynamics()
     if (!this->pointMassTranslationalOnly) {
         // - Edit r_BN_N and v_BN_N to take into account that point B and point C are not coincident
         // - Pulling the state from the hub at this time gives us r_CN_N
-        Eigen::Vector3d rInit_BN_N = this->hubR_N->getState();
+        Eigen::Vector3d rInit_BN_N = this->hubR_N->getStateReference();
         Eigen::MRPd sigma_BN;
-        sigma_BN = (Eigen::Vector3d) this->hubSigma->getState();
+        sigma_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
         Eigen::Matrix3d dcm_NB = sigma_BN.toRotationMatrix();
         // - Substract off the center mass to leave r_BN_N
         rInit_BN_N -= dcm_NB*(*this->c_B);
         // - Subtract off cDot_B to get v_BN_N
-        Eigen::Vector3d vInit_BN_N = this->hubV_N->getState();
+        Eigen::Vector3d vInit_BN_N = this->hubV_N->getStateReference();
         vInit_BN_N -= dcm_NB*(*this->cDot_B);
         // - Finally set the translational states r_BN_N and v_BN_N with the corrections
         this->hubR_N->setState(rInit_BN_N);
@@ -382,7 +382,7 @@ void Spacecraft::updateSCMassProps(double time)
     (*this->c_B) = (*this->c_B)/(*this->m_SC)(0,0);
     (*this->cPrime_B) = (*this->cPrime_B)/(*this->m_SC)(0,0)
                                              - (*this->mDot_SC)(0,0)*(*this->c_B)/(*this->m_SC)(0,0)/(*this->m_SC)(0,0);
-    Eigen::Vector3d omegaLocal_BN_B = hubOmega_BN_B->getState();
+    Eigen::Vector3d omegaLocal_BN_B = hubOmega_BN_B->getStateReference();
     Eigen::Vector3d cLocal_B = (*this->c_B);
     (*this->cDot_B) = (*this->cPrime_B) + omegaLocal_BN_B.cross(cLocal_B);
 }
@@ -406,8 +406,8 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     (*this->sysTime) << (double) integTimeNanos, integTimeSeconds;
 
     if (this->pointMassTranslationalOnly) {
-        Eigen::Vector3d rLocal_BN_N = this->hubR_N->getState();
-        Eigen::Vector3d vLocal_BN_N = this->hubV_N->getState();
+        Eigen::Vector3d rLocal_BN_N = this->hubR_N->getStateReference();
+        Eigen::Vector3d vLocal_BN_N = this->hubV_N->getStateReference();
 
         this->gravField.computeGravityField(rLocal_BN_N, vLocal_BN_N);
 
@@ -424,7 +424,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
         Eigen::MRPd sigmaLocal_BN;
         sigmaLocal_BN = this->hub.sigma_BNInit;
         if (this->hubSigma != nullptr) {
-            sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getState();
+            sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
             this->hubSigma->setDerivative(Eigen::Vector3d::Zero());
         }
         if (this->hubOmega_BN_B != nullptr) {
@@ -440,8 +440,8 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     }
 
     if (this->useHubOnlyFastPath()) {
-        Eigen::Vector3d rLocal_BN_N = this->hubR_N->getState();
-        Eigen::Vector3d vLocal_BN_N = this->hubV_N->getState();
+        Eigen::Vector3d rLocal_BN_N = this->hubR_N->getStateReference();
+        Eigen::Vector3d vLocal_BN_N = this->hubV_N->getStateReference();
 
         this->gravField.computeGravityField(rLocal_BN_N, vLocal_BN_N);
 
@@ -483,11 +483,14 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     Eigen::Matrix3d dcm_NB;
     Eigen::Vector3d cLocal_N;
 
-    sigmaBNLoc = (Eigen::Vector3d) this->hubSigma->getState();
+    Eigen::Vector3d sigmaState = this->hubSigma->getStateReference();
+    Eigen::Vector3d omegaState = this->hubOmega_BN_B->getStateReference();
+
+    sigmaBNLoc = sigmaState;
     dcm_NB = sigmaBNLoc.toRotationMatrix();
     cLocal_N = dcm_NB*(*this->c_B);
-    Eigen::Vector3d rLocal_CN_N = this->hubR_N->getState() + dcm_NB*(*this->c_B);
-    Eigen::Vector3d vLocal_CN_N = this->hubV_N->getState() + dcm_NB*(*this->cDot_B);
+    Eigen::Vector3d rLocal_CN_N = this->hubR_N->getStateReference() + dcm_NB*(*this->c_B);
+    Eigen::Vector3d vLocal_CN_N = this->hubV_N->getStateReference() + dcm_NB*(*this->cDot_B);
 
     this->gravField.computeGravityField(rLocal_CN_N, vLocal_CN_N);
 
@@ -516,7 +519,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
         this->backSubContributions.vecRot.setZero();
 
         // - Call the update contributions method for the stateEffectors and add in contributions to the hub matrices
-        (*it)->updateContributions(integTimeSeconds, this->backSubContributions, this->hubSigma->getState(), this->hubOmega_BN_B->getState(), *this->g_N);
+        (*it)->updateContributions(integTimeSeconds, this->backSubContributions, sigmaState, omegaState, *this->g_N);
         this->hub.hubBackSubMatrices.matrixA += this->backSubContributions.matrixA;
         this->hub.hubBackSubMatrices.matrixB += this->backSubContributions.matrixB;
         this->hub.hubBackSubMatrices.matrixC += this->backSubContributions.matrixC;
@@ -533,7 +536,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
 
     Eigen::Matrix3d intermediateMatrix;
     Eigen::Vector3d intermediateVector;
-    Eigen::Vector3d omegaLocalBN_B = this->hubOmega_BN_B->getState();
+    Eigen::Vector3d omegaLocalBN_B = omegaState;
     this->hub.hubBackSubMatrices.matrixA += (*this->m_SC)(0,0)*intermediateMatrix.Identity();
     intermediateMatrix = eigenTilde((*this->c_B));  // make c_B skew symmetric matrix
     this->hub.hubBackSubMatrices.matrixB += -(*this->m_SC)(0,0)*intermediateMatrix;
@@ -564,12 +567,18 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     this->hub.hubBackSubMatrices.vecRot += cLocal_B.cross(gravityForce_B) + this->sumTorquePntB_B;
 
     // - Compute the derivatives of the hub states before looping through stateEffectors
-    this->hub.computeDerivatives(integTimeSeconds, this->hubV_N->getStateDeriv(), this->hubOmega_BN_B->getStateDeriv(), this->hubSigma->getState());
+    this->hub.computeDerivatives(integTimeSeconds,
+                                 this->hubV_N->getStateDerivReference(),
+                                 this->hubOmega_BN_B->getStateDerivReference(),
+                                 sigmaState);
+
+    Eigen::Vector3d hubVDeriv = this->hubV_N->getStateDerivReference();
+    Eigen::Vector3d hubOmegaDeriv = this->hubOmega_BN_B->getStateDerivReference();
 
     // - Loop through state effectors for compute derivatives
     for(it = states.begin(); it != states.end(); it++)
     {
-        (*it)->computeDerivatives(integTimeSeconds, this->hubV_N->getStateDeriv(), this->hubOmega_BN_B->getStateDeriv(), this->hubSigma->getState());
+        (*it)->computeDerivatives(integTimeSeconds, hubVDeriv, hubOmegaDeriv, sigmaState);
     }
 }
 
@@ -588,14 +597,14 @@ void Spacecraft::preIntegration(uint64_t integrateToThisTimeNanos) {
     }
 
     // - Find v_CN_N before integration for accumulated DV
-    Eigen::Vector3d oldV_BN_N = this->hubV_N->getState();  // - V_BN_N before integration
+    Eigen::Vector3d oldV_BN_N = this->hubV_N->getStateReference();  // - V_BN_N before integration
     Eigen::Vector3d oldV_CN_N;  // - V_CN_N before integration
     Eigen::Vector3d oldC_B;     // - Center of mass offset before integration
     Eigen::MRPd oldSigma_BN;    // - Sigma_BN before integration
     // - Get the angular rate, oldOmega_BN_B from the dyn manager
-    this->oldOmega_BN_B = this->hubOmega_BN_B->getState();
+    this->oldOmega_BN_B = this->hubOmega_BN_B->getStateReference();
     // - Get center of mass, v_BN_N and dcm_NB from the dyn manager
-    oldSigma_BN = (Eigen::Vector3d) this->hubSigma->getState();
+    oldSigma_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
     // - Finally find v_CN_N
     Eigen::Matrix3d oldDcm_NB = oldSigma_BN.toRotationMatrix(); // - dcm_NB before integration
     oldV_CN_N = oldV_BN_N + oldDcm_NB*(*this->cDot_B);
@@ -620,38 +629,38 @@ void Spacecraft::postIntegration(uint64_t integrateToThisTimeNanos) {
     this->updateSCMassProps(integrateToThisTime);
 
     // - Find v_CN_N after the integration for accumulated DV
-    Eigen::Vector3d newV_BN_N = this->hubV_N->getState(); // - V_BN_N after integration
+    Eigen::Vector3d newV_BN_N = this->hubV_N->getStateReference(); // - V_BN_N after integration
     Eigen::Vector3d newV_CN_N;  // - V_CN_N after integration
     Eigen::MRPd newSigma_BN;    // - Sigma_BN after integration
     // - Get center of mass, v_BN_N and dcm_NB
     Eigen::Vector3d sigmaBNLoc;
-    sigmaBNLoc = (Eigen::Vector3d) this->hubSigma->getState();
+    sigmaBNLoc = (Eigen::Vector3d) this->hubSigma->getStateReference();
     newSigma_BN = sigmaBNLoc;
     Eigen::Matrix3d newDcm_NB = newSigma_BN.toRotationMatrix();  // - dcm_NB after integration
     newV_CN_N = newV_BN_N + newDcm_NB*(*this->cDot_B);
 
     // - Find accumulated DV of the center of mass in the body frame
     this->dvAccum_CN_B += newDcm_NB.transpose()*(newV_CN_N -
-                                              this->BcGravVelocity->getState());
+                                              this->BcGravVelocity->getStateReference());
 
     // - Find the accumulated DV of the body frame in the body frame
     this->dvAccum_BN_B += newDcm_NB.transpose()*(newV_BN_N -
-                                                 this->hubGravVelocity->getState());
+                                                 this->hubGravVelocity->getStateReference());
 
     // - Find the accumulated DV of the center of mass in the inertial frame
-    this->dvAccum_CN_N += newV_CN_N - this->BcGravVelocity->getState();
+    this->dvAccum_CN_N += newV_CN_N - this->BcGravVelocity->getStateReference();
 
     // - non-conservative acceleration of the body frame in the body frame
     if (fabs(this->timeStep) > 1e-10) {
         this->nonConservativeAccelpntB_B = (newDcm_NB.transpose()*(newV_BN_N -
-                                                                   this->hubGravVelocity->getState()))/this->timeStep;
+                                                                   this->hubGravVelocity->getStateReference()))/this->timeStep;
     } else {
         this->nonConservativeAccelpntB_B = {0., 0., 0.};
     }
 
     // - angular acceleration in the body frame
     Eigen::Vector3d newOmega_BN_B;
-    newOmega_BN_B = this->hubOmega_BN_B->getState();
+    newOmega_BN_B = this->hubOmega_BN_B->getStateReference();
     if (fabs(this->timeStep) > 1e-10) {
         this->omegaDot_BN_B = (newOmega_BN_B - this->oldOmega_BN_B)/this->timeStep; //angular acceleration of B wrt N in the Body frame
     } else {
@@ -681,10 +690,10 @@ void Spacecraft::postIntegration(uint64_t integrateToThisTimeNanos) {
 void Spacecraft::computeEnergyMomentum(double time)
 {
     // - Grab values from state Manager
-    Eigen::Vector3d rLocal_BN_N = hubR_N->getState();
-    Eigen::Vector3d rDotLocal_BN_N = hubV_N->getState();
+    Eigen::Vector3d rLocal_BN_N = hubR_N->getStateReference();
+    Eigen::Vector3d rDotLocal_BN_N = hubV_N->getStateReference();
     Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d ) hubSigma->getState();
+    sigmaLocal_BN = (Eigen::Vector3d ) hubSigma->getStateReference();
 
     // - Find DCM's
     Eigen::Matrix3d dcmLocal_NB = sigmaLocal_BN.toRotationMatrix();
@@ -709,7 +718,7 @@ void Spacecraft::computeEnergyMomentum(double time)
     this->rotEnergyContr = 0.0;
 
     // - Get the hubs contribution
-    this->hub.updateEnergyMomContributions(time, this->rotAngMomPntCContr_B, this->rotEnergyContr, this->hubOmega_BN_B->getState());
+    this->hub.updateEnergyMomContributions(time, this->rotAngMomPntCContr_B, this->rotEnergyContr, this->hubOmega_BN_B->getStateReference());
     totRotAngMomPntC_B += this->rotAngMomPntCContr_B;
     this->totRotEnergy += this->rotEnergyContr;
 
@@ -722,7 +731,7 @@ void Spacecraft::computeEnergyMomentum(double time)
         this->rotEnergyContr = 0.0;
 
         // - Call energy and momentum calulations for stateEffectors
-        (*it)->updateEnergyMomContributions(time, this->rotAngMomPntCContr_B, this->rotEnergyContr, this->hubOmega_BN_B->getState());
+        (*it)->updateEnergyMomContributions(time, this->rotAngMomPntCContr_B, this->rotEnergyContr, this->hubOmega_BN_B->getStateReference());
         totRotAngMomPntC_B += this->rotAngMomPntCContr_B;
         this->totRotEnergy += this->rotEnergyContr;
     }
@@ -736,7 +745,7 @@ void Spacecraft::computeEnergyMomentum(double time)
 
     // - Call gravity effector and add in its potential contributions to the total orbital energy calculations
     this->orbPotentialEnergyContr = 0.0;
-    Eigen::Vector3d rLocal_CN_N = this->hubR_N->getState() + dcmLocal_NB*(*this->c_B);
+    Eigen::Vector3d rLocal_CN_N = this->hubR_N->getStateReference() + dcmLocal_NB*(*this->c_B);
     gravField.updateEnergyContributions(rLocal_CN_N, this->orbPotentialEnergyContr);
     this->totOrbEnergy += (*this->m_SC)(0,0)*this->orbPotentialEnergyContr;
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -66,6 +66,7 @@ public:
     Eigen::Vector3d rotAngMomPntCContr_B;  //!< [kg m^2/s] Contribution of stateEffector to total rotational angular mom.
     HubEffector hub;                     //!< The spacecraft plus needs access to the spacecraft hub
     GravityEffector gravField;           //!< Gravity effector for gravitational field experienced by spacecraft
+    bool pointMassTranslationalOnly = false; //!< -- If true, integrate only translational point-mass dynamics
     std::vector<StateEffector*> states;               //!< Vector of state effectors attached to dynObject
     std::vector<DynamicEffector*> dynEffectors;       //!< Vector of dynamic effectors attached to dynObject
     BSKLogger bskLogger;                      //!< BSK Logging

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -148,6 +148,7 @@ private:
 
 private:
     void readOptionalRefMsg();                  //!< Read the optional attitude or translational reference input message and set the reference states
+    bool useHubOnlyFastPath() const;            //!< Return true if direct fixed-mass hub-only equations can be used
 };
 
 

--- a/src/simulation/dynamics/spacecraft/spacecraft.rst
+++ b/src/simulation/dynamics/spacecraft/spacecraft.rst
@@ -11,6 +11,18 @@ stateEffectors. :ref:`dynamicEffector`'s such as thrusters, external force and t
 by attaching dynamicEffectors. This class performs all of this interaction between stateEffectors, dynamicEffectors and
 the hub.
 
+The optional ``pointMassTranslationalOnly`` flag can be set to ``True`` to model the hub as a point mass and only
+integrate the translational position and velocity states. This mode is intended for dynamics comparisons or simple
+point-mass propagation where the rotational hub states and post-integration attitude bookkeeping are unnecessary.
+When enabled, the hub mass ``mHub`` must be positive and the hub center offset ``r_BcB_B`` must be zero.
+State effectors are not supported because they add internal generalized coordinates and mass-property coupling.
+Dynamic effectors may still be attached. Their translational force outputs are included in the point-mass acceleration,
+but torque outputs are ignored because there is no rotational equation of motion. If a dynamic effector requires hub
+attitude or angular-rate states to compute its force or torque, the spacecraft exposes fixed states initialized from
+``sigma_BNInit`` and ``omega_BN_BInit`` with zero derivatives. Thus attitude-dependent force models use the initial
+attitude as a fixed orientation in this mode. The optional attitude reference input message is not supported in
+``pointMassTranslationalOnly`` mode.
+
 The module
 :download:`PDF Description </../../src/simulation/dynamics/spacecraft/_Documentation/Spacecraft/Basilisk-SPACECRAFT-20170808.pdf>`
 contains further information on this module's function,
@@ -62,6 +74,13 @@ This section is to outline the steps needed to setup a Spacecraft module in pyth
 
         scObject.hub.r_CN_NInit,  scObject.hub.v_CN_NInit, scObject.hub.sigma_BNInit, scObject.hub.omega_BN_BInit
 
+#.  To run a translation-only point-mass propagation, set::
+
+        scObject.pointMassTranslationalOnly = True
+
+    This only integrates the hub position and velocity. Dynamic effectors can be attached if their translational
+    force contribution should act on the point mass, but state effectors cannot be attached.
+
 #.  Finally, add the spacecraft to the task::
 
         unitTestSim.AddModelToTask(unitTaskName, scObject)
@@ -104,3 +123,6 @@ This section is to outline the steps needed to setup a Spacecraft module in pyth
     * - r_BcB_B
       - double[3]
       - Center of mass location in B frame
+    * - pointMassTranslationalOnly
+      - bool
+      - If ``True``, integrate only translational point-mass dynamics

--- a/src/simulation/dynamics/spacecraft/spacecraft.rst
+++ b/src/simulation/dynamics/spacecraft/spacecraft.rst
@@ -23,6 +23,13 @@ attitude or angular-rate states to compute its force or torque, the spacecraft e
 attitude as a fixed orientation in this mode. The optional attitude reference input message is not supported in
 ``pointMassTranslationalOnly`` mode.
 
+In the default 6-DOF mode, ``spacecraft`` automatically uses a direct fixed-mass hub-only dynamics path when no
+state effectors are attached and the hub body-frame origin :math:`B` is colocated with the hub center of mass
+(``r_BcB_B`` is zero). This optimization preserves the rigid-hub translational and rotational equations of motion,
+including gravity and dynamic-effector force and torque contributions, while bypassing the general back-substitution
+matrix assembly required for coupled multi-body state effectors. If a state effector is attached, or if point
+:math:`B` is offset from the hub center of mass, the module uses the general back-substitution formulation.
+
 The module
 :download:`PDF Description </../../src/simulation/dynamics/spacecraft/_Documentation/Spacecraft/Basilisk-SPACECRAFT-20170808.pdf>`
 contains further information on this module's function,
@@ -80,6 +87,11 @@ This section is to outline the steps needed to setup a Spacecraft module in pyth
 
     This only integrates the hub position and velocity. Dynamic effectors can be attached if their translational
     force contribution should act on the point mass, but state effectors cannot be attached.
+
+    When ``pointMassTranslationalOnly`` is left at its default value of ``False``, no additional setting is needed to
+    use the fixed-mass hub-only optimization. It is selected automatically for a hub-only spacecraft with
+    ``r_BcB_B`` equal to zero, and it is bypassed automatically for spacecraft with state effectors or a nonzero hub
+    center offset.
 
 #.  Finally, add the spacecraft to the task::
 

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
@@ -208,15 +208,15 @@ void SphericalPendulum::updateContributions(double integTime, BackSubMatrices & 
     dcm_NB = sigmaLocal_BN.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
 
-    Eigen::Matrix3d dTilde;
-    Eigen::Matrix3d lTilde;
-    dTilde = eigenTilde(this->d);
-	lTilde = eigenTilde(this->l_B);
+    double radiusSquared = this->pendulumRadius*this->pendulumRadius;
+    double cosTheta = cos(this->theta);
+    Eigen::Vector3d pHat03CrossL_B = this->pHat_03.cross(this->l_B);
 
 	// - Define aPhi.transpose()
-    this->aPhi = -(this->pHat_03.transpose()*lTilde)/(this->pendulumRadius*this->pendulumRadius*cos(this->theta)*cos(this->theta));
+    this->aPhi = -pHat03CrossL_B/(radiusSquared*cosTheta*cosTheta);
     // - Define bPhi.transpose()
-    this->bPhi = this->pHat_03.transpose()*lTilde*(lTilde+dTilde)/(this->pendulumRadius*this->pendulumRadius*cos(this->theta)*cos(this->theta));
+    this->bPhi = pHat03CrossL_B.cross(this->l_B + this->d) /
+                 (radiusSquared*cosTheta*cosTheta);
 
 
       // - Map gravity to body frame
@@ -229,13 +229,12 @@ void SphericalPendulum::updateContributions(double integTime, BackSubMatrices & 
 
     // - Define cPhi
     Eigen::Vector3d omega_BN_B_local = omega_BN_B;
-    Eigen::Matrix3d omegaTilde_BN_B_local;
-    omegaTilde_BN_B_local = eigenTilde(omega_BN_B_local);
 	this->cPhi = 1.0/(this->massFSP*this->pendulumRadius*this->pendulumRadius*cos(this->theta)*cos(this->theta))*
-			(-this->massFSP*this->pHat_03.transpose().dot(lTilde*omegaTilde_BN_B_local*omegaTilde_BN_B_local*this->d)
+			(-this->massFSP*this->pHat_03.dot(this->l_B.cross(omega_BN_B_local.cross(omega_BN_B_local.cross(this->d))))
 			+this->pHat_03.transpose()*(L_T) +
 			2*this->massFSP*this->pendulumRadius*this->pendulumRadius*this->phiDot*this->thetaDot*cos(this->theta)*sin(this->theta)
-			-this->massFSP*this->pHat_03.transpose().dot(lTilde*(2*omegaTilde_BN_B_local*this->lPrime_B+omegaTilde_BN_B_local*omegaTilde_BN_B_local*this->l_B)));
+			-this->massFSP*this->pHat_03.dot(this->l_B.cross(2*omega_BN_B_local.cross(this->lPrime_B)
+            + omega_BN_B_local.cross(omega_BN_B_local.cross(this->l_B)))));
 
 	// Define pHat_02_Prime axes of rotation of theta in P0 frame
 	Eigen::Vector3d pHat_02_Prime_P0;
@@ -243,51 +242,47 @@ void SphericalPendulum::updateContributions(double integTime, BackSubMatrices & 
 	// Rotate pHat_02_Prime axes in B frame components
 	Eigen::Vector3d pHat_02_Prime;
 	pHat_02_Prime = dcm_B_P0*pHat_02_Prime_P0;
+    Eigen::Vector3d pHat02PrimeCrossL_B = pHat_02_Prime.cross(this->l_B);
 
 	// Define aTheta.transpose()
-	this->aTheta = -(pHat_02_Prime.transpose()*lTilde)/(this->pendulumRadius*this->pendulumRadius);
+	this->aTheta = -pHat02PrimeCrossL_B/radiusSquared;
 	// Define bTheta.transpose()
-	this->bTheta = pHat_02_Prime.transpose()*lTilde*(lTilde+dTilde)/(this->pendulumRadius*this->pendulumRadius);
+	this->bTheta = pHat02PrimeCrossL_B.cross(this->l_B + this->d)/radiusSquared;
 	// Define cTheta
 	this->cTheta =  1.0/(this->massFSP*this->pendulumRadius*this->pendulumRadius)*
-			(-this->massFSP*pHat_02_Prime.transpose().dot(lTilde*omegaTilde_BN_B_local*omegaTilde_BN_B_local*this->d)
+			(-this->massFSP*pHat_02_Prime.dot(this->l_B.cross(omega_BN_B_local.cross(omega_BN_B_local.cross(this->d))))
 			+pHat_02_Prime.transpose()*(L_T)
 			-this->massFSP*this->pendulumRadius*this->pendulumRadius*this->phiDot*this->phiDot*cos(this->theta)*sin(this->theta)
-			-this->massFSP*pHat_02_Prime.transpose().dot(lTilde*(2*omegaTilde_BN_B_local*this->lPrime_B+omegaTilde_BN_B_local*omegaTilde_BN_B_local*this->l_B)));
+			-this->massFSP*pHat_02_Prime.dot(this->l_B.cross(2*omega_BN_B_local.cross(this->lPrime_B)
+            + omega_BN_B_local.cross(omega_BN_B_local.cross(this->l_B)))));
 
 	// - Compute matrix/vector contributions
-	backSubContr.matrixA = -this->massFSP*this->pendulumRadius*((sin(this->phi)*cos(this->theta)*this->pHat_01
-	 - cos(this->phi)*cos(this->theta)*this->pHat_02)*this->aPhi.transpose()+(cos(this->phi)*sin(this->theta)*this->pHat_01
-	 +sin(this->phi)*sin(this->theta)*this->pHat_02+cos(this->theta)*this->pHat_03)*this->aTheta.transpose());
+    Eigen::Vector3d phiBasis_B = sin(this->phi)*cos(this->theta)*this->pHat_01
+	 - cos(this->phi)*cos(this->theta)*this->pHat_02;
+    Eigen::Vector3d thetaBasis_B = cos(this->phi)*sin(this->theta)*this->pHat_01
+	 +sin(this->phi)*sin(this->theta)*this->pHat_02+cos(this->theta)*this->pHat_03;
+	backSubContr.matrixA = -this->massFSP*this->pendulumRadius*(phiBasis_B*this->aPhi.transpose()
+        + thetaBasis_B*this->aTheta.transpose());
 
-    backSubContr.matrixB = -this->massFSP*this->pendulumRadius*((sin(this->phi)*cos(this->theta)*this->pHat_01
-	 - cos(this->phi)*cos(this->theta)*this->pHat_02)*this->bPhi.transpose() + (cos(this->phi)*sin(this->theta)*this->pHat_01
-	 +sin(this->phi)*sin(this->theta)*this->pHat_02+cos(this->theta)*this->pHat_03)*this->bTheta.transpose());
+    backSubContr.matrixB = -this->massFSP*this->pendulumRadius*(phiBasis_B*this->bPhi.transpose()
+        + thetaBasis_B*this->bTheta.transpose());
 
-    backSubContr.matrixC = -this->massFSP*this->pendulumRadius*this->rTilde_PcB_B*((sin(this->phi)*cos(this->theta)*this->pHat_01
-	 - cos(this->phi)*cos(this->theta)*this->pHat_02)*this->aPhi.transpose()+(cos(this->phi)*sin(this->theta)*this->pHat_01
-	 +sin(this->phi)*sin(this->theta)*this->pHat_02+cos(this->theta)*this->pHat_03)*this->aTheta.transpose());
+    backSubContr.matrixC = -this->massFSP*this->pendulumRadius*(this->r_PcB_B.cross(phiBasis_B)*this->aPhi.transpose()
+        + this->r_PcB_B.cross(thetaBasis_B)*this->aTheta.transpose());
 
-	backSubContr.matrixD = -this->massFSP*this->pendulumRadius*this->rTilde_PcB_B*((sin(this->phi)*cos(this->theta)*this->pHat_01
-	 - cos(this->phi)*cos(this->theta)*this->pHat_02)*this->bPhi.transpose()+(cos(this->phi)*sin(this->theta)*this->pHat_01
-	 +sin(this->phi)*sin(this->theta)*this->pHat_02+cos(this->theta)*this->pHat_03)*this->bTheta.transpose());
+	backSubContr.matrixD = -this->massFSP*this->pendulumRadius*(this->r_PcB_B.cross(phiBasis_B)*this->bPhi.transpose()
+        + this->r_PcB_B.cross(thetaBasis_B)*this->bTheta.transpose());
 
-	backSubContr.vecTrans = -this->massFSP*this->pendulumRadius*((-cos(this->phi)*cos(this->theta)*this->pHat_01
+    Eigen::Vector3d pendulumAccelerationTerm_B = (-cos(this->phi)*cos(this->theta)*this->pHat_01
 	-sin(this->phi)*cos(this->theta)*this->pHat_02)*this->phiDot*this->phiDot
 	+(-cos(this->phi)*cos(this->theta)*this->pHat_01-sin(this->phi)*cos(this->theta)*this->pHat_02+sin(this->theta)*this->pHat_03)*this->thetaDot*this->thetaDot
 	+(2*sin(this->phi)*sin(this->theta)*this->pHat_01-2*cos(this->phi)*sin(this->theta)*this->pHat_02)*this->phiDot*this->thetaDot
-	-(sin(this->phi)*cos(this->theta)*this->pHat_01-cos(this->phi)*cos(this->theta)*this->pHat_02)*this->cPhi
-	-(cos(this->phi)*sin(this->theta)*this->pHat_01+sin(this->phi)*sin(this->theta)*this->pHat_02+cos(theta)*this->pHat_03)*this->cTheta);
+	-phiBasis_B*this->cPhi
+	-thetaBasis_B*this->cTheta;
+	backSubContr.vecTrans = -this->massFSP*this->pendulumRadius*pendulumAccelerationTerm_B;
 
-	backSubContr.vecRot = -this->massFSP*(omegaTilde_BN_B_local*this->rTilde_PcB_B*this->rPrime_PcB_B
-		+this->pendulumRadius*rTilde_PcB_B*(
-	(-cos(this->phi)*cos(this->theta)*this->pHat_01-sin(this->phi)*cos(this->theta)*this->pHat_02)*this->phiDot*this->phiDot
-	+(-cos(this->phi)*cos(this->theta)*this->pHat_01-sin(this->phi)*cos(this->theta)*this->pHat_02+sin(this->theta)*this->pHat_03)*this->thetaDot*this->thetaDot
-	+(2*sin(this->phi)*sin(this->theta)*this->pHat_01-2*cos(this->phi)*sin(this->theta)*this->pHat_02)*this->phiDot*this->thetaDot
-	-(sin(this->phi)*cos(this->theta)*this->pHat_01-cos(this->phi)*cos(this->theta)*this->pHat_02)*this->cPhi
-	-(cos(this->phi)*sin(this->theta)*this->pHat_01+sin(this->phi)*sin(this->theta)*this->pHat_02+cos(theta)*this->pHat_03)*this->cTheta
-			)
-		);
+	backSubContr.vecRot = -this->massFSP*(omega_BN_B_local.cross(this->r_PcB_B.cross(this->rPrime_PcB_B))
+		+ this->pendulumRadius*this->r_PcB_B.cross(pendulumAccelerationTerm_B));
 
     return;
 }

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
@@ -114,8 +114,8 @@ void SphericalPendulum::updateEffectorMassProps(double integTime)
 {
 
     // - Grab phi and theta from state manager and define r_PcB_B
-	this->phi = this->phiState->getState()(0,0);
-	this->theta = this->thetaState->getState()(0,0);
+	this->phi = this->phiState->getStateReference()(0,0);
+	this->theta = this->thetaState->getStateReference()(0,0);
 
 	// mantain phi and theta between 0 and 2pi
 	if (this->phi>2*M_PI) {
@@ -155,7 +155,7 @@ void SphericalPendulum::updateEffectorMassProps(double integTime)
 	this->l_B=dcm_B_P0*l_P0;
 
 	this->r_PcB_B = this->d + this->l_B;
-	this->massFSP = this->massState->getState()(0, 0);
+	this->massFSP = this->massState->getStateReference()(0, 0);
 
 	// - Update the effectors mass
 	this->effProps.mEff = this->massFSP;
@@ -166,8 +166,8 @@ void SphericalPendulum::updateEffectorMassProps(double integTime)
 	this->effProps.IEffPntB_B = this->massFSP * this->rTilde_PcB_B * this->rTilde_PcB_B.transpose();
 
 	// - Grab phiDot and thetaDot from the stateManager and define rPrime_PcB_B
-	this->phiDot=this->phiDotState->getState()(0,0);
-	this->thetaDot=this->thetaDotState->getState()(0,0);
+	this->phiDot=this->phiDotState->getStateReference()(0,0);
+	this->thetaDot=this->thetaDotState->getStateReference()(0,0);
 
 	// define the derivative of l in P0 frame
 	this->lPrime_P0 << this->pendulumRadius*(-this->phiDot*sin(this->phi)*cos(this->theta)-this->thetaDot*cos(this->phi)*sin(this->theta)),
@@ -299,8 +299,8 @@ void SphericalPendulum::computeDerivatives(double integTime, Eigen::Vector3d rDD
 	dcm_BN = (sigmaLocal_BN.toRotationMatrix()).transpose();
 
 	// - Set the derivative of l to lDot
-	this->phiState->setDerivative(this->phiDotState->getState());
-	this->thetaState->setDerivative(this->thetaDotState->getState());
+	this->phiState->setDerivative(this->phiDotState->getStateReference());
+	this->thetaState->setDerivative(this->thetaDotState->getStateReference());
 
 	// - Compute lDDot
 	Eigen::MatrixXd phi_conv(1,1);

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -274,8 +274,8 @@ void SpinningBodyNDOFStateEffector::computeAttitudeProperties(std::shared_ptr<Sp
         this->thetaDotState->setState(thetaDotVector);
     }
 
-    spinningBody->theta = this->thetaState->getState()(spinningBodyIndex);
-    spinningBody->thetaDot = this->thetaDotState->getState()(spinningBodyIndex);
+    spinningBody->theta = this->thetaState->getStateReference()(spinningBodyIndex);
+    spinningBody->thetaDot = this->thetaDotState->getStateReference()(spinningBodyIndex);
 
     double dcm_S0S[3][3];
     double prv_S0S_array[3];
@@ -570,7 +570,7 @@ void SpinningBodyNDOFStateEffector::computeDerivatives(double integTime, Eigen::
     Eigen::Vector3d rDDotLocal_BN_B = this->dcm_BN * rDDot_BN_N;
 
     Eigen::VectorXd thetaDDot = this->ATheta * rDDotLocal_BN_B + this->BTheta * omegaDot_BN_B + this->CTheta;
-    this->thetaState->setDerivative(this->thetaDotState->getState());
+    this->thetaState->setDerivative(this->thetaDotState->getStateReference());
     this->thetaDotState->setDerivative(thetaDDot);
 }
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -294,7 +294,6 @@ void SpinningBodyNDOFStateEffector::computeAttitudeProperties(std::shared_ptr<Sp
 void SpinningBodyNDOFStateEffector::computeAngularVelocityProperties(std::shared_ptr<SpinningBody> spinningBody, int spinningBodyIndex) const
 {
     spinningBody->omega_SP_B = spinningBody->thetaDot * spinningBody->sHat_B;
-    spinningBody->omegaTilde_SP_B = eigenTilde(spinningBody->omega_SP_B);
     if (spinningBodyIndex == 0) {
         spinningBody->omega_SB_B = spinningBody->omega_SP_B;
     } else {
@@ -345,7 +344,6 @@ void SpinningBodyNDOFStateEffector::updateContributions(double integTime,
     this->sigma_BN = sigma_BN;
     this->dcm_BN = (this->sigma_BN.toRotationMatrix()).transpose();
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
 
     Eigen::MatrixXd MTheta = Eigen::MatrixXd::Zero(this->numberOfDegreesOfFreedom, this->numberOfDegreesOfFreedom);
     Eigen::MatrixXd AThetaStar = Eigen::MatrixXd::Zero(this->numberOfDegreesOfFreedom, 3);

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -404,14 +404,13 @@ void SpinningBodyNDOFStateEffector::computeMTheta(Eigen::MatrixXd& MTheta)
 
             for (int j = (i<=n) ? n : i; j<this->numberOfDegreesOfFreedom; j++) {
                 Eigen::Vector3d r_ScjSn_B = this->spinningBodyVec[j]->r_ScB_B - this->spinningBodyVec[n]->r_SB_B;
-                Eigen::Matrix3d rTilde_ScjSn_B = eigenTilde(r_ScjSn_B);
                 Eigen::Vector3d r_ScjSi_B = this->spinningBodyVec[j]->r_ScB_B - this->spinningBodyVec[i]->r_SB_B;
-                Eigen::Matrix3d rTilde_ScjSi_B = eigenTilde(r_ScjSi_B);
+                Eigen::Vector3d mThetaContribution =
+                    this->spinningBodyVec[j]->ISPntSc_B * this->spinningBodyVec[i]->sHat_B
+                    - this->spinningBodyVec[j]->mass *
+                      r_ScjSn_B.cross(r_ScjSi_B.cross(this->spinningBodyVec[i]->sHat_B));
 
-                MTheta(n,i) += this->spinningBodyVec[n]->sHat_B.transpose()
-                               * (this->spinningBodyVec[j]->ISPntSc_B
-                                  - this->spinningBodyVec[j]->mass * rTilde_ScjSn_B * rTilde_ScjSi_B)
-                               * this->spinningBodyVec[i]->sHat_B;
+                MTheta(n,i) += this->spinningBodyVec[n]->sHat_B.dot(mThetaContribution);
             }
         }
     }
@@ -425,9 +424,9 @@ void SpinningBodyNDOFStateEffector::computeAThetaStar(Eigen::MatrixXd& AThetaSta
 
         for (int i = n; i<this->numberOfDegreesOfFreedom; i++) {
             Eigen::Vector3d r_SciSn_B = this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[n]->r_SB_B;
-            Eigen::Matrix3d rTilde_SciSn_B = eigenTilde(r_SciSn_B);
 
-            AThetaStar.row(n) -= this->spinningBodyVec[n]->sHat_B.transpose() * this->spinningBodyVec[i]->mass * rTilde_SciSn_B;
+            AThetaStar.row(n) -= (this->spinningBodyVec[i]->mass *
+                                  this->spinningBodyVec[n]->sHat_B.cross(r_SciSn_B)).transpose();
         }
     }
 }
@@ -440,12 +439,12 @@ void SpinningBodyNDOFStateEffector::computeBThetaStar(Eigen::MatrixXd& BThetaSta
 
         for (int i = n; i < this->numberOfDegreesOfFreedom; i++) {
             Eigen::Vector3d r_SciSn_B = this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[n]->r_SB_B;
-            Eigen::Matrix3d rTilde_SciSn_B = eigenTilde(r_SciSn_B);
-            Eigen::Matrix3d rTilde_SciB_B = eigenTilde(this->spinningBodyVec[i]->r_ScB_B);
+            Eigen::Vector3d bThetaStarContribution =
+                this->spinningBodyVec[i]->ISPntSc_B * this->spinningBodyVec[n]->sHat_B
+                - this->spinningBodyVec[i]->mass * this->spinningBodyVec[i]->r_ScB_B.cross(
+                    r_SciSn_B.cross(this->spinningBodyVec[n]->sHat_B));
 
-            BThetaStar.row(n) -= this->spinningBodyVec[n]->sHat_B.transpose() * (this->spinningBodyVec[i]->ISPntSc_B
-                                                                                - this->spinningBodyVec[i]->mass *
-                                                                                  rTilde_SciSn_B * rTilde_SciB_B);
+            BThetaStar.row(n) -= bThetaStarContribution.transpose();
         }
     }
 }
@@ -466,30 +465,37 @@ void SpinningBodyNDOFStateEffector::computeCThetaStar(Eigen::VectorXd& CThetaSta
 
         for (int i = n; i<this->numberOfDegreesOfFreedom; i++) {
             Eigen::Vector3d r_SciSn_B = this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[n]->r_SB_B;
-            Eigen::Matrix3d rTilde_SciSn_B = eigenTilde(r_SciSn_B);
-            Eigen::Matrix3d omegaTilde_SiN_B = eigenTilde(this->spinningBodyVec[i]->omega_SN_B);
+            Eigen::Vector3d coriolisTranslation =
+                    - g_B
+                    + this->omega_BN_B.cross(this->omega_BN_B.cross(this->spinningBodyVec[i]->r_ScB_B))
+                    + 2 * this->omega_BN_B.cross(this->spinningBodyVec[i]->rPrime_ScB_B)
+                    + this->spinningBodyVec[i]->omega_SP_B.cross(this->spinningBodyVec[i]->rPrime_ScS_B);
+            Eigen::Vector3d cThetaContribution =
+                    this->spinningBodyVec[i]->omega_SN_B.cross(this->spinningBodyVec[i]->ISPntSc_B *
+                                                               this->spinningBodyVec[i]->omega_SN_B)
+                    - this->spinningBodyVec[i]->ISPntSc_B *
+                      this->spinningBodyVec[i]->omega_SB_B.cross(this->omega_BN_B)
+                    + this->spinningBodyVec[i]->mass * r_SciSn_B.cross(coriolisTranslation);
 
-            CThetaStar(n) -= this->spinningBodyVec[n]->sHat_B.transpose() * (
-                    omegaTilde_SiN_B * this->spinningBodyVec[i]->ISPntSc_B * this->spinningBodyVec[i]->omega_SN_B
-                    - this->spinningBodyVec[i]->ISPntSc_B * this->spinningBodyVec[i]->omegaTilde_SB_B * this->omega_BN_B
-                    + this->spinningBodyVec[i]->mass * rTilde_SciSn_B * (
-                            - g_B
-                            + this->omegaTilde_BN_B * this->omegaTilde_BN_B * this->spinningBodyVec[i]->r_ScB_B
-                            + 2 * this->omegaTilde_BN_B * this->spinningBodyVec[i]->rPrime_ScB_B
-                            + this->spinningBodyVec[i]->omegaTilde_SP_B * this->spinningBodyVec[i]->rPrime_ScS_B));
+            CThetaStar(n) -= this->spinningBodyVec[n]->sHat_B.dot(cThetaContribution);
 
             for(int j=0; j<=i-1; j++) {
-                Eigen::Vector3d omega_SiSj_B = this->spinningBodyVec[i]->omega_SB_B - this->spinningBodyVec[j]->omega_SB_B;
-                Eigen::Matrix3d omegaTilde_SiSj_B = eigenTilde(omega_SiSj_B);
-                Eigen::Vector3d r_SciSj1 = this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[j+1]->r_SB_B;
-                Eigen::Matrix3d rTilde_SciSj1 = eigenTilde(r_SciSj1);
-                Eigen::Vector3d rPrime_SciSj_B = this->spinningBodyVec[i]->rPrime_ScB_B - this->spinningBodyVec[j]->rPrime_SB_B;
+                Eigen::Vector3d omega_SiSj_B =
+                        this->spinningBodyVec[i]->omega_SB_B - this->spinningBodyVec[j]->omega_SB_B;
+                Eigen::Vector3d r_SciSj1 =
+                        this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[j+1]->r_SB_B;
+                Eigen::Vector3d rPrime_SciSj_B =
+                        this->spinningBodyVec[i]->rPrime_ScB_B - this->spinningBodyVec[j]->rPrime_SB_B;
+                Eigen::Vector3d linkAcceleration =
+                        this->spinningBodyVec[j]->omega_SP_B.cross(rPrime_SciSj_B)
+                        - r_SciSj1.cross(this->spinningBodyVec[j]->omega_SB_B.cross(
+                                         this->spinningBodyVec[j+1]->omega_SP_B));
+                Eigen::Vector3d innerCThetaContribution =
+                        - this->spinningBodyVec[i]->ISPntSc_B *
+                          omega_SiSj_B.cross(this->spinningBodyVec[j]->omega_SP_B)
+                        + this->spinningBodyVec[i]->mass * r_SciSn_B.cross(linkAcceleration);
 
-                CThetaStar(n) -= this->spinningBodyVec[n]->sHat_B.transpose() * (
-                        - this->spinningBodyVec[i]->ISPntSc_B * omegaTilde_SiSj_B * this->spinningBodyVec[j]->omega_SP_B
-                        + this->spinningBodyVec[i]->mass * rTilde_SciSn_B * (
-                                this->spinningBodyVec[j]->omegaTilde_SP_B * rPrime_SciSj_B
-                                - rTilde_SciSj1 * this->spinningBodyVec[j]->omegaTilde_SB_B * this->spinningBodyVec[j+1]->omega_SP_B));
+                CThetaStar(n) -= this->spinningBodyVec[n]->sHat_B.dot(innerCThetaContribution);
             }
         }
     }
@@ -500,17 +506,16 @@ void SpinningBodyNDOFStateEffector::computeBackSubMatrices(BackSubMatrices& back
     for (int i = 0; i<this->numberOfDegreesOfFreedom; i++) {
         for (int j = i; j < this->numberOfDegreesOfFreedom; j++) {
             Eigen::Vector3d r_ScjSi = this->spinningBodyVec[j]->r_ScB_B - this->spinningBodyVec[i]->r_SB_B;
-            Eigen::Matrix3d rTilde_ScjSi = eigenTilde(r_ScjSi);
-            Eigen::Matrix3d rTilde_ScjB = eigenTilde(this->spinningBodyVec[j]->r_ScB_B);
+            Eigen::Vector3d matrixABVector = r_ScjSi.cross(this->spinningBodyVec[i]->sHat_B);
+            Eigen::Vector3d matrixCDVector =
+                    this->spinningBodyVec[j]->ISPntSc_B * this->spinningBodyVec[i]->sHat_B
+                    - this->spinningBodyVec[j]->mass *
+                      this->spinningBodyVec[j]->r_ScB_B.cross(r_ScjSi.cross(this->spinningBodyVec[i]->sHat_B));
 
-            backSubContr.matrixA -= this->spinningBodyVec[j]->mass * rTilde_ScjSi * this->spinningBodyVec[i]->sHat_B * this->ATheta.row(i);
-            backSubContr.matrixB -= this->spinningBodyVec[j]->mass * rTilde_ScjSi * this->spinningBodyVec[i]->sHat_B * this->BTheta.row(i);
-            backSubContr.matrixC += (this->spinningBodyVec[j]->ISPntSc_B
-                                     - this->spinningBodyVec[j]->mass * rTilde_ScjB * rTilde_ScjSi)
-                                    * this->spinningBodyVec[i]->sHat_B * this->ATheta.row(i);
-            backSubContr.matrixD += (this->spinningBodyVec[j]->ISPntSc_B
-                                     - this->spinningBodyVec[j]->mass * rTilde_ScjB * rTilde_ScjSi)
-                                    * this->spinningBodyVec[i]->sHat_B * this->BTheta.row(i);
+            backSubContr.matrixA -= this->spinningBodyVec[j]->mass * matrixABVector * this->ATheta.row(i);
+            backSubContr.matrixB -= this->spinningBodyVec[j]->mass * matrixABVector * this->BTheta.row(i);
+            backSubContr.matrixC += matrixCDVector * this->ATheta.row(i);
+            backSubContr.matrixD += matrixCDVector * this->BTheta.row(i);
         }
     }
 }
@@ -518,36 +523,43 @@ void SpinningBodyNDOFStateEffector::computeBackSubMatrices(BackSubMatrices& back
 void SpinningBodyNDOFStateEffector::computeBackSubVectors(BackSubMatrices &backSubContr) const
 {
     for (int i = 0; i<this->numberOfDegreesOfFreedom; i++) {
-        Eigen::Matrix3d omegaTilde_SiN_B = eigenTilde(this->spinningBodyVec[i]->omega_SN_B);
-        backSubContr.vecRot -= omegaTilde_SiN_B * this->spinningBodyVec[i]->ISPntSc_B * this->spinningBodyVec[i]->omega_SB_B
-                + this->spinningBodyVec[i]->mass * this->omegaTilde_BN_B * this->spinningBodyVec[i]->rTilde_ScB_B * this->spinningBodyVec[i]->rPrime_ScB_B;
+        backSubContr.vecRot -= this->spinningBodyVec[i]->omega_SN_B.cross(this->spinningBodyVec[i]->ISPntSc_B *
+                                                                         this->spinningBodyVec[i]->omega_SB_B)
+                + this->spinningBodyVec[i]->mass * this->omega_BN_B.cross(
+                    this->spinningBodyVec[i]->r_ScB_B.cross(this->spinningBodyVec[i]->rPrime_ScB_B));
 
         for(int j=0; j<=i-1; j++) {
-            Eigen::Vector3d omega_SiSj_B = this->spinningBodyVec[i]->omega_SB_B - this->spinningBodyVec[j]->omega_SB_B;
-            Eigen::Matrix3d omegaTilde_SiSj_B = eigenTilde(omega_SiSj_B);
-            Eigen::Vector3d r_SciSj1 = this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[j+1]->r_SB_B;
-            Eigen::Matrix3d rTilde_SciSj1 = eigenTilde(r_SciSj1);
-            Eigen::Vector3d rPrime_SciSj_B = this->spinningBodyVec[i]->rPrime_ScB_B - this->spinningBodyVec[j]->rPrime_SB_B;
+            Eigen::Vector3d omega_SiSj_B =
+                    this->spinningBodyVec[i]->omega_SB_B - this->spinningBodyVec[j]->omega_SB_B;
+            Eigen::Vector3d r_SciSj1 =
+                    this->spinningBodyVec[i]->r_ScB_B - this->spinningBodyVec[j+1]->r_SB_B;
+            Eigen::Vector3d rPrime_SciSj_B =
+                    this->spinningBodyVec[i]->rPrime_ScB_B - this->spinningBodyVec[j]->rPrime_SB_B;
+            Eigen::Vector3d linkAcceleration =
+                    this->spinningBodyVec[j]->omega_SP_B.cross(rPrime_SciSj_B)
+                    - r_SciSj1.cross(this->spinningBodyVec[j]->omega_SB_B.cross(
+                                     this->spinningBodyVec[j+1]->omega_SP_B));
 
-            backSubContr.vecTrans -= this->spinningBodyVec[i]->mass * (this->spinningBodyVec[j]->omegaTilde_SP_B * rPrime_SciSj_B
-                    - rTilde_SciSj1 * this->spinningBodyVec[j]->omegaTilde_SB_B * this->spinningBodyVec[j+1]->omega_SP_B);
-            backSubContr.vecRot -= - this->spinningBodyVec[i]->ISPntSc_B * omegaTilde_SiSj_B * this->spinningBodyVec[j]->omega_SP_B
-                    + this->spinningBodyVec[i]->mass * this->spinningBodyVec[i]->rTilde_ScB_B * (
-                        this->spinningBodyVec[j]->omegaTilde_SP_B * rPrime_SciSj_B
-                        - rTilde_SciSj1 * this->spinningBodyVec[j]->omegaTilde_SB_B * this->spinningBodyVec[j+1]->omega_SP_B);
+            backSubContr.vecTrans -= this->spinningBodyVec[i]->mass * linkAcceleration;
+            backSubContr.vecRot -= - this->spinningBodyVec[i]->ISPntSc_B *
+                    omega_SiSj_B.cross(this->spinningBodyVec[j]->omega_SP_B)
+                    + this->spinningBodyVec[i]->mass * this->spinningBodyVec[i]->r_ScB_B.cross(linkAcceleration);
         }
-        backSubContr.vecTrans -= this->spinningBodyVec[i]->mass * this->spinningBodyVec[i]->omegaTilde_SP_B * this->spinningBodyVec[i]->rPrime_ScS_B;
-        backSubContr.vecRot -= this->spinningBodyVec[i]->mass * this->spinningBodyVec[i]->rTilde_ScB_B * this->spinningBodyVec[i]->omegaTilde_SP_B * this->spinningBodyVec[i]->rPrime_ScS_B;
+        Eigen::Vector3d tipAcceleration =
+                this->spinningBodyVec[i]->omega_SP_B.cross(this->spinningBodyVec[i]->rPrime_ScS_B);
+        backSubContr.vecTrans -= this->spinningBodyVec[i]->mass * tipAcceleration;
+        backSubContr.vecRot -= this->spinningBodyVec[i]->mass * this->spinningBodyVec[i]->r_ScB_B.cross(tipAcceleration);
 
         for (int j = i; j < this->numberOfDegreesOfFreedom; j++) {
             Eigen::Vector3d r_ScjSi = this->spinningBodyVec[j]->r_ScB_B - this->spinningBodyVec[i]->r_SB_B;
-            Eigen::Matrix3d rTilde_ScjSi = eigenTilde(r_ScjSi);
-            Eigen::Matrix3d rTilde_ScjB = eigenTilde(this->spinningBodyVec[j]->r_ScB_B);
+            Eigen::Vector3d vecTransContribution = r_ScjSi.cross(this->spinningBodyVec[i]->sHat_B);
+            Eigen::Vector3d vecRotContribution =
+                    this->spinningBodyVec[j]->ISPntSc_B * this->spinningBodyVec[i]->sHat_B
+                    - this->spinningBodyVec[j]->mass *
+                      this->spinningBodyVec[j]->r_ScB_B.cross(r_ScjSi.cross(this->spinningBodyVec[i]->sHat_B));
 
-            backSubContr.vecTrans += this->spinningBodyVec[j]->mass * rTilde_ScjSi * this->spinningBodyVec[i]->sHat_B * this->CTheta.row(i);
-            backSubContr.vecRot -= (this->spinningBodyVec[j]->ISPntSc_B
-                                    - this->spinningBodyVec[j]->mass * rTilde_ScjB * rTilde_ScjSi)
-                                   * this->spinningBodyVec[i]->sHat_B * this->CTheta.row(i);
+            backSubContr.vecTrans += this->spinningBodyVec[j]->mass * vecTransContribution * this->CTheta.row(i);
+            backSubContr.vecRot -= vecRotContribution * this->CTheta.row(i);
         }
 
         // note: external forces and torques contributed by attached effectors are added to vecTrans

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
@@ -123,7 +123,6 @@ private:
     Eigen::Matrix3d IPrimeSPntSc_B = Eigen::Matrix3d::Zero();    //!< [kg-m^2] body frame derivative of the inertia of spinning body about point Sc in S frame components
     Eigen::Matrix3d dcm_BS = Eigen::Matrix3d::Identity();        //!< DCM from spinner frame to body frame
     Eigen::Matrix3d rTilde_ScB_B = Eigen::Matrix3d::Zero();      //!< [m] tilde matrix of r_ScB_B
-    Eigen::Matrix3d omegaTilde_SP_B = Eigen::Matrix3d::Zero();   //!< [rad/s] tilde matrix of omega_SP_B
     Eigen::Matrix3d omegaTilde_SB_B = Eigen::Matrix3d::Zero();   //!< [rad/s] tilde matrix of omega_SB_B
 
     std::vector<DynamicEffector*> dynEffectors;     //!< -- Vector of dynamic effectors attached

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -259,11 +259,11 @@ void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
     this->omega_BN_B = omega_BN_B;
     this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
     this->omega_SN_B = this->omega_SB_B + this->omega_BN_B;
-    Eigen::Matrix3d omegaTilde_SN_B = eigenTilde(this->omega_SN_B);
 
     // Define IPntS_B for compactness
     Eigen::Matrix3d rTilde_ScS_B = eigenTilde(this->r_ScS_B);
     Eigen::Matrix3d IPntS_B = this->IPntSc_B - this->mass * rTilde_ScS_B * rTilde_ScS_B;
+    const Eigen::Vector3d rScSCrossSHat_B = this->r_ScS_B.cross(this->sHat_B);
 
     // Find the DCM from N to B frames
     this->sigma_BN = sigma_BN;
@@ -298,38 +298,38 @@ void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
     }
     else {
         // Define aTheta
-        this->aTheta = this->mass * rTilde_ScS_B * this->sHat_B / this->mTheta;
+        this->aTheta = this->mass * rScSCrossSHat_B / this->mTheta;
 
         // Define bTheta
-        Eigen::Matrix3d rTilde_SB_B = eigenTilde(this->r_SB_B);
-        this->bTheta = -(IPntS_B - this->mass * rTilde_SB_B * rTilde_ScS_B) * this->sHat_B / this->mTheta;
+        this->bTheta = -(IPntS_B * this->sHat_B - this->mass * this->r_SB_B.cross(rScSCrossSHat_B))
+                       / this->mTheta;
 
         // Define cTheta
-        this->rDot_SB_B = this->omegaTilde_BN_B * this->r_SB_B;
-        Eigen::Vector3d gravityTorquePntS_B = rTilde_ScS_B * this->mass * g_B;
+        this->rDot_SB_B = this->omega_BN_B.cross(this->r_SB_B);
+        Eigen::Vector3d gravityTorquePntS_B = this->r_ScS_B.cross(this->mass * g_B);
         this->cTheta = (this->u - this->k * (this->theta - this->thetaRef) - this->c * (this->thetaDot - this->thetaDotRef)
-                + this->sHat_B.dot(gravityTorquePntS_B - omegaTilde_SN_B * IPntS_B * this->omega_SN_B
-                - IPntS_B * this->omegaTilde_BN_B * this->omega_SB_B + this->dcm_BS * attBodyTorquePntS_S
-                - this->mass * rTilde_ScS_B * this->omegaTilde_BN_B * this->rDot_SB_B)) / this->mTheta;
+                + this->sHat_B.dot(gravityTorquePntS_B - this->omega_SN_B.cross(IPntS_B * this->omega_SN_B)
+                - IPntS_B * this->omega_BN_B.cross(this->omega_SB_B) + this->dcm_BS * attBodyTorquePntS_S
+                - this->mass * this->r_ScS_B.cross(this->omega_BN_B.cross(this->rDot_SB_B)))) / this->mTheta;
     }
 
     // For documentation on contributions see Vaz Carneiro, Allard, Schaub spinning body paper
     // Translation contributions
-    backSubContr.matrixA = -this->mass * rTilde_ScS_B * this->sHat_B * this->aTheta.transpose();
-    backSubContr.matrixB = -this->mass * rTilde_ScS_B * this->sHat_B * this->bTheta.transpose();
-    backSubContr.vecTrans = -this->mass * this->omegaTilde_SB_B * this->rPrime_ScS_B
-            + this->mass * rTilde_ScS_B * this->sHat_B * this->cTheta + this->dcm_BS * attBodyForce_S;
+    backSubContr.matrixA = -this->mass * rScSCrossSHat_B * this->aTheta.transpose();
+    backSubContr.matrixB = -this->mass * rScSCrossSHat_B * this->bTheta.transpose();
+    backSubContr.vecTrans = -this->mass * this->omega_SB_B.cross(this->rPrime_ScS_B)
+            + this->mass * rScSCrossSHat_B * this->cTheta + this->dcm_BS * attBodyForce_S;
 
     // Rotation contributions
-    backSubContr.matrixC = (this->IPntSc_B - this->mass * this->rTilde_ScB_B * rTilde_ScS_B)
-                           * this->sHat_B * this->aTheta.transpose();
-    backSubContr.matrixD = (this->IPntSc_B - this->mass * this->rTilde_ScB_B * rTilde_ScS_B)
-                           * this->sHat_B * this->bTheta.transpose();
-    backSubContr.vecRot = -omegaTilde_SN_B * this->IPntSc_B * this->omega_SB_B
-            - this->mass * this->omegaTilde_BN_B * this->rTilde_ScB_B * this->rPrime_ScB_B
-            - this->mass * this->rTilde_ScB_B * this->omegaTilde_SB_B * this->rPrime_ScS_B
-            - (this->IPntSc_B - this->mass * this->rTilde_ScB_B * rTilde_ScS_B) * this->sHat_B * this->cTheta
-            + this->dcm_BS * attBodyTorquePntS_S + eigenTilde(this->r_SB_B) * (this->dcm_BS * attBodyForce_S);
+    Eigen::Vector3d rotThetaFactor_B = this->IPntSc_B * this->sHat_B
+                                       - this->mass * this->r_ScB_B.cross(rScSCrossSHat_B);
+    backSubContr.matrixC = rotThetaFactor_B * this->aTheta.transpose();
+    backSubContr.matrixD = rotThetaFactor_B * this->bTheta.transpose();
+    backSubContr.vecRot = -this->omega_SN_B.cross(this->IPntSc_B * this->omega_SB_B)
+            - this->mass * this->omega_BN_B.cross(this->r_ScB_B.cross(this->rPrime_ScB_B))
+            - this->mass * this->r_ScB_B.cross(this->omega_SB_B.cross(this->rPrime_ScS_B))
+            - rotThetaFactor_B * this->cTheta
+            + this->dcm_BS * attBodyTorquePntS_S + this->r_SB_B.cross(this->dcm_BS * attBodyForce_S);
 }
 
 void SpinningBodyOneDOFStateEffector::addPrescribedMotionCouplingContributions(BackSubMatrices & backSubContr) {

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -210,8 +210,8 @@ void SpinningBodyOneDOFStateEffector::updateEffectorMassProps(double integTime)
     }
 
     // Grab current states
-    this->theta = this->thetaState->getState()(0, 0);
-    this->thetaDot = this->thetaDotState->getState()(0, 0);
+    this->theta = this->thetaState->getStateReference()(0, 0);
+    this->thetaDot = this->thetaDotState->getStateReference()(0, 0);
 
     // Compute the DCM from S frame to B frame and write sHat in B frame
     double dcm_S0S[3][3];
@@ -345,7 +345,7 @@ void SpinningBodyOneDOFStateEffector::addPrescribedMotionCouplingContributions(B
     Eigen::Matrix3d dcm_PB = sigma_PB.toRotationMatrix().transpose();
 
     // Collect hub states
-    Eigen::Vector3d omega_BN_B = this->hubOmega->getState();
+    Eigen::Vector3d omega_BN_B = this->hubOmega->getStateReference();
     Eigen::Vector3d omega_BN_P = dcm_PB * omega_BN_B;
 
     // Prescribed motion translation coupling contributions
@@ -430,7 +430,7 @@ void SpinningBodyOneDOFStateEffector::computeDerivatives(double integTime,
     rDDotLocal_BN_B = this->dcm_BN * rDDotLocal_BN_N;
 
     // Compute Derivatives
-    this->thetaState->setDerivative(this->thetaDotState->getState());
+    this->thetaState->setDerivative(this->thetaDotState->getStateReference());
     Eigen::MatrixXd thetaDDot(1, 1);
     thetaDDot(0, 0) = this->aTheta.dot(rDDotLocal_BN_B)
             + this->bTheta.dot(omegaDotLocal_BN_B) + this->cTheta;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -390,19 +390,12 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
 
     // Define auxiliary rtilde matrices
     Eigen::Matrix3d rTilde_Sc1S1_B = eigenTilde(this->r_Sc1S1_B);
-    Eigen::Matrix3d rTilde_S1B_B = eigenTilde(this->r_S1B_B);
     Eigen::Matrix3d rTilde_Sc2S1_B = eigenTilde(r_Sc2S1_B);
     Eigen::Matrix3d rTilde_Sc2S2_B = eigenTilde(this->r_Sc2S2_B);
     Eigen::Matrix3d rTilde_S2S1_B = eigenTilde(this->r_S2S1_B);
-    Eigen::Matrix3d rTilde_S2B_B = eigenTilde(r_S2B_B);
-    Eigen::Matrix3d rTilde_ScS1_B = eigenTilde(r_ScS1_B);
     Eigen::Matrix3d rPrimeTilde_Sc1S1_B = eigenTilde(this->rPrime_Sc1S1_B);
     Eigen::Matrix3d rPrimeTilde_Sc2S1_B = eigenTilde(this->rPrime_Sc2S1_B);
     Eigen::Matrix3d rPrimeTilde_Sc2S2_B = eigenTilde(this->rPrime_Sc2S2_B);
-
-    // Define auxiliary omegaTilde matrices
-    Eigen::Matrix3d omegaTilde_S2S1_B = eigenTilde(this->omega_S2S1_B);
-    Eigen::Matrix3d omegaTilde_S1N_B = eigenTilde(this->omega_S1N_B);
 
     // Define auxiliary inertia matrices
     Eigen::Matrix3d IS2PntS2_B = this->IS2PntSc2_B - this->mass2 * rTilde_Sc2S2_B * rTilde_Sc2S2_B;
@@ -418,38 +411,52 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
 
     // Define AThetaStar matrix
     Eigen::Matrix<double, 2, 3> AThetaStar;
-    AThetaStar.row(0) = - this->mass * this->s1Hat_B.transpose() * rTilde_ScS1_B;
-    AThetaStar.row(1) = - this->mass2 * this->s2Hat_B.transpose() * rTilde_Sc2S2_B;
+    const Eigen::Vector3d rScS1CrossS1Hat_B = r_ScS1_B.cross(this->s1Hat_B);
+    const Eigen::Vector3d rSc2S2CrossS2Hat_B = this->r_Sc2S2_B.cross(this->s2Hat_B);
+    AThetaStar.row(0) = this->mass * rScS1CrossS1Hat_B.transpose();
+    AThetaStar.row(1) = this->mass2 * rSc2S2CrossS2Hat_B.transpose();
 
     // Define BThetaStar matrix
     Eigen::Matrix<double, 2, 3> BThetaStar;
-    BThetaStar.row(0) = - this->s1Hat_B.transpose() * (ISPntS1_B - this->mass * rTilde_ScS1_B * rTilde_S1B_B);
-    BThetaStar.row(1) = - this->s2Hat_B.transpose() * (IS2PntS2_B - this->mass2 * rTilde_Sc2S2_B * rTilde_S2B_B);
+    BThetaStar.row(0) = (-ISPntS1_B * this->s1Hat_B
+                         + this->mass * this->r_S1B_B.cross(r_ScS1_B.cross(this->s1Hat_B))).transpose();
+    BThetaStar.row(1) = (-IS2PntS2_B * this->s2Hat_B
+                         + this->mass2 * r_S2B_B.cross(this->r_Sc2S2_B.cross(this->s2Hat_B))).transpose();
 
     // Define CThetaStar vector
-    Eigen::Vector3d rDot_S1B_B = this->omegaTilde_BN_B * this->r_S1B_B;
-    Eigen::Vector3d rDot_S2S1_B = this->rPrime_S2S1_B + this->omegaTilde_BN_B * this->r_S2S1_B;
-    Eigen::Vector3d gravityTorquePntS1_B = rTilde_ScS1_B * this->mass * g_B;
-    Eigen::Vector3d gravityTorquePntS2_B = rTilde_Sc2S2_B * this->mass2 * g_B;
+    Eigen::Vector3d rDot_S1B_B = this->omega_BN_B.cross(this->r_S1B_B);
+    Eigen::Vector3d rDot_S2S1_B = this->rPrime_S2S1_B + this->omega_BN_B.cross(this->r_S2S1_B);
+    Eigen::Vector3d gravityTorquePntS1_B = r_ScS1_B.cross(this->mass * g_B);
+    Eigen::Vector3d gravityTorquePntS2_B = this->r_Sc2S2_B.cross(this->mass2 * g_B);
+    Eigen::Vector3d cThetaTerm0_B = IPrimeSPntS1_B * this->omega_BN_B
+        + this->omega_BN_B.cross(ISPntS1_B * this->omega_BN_B)
+        + this->IPrimeS1PntSc1_B * this->omega_S1B_B
+        + this->omega_BN_B.cross(this->IS1PntSc1_B * this->omega_S1B_B)
+        + this->IPrimeS2PntSc2_B * this->omega_S2B_B
+        + this->omega_BN_B.cross(this->IS2PntSc2_B * this->omega_S2B_B)
+        + this->IS2PntSc2_B * this->omega_S1B_B.cross(this->omega_S2S1_B)
+        - this->mass2 * r_Sc2S1_B.cross(this->r_Sc2S2_B.cross(this->omega_S1B_B.cross(this->omega_S2S1_B)))
+        + this->mass1 * (this->r_Sc1S1_B.cross(this->omega_S1B_B.cross(this->rPrime_Sc1S1_B))
+        + this->omega_BN_B.cross(this->r_Sc1S1_B.cross(this->rPrime_Sc1S1_B)))
+        + this->mass2 * (r_Sc2S1_B.cross(this->omega_S1B_B.cross(this->rPrime_Sc2S1_B))
+        + this->omega_BN_B.cross(r_Sc2S1_B.cross(this->rPrime_Sc2S1_B)))
+        + this->mass2 * r_Sc2S1_B.cross(this->omega_S2S1_B.cross(this->rPrime_Sc2S2_B))
+        + this->mass * r_ScS1_B.cross(this->omega_BN_B.cross(rDot_S1B_B))
+        - this->dcm_BS1 * attBodyTorquePntS1_S1 + this->dcm_BS2 * attBodyTorquePntS2_S2
+        - this->r_S2S1_B.cross(this->dcm_BS2 * attBodyForce_S2);
+    Eigen::Vector3d cThetaTerm1_B = IPrimeS2PntS2_B * this->omega_S2N_B
+        + this->omega_BN_B.cross(IS2PntS2_B * this->omega_S2N_B)
+        + IS2PntS2_B * this->omega_S1B_B.cross(this->omega_S2S1_B)
+        + this->mass2 * this->r_Sc2S2_B.cross(this->omega_S1N_B.cross(this->rPrime_S2S1_B))
+        + this->mass2 * this->r_Sc2S2_B.cross(this->omega_BN_B.cross(rDot_S2S1_B + rDot_S1B_B))
+        - this->dcm_BS2 * attBodyTorquePntS2_S2;
     Eigen::Vector2d CThetaStar;
     CThetaStar(0,0) = this->u1 - this->k1 * (this->theta1 - this->theta1Ref)
-        - this->c1 * (this->theta1Dot - this->theta1DotRef) + this->s1Hat_B.transpose() * gravityTorquePntS1_B
-        - this->s1Hat_B.transpose() * ((IPrimeSPntS1_B + this->omegaTilde_BN_B * ISPntS1_B) * this->omega_BN_B
-        + (this->IPrimeS1PntSc1_B + this->omegaTilde_BN_B * this->IS1PntSc1_B) * this->omega_S1B_B
-        + (this->IPrimeS2PntSc2_B + this->omegaTilde_BN_B * this->IS2PntSc2_B) * this->omega_S2B_B
-        + (this->IS2PntSc2_B - this->mass2 * rTilde_Sc2S1_B * rTilde_Sc2S2_B) * this->omegaTilde_S1B_B * this->omega_S2S1_B
-        + this->mass1 * (rTilde_Sc1S1_B * this->omegaTilde_S1B_B + this->omegaTilde_BN_B * rTilde_Sc1S1_B) * this->rPrime_Sc1S1_B
-        + this->mass2 * (rTilde_Sc2S1_B * this->omegaTilde_S1B_B + this->omegaTilde_BN_B * rTilde_Sc2S1_B) * this->rPrime_Sc2S1_B
-        + this->mass2 * rTilde_Sc2S1_B * omegaTilde_S2S1_B * this->rPrime_Sc2S2_B
-        + this->mass * rTilde_ScS1_B * this->omegaTilde_BN_B * rDot_S1B_B
-        - this->dcm_BS1 * attBodyTorquePntS1_S1 + this->dcm_BS2 * attBodyTorquePntS2_S2
-        - eigenTilde(this->r_S2S1_B) * (this->dcm_BS2 * attBodyForce_S2));
+        - this->c1 * (this->theta1Dot - this->theta1DotRef) + this->s1Hat_B.dot(gravityTorquePntS1_B)
+        - this->s1Hat_B.dot(cThetaTerm0_B);
     CThetaStar(1, 0) = this->u2 - this->k2 * (this->theta2 - this->theta2Ref)
-        - this->c2 * (this->theta2Dot - this->theta2DotRef) + this->s2Hat_B.transpose() * gravityTorquePntS2_B
-        - this->s2Hat_B.transpose() * ((IPrimeS2PntS2_B + this->omegaTilde_BN_B * IS2PntS2_B) * this->omega_S2N_B
-        + IS2PntS2_B * this->omegaTilde_S1B_B * this->omega_S2S1_B + this->mass2 * rTilde_Sc2S2_B * omegaTilde_S1N_B * this->rPrime_S2S1_B
-        + this->mass2 * rTilde_Sc2S2_B * this->omegaTilde_BN_B * (rDot_S2S1_B + rDot_S1B_B)
-        - this->dcm_BS2 * attBodyTorquePntS2_S2);
+        - this->c2 * (this->theta2Dot - this->theta2DotRef) + this->s2Hat_B.dot(gravityTorquePntS2_B)
+        - this->s2Hat_B.dot(cThetaTerm1_B);
 
     // Check if any of the axis are locked and change dynamics accordingly
     if (this->lockFlag1 == 1 || this->lockFlag2 == 1)
@@ -480,27 +487,32 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
 
     // For documentation on contributions see Vaz Carneiro, Allard, Schaub spinning body paper
     // Translation contributions
-    backSubContr.matrixA = - this->mass * rTilde_ScS1_B * this->s1Hat_B * this->ATheta.row(0) - this->mass2 * rTilde_Sc2S2_B * this->s2Hat_B * this->ATheta.row(1);
-    backSubContr.matrixB = - this->mass * rTilde_ScS1_B * this->s1Hat_B * this->BTheta.row(0) - this->mass2 * rTilde_Sc2S2_B * this->s2Hat_B * this->BTheta.row(1);
-    backSubContr.vecTrans = - this->mass * this->omegaTilde_S1B_B * this->rPrime_ScB_B - this->mass2 * (omegaTilde_S2S1_B * this->rPrime_Sc2S2_B - rTilde_Sc2S2_B * this->omegaTilde_S1B_B * this->omega_S2S1_B)
-        + this->mass * rTilde_ScS1_B * this->s1Hat_B * this->CTheta.row(0) + this->mass2 * rTilde_Sc2S2_B * this->s2Hat_B * this->CTheta.row(1)
+    backSubContr.matrixA = - this->mass * rScS1CrossS1Hat_B * this->ATheta.row(0) - this->mass2 * rSc2S2CrossS2Hat_B * this->ATheta.row(1);
+    backSubContr.matrixB = - this->mass * rScS1CrossS1Hat_B * this->BTheta.row(0) - this->mass2 * rSc2S2CrossS2Hat_B * this->BTheta.row(1);
+    backSubContr.vecTrans = - this->mass * this->omega_S1B_B.cross(this->rPrime_ScB_B) - this->mass2 * (this->omega_S2S1_B.cross(this->rPrime_Sc2S2_B) - this->r_Sc2S2_B.cross(this->omega_S1B_B.cross(this->omega_S2S1_B)))
+        + this->mass * rScS1CrossS1Hat_B * this->CTheta(0, 0) + this->mass2 * rSc2S2CrossS2Hat_B * this->CTheta(1, 0)
         + this->dcm_BS1 * attBodyForce_S1 + this->dcm_BS2 * attBodyForce_S2;
 
     // Rotation contributions
-    backSubContr.matrixC = (this->IS1PntSc1_B + this->IS2PntSc2_B - this->mass1 * this->rTilde_Sc1B_B * rTilde_Sc1S1_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S1_B) * this->s1Hat_B * this->ATheta.row(0)
-        + (this->IS2PntSc2_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S2_B) * this->s2Hat_B * this->ATheta.row(1);
-    backSubContr.matrixD = (this->IS1PntSc1_B + this->IS2PntSc2_B - this->mass1 * this->rTilde_Sc1B_B * rTilde_Sc1S1_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S1_B) * this->s1Hat_B * this->BTheta.row(0)
-        + (this->IS2PntSc2_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S2_B) * this->s2Hat_B * this->BTheta.row(1);
-    backSubContr.vecRot = - (this->IPrimeS1PntSc1_B + this->omegaTilde_BN_B * this->IS1PntSc1_B) * this->omega_S1B_B - (this->IPrimeS2PntSc2_B + this->omegaTilde_BN_B * this->IS2PntSc2_B) * this->omega_S2B_B
-        - (this->IS2PntSc2_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S2_B) * this->omegaTilde_S1B_B * this->omega_S2S1_B
-        - this->mass1 * (this->rTilde_Sc1B_B * this->omegaTilde_S1B_B + this->omegaTilde_BN_B * this->rTilde_Sc1B_B) * this->rPrime_Sc1B_B
-        - this->mass2 * (this->rTilde_Sc2B_B * this->omegaTilde_S1B_B + this->omegaTilde_BN_B * this->rTilde_Sc2B_B) * this->rPrime_Sc2B_B
-        - this->mass2 * this->rTilde_Sc2B_B * omegaTilde_S2S1_B * this->rPrime_Sc2S2_B
-        - (this->IS1PntSc1_B + this->IS2PntSc2_B - this->mass1 * this->rTilde_Sc1B_B * rTilde_Sc1S1_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S1_B) * this->s1Hat_B * this->CTheta.row(0)
-        - (this->IS2PntSc2_B - this->mass2 * this->rTilde_Sc2B_B * rTilde_Sc2S2_B) * this->s2Hat_B * this->CTheta.row(1)
+    Eigen::Vector3d rotFactor0_B = (this->IS1PntSc1_B + this->IS2PntSc2_B) * this->s1Hat_B
+        - this->mass1 * this->r_Sc1B_B.cross(this->r_Sc1S1_B.cross(this->s1Hat_B))
+        - this->mass2 * this->r_Sc2B_B.cross(r_Sc2S1_B.cross(this->s1Hat_B));
+    Eigen::Vector3d rotFactor1_B = this->IS2PntSc2_B * this->s2Hat_B
+        - this->mass2 * this->r_Sc2B_B.cross(this->r_Sc2S2_B.cross(this->s2Hat_B));
+    backSubContr.matrixC = rotFactor0_B * this->ATheta.row(0) + rotFactor1_B * this->ATheta.row(1);
+    backSubContr.matrixD = rotFactor0_B * this->BTheta.row(0) + rotFactor1_B * this->BTheta.row(1);
+    backSubContr.vecRot = - this->IPrimeS1PntSc1_B * this->omega_S1B_B - this->omega_BN_B.cross(this->IS1PntSc1_B * this->omega_S1B_B)
+        - this->IPrimeS2PntSc2_B * this->omega_S2B_B - this->omega_BN_B.cross(this->IS2PntSc2_B * this->omega_S2B_B)
+        - this->IS2PntSc2_B * this->omega_S1B_B.cross(this->omega_S2S1_B)
+        + this->mass2 * this->r_Sc2B_B.cross(this->r_Sc2S2_B.cross(this->omega_S1B_B.cross(this->omega_S2S1_B)))
+        - this->mass1 * (this->r_Sc1B_B.cross(this->omega_S1B_B.cross(this->rPrime_Sc1B_B)) + this->omega_BN_B.cross(this->r_Sc1B_B.cross(this->rPrime_Sc1B_B)))
+        - this->mass2 * (this->r_Sc2B_B.cross(this->omega_S1B_B.cross(this->rPrime_Sc2B_B)) + this->omega_BN_B.cross(this->r_Sc2B_B.cross(this->rPrime_Sc2B_B)))
+        - this->mass2 * this->r_Sc2B_B.cross(this->omega_S2S1_B.cross(this->rPrime_Sc2S2_B))
+        - rotFactor0_B * this->CTheta(0, 0)
+        - rotFactor1_B * this->CTheta(1, 0)
         + this->dcm_BS1 * attBodyTorquePntS1_S1 + this->dcm_BS2 * attBodyTorquePntS2_S2
-        + eigenTilde(this->r_S1B_B) * (this->dcm_BS1 * attBodyForce_S1)
-        + eigenTilde(this->r_S2S1_B + this->r_S1B_B) * (this->dcm_BS2 * attBodyForce_S2);
+        + this->r_S1B_B.cross(this->dcm_BS1 * attBodyForce_S1)
+        + (this->r_S2S1_B + this->r_S1B_B).cross(this->dcm_BS2 * attBodyForce_S2);
 }
 
 void SpinningBodyTwoDOFStateEffector::addPrescribedMotionCouplingContributions(BackSubMatrices & backSubContr) {

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -270,10 +270,10 @@ void SpinningBodyTwoDOFStateEffector::updateEffectorMassProps(double integTime)
     }
 
     // Grab current states
-    this->theta1 = this->theta1State->getState()(0, 0);
-    this->theta1Dot = this->theta1DotState->getState()(0, 0);
-    this->theta2 = this->theta2State->getState()(0, 0);
-    this->theta2Dot = this->theta2DotState->getState()(0, 0);
+    this->theta1 = this->theta1State->getStateReference()(0, 0);
+    this->theta1Dot = this->theta1DotState->getStateReference()(0, 0);
+    this->theta2 = this->theta2State->getStateReference()(0, 0);
+    this->theta2Dot = this->theta2DotState->getStateReference()(0, 0);
 
     // Compute the DCM from both S frames to B frame
     double dcm_S0S[3][3];
@@ -528,7 +528,7 @@ void SpinningBodyTwoDOFStateEffector::addPrescribedMotionCouplingContributions(B
     Eigen::Matrix3d dcm_PB = sigma_PB.toRotationMatrix().transpose();
 
     // Collect hub states
-    Eigen::Vector3d omega_BN_B = this->hubOmega->getState();
+    Eigen::Vector3d omega_BN_B = this->hubOmega->getStateReference();
     Eigen::Vector3d omega_BN_P = dcm_PB * omega_BN_B;
 
     // Prescribed motion translation coupling contributions
@@ -657,9 +657,9 @@ void SpinningBodyTwoDOFStateEffector::computeDerivatives(double integTime, Eigen
     // Compute theta and thetaDot derivatives
     Eigen::Vector2d thetaDDot;
     thetaDDot = this->ATheta * rDDotLocal_BN_B + this->BTheta * omegaDotLocal_BN_B + this->CTheta;
-    this->theta1State->setDerivative(this->theta1DotState->getState());
+    this->theta1State->setDerivative(this->theta1DotState->getStateReference());
     this->theta1DotState->setDerivative(thetaDDot.row(0));
-    this->theta2State->setDerivative(this->theta2DotState->getState());
+    this->theta2State->setDerivative(this->theta2DotState->getStateReference());
     this->theta2DotState->setDerivative(thetaDDot.row(1));
 }
 


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

This PR adds optional performance benchmark infrastructure and uses it to guide several targeted BSM dynamics optimizations.

The production changes include:

- Replacing hot-path skew-matrix products with equivalent Eigen `cross()` expressions.
- Adding an opt-in `Spacecraft::pointMassTranslationalOnly` mode that integrates translation without rotational dynamics.
- Adding an automatic direct rigid-body fast path for eligible fixed-mass, hub-only spacecraft.
- Reducing repeated Eigen state copies through C++-only const-reference accessors.

Existing spacecraft behavior remains the default. The point-mass mode must be explicitly enabled, while the hub-only fast path automatically falls back to the general back-substitution equations whenever its eligibility conditions are not met.

Commits are organized as follows:

1. Add optional benchmark suite mechanics, including the generalized Python dynamics benchmark, the Eigen versus `linearAlgebra` C++ benchmark, CMake targets, pytest smoke tests, and pytest collection wiring.
2. Replace hot-path `tilde()` products with equivalent `cross()` expressions in `SpinningBodyNDOFStateEffector`.
3. Apply the same optimization to selected hinged, translating, spinning, pendulum, prescribed-motion, and VSCMG state effectors.
4. Prevent duplicate Sphinx folder labels between benchmark and simulation dynamics documentation.
5. Add developer documentation for the optional benchmark suite.
6. Add the initial benchmark and effector optimization release notes.
7. Initialize the MSVC environment when the Windows benchmark smoke test invokes CMake.
8. Remove unused variables exposed by the dynamics cleanup.
9. Add the translation-only point-mass spacecraft mode, benchmark cases, documentation, and unit tests.
10. Add the automatic fixed-mass hub-only spacecraft fast path, documentation, and unit test.
11. Add C++ const-reference state accessors and use them to reduce copies in BSM dynamics hot paths.
12. Finalize release-note coverage for the spacecraft performance modes.

The `tilde()` replacements preserve identities such as
`eigenTilde(a) * b == a.cross(b)` while avoiding temporary 3x3 matrices.

When `pointMassTranslationalOnly` is enabled, only hub position and velocity are integrated. State effectors are rejected, but dynamic effectors remain supported. Their forces contribute to translation, their torques are ignored, and fixed attitude and angular-rate states are provided for effectors that require those state handles.

The hub-only fast path applies when there are no state effectors and the hub origin is colocated with its center of mass. It evaluates the direct translational, attitude, and Euler rotational equations in `HubEffector` while retaining gravity and dynamic-effector forces and torques.

The new `StateData` accessors avoid allocating and copying `Eigen::MatrixXd` values in C++ hot paths. Existing copy-returning APIs remain unchanged, and the reference accessors are excluded from SWIG.

## Verification

Added benchmark smoke tests that verify entry-point freshness without enforcing timing thresholds:

- The Python smoke test runs every dynamics benchmark case with a minimal workload.
- The C++ smoke test builds and runs the Eigen versus `linearAlgebra` benchmark in smoke mode.
- Windows smoke-test execution initializes the Visual Studio compiler environment when required.

Added spacecraft unit coverage for:

- Point-mass translation matching the normal spacecraft translational solution.
- Dynamic-effector force handling in point-mass mode.
- Fixed attitude handles for attitude-dependent dynamic effectors.
- Rejection of state effectors in point-mass mode.
- Hub-only fast-path translation, rotation, and attitude against an analytic rigid-body solution.

Additional verification included a complete Release build, focused dynamics and state-architecture tests, all-effector benchmark smoke testing, and confirmation that the new reference accessors are absent from the Python wrappers. No numerical baselines were regenerated.

Representative local measurements showed:

- The 16-body spinning NDOF benchmark improved from 3.135 s to 1.679 s median runtime after replacing tilde-matrix products.
- Hub-only spacecraft cases improved by approximately 7-10%.
- Reducing repeated state copies lowered total generalized benchmark wall time by approximately 7-8%.

These timings are informational and are not CI acceptance criteria.

## Documentation

Added `docs/source/Support/Developer/performanceBenchmarks.rst`, which links to the benchmark sources, documents build and run commands, provides representative terminal output, explains benchmark columns, and describes the smoke tests.

Updated the Sphinx configuration to render benchmark script docstrings without including the benchmark directory as a second documentation hierarchy. Folder labels are path-qualified to avoid collisions with simulation documentation.

Updated `spacecraft.rst` to document:

- `pointMassTranslationalOnly`
- Supported dynamic-effectors and ignored torques
- Fixed attitude behavior
- Unsupported state effectors and attitude reference messages
- Hub-only fast-path eligibility and fallback behavior

Reviewers should check:

- `docs/source/Support/Developer/performanceBenchmarks.rst`
- `src/simulation/dynamics/spacecraft/spacecraft.rst`
- Benchmark script docstrings rendered through Sphinx
- `docs/source/conf.py`
- `docs/source/Support/bskReleaseNotesSnippets/dynamics-effector-benchmark.rst`

## Future work

Continue using the benchmark suite to guide BSM optimization and comparisons with MuJoCo. Additional benchmark cases and targeted profiling can be added as new hot paths are identified; performance thresholds should remain separate from the smoke tests because timings depend on compiler, hardware, and system load.