### PR TITLE
feat: validate hub mass and inertia on spacecraft reset [#469]

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -19,6 +19,10 @@ Version |release|
   called ``Eigen``'s static ``Identity()`` factory as a statement and discarded the result, so the default
   ``dcm_HB`` (and ``IPntS_S`` for the single hinged effector) held uninitialized memory instead of identity.
   Configurations that set these members explicitly (all shipped examples and tests do) were unaffected.
+- BSK-469: The spacecraft hub properties were not validated, so a zero hub mass or a singular hub
+  inertia tensor silently produced ``NaN`` states, and a negative hub mass silently reversed the
+  translational response to applied forces. :ref:`spacecraft` and :ref:`spacecraftSystem` now verify
+  on reset that ``mHub`` is strictly positive and ``IHubPntBc_B`` is symmetric positive definite.
   This is fixed in the current version.
 - BSK-1446: Several BSK modules deallocated output message objects created with C++ ``new`` by calling
   ``free()``, and retained image buffers in :ref:`camera` and :ref:`vizInterface` were not released during

--- a/docs/source/Support/bskReleaseNotesSnippets/469-hub-reset-checks.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/469-hub-reset-checks.rst
@@ -1,0 +1,6 @@
+- :ref:`spacecraft` and :ref:`spacecraftSystem` now validate the user-supplied hub configuration on
+  reset: the hub mass ``mHub`` must be strictly positive and the hub inertia tensor ``IHubPntBc_B``
+  must be symmetric and positive definite, raising a descriptive error when the configuration is
+  inconsistent (issue #469). Previously a zero hub mass or singular hub inertia silently produced
+  ``NaN`` states, and a negative hub mass silently reversed the translational response to applied
+  forces.

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
@@ -57,6 +57,21 @@ HubEffector::~HubEffector()
     return;
 }
 
+/*! This method verifies the user-supplied hub properties are physically valid. The hub mass
+ must be strictly positive and the hub inertia tensor must be symmetric positive definite.
+ It is intended to be called by the owning spacecraft at reset time, before the dynamics
+ are initialized. */
+void HubEffector::validateConfiguration()
+{
+    if (this->mHub <= 0.0) {
+        bskLogger.bskError("hubEffector: mHub must be greater than 0. It may not have been set properly by the user.");
+    }
+    if (!eigenIsValidInertiaMatrix(this->IHubPntBc_B)) {
+        bskLogger.bskError("hubEffector: IHubPntBc_B is not a valid inertia tensor; it must be symmetric and positive"
+                           " definite. It may not have been set properly by the user.");
+    }
+}
+
 /*! This method allows the hub access to gravity and also gets access to the properties in the dyn Manager because uses
  these values in the computeDerivatives method call */
 void HubEffector::linkInStates(DynParamManager& statesIn)
@@ -185,7 +200,7 @@ void HubEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d
 
     // - Find rotational energy contribution from the hub
     rotEnergyContr = 1.0/2.0*omegaLocal_BN_B.dot(IHubPntBc_P*omegaLocal_BN_B) + 1.0/2.0*mHub*rDot_BcB_B.dot(rDot_BcB_B);
-    
+
     return;
 }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
@@ -58,6 +58,7 @@ public:
     void modifyStates(double integTime); //!< -- Method to switch MRPs
     void prependSpacecraftNameToStates(); //!< class method
     void matchGravitytoVelocityState(Eigen::Vector3d v_CN_N); //!< method to set the gravity velocity to base velocity
