### PR TITLE
fix: initialize hinged effector dcm_HB and IPntS_S defaults [#469]

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -15,6 +15,11 @@ Version |release|
   visible destructors. Internal-only members are now private or hidden from Python, and public value-type
   members now include the required Eigen, STL, enum, and BSpline wrapper support. This is fixed in the
   current version.
+- BSK-469: The :ref:`hingedRigidBodyStateEffector` and :ref:`nHingedRigidBodyStateEffector` constructors
+  called ``Eigen``'s static ``Identity()`` factory as a statement and discarded the result, so the default
+  ``dcm_HB`` (and ``IPntS_S`` for the single hinged effector) held uninitialized memory instead of identity.
+  Configurations that set these members explicitly (all shipped examples and tests do) were unaffected.
+  This is fixed in the current version.
 - BSK-1446: Several BSK modules deallocated output message objects created with C++ ``new`` by calling
   ``free()``, and retained image buffers in :ref:`camera` and :ref:`vizInterface` were not released during
   module destruction. This could cause invalid deallocation behavior or memory leaks when these modules were

--- a/docs/source/Support/bskReleaseNotesSnippets/469-hinged-default-identity.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/469-hinged-default-identity.rst
@@ -1,0 +1,4 @@
+- Fixed :ref:`hingedRigidBodyStateEffector` and :ref:`nHingedRigidBodyStateEffector` constructors that
+  called ``Eigen``'s static ``Identity()`` factory as a statement and discarded the result, leaving the
+  default ``dcm_HB`` (and ``IPntS_S`` for the single hinged effector) uninitialized instead of identity
+  (issue #469).

--- a/src/simulation/dynamics/HingedRigidBodies/_UnitTest/test_hingedRigidBodyDefaultConfig.py
+++ b/src/simulation/dynamics/HingedRigidBodies/_UnitTest/test_hingedRigidBodyDefaultConfig.py
@@ -1,0 +1,48 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#
+#   Unit Test Script
+#   Module Name:        hingedRigidBodyStateEffector
+#   Author:             robotrocketscience (https://github.com/robotrocketscience)
+#   Creation Date:      July 4, 2026
+#
+
+"""
+Regression test for issue #469: the constructor used to call
+``this->IPntS_S.Identity()`` and ``this->dcm_HB.Identity()`` as statements.
+``Eigen::Matrix3d::Identity()`` is a static factory whose return value was
+discarded, so the members were left uninitialized instead of defaulting to
+identity. This test asserts a freshly constructed effector exposes identity
+defaults for both members.
+"""
+
+import numpy as np
+from Basilisk.simulation import hingedRigidBodyStateEffector
+
+
+def test_defaultDcmAndInertiaAreIdentity():
+    """A fresh effector must default dcm_HB and IPntS_S to identity."""
+    effector = hingedRigidBodyStateEffector.HingedRigidBodyStateEffector()
+
+    np.testing.assert_allclose(np.asarray(effector.dcm_HB, dtype=float), np.eye(3),
+                               err_msg="default dcm_HB is not identity")
+    np.testing.assert_allclose(np.asarray(effector.IPntS_S, dtype=float), np.eye(3),
+                               err_msg="default IPntS_S is not identity")
+
+
+if __name__ == "__main__":
+    test_defaultDcmAndInertiaAreIdentity()

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -41,9 +41,9 @@ HingedRigidBodyStateEffector::HingedRigidBodyStateEffector()
     this->thetaDotRef = 0.0;
     this->thetaInit = 0.00;
     this->thetaDotInit = 0.0;
-    this->IPntS_S.Identity();
+    this->IPntS_S.setIdentity();
     this->r_HB_B.setZero();
-    this->dcm_HB.Identity();
+    this->dcm_HB.setIdentity();
 
     this->nameOfThetaState = "hingedRigidBodyTheta" + std::to_string(this->effectorID);
     this->nameOfThetaDotState = "hingedRigidBodyThetaDot" + std::to_string(this->effectorID);

--- a/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyDefaultConfig.py
+++ b/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyDefaultConfig.py
@@ -1,0 +1,45 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#
+#   Unit Test Script
+#   Module Name:        nHingedRigidBodyStateEffector
+#   Author:             robotrocketscience (https://github.com/robotrocketscience)
+#   Creation Date:      July 4, 2026
+#
+
+"""
+Regression test for issue #469: the constructor used to call
+``this->dcm_HB.Identity()`` as a statement. ``Eigen::Matrix3d::Identity()``
+is a static factory whose return value was discarded, so the member was left
+uninitialized instead of defaulting to identity. This test asserts a freshly
+constructed effector exposes an identity default.
+"""
+
+import numpy as np
+from Basilisk.simulation import nHingedRigidBodyStateEffector
+
+
+def test_defaultDcmIsIdentity():
+    """A fresh effector must default dcm_HB to identity."""
+    effector = nHingedRigidBodyStateEffector.NHingedRigidBodyStateEffector()
+
+    np.testing.assert_allclose(np.asarray(effector.dcm_HB, dtype=float), np.eye(3),
+                               err_msg="default dcm_HB is not identity")
+
+
+if __name__ == "__main__":
+    test_defaultDcmIsIdentity()

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -31,7 +31,7 @@ NHingedRigidBodyStateEffector::NHingedRigidBodyStateEffector()
     this->effProps.rEffPrime_CB_B.fill(0.0);
     this->effProps.IEffPrimePntB_B.fill(0.0);
     this->r_HB_B.setZero();
-    this->dcm_HB.Identity();
+    this->dcm_HB.setIdentity();
     this->nameOfThetaState ="nHingedRigidBody" + std::to_string(this->effectorID) + "Theta";
     this->nameOfThetaDotState = "nHingedRigidBody" + std::to_string(this->effectorID) + "ThetaDot";
     this->effectorID++;


### PR DESCRIPTION
* **Tickets addressed:** bsk-469 (supporting fix discovered while scoping the effector Reset() checks)
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

The `HingedRigidBodyStateEffector` and `NHingedRigidBodyStateEffector` constructors call
`this->dcm_HB.Identity();` (and `this->IPntS_S.Identity();` in the single hinged effector) as
statements. `Eigen::Matrix3d::Identity()` is a static factory whose return value was discarded, so
these members were left **uninitialized** instead of defaulting to identity — a freshly constructed
effector exposes zeros or arbitrary memory (verified from Python; the values vary run to run).
These are the only three such call sites in the codebase, and every shipped example and test sets
the members explicitly, so no shipped configuration relied on the broken defaults.

Found while scoping the remaining #469 Reset() validation work (see
https://github.com/AVSLab/basilisk/issues/469#issuecomment-4880715337): a future
`eigenIsRotationMatrix(dcm_HB)` check would fire on default-constructed effectors until the
constructors are fixed, so this lands first.

Commits: (1) the constructor fix, (2) regression tests, (3) documentation.

## Verification

Built clean on Linux. New regression tests `test_hingedRigidBodyDefaultConfig.py` and
`test_nHingedRigidBodyDefaultConfig.py` assert a freshly constructed effector exposes identity
defaults (these fail before the fix, since the uninitialized values are never identity). The
existing hinged and nHinged module test suites pass unchanged.

## Documentation

Release-note snippet added and a BSK-469 entry added to the current-release section of
`bskKnownIssues.rst`.

## Future work

The per-tranche Reset() validation checks scoped in the #469 comment above, starting with the hub
checks (separate PR).