+    void validateConfiguration();        //!< -- Verify the user-set hub mass and inertia are physically valid
 
 private:
     Eigen::Vector3d r_BcP_P;             //!< [m] vector from point B to CoM of hub in B frame components

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftHubResetChecks.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftHubResetChecks.py
@@ -1,0 +1,141 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#
+#   Unit Test Script
+#   Module Name:        spacecraft (hub configuration checks)
+#   Author:             robotrocketscience (https://github.com/robotrocketscience)
+#   Creation Date:      July 4, 2026
+#
+
+"""
+Regression tests for issue #469: hub configuration checks on spacecraft reset.
+
+``Spacecraft::Reset()`` validates the user-supplied hub properties before the
+dynamics are initialized: the hub mass must be strictly positive and the hub
+inertia tensor must be symmetric positive definite. Without these checks a
+zero hub mass or a singular hub inertia silently produced NaN states, and a
+negative hub mass silently reversed the translational response to applied
+forces. These tests start from a valid configuration, break exactly one
+precondition at a time, and assert that initialization raises a
+``BasiliskError`` naming the offending quantity.
+"""
+
+import pytest
+
+from Basilisk.architecture.bskLogging import BasiliskError
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass, macros
+
+
+TEST_TASK_PERIOD = 0.001  # [s]
+
+
+def _validSpacecraft():
+    """Build a Spacecraft with a fully valid hub configuration."""
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.r_BcB_B = [[0.0], [0.0], [1.0]]  # [m]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg-m^2]
+    return scObject
+
+
+def _setZeroHubMass(scObject):
+    scObject.hub.mHub = 0.0  # [kg]
+
+
+def _setNegativeHubMass(scObject):
+    scObject.hub.mHub = -750.0  # [kg]
+
+
+def _setNonSymmetricHubInertia(scObject):
+    scObject.hub.IHubPntBc_B = [  # [kg-m^2]
+        [900.0, 50.0, 0.0],
+        [0.0, 800.0, 0.0],
+        [0.0, 0.0, 600.0],
+    ]
+
+
+def _setNegativeHubInertia(scObject):
+    scObject.hub.IHubPntBc_B = [  # [kg-m^2]
+        [-900.0, 0.0, 0.0],
+        [0.0, 800.0, 0.0],
+        [0.0, 0.0, 600.0],
+    ]
+
+
+def _setZeroHubInertia(scObject):
+    scObject.hub.IHubPntBc_B = [  # [kg-m^2]
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ]
+
+
+# Each case breaks exactly one precondition from the valid baseline above.
+RESET_ERROR_CASES = [
+    ("mHub zero", "mHub", _setZeroHubMass),
+    ("mHub negative", "mHub", _setNegativeHubMass),
+    ("IHubPntBc_B not symmetric", "IHubPntBc_B", _setNonSymmetricHubInertia),
+    ("IHubPntBc_B not positive definite", "IHubPntBc_B", _setNegativeHubInertia),
+    ("IHubPntBc_B zero", "IHubPntBc_B", _setZeroHubInertia),
+]
+
+
+@pytest.mark.parametrize("brokenPrecondition, expectedMessage, breakIt", RESET_ERROR_CASES,
+                         ids=[c[0] for c in RESET_ERROR_CASES])
+def test_spacecraftHub_resetErrors(brokenPrecondition, expectedMessage, breakIt):
+    """Reset() must raise a BasiliskError naming the misconfigured hub quantity."""
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProc = unitTestSim.CreateNewProcess("testProcess")
+    testProc.addTask(unitTestSim.CreateNewTask("testTask", macros.sec2nano(TEST_TASK_PERIOD)))
+
+    scObject = _validSpacecraft()
+    breakIt(scObject)
+    unitTestSim.AddModelToTask("testTask", scObject)
+
+    with pytest.raises(BasiliskError, match=expectedMessage):
+        unitTestSim.InitializeSimulation()
+
+
+def test_spacecraftHub_resetAcceptsValidConfig():
+    """A fully valid hub configuration must initialize without raising."""
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProc = unitTestSim.CreateNewProcess("testProcess")
+    testProc.addTask(unitTestSim.CreateNewTask("testTask", macros.sec2nano(TEST_TASK_PERIOD)))
+
+    scObject = _validSpacecraft()
+    unitTestSim.AddModelToTask("testTask", scObject)
+
+    unitTestSim.InitializeSimulation()
+
+
+def test_spacecraftHub_resetAcceptsDefaultHub():
+    """The constructor defaults (1 kg, identity inertia) must initialize without raising."""
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProc = unitTestSim.CreateNewProcess("testProcess")
+    testProc.addTask(unitTestSim.CreateNewTask("testTask", macros.sec2nano(TEST_TASK_PERIOD)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    unitTestSim.AddModelToTask("testTask", scObject)
+
+    unitTestSim.InitializeSimulation()
+
+
+if __name__ == "__main__":
+    test_spacecraftHub_resetAcceptsValidConfig()

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -58,6 +58,9 @@ Spacecraft::~Spacecraft()
  */
 void Spacecraft::Reset(uint64_t CurrentSimNanos)
 {
+    // - Verify the user-supplied hub configuration before the dynamics are initialized
+    this->hub.validateConfiguration();
+
     this->gravField.Reset(CurrentSimNanos);
     // - Call method for initializing the dynamics of spacecraft
     this->initializeDynamics();

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -76,6 +76,9 @@ void SpacecraftUnit::SelfInitSC(int64_t moduleID)
  */
 void SpacecraftUnit::ResetSC(uint64_t CurrentSimNanos)
 {
+    // - Verify the user-supplied hub configuration before the dynamics are initialized
+    this->hub.validateConfiguration();
+
     this->gravField.Reset(CurrentSimNanos);
 }
 


### PR DESCRIPTION
* **Tickets addressed:** bsk-469 (hub tranche, per https://github.com/AVSLab/basilisk/issues/469#issuecomment-4876546345)
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Adds the hub configuration checks requested in #469: a new
`HubEffector::validateConfiguration()` verifies the user-set hub mass is strictly positive and the
hub inertia tensor is symmetric positive definite (via the existing `eigenIsValidInertiaMatrix`
helper from #1436), raising a descriptive `bskError` naming the offending quantity. Because
`HubEffector` is not a `SysModel` (it has no auto-called `Reset()`), the owning spacecraft invokes
it: `Spacecraft::Reset()` and `SpacecraftUnit::ResetSC()` (spacecraftSystem) both call it before
the dynamics are initialized.

Without these checks (verified on `develop`): `mHub = 0` silently produces NaN states (division in
`updateSCMassProps`); a **negative** `mHub` exactly sign-flips the translational response to
applied forces (measured Δv `+0.01333` → `-0.01333` m/s with a thruster) while looking
near-identical in torque-free coast; non-symmetric and negative-definite `IHubPntBc_B` integrate
silently wrong; a zero inertia produces NaN. No example, scenario, or test in the repo uses
`mHub <= 0` or a non-SPD hub inertia, so the check has no blast radius on shipped code.

Commits: (1) the checks, (2) tests, (3) documentation.

## Verification

Built clean on Linux. New parametrized test `test_spacecraftHubResetChecks.py` breaks exactly one
precondition at a time (zero mass, negative mass, non-symmetric / non-positive-definite / zero
inertia) and asserts initialization raises a `BasiliskError` naming the quantity, mirroring the
#1436 test pattern; positive tests confirm a valid configuration and the constructor defaults
(1 kg, identity inertia) initialize cleanly. The spacecraft module test suite passes unchanged.
`SpacecraftUnit::ResetSC` calls the same validated method (spacecraftSystem has no existing unit
tests to extend).

## Documentation

Release-note snippet added and a BSK-469 entry added to the current-release section of
`bskKnownIssues.rst`.

## Future work

The remaining #469 tranches (hinged family, translational/pendulum/spring-mass-damper,
RW/VSCMG/thrusters, facetSRP/fuelTank/prescribedMotion) as scoped in
https://github.com/AVSLab/basilisk/issues/469#issuecomment-4880715337, pending maintainer steer on
the design questions raised there.
