### PR TITLE
[#97] Modernize Eigen MRPd support and attitude conversions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,33 +42,39 @@ the surrounding work is already touching that area.
    - For legacy non-conforming files: keep style consistent for minor edits; use major refactors to move code toward guideline compliance.
    - Follow the checkout recommendation in `docs/source/Support/Developer/bskModuleCheckoutList.rst`
 
-5. **String and logging security review**
+5. **MRP attitude typing**
+   - For new or modified C++ code, use `Eigen::MRPd` for values that semantically represent Modified Rodrigues Parameter attitudes, such as `sigma_*` attitude variables, state values, properties, and function parameters.
+   - Avoid using generic `Eigen::Vector3d` for MRP attitudes unless the code is crossing a boundary that requires raw vector storage, such as message payloads, C arrays, state/property containers, SWIG/Python-facing initialization fields, or generic math APIs.
+   - Prefer MRP-specific helpers and methods, such as `cArray2EigenMRPd`, `eigenMRPd2CArray`, `.coeffs()`, `.Bmat()`, `.toRotationMatrix()`, and `.shadow()`, instead of casting MRPs through `Eigen::Vector3d`.
+   - Do not convert unrelated three-component physical vectors, such as position, velocity, acceleration, angular rate, force, torque, or magnetic field vectors, to `Eigen::MRPd`.
+
+6. **String and logging security review**
    - For new or modified C/C++ code, check for unsafe writes to fixed-size C buffers, including `strcpy`, `strcat`, `sprintf`, unbounded `%s` scans, and `strncpy` uses that can silently truncate or omit null termination.
    - Prefer bounded formatting/copying APIs such as `snprintf` with `sizeof(destination)` when writing to fixed-size buffers.
    - If a user- or module-supplied string is too long for a fixed-size Basilisk payload field, emit `BSK_ERROR` so execution stops immediately rather than silently truncating.
    - For `bskLog()` and other printf-style logging calls, ensure the format string is a string literal. Dynamic text must be passed through a literal format such as `"%s"`.
    - When a PR fixes one instance of a buffer-write or format-string issue, search nearby BSK modules and related payload paths for the same pattern and flag or fix matching issues.
 
-6. **PR metadata requirements**
+7. **PR metadata requirements**
    - Follow `docs/source/Support/bskReleaseNotesSnippets/README.md` for when a
      release-note snippet is required and how snippet files should be formatted.
    - Update `docs/source/Support/bskKnownIssues.rst` when a PR fixes, changes, or
      documents a known user-visible issue or workaround.
 
-7. **SysModel documentation requirement**
+8. **SysModel documentation requirement**
    - Every new SysModel must include a corresponding `.rst` documentation file.
    - Pattern new module docs after:
      `src/moduleTemplates/cModuleTemplate/cModuleTemplate.rst` or
      `src/moduleTemplates/cppModuleTemplate/cppModuleTemplate.rst`.
    - For new or modified BSK module `.rst` files, ensure module input/output message documentation uses the `.. bsk-module-io::` directive rather than hand-written module I/O tables or standalone module I/O SVG images.
 
-8. **Basilisk Module Creation**
+9. **Basilisk Module Creation**
     - Ensure new Basilisk modules have a unit test
     - Unit test method needs to have documentation strings
     - Ensure the copyright statement is in new files using the current year
 
 
-9. **Basilisk Example Files**
+10. **Basilisk Example Files**
    - If an example scenario is included in the `examples` folder, ensure this example has a unit test in `src/tests` that imports and runs this example file.
    - If the example file includes the `enableUnityVisualization()` method, ensure the `saveFile` argument is included but commented out.
    - Ensure new Python example scripts are linked in `examples/_default.rst`.

--- a/docs/source/Support/bskReleaseNotesSnippets/97-mrpd-conversions.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/97-mrpd-conversions.rst
@@ -1,0 +1,4 @@
+- Refactored MRP conversion helpers and selected attitude reads to use ``Eigen::MRPd`` directly; ``eigenMRPd2CArray()`` now takes ``const Eigen::MRPd&`` instead of ``Eigen::Vector3d&``.
+- Updated the C++ ``StateEffector`` attitude interfaces to pass ``sigma_BN`` as ``Eigen::MRPd`` for ``updateContributions()`` and ``computeDerivatives()``; custom state effectors must update matching overrides.
+- Updated ``Eigen::MRPd`` DCM and angle-axis conversions to return the equivalent short-rotation MRP set.
+- Documented that ``Eigen::MRPd::FromTwoVectors()`` returns the identity MRP when either input vector has zero or underflow-level norm.

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -23,17 +23,15 @@
 #ifndef EIGEN_MRP_H
 #define EIGEN_MRP_H
 
-//#include <Eigen/Core>
-//#include <Eigen/src/Core//util//DisableStupidWarnings.h>
-//#include <Eigen/SVD>
-//#include <Eigen/LU>
-//#include "Eigen/src/Geometry/Quaternion.h"
+#include <cmath>
+#include <limits>
+#include <Eigen/Geometry>
 
 namespace Eigen {
     template<typename Scalar, int Options = AutoAlign> class MRP;
 
 
-    
+
     /***************************************************************************
      * Definition of MRPBase<Derived>
      * The implementation is at the end of the file
@@ -133,22 +131,35 @@ namespace Eigen {
          */
         inline Scalar squaredNorm() const { return coeffs().squaredNorm(); }
 
-        /** \returns the norm of the MRP's coefficients
+        /** \returns the norm of the MRP's coefficients.
+         *
+         * For a nonzero MRP, \c coeffs()/norm() is the principal rotation axis
+         * and \c norm() is \f$\tan(\phi/4)\f$, where \f$\phi\f$ is the principal
+         * rotation angle.
+         *
          * \sa MRPBase::squaredNorm(), MatrixBase::norm()
          */
         inline Scalar norm() const { return coeffs().norm(); }
 
-        /** Normalizes the MRP \c *this
+        /** Normalizes the coefficient vector of \c *this.
+         *
+         * This is useful to recover the principal rotation axis direction for a
+         * nonzero MRP. It changes the attitude represented by the MRP and should
+         * not be used as an attitude normalization operation.
+         *
          * \sa normalized(), MatrixBase::normalize() */
         inline void normalize() { coeffs().normalize(); }
-        /** \returns a normalized copy of \c *this
+        /** \returns a copy of \c *this with a normalized coefficient vector.
+         *
+         * For a nonzero MRP, this returns the principal rotation axis direction
+         * stored as MRP coefficients. It changes the represented attitude.
+         *
          * \sa normalize(), MatrixBase::normalized() */
         inline MRP<Scalar> normalized() const { return MRP<Scalar>(coeffs().normalized()); }
 
-        /** \returns the dot product of \c *this and \a other
-         * Geometrically speaking, the dot product of two unit MRPs
-         * corresponds to the cosine of half the angle between the two rotations.
-         * \sa angularDistance()
+        /** \returns the Euclidean dot product of this MRP coefficient vector and \a other.
+         *
+         * \sa MatrixBase::dot()
          */
         template<class OtherDerived> inline Scalar dot(const MRPBase<OtherDerived>& other) const { return coeffs().dot(other.coeffs()); }
 
@@ -157,7 +168,7 @@ namespace Eigen {
         /** \returns an equivalent 3x3 rotation matrix */
         Matrix3 toRotationMatrix() const;
 
-        /** \returns the MRP which transform \a a into \a b through a rotation */
+        /** \returns the MRP which transforms \a a into \a b through a rotation */
         template<typename Derived1, typename Derived2>
         Derived& setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
 
@@ -227,7 +238,12 @@ namespace Eigen {
      * \li \c MRPf for \c float
      * \li \c MRPd for \c double
      *
-     * \warning Operations interpreting the MRP as rotation have undefined behavior if the MRP is not normalized.
+     * The coefficient norm is \f$\tan(\phi/4)\f$, where \f$\phi\f$ is the principal
+     * rotation angle. MRPs do not require unit-norm coefficients to represent a
+     * rotation.
+     *
+     * \warning MRPs are singular for rotations of \f$2\pi\f$. Use \c shadow()
+     * to map large-norm MRPs to the equivalent shadow set when needed.
      *
      * \sa  class AngleAxis, class Transform
      */
@@ -269,12 +285,17 @@ namespace Eigen {
         inline MRP() {}
 
         /** Constructs and initializes the MRP \f$ (x,y,z) \f$ from
-         * its four coefficients \a x, \a y and \a z.
+         * its three coefficients \a x, \a y and \a z.
          */
         inline MRP(const Scalar& x, const Scalar& y, const Scalar& z) : m_coeffs(x, y, z){}
 
         /** Constructs and initialize a MRP from the array data */
         inline MRP(const Scalar* data) : m_coeffs(data) {}
+
+        /** Explicit copy constructor with scalar conversion */
+        template<typename OtherScalar, int OtherOptions>
+        explicit inline MRP(const MRP<OtherScalar, OtherOptions>& other)
+            : m_coeffs(other.coeffs().template cast<Scalar>()) {}
 
         /** Copy constructor */
         template<class Derived> EIGEN_STRONG_INLINE MRP(const MRPBase<Derived>& other) { this->Base::operator=(other); }
@@ -288,11 +309,6 @@ namespace Eigen {
          */
         template<typename Derived>
         explicit inline MRP(const MatrixBase<Derived>& other) { *this = other; }
-
-        /** Explicit copy constructor with scalar conversion */
-        //        template<typename OtherScalar, int OtherOptions>
-        //        explicit inline MRP(const MRP<OtherScalar, OtherOptions>& other)
-        //        { m_coeffs = other.coeffs().template cast<Scalar>(); }
 
         template<typename Derived1, typename Derived2>
         static MRP FromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
@@ -453,6 +469,7 @@ namespace Eigen {
         template<int Arch, class Derived1, class Derived2, typename Scalar, int _Options> struct mrp_product
         {
             static EIGEN_STRONG_INLINE MRP<Scalar> run(const MRPBase<Derived1>& a, const MRPBase<Derived2>& b){
+                using std::abs;
                 Scalar det;     //!< variable
                 Scalar s1N2;    //!< variable
                 Scalar s2N2;    //!< variable
@@ -460,14 +477,16 @@ namespace Eigen {
                 MRP<Scalar> answer;
                 s1N2 = a.squaredNorm();
                 s2N2 = s2.squaredNorm();
-                det = Scalar(1.0) + s1N2*s2N2 - 2*a.dot(b);
-                if (det < 0.01) {
+                det = Scalar(1) + s1N2*s2N2 - Scalar(2)*a.dot(s2);
+                if (abs(det) < Scalar(0.01)) {
                     s2 = s2.shadow();
                     s2N2 = s2.squaredNorm();
-                    det = Scalar(1.0) + s1N2*s2N2 - 2*a.dot(b);
+                    det = Scalar(1) + s1N2*s2N2 - Scalar(2)*a.dot(s2);
                 }
-                answer = MRP<Scalar> (((1-s1N2)*s2.vec() + (1-s2N2)*a.vec() - 2*b.vec().cross(a.vec()))/det);
-                if (answer.squaredNorm() > 1)
+                answer = MRP<Scalar>(((Scalar(1) - s1N2)*s2.vec()
+                                      + (Scalar(1) - s2N2)*a.vec()
+                                      - Scalar(2)*s2.vec().cross(a.vec()))/det);
+                if (answer.squaredNorm() > Scalar(1))
                     answer = answer.shadow();
                 return answer;
             }
@@ -514,25 +533,16 @@ namespace Eigen {
     }
 
 
-    /** Rotation of a vector by a MRP.
-     * \remarks If the MRP is used to rotate several points (>1)
-     * then it is much more efficient to first convert it to a 3x3 Matrix.
-     * Comparison of the operation cost for n transformations:
-     *   - MRP2:    30n
-     *   - Via a Matrix3: 24 + 15n
+    /** Rotation of a vector by an MRP.
+     *
+     * \remarks If the MRP is used to rotate several points, it is more efficient
+     * to compute the 3x3 rotation matrix once and reuse it.
      */
     template <class Derived>
     EIGEN_STRONG_INLINE typename MRPBase<Derived>::Vector3
     MRPBase<Derived>::_transformVector(const Vector3& v) const
     {
-        // Note that this algorithm comes from the optimization by hand
-        // of the conversion to a Matrix followed by a Matrix/Vector product.
-        // It appears to be much faster than the common algorithm found
-        // in the literature (30 versus 39 flops). It also requires two
-        // Vector3 as temporaries.
-        Vector3 uv = this->vec().cross(v);
-        uv += uv;
-        return v + this->w() * uv + this->vec().cross(uv);
+        return this->toRotationMatrix()*v;
     }
 
     template<class Derived>
@@ -556,7 +566,7 @@ namespace Eigen {
     EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const AngleAxisType& aa)
     {
         using std::tan;
-        Scalar tanPhi = Scalar(0.25)*aa.angle(); // Scalar(0.25) to suppress precision loss warnings
+        Scalar tanPhi = tan(Scalar(0.25)*aa.angle()); // Scalar(0.25) suppresses precision loss warnings
         this->vec() = tanPhi * aa.axis();
         return derived();
     }
@@ -609,13 +619,13 @@ namespace Eigen {
         res.coeffRef(2,1) = s2s3 + Scalar(4)*this->x()*ms2;
         res.coeffRef(2,2) = Scalar(4)*(-s1Sq - s2Sq + s3Sq)+ms2Sq;
         res = res / ps2 / ps2;
-        
+
         return res;
     }
 
     /** Sets \c *this to be a MRP representing a rotation between
      * the two arbitrary vectors \a a and \a b. In other words, the built
-     * rotation represent a rotation sending the line of direction \a a
+     * rotation represents a rotation sending the line of direction \a a
      * to the line of direction \a b, both lines passing through the origin.
      *
      * \returns a reference to \c *this.
@@ -627,28 +637,27 @@ namespace Eigen {
     template<typename Derived1, typename Derived2>
     inline Derived& MRPBase<Derived>::setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b)
     {
-        using std::acos;
-        using std::tan;
-
-        Vector3 v0 = a.normalized();
-        Vector3 v1 = b.normalized();
-        Scalar c = v1.dot(v0);
-
-        if (c <= 1 && c >= -1) {
-            Vector3 axis = v0.cross(v1);
-            axis.normalize();
-
-            this->vec() = axis*tan(acos(c)/Scalar(4.0));
-        } else {
-            this->vec() << 0., 0., 0.;
+        const RealScalar minimumUsableSquaredNorm = std::numeric_limits<RealScalar>::min();
+        if (a.squaredNorm() <= minimumUsableSquaredNorm
+            || b.squaredNorm() <= minimumUsableSquaredNorm) {
+            this->setIdentity();
+            return derived();
         }
+
+        Quaternion<Scalar> q;
+        q.setFromTwoVectors(a, b);
+        if (q.w() < Scalar(0)) {
+            q.coeffs() = -q.coeffs();
+        }
+
+        this->vec() = q.vec()/(Scalar(1) + q.w());
         return derived();
     }
 
 
     /** Returns a MRP representing a rotation between
      * the two arbitrary vectors \a a and \a b. In other words, the built
-     * rotation represent a rotation sending the line of direction \a a
+     * rotation represents a rotation sending the line of direction \a a
      * to the line of direction \a b, both lines passing through the origin.
      *
      * \returns resulting MRP
@@ -683,7 +692,7 @@ namespace Eigen {
     /** \returns the MRP [B] matrix of \c *this
      * This is used in
      *
-     *  d(sigmda_B/N) = 1/4 [B(sigma_B/N)] omega_BN_B
+     *  d(sigma_B/N) = 1/4 [B(sigma_B/N)] omega_BN_B
      *
      * \sa MRPBase::shadow()
      */
@@ -712,8 +721,7 @@ namespace Eigen {
     }
 
     /** \returns the multiplicative inverse of \c *this
-     * Note that in most cases, i.e., if you simply want the opposite rotation,
-     * and/or the MRP is normalized, then it is enough to use the conjugate.
+     * For MRPs, the inverse rotation is represented by \f$-\sigma\f$.
      *
      * \sa MRPBase::conjugate()
      */
@@ -723,11 +731,12 @@ namespace Eigen {
         return MRP<Scalar>(-this->coeffs());
     }
 
-    /** \returns the conjugate of the \c *this which is equal to the multiplicative inverse
-     * if the MRP is normalized.
-     * The conjugate of a MRP represents the opposite rotation.
+    /** \returns the conjugate of \c *this.
      *
-     * \sa MRP2::inverse()
+     * For MRPs, the conjugate represents the opposite rotation and is equal to
+     * the multiplicative inverse.
+     *
+     * \sa MRPBase::inverse()
      */
     template <class Derived>
     inline MRP<typename internal::traits<Derived>::Scalar>
@@ -810,6 +819,9 @@ namespace Eigen {
 
                 /* convert DCM to quaternions */
                 q = mat;
+                if (q.w() < Scalar(0)) {
+                    q.coeffs() = -q.coeffs();
+                }
                 num = Scalar(1) + q.w();
 
                 /* convert quaternions to MRP */
@@ -818,7 +830,7 @@ namespace Eigen {
                 sig.z() = q.z()/num;
             }
         };
-        
+
         // set from a vector of coefficients assumed to be a MRP
         template<typename Other>
         /**
@@ -833,9 +845,9 @@ namespace Eigen {
                 q.coeffs() = vec;
             }
         };
-        
+
     } // end namespace internal
-    
+
 } // end namespace Eigen
 
 #endif // EIGEN_MRP_H

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -182,8 +182,21 @@ namespace Eigen {
         Derived& setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
 
         template<class OtherDerived> EIGEN_STRONG_INLINE MRP<Scalar> operator* (const MRPBase<OtherDerived>& q) const; //!< method
+        /** Right-composes \c *this with another MRP attitude. */
         template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator*= (const MRPBase<OtherDerived>& q);
+        /** Adds MRP coefficients component-wise.
+         *
+         * This is coefficient arithmetic, not attitude composition. It is useful
+         * for estimation, filtering, and linearized updates where the MRP
+         * coefficients are manipulated as a vector.
+         */
         template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator+= (const MRPBase<OtherDerived>& q);
+        /** Subtracts MRP coefficients component-wise.
+         *
+         * This is coefficient arithmetic, not attitude composition. It is useful
+         * for estimation, filtering, and linearized updates where the MRP
+         * coefficients are manipulated as a vector.
+         */
         template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator-= (const MRPBase<OtherDerived>& q);
 
         /** \returns the MRP describing the shadow set */
@@ -555,7 +568,7 @@ namespace Eigen {
         return derived();
     }
 
-    /** \sa operator*(MRP) */
+    /** Coefficient-wise MRP addition; this is not attitude composition. */
     template <class Derived>
     template <class OtherDerived>
     EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator+= (const MRPBase<OtherDerived>& other)
@@ -563,7 +576,7 @@ namespace Eigen {
         derived().coeffs() = derived().coeffs() + other.derived().coeffs();
         return derived();
     }
-    /** \sa operator*(MRP) */
+    /** Coefficient-wise MRP subtraction; this is not attitude composition. */
     template <class Derived>
     template <class OtherDerived>
     EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator-= (const MRPBase<OtherDerived>& other)

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -838,6 +838,16 @@ namespace Eigen {
 
     namespace internal {
 
+        template<typename Other, int OtherRows, int OtherCols>
+        struct MRPbase_assign_impl
+        {
+            template<class Derived> static inline void run(MRPBase<Derived>&, const Other&)
+            {
+                static_assert(OtherRows == 3 && (OtherCols == 1 || OtherCols == 3),
+                              "Eigen::MRP assignment expects a 3x1 coefficient vector or 3x3 rotation matrix.");
+            }
+        };
+
         // set from a rotation matrix
         // this maps the [NB] DCM to the equivalent sigma_B/N set
         template<typename Other>

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -465,6 +465,17 @@ namespace Eigen {
     // Generic MRP * MRP product
     // This product can be specialized for a given architecture via the Arch template argument.
     namespace internal {
+        template<class Derived, typename QuaternionType>
+        EIGEN_STRONG_INLINE void assign_mrp_from_quaternion_short(MRPBase<Derived>& sig, QuaternionType q)
+        {
+            typedef typename internal::traits<Derived>::Scalar Scalar;
+
+            if (q.w() < Scalar(0)) {
+                q.coeffs() = -q.coeffs();
+            }
+            sig.vec() = q.vec()/(Scalar(1) + q.w());
+        }
+
         /*! template definition */
         template<int Arch, class Derived1, class Derived2, typename Scalar, int _Options> struct mrp_product
         {
@@ -565,9 +576,8 @@ namespace Eigen {
     template<class Derived>
     EIGEN_STRONG_INLINE Derived& MRPBase<Derived>::operator=(const AngleAxisType& aa)
     {
-        using std::tan;
-        Scalar tanPhi = tan(Scalar(0.25)*aa.angle()); // Scalar(0.25) suppresses precision loss warnings
-        this->vec() = tanPhi * aa.axis();
+        Quaternion<Scalar> q(aa);
+        internal::assign_mrp_from_quaternion_short(*this, q);
         return derived();
     }
 
@@ -646,11 +656,7 @@ namespace Eigen {
 
         Quaternion<Scalar> q;
         q.setFromTwoVectors(a, b);
-        if (q.w() < Scalar(0)) {
-            q.coeffs() = -q.coeffs();
-        }
-
-        this->vec() = q.vec()/(Scalar(1) + q.w());
+        internal::assign_mrp_from_quaternion_short(*this, q);
         return derived();
     }
 
@@ -815,19 +821,10 @@ namespace Eigen {
             template<class Derived> static inline void run(MRPBase<Derived>& sig, const Other& mat)
             {
                 Quaternion<Scalar> q;
-                Scalar num;
 
                 /* convert DCM to quaternions */
                 q = mat;
-                if (q.w() < Scalar(0)) {
-                    q.coeffs() = -q.coeffs();
-                }
-                num = Scalar(1) + q.w();
-
-                /* convert quaternions to MRP */
-                sig.x() = q.x()/num;
-                sig.y() = q.y()/num;
-                sig.z() = q.z()/num;
+                internal::assign_mrp_from_quaternion_short(sig, q);
             }
         };
 

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -42,6 +42,15 @@ namespace Eigen {
         int OtherRows=Other::RowsAtCompileTime,
         int OtherCols=Other::ColsAtCompileTime>
         struct MRPbase_assign_impl;
+
+        // Helper for MRPBase::cast().  Same-scalar casts should behave like
+        // Eigen and return a const reference to the existing expression, while
+        // cross-scalar casts must explicitly cast the coefficient vector.  The
+        // explicit coefficient cast avoids Eigen's mixed-scalar assignment path,
+        // which rejects cases such as MRPMapd::cast<float>().
+        template<class Derived, typename NewScalarType,
+        bool IsSame = is_same<typename traits<Derived>::Scalar, NewScalarType>::value>
+        struct mrp_cast_impl;
     }
 
     /**
@@ -210,7 +219,7 @@ namespace Eigen {
         template<typename NewScalarType>
         inline typename internal::cast_return_type<Derived, MRP<NewScalarType> >::type cast() const
         {
-            return typename internal::cast_return_type<Derived,MRP<NewScalarType> >::type(derived());
+            return internal::mrp_cast_impl<Derived, NewScalarType>::run(derived());
         }
 
     };
@@ -332,6 +341,26 @@ namespace Eigen {
         }
 #endif
     };
+
+    namespace internal {
+        template<class Derived, typename NewScalarType>
+        struct mrp_cast_impl<Derived, NewScalarType, true>
+        {
+            static EIGEN_STRONG_INLINE const Derived& run(const Derived& sig)
+            {
+                return sig;
+            }
+        };
+
+        template<class Derived, typename NewScalarType>
+        struct mrp_cast_impl<Derived, NewScalarType, false>
+        {
+            static EIGEN_STRONG_INLINE MRP<NewScalarType> run(const Derived& sig)
+            {
+                return MRP<NewScalarType>(sig.coeffs().template cast<NewScalarType>());
+            }
+        };
+    }
 
     /**
      * single precision MRP type */

--- a/src/architecture/utilities/avsEigenMRP.h
+++ b/src/architecture/utilities/avsEigenMRP.h
@@ -67,9 +67,9 @@ namespace Eigen {
         using Base::operator*;
         using Base::derived;
 
-        typedef typename internal::traits<Derived>::Scalar Scalar;              //!< variable
-        typedef typename NumTraits<Scalar>::Real RealScalar;                    //!< variable
-        typedef typename internal::traits<Derived>::Coefficients Coefficients;  //!< variable
+        typedef typename internal::traits<Derived>::Scalar Scalar;
+        typedef typename NumTraits<Scalar>::Real RealScalar;
+        typedef typename internal::traits<Derived>::Coefficients Coefficients;
         enum {
             Flags = Eigen::internal::traits<Derived>::Flags
         };
@@ -113,8 +113,8 @@ namespace Eigen {
         /** \returns a vector expression of the coefficients (x,y,z) */
         inline typename internal::traits<Derived>::Coefficients& coeffs() { return derived().coeffs(); }
 
-        EIGEN_STRONG_INLINE MRPBase<Derived>& operator=(const MRPBase<Derived>& other); //!< method
-        template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator=(const MRPBase<OtherDerived>& other); //!< method
+        EIGEN_STRONG_INLINE MRPBase<Derived>& operator=(const MRPBase<Derived>& other);
+        template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator=(const MRPBase<OtherDerived>& other);
 
         // disabled this copy operator as it is giving very strange compilation errors when compiling
         // test_stdvector with GCC 4.4.2. This looks like a GCC bug though, so feel free to re-enable it if it's
@@ -124,7 +124,7 @@ namespace Eigen {
         //  { return operator=<Derived>(other); }
 
         Derived& operator=(const AngleAxisType& aa);
-        template<class OtherDerived> Derived& operator=(const MatrixBase<OtherDerived>& m); //!< method
+        template<class OtherDerived> Derived& operator=(const MatrixBase<OtherDerived>& m);
 
         /** \returns a MRP representing an identity mapping or zero rotation
          * \sa MatrixBase::Identity()
@@ -172,7 +172,7 @@ namespace Eigen {
          */
         template<class OtherDerived> inline Scalar dot(const MRPBase<OtherDerived>& other) const { return coeffs().dot(other.coeffs()); }
 
-        template<class OtherDerived> Scalar angularDistance(const MRPBase<OtherDerived>& other) const; //!< method
+        template<class OtherDerived> Scalar angularDistance(const MRPBase<OtherDerived>& other) const;
 
         /** \returns an equivalent 3x3 rotation matrix */
         Matrix3 toRotationMatrix() const;
@@ -181,7 +181,8 @@ namespace Eigen {
         template<typename Derived1, typename Derived2>
         Derived& setFromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
 
-        template<class OtherDerived> EIGEN_STRONG_INLINE MRP<Scalar> operator* (const MRPBase<OtherDerived>& q) const; //!< method
+        /** \returns the attitude composition of \c *this and \a q. */
+        template<class OtherDerived> EIGEN_STRONG_INLINE MRP<Scalar> operator* (const MRPBase<OtherDerived>& q) const;
         /** Right-composes \c *this with another MRP attitude. */
         template<class OtherDerived> EIGEN_STRONG_INLINE Derived& operator*= (const MRPBase<OtherDerived>& q);
         /** Adds MRP coefficients component-wise.
@@ -272,14 +273,10 @@ namespace Eigen {
 
     namespace internal {
         template<typename _Scalar,int _Options>
-        /*! structure definition */
         struct traits<MRP<_Scalar,_Options> >
         {
-            /** struct definition */
             typedef MRP<_Scalar,_Options> PlainObject;
-            /** struct definition */
             typedef _Scalar Scalar;
-            /** struct definition */
             typedef Matrix<_Scalar,3,1,_Options> Coefficients;
             enum{
                 IsAligned = internal::traits<Coefficients>::Flags & PacketAccessBit,
@@ -295,13 +292,13 @@ namespace Eigen {
         enum { IsAligned = internal::traits<MRP>::IsAligned };
 
     public:
-        typedef _Scalar Scalar; //!< variable
+        typedef _Scalar Scalar;
 
         EIGEN_INHERIT_ASSIGNMENT_OPERATORS(MRP)
         using Base::operator*=;
 
-        typedef typename internal::traits<MRP>::Coefficients Coefficients;  //!< variable
-        typedef typename Base::AngleAxisType AngleAxisType;                 //!< variable
+        typedef typename internal::traits<MRP>::Coefficients Coefficients;
+        typedef typename Base::AngleAxisType AngleAxisType;
 
         /** Default constructor leaving the MRP uninitialized. */
         inline MRP() {}
@@ -335,19 +332,19 @@ namespace Eigen {
         template<typename Derived1, typename Derived2>
         static MRP FromTwoVectors(const MatrixBase<Derived1>& a, const MatrixBase<Derived2>& b);
 
-        inline Coefficients& coeffs() { return m_coeffs;} //!< method
-        inline const Coefficients& coeffs() const { return m_coeffs;} //!< method
+        inline Coefficients& coeffs() { return m_coeffs;}
+        inline const Coefficients& coeffs() const { return m_coeffs;}
 
         EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(bool(IsAligned))
 
     protected:
-        Coefficients m_coeffs; //!< variable
+        Coefficients m_coeffs; //!< MRP coefficient storage
 
 #ifndef EIGEN_PARSED_BY_DOXYGEN
         /**
          Check template parameters
          */
-        static EIGEN_STRONG_INLINE void _check_template_params()         //!< method
+        static EIGEN_STRONG_INLINE void _check_template_params()
         {
             EIGEN_STATIC_ASSERT( (_Options & DontAlign) == _Options,
                                 INVALID_MATRIX_TEMPLATE_PARAMETERS)
@@ -387,24 +384,18 @@ namespace Eigen {
      ***************************************************************************/
 
     namespace internal {
-        /** struct definition */
         template<typename _Scalar, int _Options>
-        /** struct definition */
         struct traits<Map<MRP<_Scalar>, _Options> > : traits<MRP<_Scalar, (int(_Options)&Aligned)==Aligned ? AutoAlign : DontAlign> >
         {
-            /** struct definition */
             typedef Map<Matrix<_Scalar,3,1>, _Options> Coefficients;
         };
     }
 
     namespace internal {
         template<typename _Scalar, int _Options>
-        /** struct definition */
         struct traits<Map<const MRP<_Scalar>, _Options> > : traits<MRP<_Scalar, (int(_Options)&Aligned)==Aligned ? AutoAlign : DontAlign> >
         {
-            /** struct definition */
             typedef Map<const Matrix<_Scalar,3,1>, _Options> Coefficients;
-            /** struct definition */
             typedef traits<MRP<_Scalar, (int(_Options)&Aligned)==Aligned ? AutoAlign : DontAlign> > TraitsBase;
             enum {
                 Flags = TraitsBase::Flags & ~LvalueBit
@@ -430,8 +421,8 @@ namespace Eigen {
         typedef MRPBase<Map<const MRP<_Scalar>, _Options> > Base;
 
     public:
-        typedef _Scalar Scalar;     //!< variable
-        typedef typename internal::traits<Map>::Coefficients Coefficients; //!< variable
+        typedef _Scalar Scalar;
+        typedef typename internal::traits<Map>::Coefficients Coefficients;
         EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
         using Base::operator*=;
 
@@ -443,10 +434,10 @@ namespace Eigen {
          * If the template parameter _Options is set to Aligned, then the pointer coeffs must be aligned. */
         EIGEN_STRONG_INLINE Map(const Scalar* coeffs) : m_coeffs(coeffs) {}
 
-        inline const Coefficients& coeffs() const { return m_coeffs;} //!< method
+        inline const Coefficients& coeffs() const { return m_coeffs;}
 
     protected:
-        const Coefficients m_coeffs; //!< variable
+        const Coefficients m_coeffs; //!< mapped MRP coefficient storage
     };
 
     /**
@@ -467,8 +458,8 @@ namespace Eigen {
         typedef MRPBase<Map<MRP<_Scalar>, _Options> > Base;
 
     public:
-        typedef _Scalar Scalar; //!< variable
-        typedef typename internal::traits<Map>::Coefficients Coefficients; //!< variable
+        typedef _Scalar Scalar;
+        typedef typename internal::traits<Map>::Coefficients Coefficients;
         EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Map)
         using Base::operator*=;
 
@@ -480,11 +471,11 @@ namespace Eigen {
          * If the template parameter _Options is set to Aligned, then the pointer coeffs must be aligned. */
         EIGEN_STRONG_INLINE Map(Scalar* coeffs) : m_coeffs(coeffs) {}
 
-        inline Coefficients& coeffs() { return m_coeffs; } //!< method
-        inline const Coefficients& coeffs() const { return m_coeffs; } //!< method
+        inline Coefficients& coeffs() { return m_coeffs; }
+        inline const Coefficients& coeffs() const { return m_coeffs; }
 
     protected:
-        Coefficients m_coeffs; //!< variable
+        Coefficients m_coeffs; //!< mapped MRP coefficient storage
     };
 
     /**
@@ -518,14 +509,13 @@ namespace Eigen {
             sig.vec() = q.vec()/(Scalar(1) + q.w());
         }
 
-        /*! template definition */
         template<int Arch, class Derived1, class Derived2, typename Scalar, int _Options> struct mrp_product
         {
             static EIGEN_STRONG_INLINE MRP<Scalar> run(const MRPBase<Derived1>& a, const MRPBase<Derived2>& b){
                 using std::abs;
-                Scalar det;     //!< variable
-                Scalar s1N2;    //!< variable
-                Scalar s2N2;    //!< variable
+                Scalar det;
+                Scalar s1N2;
+                Scalar s2N2;
                 MRP<Scalar> s2 = b;
                 MRP<Scalar> answer;
                 s1N2 = a.squaredNorm();
@@ -684,6 +674,10 @@ namespace Eigen {
      *
      * Note that the two input vectors do \b not have to be normalized, and
      * do not need to have the same norm.
+     *
+     * If either input vector has zero or underflow-level norm, this method
+     * returns the identity MRP because the rotation direction is not uniquely
+     * defined.
      */
     template<class Derived>
     template<typename Derived1, typename Derived2>
@@ -712,6 +706,10 @@ namespace Eigen {
      *
      * Note that the two input vectors do \b not have to be normalized, and
      * do not need to have the same norm.
+     *
+     * If either input vector has zero or underflow-level norm, this method
+     * returns the identity MRP because the rotation direction is not uniquely
+     * defined.
      */
     template<typename Scalar, int Options>
     template<typename Derived1, typename Derived2>
@@ -864,12 +862,9 @@ namespace Eigen {
         // set from a rotation matrix
         // this maps the [NB] DCM to the equivalent sigma_B/N set
         template<typename Other>
-        /*! struct definition */
         struct MRPbase_assign_impl<Other,3,3>
         {
-            typedef typename Other::Scalar Scalar; //!< variable
-            typedef DenseIndex Index; //!< variable
-            /** Class Definition */
+            typedef typename Other::Scalar Scalar;
             template<class Derived> static inline void run(MRPBase<Derived>& sig, const Other& mat)
             {
                 Quaternion<Scalar> q;
@@ -882,13 +877,8 @@ namespace Eigen {
 
         // set from a vector of coefficients assumed to be a MRP
         template<typename Other>
-        /**
-         structure definition
-         */
         struct MRPbase_assign_impl<Other,3,1>
         {
-            typedef typename Other::Scalar Scalar; //!< variable
-            /** Class definition */
             template<class Derived> static inline void run(MRPBase<Derived>& q, const Other& vec)
             {
                 q.coeffs() = vec;

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -73,10 +73,10 @@ void eigenVector3d2CArray(const Eigen::Vector3d& inMat, double *outArray)
     @param inMat Source Eigen MRP vector.
     @param outArray Destination three-element array.
 */
-void eigenMRPd2CArray(const Eigen::Vector3d& inMat, double* outArray)
+void eigenMRPd2CArray(const Eigen::MRPd& inMat, double* outArray)
 {
     Eigen::Map<Eigen::Vector3d> outVector(outArray);
-    outVector = inMat;
+    outVector = inMat.coeffs();
 }
 
 /*! Copy an Eigen 3x3 matrix into a row-major C array.
@@ -118,9 +118,9 @@ Eigen::Vector3d cArray2EigenVector3d(double *inArray)
     @param inArray Source three-element array.
     @return Eigen MRP containing the source values.
 */
-Eigen::MRPd cArray2EigenMRPd(double* inArray)
+Eigen::MRPd cArray2EigenMRPd(const double* inArray)
 {
-    return Eigen::MRPd(cArray2EigenVector3d(inArray));
+    return Eigen::MRPd(inArray);
 }
 
 /*! Convert a row-major C array into an Eigen 3x3 matrix.
@@ -239,7 +239,7 @@ Eigen::MRPd eigenC2MRP(Eigen::Matrix3d dcm_Eigen)
 
     eigenMatrix3d2CArray(dcm_Eigen, dcm_Array);
     C2MRP(RECAST3X3 dcm_Array, sigma_Array);
-    sigma_Eigen = cArray2EigenVector3d(sigma_Array);
+    sigma_Eigen = cArray2EigenMRPd(sigma_Array);
 
     return sigma_Eigen;
 }

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -60,7 +60,7 @@ void eigenMatrixXi2CArray(const Eigen::MatrixBase<Derived>& inMat, int *outArray
 //! Rapid conversion between 3-vector and output array.
 void eigenVector3d2CArray(const Eigen::Vector3d& inMat, double *outArray);
 //! Rapid conversion between MRP and output array.
-void eigenMRPd2CArray(const Eigen::Vector3d& inMat, double* outArray);
+void eigenMRPd2CArray(const Eigen::MRPd& inMat, double* outArray);
 //! Rapid conversion between 3x3 matrix and output array.
 void eigenMatrix3d2CArray(const Eigen::Matrix3d& inMat, double *outArray);
 //! General conversion between a C array and an Eigen matrix.
@@ -68,7 +68,7 @@ Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols);
 //! Specific conversion between a C array and an Eigen 3-vector.
 Eigen::Vector3d cArray2EigenVector3d(double *inArray);
 //! Specific conversion between a C array and an Eigen MRP.
-Eigen::MRPd cArray2EigenMRPd(double* inArray);
+Eigen::MRPd cArray2EigenMRPd(const double* inArray);
 //! Specific conversion between a C array and an Eigen 3x3 matrix.
 Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray);
 //! Specific conversion between a C 2D array and an Eigen 3x3 matrix.

--- a/src/architecture/utilities/tests/test_avsEigenMRP.cpp
+++ b/src/architecture/utilities/tests/test_avsEigenMRP.cpp
@@ -114,6 +114,16 @@ TEST(eigenMRP, testAngleAxisConversionUsesTangentQuarterAngle) {
     expectMatrixNear(sigma.toRotationMatrix(), angleAxis.toRotationMatrix(), kTolerance);
 }
 
+TEST(eigenMRP, testAngleAxisConversionChoosesEquivalentInnerSet) {
+    const double angle = 1.5*kPi;  // [rad]
+    Eigen::AngleAxisd angleAxis(angle, Eigen::Vector3d::UnitZ());
+
+    Eigen::MRPd sigma(angleAxis);
+
+    EXPECT_LT(sigma.norm(), 1.0);
+    expectMatrixNear(sigma.toRotationMatrix(), angleAxis.toRotationMatrix(), kTolerance);
+}
+
 TEST(eigenMRP, testRotationMatrixConversionChoosesEquivalentInnerSet) {
     const double angle = 1.5*kPi;  // [rad]
     Eigen::AngleAxisd angleAxis(angle, Eigen::Vector3d::UnitZ());

--- a/src/architecture/utilities/tests/test_avsEigenMRP.cpp
+++ b/src/architecture/utilities/tests/test_avsEigenMRP.cpp
@@ -348,6 +348,19 @@ TEST(eigenMRP, testMapAliasesAndMappedOperations) {
     expectMatrixNear((sigmaMap*sigmaMap.inverse()).toRotationMatrix(), Eigen::Matrix3d::Identity(), kTolerance);
 }
 
+TEST(eigenMRP, testMapCastConvertsScalarType) {
+    double coeffs[3] = {0.2, -0.3, 0.1};
+    Eigen::MRPMapd sigmaMap(coeffs);
+
+    const Eigen::MRPMapd& sigmaDouble = sigmaMap.cast<double>();
+    Eigen::MRPf sigmaFloat = sigmaMap.cast<float>();
+
+    EXPECT_EQ(&sigmaDouble, &sigmaMap);
+    EXPECT_NEAR(sigmaFloat.x(), 0.20F, kLooseTolerance);
+    EXPECT_NEAR(sigmaFloat.y(), -0.30F, kLooseTolerance);
+    EXPECT_NEAR(sigmaFloat.z(), 0.10F, kLooseTolerance);
+}
+
 TEST(eigenMRP, testAlignedMapAlias) {
     EIGEN_ALIGN16 double coeffs[4] = {0.1, -0.2, 0.3, 0.0};
     Eigen::MRPMapAlignedd sigmaMap(coeffs);

--- a/src/architecture/utilities/tests/test_avsEigenMRP.cpp
+++ b/src/architecture/utilities/tests/test_avsEigenMRP.cpp
@@ -17,15 +17,334 @@
 
  */
 
-#include <Eigen/Dense>
 #include "architecture/utilities/avsEigenMRP.h"
+
+#include <cmath>
 #include <gtest/gtest.h>
 
+namespace {
+
+constexpr double kTolerance = 1e-12;  // [-]
+constexpr double kLooseTolerance = 1e-6;  // [-]
+constexpr double kPi = 3.14159265358979323846;  // [rad]
+
+void expectVectorNear(const Eigen::Vector3d& actual, const Eigen::Vector3d& expected, double tolerance)
+{
+    for (int i = 0; i < 3; i++) {
+        EXPECT_NEAR(actual(i), expected(i), tolerance);
+    }
+}
+
+void expectMatrixNear(const Eigen::Matrix3d& actual, const Eigen::Matrix3d& expected, double tolerance)
+{
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            EXPECT_NEAR(actual(i, j), expected(i, j), tolerance);
+        }
+    }
+}
+
+void expectFiniteMRP(const Eigen::MRPd& sigma)
+{
+    for (int i = 0; i < 3; i++) {
+        EXPECT_TRUE(std::isfinite(sigma.coeffs()(i)));
+    }
+}
+
+Eigen::Matrix3d expectedBmat(const Eigen::MRPd& sigma)
+{
+    const double sigmaSquared = sigma.squaredNorm();  // [-]
+    Eigen::Matrix3d expected = (1.0 - sigmaSquared)*Eigen::Matrix3d::Identity();  // [-]
+    expected += 2.0*sigma.coeffs()*sigma.coeffs().transpose();
+
+    Eigen::Matrix3d sigmaTilde;
+    sigmaTilde << 0.0, -sigma.z(), sigma.y(),
+                  sigma.z(), 0.0, -sigma.x(),
+                  -sigma.y(), sigma.x(), 0.0;
+    expected += 2.0*sigmaTilde;
+    return expected;
+}
+
+}
 
 TEST(eigenMRP, testIdentity) {
     Eigen::MRPd sigma;
     sigma = sigma.Identity();
 
-    EXPECT_TRUE(sigma.norm() < 1e-10);
+    EXPECT_TRUE(sigma.norm() < kTolerance);
 }
 
+TEST(eigenMRP, testCoefficientConstructorsAndAccessors) {
+    const double rawCoefficients[3] = {0.10, -0.20, 0.30};  // [-]
+
+    Eigen::MRPd fromScalars(0.10, -0.20, 0.30);
+    Eigen::MRPd fromPointer(rawCoefficients);
+    Eigen::MRPd fromVector(Eigen::Vector3d(0.10, -0.20, 0.30));
+
+    expectVectorNear(fromScalars.coeffs(), Eigen::Vector3d(0.10, -0.20, 0.30), kTolerance);
+    expectVectorNear(fromPointer.coeffs(), fromScalars.coeffs(), kTolerance);
+    expectVectorNear(fromVector.vec(), fromScalars.coeffs(), kTolerance);
+
+    fromScalars.x() = -0.40;
+    fromScalars.y() = 0.50;
+    fromScalars.z() = -0.60;
+
+    EXPECT_NEAR(fromScalars.x(), -0.40, kTolerance);
+    EXPECT_NEAR(fromScalars.y(), 0.50, kTolerance);
+    EXPECT_NEAR(fromScalars.z(), -0.60, kTolerance);
+    expectVectorNear(fromScalars.coeffs(), Eigen::Vector3d(-0.40, 0.50, -0.60), kTolerance);
+}
+
+TEST(eigenMRP, testSetIdentity) {
+    Eigen::MRPd sigma(0.20, -0.10, 0.40);
+
+    sigma.setIdentity();
+
+    expectVectorNear(sigma.coeffs(), Eigen::Vector3d::Zero(), kTolerance);
+    expectMatrixNear(sigma.toRotationMatrix(), Eigen::Matrix3d::Identity(), kTolerance);
+}
+
+TEST(eigenMRP, testAngleAxisConversionUsesTangentQuarterAngle) {
+    const double angle = kPi;  // [rad]
+    Eigen::AngleAxisd angleAxis(angle, Eigen::Vector3d::UnitY());
+
+    Eigen::MRPd sigma(angleAxis);
+
+    EXPECT_NEAR(sigma.norm(), std::tan(angle/4.0), kTolerance);
+    expectMatrixNear(sigma.toRotationMatrix(), angleAxis.toRotationMatrix(), kTolerance);
+}
+
+TEST(eigenMRP, testRotationMatrixConversionChoosesEquivalentInnerSet) {
+    const double angle = 1.5*kPi;  // [rad]
+    Eigen::AngleAxisd angleAxis(angle, Eigen::Vector3d::UnitZ());
+
+    Eigen::MRPd sigma(angleAxis.toRotationMatrix());
+
+    EXPECT_LT(sigma.norm(), 1.0);
+    expectMatrixNear(sigma.toRotationMatrix(), angleAxis.toRotationMatrix(), kTolerance);
+}
+
+TEST(eigenMRP, testCompositionMatchesRotationMatrixProduct) {
+    Eigen::MRPd sigmaOne(0.15, -0.20, 0.10);
+    Eigen::MRPd sigmaTwo(-0.05, 0.08, 0.12);
+
+    Eigen::MRPd sigmaCombined = sigmaOne*sigmaTwo;
+
+    expectMatrixNear(sigmaCombined.toRotationMatrix(),
+                     sigmaOne.toRotationMatrix()*sigmaTwo.toRotationMatrix(),
+                     kTolerance);
+}
+
+TEST(eigenMRP, testCompositionUsesShadowSetNearSingularity) {
+    Eigen::MRPd sigmaOne(1.0, 0.0, 0.0);
+    Eigen::MRPd sigmaTwo(1.0, 0.0, 0.0);
+
+    Eigen::MRPd sigmaCombined = sigmaOne*sigmaTwo;
+
+    expectFiniteMRP(sigmaCombined);
+    EXPECT_NEAR(sigmaCombined.norm(), 0.0, kTolerance);
+    expectMatrixNear(sigmaCombined.toRotationMatrix(), Eigen::Matrix3d::Identity(), kTolerance);
+}
+
+TEST(eigenMRP, testCompoundCompositionMatchesBinaryComposition) {
+    Eigen::MRPd sigmaOne(0.25, 0.10, -0.05);
+    Eigen::MRPd sigmaTwo(-0.15, 0.05, 0.20);
+    Eigen::MRPd sigmaProduct = sigmaOne;
+
+    sigmaProduct *= sigmaTwo;
+
+    expectVectorNear(sigmaProduct.coeffs(), (sigmaOne*sigmaTwo).coeffs(), kTolerance);
+    expectMatrixNear(sigmaProduct.toRotationMatrix(),
+                     sigmaOne.toRotationMatrix()*sigmaTwo.toRotationMatrix(),
+                     kTolerance);
+}
+
+TEST(eigenMRP, testCoefficientAdditionAndSubtractionOperators) {
+    Eigen::MRPd sigma(0.20, -0.30, 0.10);
+    Eigen::MRPd delta(-0.05, 0.10, 0.20);
+
+    sigma += delta;
+    expectVectorNear(sigma.coeffs(), Eigen::Vector3d(0.15, -0.20, 0.30), kTolerance);
+
+    sigma -= delta;
+    expectVectorNear(sigma.coeffs(), Eigen::Vector3d(0.20, -0.30, 0.10), kTolerance);
+}
+
+TEST(eigenMRP, testVectorTransformUsesRotationMatrix) {
+    const double angle = kPi/2.0;  // [rad]
+    Eigen::MRPd sigma(Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitZ()));
+    Eigen::Vector3d vector(1.0, -2.0, 0.5);
+
+    expectVectorNear(sigma*vector, sigma.toRotationMatrix()*vector, kTolerance);
+}
+
+TEST(eigenMRP, testFromTwoVectorsHandlesGeneralParallelAntiparallelAndZeroVectors) {
+    Eigen::Vector3d vectorOne(2.0, 0.0, 0.0);
+    Eigen::Vector3d vectorTwo(0.0, -3.0, 0.0);
+    Eigen::Vector3d smallVectorOne(1.0e-7, 0.0, 0.0);
+    Eigen::Vector3d smallVectorTwo(0.0, -2.0e-7, 0.0);
+    Eigen::MRPd sigmaMember;
+    Eigen::MRPd sigmaGeneral = Eigen::MRPd::FromTwoVectors(vectorOne, vectorTwo);
+    Eigen::MRPd sigmaParallel = Eigen::MRPd::FromTwoVectors(vectorOne, vectorOne);
+    Eigen::MRPd sigmaAntiparallel = Eigen::MRPd::FromTwoVectors(vectorOne, -vectorOne);
+    Eigen::MRPd sigmaSmall = Eigen::MRPd::FromTwoVectors(smallVectorOne, smallVectorTwo);
+    Eigen::MRPd sigmaZero = Eigen::MRPd::FromTwoVectors(Eigen::Vector3d::Zero(), vectorTwo);
+
+    sigmaMember.setFromTwoVectors(vectorOne, vectorTwo);
+
+    expectFiniteMRP(sigmaGeneral);
+    expectFiniteMRP(sigmaParallel);
+    expectFiniteMRP(sigmaAntiparallel);
+    expectFiniteMRP(sigmaSmall);
+    expectFiniteMRP(sigmaZero);
+    expectVectorNear(sigmaMember.coeffs(), sigmaGeneral.coeffs(), kTolerance);
+    expectVectorNear((sigmaGeneral*vectorOne).normalized(), vectorTwo.normalized(), kTolerance);
+    expectVectorNear(sigmaParallel*vectorOne, vectorOne, kTolerance);
+    expectVectorNear(sigmaAntiparallel*vectorOne, -vectorOne, kTolerance);
+    expectVectorNear((sigmaSmall*smallVectorOne).normalized(), smallVectorTwo.normalized(), kTolerance);
+    expectMatrixNear(sigmaZero.toRotationMatrix(), Eigen::Matrix3d::Identity(), kTolerance);
+}
+
+TEST(eigenMRP, testNormSquaredNormDotAndIsApprox) {
+    Eigen::MRPd sigma(0.20, -0.30, 0.40);
+    Eigen::MRPd other(-0.10, 0.05, 0.20);
+
+    EXPECT_NEAR(sigma.squaredNorm(), 0.29, kTolerance);
+    EXPECT_NEAR(sigma.norm(), std::sqrt(0.29), kTolerance);
+    EXPECT_NEAR(sigma.dot(other), 0.045, kTolerance);
+    EXPECT_TRUE(sigma.isApprox(Eigen::MRPd(0.20 + 1e-13, -0.30, 0.40), 1e-12));
+    EXPECT_FALSE(sigma.isApprox(Eigen::MRPd(0.21, -0.30, 0.40), 1e-12));
+}
+
+TEST(eigenMRP, testNormalizeInPlaceReturnsPrincipalAxisDirection) {
+    Eigen::MRPd sigma(3.0, 4.0, 0.0);
+
+    sigma.normalize();
+
+    EXPECT_NEAR(sigma.norm(), 1.0, kTolerance);
+    expectVectorNear(sigma.coeffs(), Eigen::Vector3d(0.6, 0.8, 0.0), kTolerance);
+}
+
+TEST(eigenMRP, testShadowSet) {
+    Eigen::MRPd sigma(2.0, -1.0, 0.0);
+    Eigen::MRPd zero = Eigen::MRPd::Identity();
+
+    Eigen::MRPd shadow = sigma.shadow();
+
+    expectVectorNear(shadow.coeffs(), Eigen::Vector3d(-0.4, 0.2, 0.0), kTolerance);
+    expectMatrixNear(shadow.toRotationMatrix(), sigma.toRotationMatrix(), kTolerance);
+    expectVectorNear(zero.shadow().coeffs(), Eigen::Vector3d::Zero(), kTolerance);
+}
+
+TEST(eigenMRP, testBmatMatchesMRPKinematicsDefinition) {
+    Eigen::MRPd sigma(0.20, -0.30, 0.10);
+
+    expectMatrixNear(sigma.Bmat(), expectedBmat(sigma), kTolerance);
+}
+
+TEST(eigenMRP, testInverseAndConjugateRepresentOppositeRotation) {
+    Eigen::MRPd sigma(0.20, -0.10, 0.05);
+    Eigen::MRPd inverse = sigma.inverse();
+    Eigen::MRPd conjugate = sigma.conjugate();
+    Eigen::MRPd identityProduct = sigma*inverse;
+
+    expectVectorNear(inverse.coeffs(), -sigma.coeffs(), kTolerance);
+    expectVectorNear(conjugate.coeffs(), -sigma.coeffs(), kTolerance);
+    expectMatrixNear(inverse.toRotationMatrix(), sigma.toRotationMatrix().transpose(), kTolerance);
+    expectMatrixNear(identityProduct.toRotationMatrix(), Eigen::Matrix3d::Identity(), kTolerance);
+}
+
+TEST(eigenMRP, testAngularDistance) {
+    const double angle = kPi/3.0;  // [rad]
+    Eigen::MRPd identity = Eigen::MRPd::Identity();
+    Eigen::MRPd sigma(Eigen::AngleAxisd(angle, Eigen::Vector3d::UnitX()));
+
+    EXPECT_NEAR(identity.angularDistance(sigma), angle, kTolerance);
+    EXPECT_NEAR(sigma.angularDistance(identity), angle, kTolerance);
+    EXPECT_NEAR(sigma.angularDistance(sigma), 0.0, kTolerance);
+}
+
+TEST(eigenMRP, testCastConvertsScalarType) {
+    Eigen::MRPd sigma(0.20, -0.30, 0.10);
+
+    const Eigen::MRPd& sigmaDouble = sigma.cast<double>();
+    Eigen::MRPf sigmaFloat = sigma.cast<float>();
+    Eigen::MRPf constructedFloat(sigma);
+
+    EXPECT_EQ(&sigmaDouble, &sigma);
+    EXPECT_NEAR(sigmaFloat.x(), 0.20F, kLooseTolerance);
+    EXPECT_NEAR(sigmaFloat.y(), -0.30F, kLooseTolerance);
+    EXPECT_NEAR(sigmaFloat.z(), 0.10F, kLooseTolerance);
+    EXPECT_NEAR(constructedFloat.x(), 0.20F, kLooseTolerance);
+    EXPECT_NEAR(constructedFloat.y(), -0.30F, kLooseTolerance);
+    EXPECT_NEAR(constructedFloat.z(), 0.10F, kLooseTolerance);
+}
+
+TEST(eigenMRP, testNormalizedReturnsPrincipalAxisDirection) {
+    Eigen::MRPd sigma(0.0, -2.0, 0.0);
+
+    Eigen::MRPd axis = sigma.normalized();
+
+    EXPECT_NEAR(axis.norm(), 1.0, kTolerance);
+    expectVectorNear(axis.coeffs(), Eigen::Vector3d(0.0, -1.0, 0.0), kTolerance);
+}
+
+TEST(eigenMRP, testAssignmentFromVectorMatrixAndMRPBase) {
+    Eigen::MRPd sigma;
+    Eigen::Vector3d coeffs(0.10, -0.20, 0.30);
+    const double angle = kPi/4.0;  // [rad]
+    Eigen::AngleAxisd angleAxis(angle, Eigen::Vector3d::UnitZ());
+
+    sigma = coeffs;
+    expectVectorNear(sigma.coeffs(), coeffs, kTolerance);
+
+    sigma = angleAxis;
+    expectMatrixNear(sigma.toRotationMatrix(), angleAxis.toRotationMatrix(), kTolerance);
+
+    sigma = angleAxis.toRotationMatrix();
+    expectMatrixNear(sigma.toRotationMatrix(), angleAxis.toRotationMatrix(), kTolerance);
+
+    Eigen::MRPd copied;
+    copied = sigma;
+    expectVectorNear(copied.coeffs(), sigma.coeffs(), kTolerance);
+}
+
+TEST(eigenMRP, testMapReadWrite) {
+    double coeffs[3] = {0.1, -0.2, 0.3};
+    Eigen::Map<Eigen::MRPd> sigmaMap(coeffs);
+
+    sigmaMap = Eigen::MRPd(0.4, -0.5, 0.6);
+
+    EXPECT_NEAR(coeffs[0], 0.4, kTolerance);
+    EXPECT_NEAR(coeffs[1], -0.5, kTolerance);
+    EXPECT_NEAR(coeffs[2], 0.6, kTolerance);
+
+    Eigen::Map<const Eigen::MRPd> constSigmaMap(coeffs);
+    expectVectorNear(constSigmaMap.coeffs(), Eigen::Vector3d(0.4, -0.5, 0.6), kTolerance);
+}
+
+TEST(eigenMRP, testMapAliasesAndMappedOperations) {
+    double coeffs[3] = {0.2, 0.0, 0.0};
+    Eigen::MRPMapd sigmaMap(coeffs);
+
+    sigmaMap.x() = 0.1;
+    sigmaMap.y() = -0.2;
+    sigmaMap.z() = 0.3;
+    sigmaMap += Eigen::MRPd(0.1, 0.1, -0.1);
+
+    EXPECT_NEAR(coeffs[0], 0.2, kTolerance);
+    EXPECT_NEAR(coeffs[1], -0.1, kTolerance);
+    EXPECT_NEAR(coeffs[2], 0.2, kTolerance);
+    expectMatrixNear((sigmaMap*sigmaMap.inverse()).toRotationMatrix(), Eigen::Matrix3d::Identity(), kTolerance);
+}
+
+TEST(eigenMRP, testAlignedMapAlias) {
+    EIGEN_ALIGN16 double coeffs[4] = {0.1, -0.2, 0.3, 0.0};
+    Eigen::MRPMapAlignedd sigmaMap(coeffs);
+
+    sigmaMap = Eigen::MRPd(-0.4, 0.5, -0.6);
+
+    EXPECT_NEAR(coeffs[0], -0.4, kTolerance);
+    EXPECT_NEAR(coeffs[1], 0.5, kTolerance);
+    EXPECT_NEAR(coeffs[2], -0.6, kTolerance);
+}

--- a/src/architecture/utilities/tests/test_avsEigenSupport.cpp
+++ b/src/architecture/utilities/tests/test_avsEigenSupport.cpp
@@ -103,15 +103,15 @@ TEST(avsEigenSupport, TildeMatrix) {
 
 // Test MRP conversions
 TEST(avsEigenSupport, MRPConversions) {
-    Eigen::Vector3d mrp(0.1, 0.2, 0.3);
+    Eigen::MRPd mrp(0.1, 0.2, 0.3);  // [-]
     double array[3];
 
     eigenMRPd2CArray(mrp, array);
     Eigen::MRPd result = cArray2EigenMRPd(array);
 
-    EXPECT_NEAR(mrp[0], result.x(), 1e-10);
-    EXPECT_NEAR(mrp[1], result.y(), 1e-10);
-    EXPECT_NEAR(mrp[2], result.z(), 1e-10);
+    EXPECT_NEAR(mrp.x(), result.x(), 1e-10);
+    EXPECT_NEAR(mrp.y(), result.y(), 1e-10);
+    EXPECT_NEAR(mrp.z(), result.z(), 1e-10);
 }
 
 // Test Newton-Raphson solver

--- a/src/fswAlgorithms/stateEstimation/thrustCMEstimation/thrustCMEstimation.cpp
+++ b/src/fswAlgorithms/stateEstimation/thrustCMEstimation/thrustCMEstimation.cpp
@@ -86,7 +86,7 @@ void ThrustCMEstimation::UpdateState(uint64_t CurrentSimNanos)
 
     /*! compute error w.r.t. target attitude */
     AttGuidMsgPayload attGuidBuffer = this->attGuidInMsg();
-    Eigen::Vector3d sigma_BR   = cArray2EigenVector3d(attGuidBuffer.sigma_BR);
+    Eigen::MRPd sigma_BR = cArray2EigenMRPd(attGuidBuffer.sigma_BR);
     Eigen::Vector3d omega_BR_B = cArray2EigenVector3d(attGuidBuffer.omega_BR_B);
     double attError = pow(sigma_BR.squaredNorm() + omega_BR_B.squaredNorm(), 0.5);
 

--- a/src/simulation/communication/simpleAntenna/simpleAntenna.cpp
+++ b/src/simulation/communication/simpleAntenna/simpleAntenna.cpp
@@ -518,7 +518,7 @@ void SimpleAntenna::calculateAntennaPositionAndOrientation()
 
         // Calculate the antenna orientation in {N} frame
         dcm_NA                    = dcm_NB * this->sigma_AB.toRotationMatrix();               // DCM from {A} frame to {N} frame:   dcm_NA = dcm_NB * dcm_BA
-        this->sigma_AN            = eigenMRPd2Vector3d(eigenC2MRP(dcm_NA.transpose()));       // Convert DCM to MRP
+        this->sigma_AN            = eigenC2MRP(dcm_NA.transpose());                           // Convert DCM to MRP
 
         // Calculate the antenna velocity in the {N} frame
         this->v_AN_N = cArray2EigenVector3d(this->scState.v_BN_N);                            // Antenna velocity in {N} frame (assumed same as spacecraft velocity)

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.cpp
@@ -650,14 +650,14 @@ void PrescribedRotation1DOF::writeOutputMessages(uint64_t callTime) {
     Eigen::Vector3d omegaPrime_PM_P = this->thetaDDot * this->rotHat_M;  // [rad/s^2]
 
     // Compute the MRP attitude of spinning body frame P with respect to frame M
-    Eigen::Vector3d sigma_PM = this->computeSigma_PM();
+    Eigen::MRPd sigma_PM = this->computeSigma_PM();
 
     // Copy the module variables to the output buffer messages
     spinningBodyOut.theta = this->theta;
     spinningBodyOut.thetaDot = this->thetaDot;
     eigenVector3d2CArray(omega_PM_P, prescribedRotationOut.omega_PM_P);
     eigenVector3d2CArray(omegaPrime_PM_P, prescribedRotationOut.omegaPrime_PM_P);
-    eigenVector3d2CArray(sigma_PM, prescribedRotationOut.sigma_PM);
+    eigenMRPd2CArray(sigma_PM, prescribedRotationOut.sigma_PM);
 
     // Write the output messages
     this->spinningBodyOutMsg.write(&spinningBodyOut, moduleID, callTime);
@@ -681,7 +681,7 @@ void PrescribedRotation1DOF::writeOutputMessages(uint64_t callTime) {
 /*! This method computes the current spinning body MRP attitude relative to the mount frame: sigma_PM
 
 */
-Eigen::Vector3d PrescribedRotation1DOF::computeSigma_PM() {
+Eigen::MRPd PrescribedRotation1DOF::computeSigma_PM() {
     // Determine dcm_PP0 for the current spinning body attitude relative to the initial attitude
     double dcm_PP0[3][3];
     double prv_PP0_array[3];
@@ -704,7 +704,7 @@ Eigen::Vector3d PrescribedRotation1DOF::computeSigma_PM() {
     // Compute the MRP sigma_PM representing the current spinning body attitude relative to the mount frame
     double sigma_PM_array[3];
     C2MRP(dcm_PM, sigma_PM_array);
-    return cArray2EigenVector3d(sigma_PM_array);
+    return cArray2EigenMRPd(sigma_PM_array);
 }
 
 /*! Setter method for the coast option bang duration.

--- a/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
+++ b/src/simulation/deviceInterface/prescribedRotation1DOF/prescribedRotation1DOF.h
@@ -21,6 +21,7 @@
 
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/messaging/messaging.h"
+#include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
 #include "cMsgCInterface/HingedRigidBodyMsg_C.h"
 #include "cMsgCInterface/PrescribedRotationMsg_C.h"
@@ -91,7 +92,7 @@ private:
     void computeRotationComplete();                                        //!< Method for computing the scalar rotational states when the rotation is complete
 
     void writeOutputMessages(uint64_t CurrentSimNanos);                    //!< Method for writing the module output messages and computing the output message data
-    Eigen::Vector3d computeSigma_PM();                                     //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_PM
+    Eigen::MRPd computeSigma_PM();                                         //!< Method for computing the current spinning body MRP attitude relative to the mount frame: sigma_PM
 
     /* User-configurable variables */
     double rhoInit{};                                                      //!< [m] Initial displacement from frame M to frame P along rotHat_M

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -229,7 +229,7 @@ void FuelTank::updateEffectorMassProps(double integTime) {
 /*! Fuel tank adds its contributions to the matrices for the back-sub method. */
 void FuelTank::updateContributions(double integTime,
                                    BackSubMatrices &backSubContr,
-                                   Eigen::Vector3d sigma_BN,
+                                   Eigen::MRPd sigma_BN,
                                    Eigen::Vector3d omega_BN_B,
                                    Eigen::Vector3d g_N) {
     Eigen::Vector3d omega_BN_BLocal;
@@ -267,7 +267,7 @@ void FuelTank::updateContributions(double integTime,
 void FuelTank::computeDerivatives(double integTime,
                                   Eigen::Vector3d rDDot_BN_N,
                                   Eigen::Vector3d omegaDot_BN_B,
-                                  Eigen::Vector3d sigma_BN) {
+                                  Eigen::MRPd sigma_BN) {
     Eigen::MatrixXd conv(1, 1);
     double massLocal = this->massState->getState()(0, 0);
     double tankFuelConsumptionLocal = this->tankFuelConsumption;

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -315,7 +315,7 @@ public:
     void addThrusterSet(ThrusterStateEffector *stateEff);       //!< -- Add StateEffector thruster
     void updateContributions(double integTime,
                              BackSubMatrices &backSubContr,
-                             Eigen::Vector3d sigma_BN,
+                             Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;     //!< -- Back-sub contributions
     void updateEnergyMomContributions(double integTime,
@@ -325,7 +325,7 @@ public:
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override; //!< -- Calculate stateEffector's derivatives
+                            Eigen::MRPd sigma_BN) override; //!< -- Calculate stateEffector's derivatives
 };
 
 

--- a/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.cpp
+++ b/src/simulation/dynamics/GravityGradientEffector/GravityGradientEffector.cpp
@@ -103,8 +103,7 @@ void GravityGradientEffector::computeForceTorque(double integTime, double timeSt
     this->torqueExternalPntB_B.setZero();
 
     /* compute DCN [BN] */
-    Eigen::MRPd sigmaBN;
-    sigmaBN = (Eigen::Vector3d)this->hubSigma->getStateReference();
+    Eigen::MRPd sigmaBN(this->hubSigma->getStateReference().data());
     Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
     /* evaluate inertia tensor about center of mass */

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -217,7 +217,7 @@ void HingedRigidBodyStateEffector::updateEffectorMassProps(double integTime)
 
 /*! This method allows the HRB state effector to give its contributions to the matrices needed for the back-sub
  method */
-void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_PN;
@@ -291,7 +291,7 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
 }
 
 /*! This method is used to find the derivatives for the HRB stateEffector: thetaDDot and the kinematic derivative */
-void HingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void HingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     // - Grab necessarry values from manager (these have been previously computed in hubEffector)
     Eigen::Vector3d rDDotLoc_PN_N = rDDot_BN_N;
@@ -424,7 +424,8 @@ void HingedRigidBodyStateEffector::computePanelInertialStates()
     Eigen::Matrix3d dcm_NP = sigmaBN.toRotationMatrix();  // assumes P and B are idential
     Eigen::Matrix3d dcm_SN;
     dcm_SN = this->dcm_SP*dcm_NP.transpose();
-    *this->sigma_SN = eigenMRPd2Vector3d(eigenC2MRP(dcm_SN));
+    const Eigen::MRPd sigma_SN = eigenC2MRP(dcm_SN);
+    *this->sigma_SN = sigma_SN.coeffs();
 
 
     // inertial angular velocity

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.h
@@ -134,8 +134,8 @@ public:
     void linkInStates(DynParamManager& states) override;  //!< -- Method for getting access to other states
     void addDynamicEffector(DynamicEffector *newDynamicEffector, int segment = 1) override;  //!< -- Method for adding attached dynamic effector
     void registerProperties(DynParamManager& states) override;       //!< -- Method for registering the HRB inertial properties
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N) override;  //!< -- Method for back-sub contributions
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN) override;  //!< -- Method for HRB to compute its derivatives
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N) override;  //!< -- Method for back-sub contributions
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN) override;  //!< -- Method for HRB to compute its derivatives
     void updateEffectorMassProps(double integTime) override;  //!< -- Method for giving the s/c the HRB mass props and prop rates
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B) override; //!< -- Computing energy and momentum for HRBs
     void calcForceTorqueOnBody(double integTime, Eigen::Vector3d omega_BN_B) override;  //!< -- Force and torque on s/c due to HRBs

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
@@ -130,13 +130,13 @@ void LinearSpringMassDamper::retrieveMassValue(double integTime)
 }
 
 /*! This method is for the SMD to add its contributions to the back-sub method */
-void LinearSpringMassDamper::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void LinearSpringMassDamper::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_BN;
     Eigen::Matrix3d dcm_BN;
     Eigen::Matrix3d dcm_NB;
-    sigmaLocal_BN = (Eigen::Vector3d ) sigma_BN;
+    sigmaLocal_BN = sigma_BN;
     dcm_NB = sigmaLocal_BN.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
 
@@ -171,13 +171,13 @@ void LinearSpringMassDamper::updateContributions(double integTime, BackSubMatric
 
 /*! This method is used to define the derivatives of the SMD. One is the trivial kinematic derivative and the other is
  derived using the back-sub method */
-void LinearSpringMassDamper::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void LinearSpringMassDamper::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
 
 	// - Find DCM
 	Eigen::MRPd sigmaLocal_BN;
 	Eigen::Matrix3d dcm_BN;
-	sigmaLocal_BN = (Eigen::Vector3d) sigma_BN;
+	sigmaLocal_BN = sigma_BN;
 	dcm_BN = (sigmaLocal_BN.toRotationMatrix()).transpose();
 
 	// - Set the derivative of rho to rhoDot

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.h
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.h
@@ -71,10 +71,10 @@ public:
     void retrieveMassValue(double integTime);
     void calcForceTorqueOnBody(double integTime, Eigen::Vector3d omega_BN_B);  //!< -- Force and torque on s/c due to linear spring mass damper
     void updateEffectorMassProps(double integTime);  //!< -- Method for stateEffector to give mass contributions
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
 };
 
 

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.cpp
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.cpp
@@ -121,7 +121,7 @@ void MtbEffector::computeForceTorque(double integTime, double timeStep)
     /*
      * Construct bTilde matrix.
      */
-    sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
+    sigmaBN = Eigen::MRPd(this->hubSigma->getState().data());
     dcm_BN = sigmaBN.toRotationMatrix().transpose();
     magField_N = cArray2EigenVector3d(this->magInMsgBuffer.magField_N);
     magField_B = dcm_BN * magField_N;

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -206,13 +206,13 @@ double NHingedRigidBodyStateEffector::HeaviFunc(double cond)
 
 /*! This method allows the HRB state effector to give its contributions to the matrices needed for the back-sub
  method */
-void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_BN;
     Eigen::Matrix3d dcm_BN;
     Eigen::Matrix3d dcm_NB;
-    sigmaLocal_BN = (Eigen::Vector3d )sigma_BN;
+    sigmaLocal_BN = sigma_BN;
     dcm_NB = sigmaLocal_BN.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
 
@@ -444,14 +444,14 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
 }
 
 /*! This method is used to find the derivatives for the HRB stateEffector: thetaDDot and the kinematic derivative */
-void NHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void NHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     // - Grab necessarry values from manager (these have been previously computed in hubEffector)
     Eigen::Vector3d rDDotLoc_BN_N;
     Eigen::MRPd sigmaLocal_BN;
     Eigen::Vector3d omegaDotLoc_BN_B;
     rDDotLoc_BN_N = rDDot_BN_N;
-    sigmaLocal_BN = (Eigen::Vector3d )sigma_BN;
+    sigmaLocal_BN = sigma_BN;
     omegaDotLoc_BN_B = omegaDot_BN_B;
 
     // - Find rDDotLoc_BN_B

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -96,10 +96,10 @@ public:
     void registerStates(DynParamManager& statesIn);  //!< -- Method for registering the HRB states
     void linkInStates(DynParamManager& states);  //!< -- Method for getting access to other states
     void updateEffectorMassProps(double integTime);  //!< -- Method for stateEffector to give mass contributions
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
     void readInputMessages();       //!< -- method to read input messages
 };
 

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.cpp
@@ -188,11 +188,11 @@ void ThrusterDynamicEffector::UpdateThrusterProperties()
     Eigen::Vector3d omega_BN_B;
     if (!this->stateNameOfSigma.empty()) {
         omega_BN_B = this->hubOmega->getState();
-        sigma_BN = (Eigen::Vector3d)this->hubSigma->getState();
+        sigma_BN = Eigen::MRPd(this->hubSigma->getState().data());
     }
     else {
         omega_BN_B = *this->inertialAngVelocityProperty;
-        sigma_BN = (Eigen::Vector3d)*this->inertialAttitudeProperty;
+        sigma_BN = Eigen::MRPd(this->inertialAttitudeProperty->data());
     }
 
     Eigen::Matrix3d dcm_BN = (sigma_BN.toRotationMatrix()).transpose();

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -198,8 +198,7 @@ void ThrusterStateEffector::UpdateThrusterProperties()
     // Save hub variables
     Eigen::Vector3d r_BN_N = (Eigen::Vector3d)*this->inertialPositionProperty;
     Eigen::Vector3d omega_BN_B = this->hubOmega->getState();
-    Eigen::MRPd sigma_BN;
-    sigma_BN = (Eigen::Vector3d) this->hubSigma->getState();
+    Eigen::MRPd sigma_BN(this->hubSigma->getState().data());
     Eigen::Matrix3d dcm_BN = (sigma_BN.toRotationMatrix()).transpose();
 
     // Define the variables related to which body the thruster is attached to. The F frame represents the platform body where the thruster attaches to
@@ -321,7 +320,7 @@ void ThrusterStateEffector::registerStates(DynParamManager& states)
 }
 
 /*! This method is used to find the derivatives for the thruster stateEffector */
-void ThrusterStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void ThrusterStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     std::vector<std::shared_ptr<THRSimConfig>>::iterator itp;
     std::shared_ptr<THRSimConfig> it;
@@ -437,7 +436,7 @@ void ThrusterStateEffector::calcForceTorqueOnBody(double integTime, Eigen::Vecto
     return;
 }
 
-void ThrusterStateEffector::updateContributions(double integTime, BackSubMatrices& backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void ThrusterStateEffector::updateContributions(double integTime, BackSubMatrices& backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // Define the translational and rotational contributions from the computed force and torque
     backSubContr.vecTrans = this->forceOnBody_B;

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.h
@@ -50,9 +50,9 @@ public:
     void writeOutputStateMessages(uint64_t CurrentClock);
     void registerStates(DynParamManager& states);  //!< -- Method for the effector to register its states
     void linkInStates(DynParamManager& states);  //!< -- Method for the effector to get access of other states
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
     void calcForceTorqueOnBody(double integTime, Eigen::Vector3d omega_BN_B);
-    void updateContributions(double integTime, BackSubMatrices& backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< Method to pass the forces and torques onto the hub
+    void updateContributions(double integTime, BackSubMatrices& backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< Method to pass the forces and torques onto the hub
     void updateEffectorMassProps(double integTime);
     void UpdateState(uint64_t CurrentSimNanos);
 

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.cpp
@@ -260,7 +260,7 @@ void VSCMGStateEffector::updateEffectorMassProps(double integTime)
 	return;
 }
 
-void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
 	Eigen::Vector3d omegaLoc_BN_B;
 	Eigen::Vector3d tempF;
@@ -286,7 +286,7 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 
 
     //! - Find dcm_BN
-    sigmaBNLocal = (Eigen::Vector3d ) sigma_BN;
+    sigmaBNLocal = sigma_BN;
     dcm_NB = sigmaBNLocal.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
     //! - Map gravity to body frame
@@ -389,7 +389,7 @@ void VSCMGStateEffector::updateContributions(double integTime, BackSubMatrices &
 	return;
 }
 
-void VSCMGStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void VSCMGStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
 	Eigen::MatrixXd OmegasDot(this->numVSCMG,1);
     Eigen::MatrixXd thetasDot(this->numVSCMGJitter,1);
@@ -412,7 +412,7 @@ void VSCMGStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rD
 	omegaDotBNLoc_B = omegaDot_BN_B;
 	omegaLoc_BN_B = this->hubOmega->getStateReference();
 	rDDotBNLoc_N = rDDot_BN_N;
-	sigmaBNLocal = (Eigen::Vector3d ) sigma_BN;
+	sigmaBNLocal = sigma_BN;
 	dcm_NB = sigmaBNLocal.toRotationMatrix();
 	dcm_BN = dcm_NB.transpose();
 	rDDotBNLoc_B = dcm_BN*rDDotBNLoc_N;

--- a/src/simulation/dynamics/VSCMGs/vscmgStateEffector.h
+++ b/src/simulation/dynamics/VSCMGs/vscmgStateEffector.h
@@ -55,10 +55,10 @@ public:
 	void WriteOutputMessages(uint64_t CurrentClock);
 	void ReadInputs();
 	void ConfigureVSCMGRequests(double CurrentTime);
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< [-] Back-sub contributions
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< [-] Back-sub contributions
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< [-] Energy and momentum calculations
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< [-] Method for each stateEffector to calculate derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< [-] Method for each stateEffector to calculate derivatives
 
 public:
 	std::vector<VSCMGConfigMsgPayload> VSCMGData; //!< [-] VSCMG data structure

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
@@ -165,17 +165,16 @@ void HubEffector::updateEffectorMassProps(double integTime)
 
 /*! This method is for computing the derivatives of the hub: rDDot_BN_N and omegaDot_BN_B, along with the kinematic
  derivatives */
-void HubEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void HubEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     // - Get variables from state manager
     Eigen::Vector3d rDotLocal_BN_N;
-    Eigen::MRPd sigmaLocal_BN;
+    Eigen::MRPd sigmaLocal_BN = sigma_BN;
     Eigen::Vector3d omegaLocal_BN_B;
     Eigen::Vector3d cLocal_B;
     Eigen::Vector3d cPrimeLocal_B;
     Eigen::Vector3d gLocal_N;
     rDotLocal_BN_N = velocityState->getStateReference();
-    sigmaLocal_BN = (Eigen::Vector3d )sigmaState->getStateReference();
     omegaLocal_BN_B = omegaState->getStateReference();
     gLocal_N = *this->g_N;
 
@@ -262,11 +261,10 @@ void HubEffector::updateEnergyMomContributions(double integTime, Eigen::Vector3d
 void HubEffector::modifyStates(double integTime)
 {
     // Lets switch those MRPs!!
-    Eigen::Vector3d sigmaBNLoc;
-    sigmaBNLoc = (Eigen::Vector3d) this->sigmaState->getStateReference();
+    Eigen::MRPd sigmaBNLoc(this->sigmaState->getStateReference().data());
     if (sigmaBNLoc.norm() > 1) {
-        sigmaBNLoc = -sigmaBNLoc/(sigmaBNLoc.dot(sigmaBNLoc));
-        this->sigmaState->setState(sigmaBNLoc);
+        sigmaBNLoc = sigmaBNLoc.shadow();
+        this->sigmaState->setState(sigmaBNLoc.coeffs());
         this->MRPSwitchCount++;
     }
     return;

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.h
@@ -54,7 +54,7 @@ public:
     void registerTranslationalStates(DynParamManager& states);  //!< -- Register only translational hub states
     void registerAttitudeStates(DynParamManager& states);       //!< -- Register constant attitude hub states
     void updateEffectorMassProps(double integTime);  //!< -- Method for the hub to update its mass props for the s/c
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for the hub to compute it's derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for the hub to compute it's derivatives
     void computeHubOnlyDerivatives(const Eigen::Vector3d& forceExternal_N,
                                    const Eigen::Vector3d& forceExternal_B,
                                    const Eigen::Vector3d& torquePntB_B);  //!< -- Compute direct hub derivatives

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.cpp
@@ -63,7 +63,7 @@ void StateEffector::receiveMotherSpacecraftData(Eigen::Vector3d rSC_BP_P, Eigen:
 /*! This method is strictly for the back-substituion method for computing the dynamics of the spacecraft. The back-sub
  method first computes rDDot_BN_N and omegaDot_BN_B for the spacecraft using these contributions from the state
  effectors. Then computeDerivatives is called to compute the stateEffectors derivatives using rDDot_BN_N omegaDot_BN_B*/
-void StateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void StateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     return;
 }

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.h
@@ -148,7 +148,7 @@ public:
     StateEffector();                       //!< Contructor
     virtual ~StateEffector();              //!< Destructor
     virtual void updateEffectorMassProps(double integTime);  //!< Method for stateEffector to give mass contributions
-    virtual void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< Back-sub contributions
+    virtual void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< Back-sub contributions
     virtual void addPrescribedMotionCouplingContributions(BackSubMatrices& backSubContr);  //!< Method for adding coupling contributions for state effector branching on prescribed motion
     virtual void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< Energy and momentum calculations
@@ -160,7 +160,7 @@ public:
     virtual void addDynamicEffector(DynamicEffector *newDynamicEffector, int segment);  //!< Method to attach a dynamic effector
     virtual void linkInStates(DynParamManager& states) = 0;  //!< Method for stateEffectors to get other states
     virtual void linkInPrescribedMotionProperties(DynParamManager& properties);  //!< Method for stateEffectors to access prescribed motion properties
-    virtual void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)=0;  //!< Method for each stateEffector to calculate derivatives
+    virtual void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)=0;  //!< Method for each stateEffector to calculate derivatives
     virtual void prependSpacecraftNameToStates();
     virtual void receiveMotherSpacecraftData(Eigen::Vector3d rSC_BP_P, Eigen::Matrix3d dcmSC_BP); //!< class method
 

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.cpp
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.cpp
@@ -316,24 +316,24 @@ void ConstraintDynamicEffector::computeForceTorque(double integTime, double time
                 r_B1N_N = this->hubPosition[parent1.idx]->getState();
                 rDot_B1N_N = this->hubVelocity[parent1.idx]->getState();
                 omega_B1N_B1 = this->hubOmega[parent1.idx]->getState();
-                sigma_B1N = (Eigen::Vector3d)this->hubSigma[parent1.idx]->getState();
+                sigma_B1N = Eigen::MRPd(this->hubSigma[parent1.idx]->getState().data());
             } else if (this->parent1.parentType == "effector") {
                 // - Collect properties from parent effector
                 r_B1N_N = *this->inertialPositionProperty[parent1.idx];
                 rDot_B1N_N = *this->inertialVelocityProperty[parent1.idx];
                 omega_B1N_B1 = *this->inertialAngVelocityProperty[parent1.idx];
-                sigma_B1N = (Eigen::Vector3d)*this->inertialAttitudeProperty[parent1.idx];
+                sigma_B1N = Eigen::MRPd(this->inertialAttitudeProperty[parent1.idx]->data());
             }
             if (this->parent2.parentType == "hub") {
                 r_B2N_N = this->hubPosition[parent2.idx]->getState();
                 rDot_B2N_N = this->hubVelocity[parent2.idx]->getState();
                 omega_B2N_B2 = this->hubOmega[parent2.idx]->getState();
-                sigma_B2N = (Eigen::Vector3d)this->hubSigma[parent2.idx]->getState();
+                sigma_B2N = Eigen::MRPd(this->hubSigma[parent2.idx]->getState().data());
             } else if (this->parent2.parentType == "effector") {
                 r_B2N_N = *this->inertialPositionProperty[parent2.idx];
                 rDot_B2N_N = *this->inertialVelocityProperty[parent2.idx];
                 omega_B2N_B2 = *this->inertialAngVelocityProperty[parent2.idx];
-                sigma_B2N = (Eigen::Vector3d)*this->inertialAttitudeProperty[parent2.idx];
+                sigma_B2N = Eigen::MRPd(this->inertialAttitudeProperty[parent2.idx]->data());
             }
 
             // computing direction constraint psi in the N frame
@@ -372,7 +372,7 @@ void ConstraintDynamicEffector::computeForceTorque(double integTime, double time
 
             // calculate the constraint torque imparted on each spacecraft from the attitude constraint
             Eigen::Matrix3d dcm_B1B2 = dcm_B1N * dcm_B2N.transpose();
-            Eigen::Vector3d L_B2_att = -this->k_a * eigenMRPd2Vector3d(this->phi) - this->c_a * 0.25 * this->phi.Bmat() * omega_B2B1_B2;
+            Eigen::Vector3d L_B2_att = -this->k_a * this->phi.coeffs() - this->c_a * 0.25 * this->phi.Bmat() * omega_B2B1_B2;
             Eigen::Vector3d L_B1_att = - dcm_B1B2 * L_B2_att;
             this->T_B2 = L_B2_len + L_B2_att; // store the constraint torque for spacecraft 2
 

--- a/src/simulation/dynamics/dragEffector/dragDynamicEffector.cpp
+++ b/src/simulation/dynamics/dragEffector/dragDynamicEffector.cpp
@@ -103,8 +103,7 @@ void DragDynamicEffector::linkInStates(DynParamManager& states){
  * It accounts for wind velocity if the wind message is linked.
 */
 void DragDynamicEffector::updateDragDir(){
-    Eigen::MRPd sigmaBN;
-    sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
+    Eigen::MRPd sigmaBN(this->hubSigma->getState().data());
     Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
     Eigen::Vector3d v_BN_N = this->hubVelocity->getState();

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -206,7 +206,7 @@ void DualHingedRigidBodyStateEffector::updateEffectorMassProps(double integTime)
     return;
 }
 
-void DualHingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void DualHingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     Eigen::MRPd sigmaPNLocal;
     Eigen::Matrix3d dcmPN;                        /* direction cosine matrix from N to B */
@@ -301,7 +301,7 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime, Bac
     return;
 }
 
-void DualHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void DualHingedRigidBodyStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     // - Define necessarry variables
     Eigen::MRPd sigmaBNLocal;
@@ -403,7 +403,7 @@ void DualHingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t Current
         configLogMsg = this->dualHingedRigidBodyConfigLogOutMsgs[i]->zeroMsgPayload;
         eigenVector3d2CArray(this->r_SN_N[i], configLogMsg.r_BN_N);
         eigenVector3d2CArray(this->v_SN_N[i], configLogMsg.v_BN_N);
-        eigenVector3d2CArray(this->sigma_SN[i], configLogMsg.sigma_BN);
+        eigenMRPd2CArray(this->sigma_SN[i], configLogMsg.sigma_BN);
         eigenVector3d2CArray(this->omega_SN_S[i], configLogMsg.omega_BN_B);
         this->dualHingedRigidBodyConfigLogOutMsgs[i]->write(&configLogMsg, this->moduleID, CurrentClock);
     }
@@ -441,8 +441,8 @@ void DualHingedRigidBodyStateEffector::computePanelInertialStates()
     Eigen::MRPd sigmaPN;
     sigmaPN = this->sigma_BN;
     Eigen::Matrix3d dcm_NP = sigmaPN.toRotationMatrix();
-    this->sigma_SN[0] = eigenMRPd2Vector3d(eigenC2MRP(this->dcm_S1P*dcm_NP.transpose()));
-    this->sigma_SN[1] = eigenMRPd2Vector3d(eigenC2MRP(this->dcm_S2P*dcm_NP.transpose()));
+    this->sigma_SN[0] = eigenC2MRP(this->dcm_S1P*dcm_NP.transpose());
+    this->sigma_SN[1] = eigenC2MRP(this->dcm_S2P*dcm_NP.transpose());
 
     // inertial angular velocities
     Eigen::Vector3d omega_PN_P;

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.h
@@ -45,10 +45,10 @@ public:
     void registerStates(DynParamManager& statesIn);     //!< class method
     void linkInStates(DynParamManager& states);         //!< class method
     void updateEffectorMassProps(double integTime);     //!< class method
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
     void Reset(uint64_t CurrentSimNanos);
     void UpdateState(uint64_t CurrentSimNanos);
     void writeOutputStateMessages(uint64_t CurrentClock);
@@ -129,7 +129,7 @@ private:
     StateData *theta2DotState;        //!< [-] state manager of thetaDot for hinged rigid body
     Eigen::Vector3d r_SN_N[2];        //!< [m] position vector of hinge CM S relative to inertial frame
     Eigen::Vector3d v_SN_N[2];        //!< [m/s] inertial velocity vector of S relative to inertial frame
-    Eigen::Vector3d sigma_SN[2];      //!< -- MRP attitude of panel frame S relative to inertial frame
+    Eigen::MRPd sigma_SN[2];          //!< -- MRP attitude of panel frame S relative to inertial frame
     Eigen::Vector3d omega_SN_S[2];    //!< [rad/s] inertial panel frame angular velocity vector
     Eigen::MRPd sigma_BN{0.0, 0.0, 0.0};        //!< Hub/Inertial attitude represented by MRP of body relative to inertial frame
     Eigen::Vector3d omega_BN_B{0.0, 0.0, 0.0};  //!< Hub/Inertial angular velocity vector in B frame components

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.cpp
@@ -110,8 +110,7 @@ void FacetDragDynamicEffector::linkInStates(DynParamManager& states){
  * It accounts for wind velocity if the wind message is linked.
 */
 void FacetDragDynamicEffector::updateDragDir(){
-    Eigen::MRPd sigmaBN;
-    sigmaBN = (Eigen::Vector3d)this->hubSigma->getState();
+    Eigen::MRPd sigmaBN(this->hubSigma->getState().data());
     Eigen::Matrix3d dcm_BN = sigmaBN.toRotationMatrix().transpose();
 
     Eigen::Vector3d v_BN_N = this->hubVelocity->getState();

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -131,8 +131,7 @@ void FacetSRPDynamicEffector::computeForceTorque(double callTime, double timeSte
     ReadMessages();
 
     // Compute dcm_BN
-    Eigen::MRPd sigma_BN;
-    sigma_BN = (Eigen::Vector3d)this->hubSigma->getState();
+    Eigen::MRPd sigma_BN(this->hubSigma->getState().data());
     Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
 
     // Grab the current spacecraft inertial position

--- a/src/simulation/dynamics/facetedSRPEffector/facetedSRPEffector.cpp
+++ b/src/simulation/dynamics/facetedSRPEffector/facetedSRPEffector.cpp
@@ -104,8 +104,7 @@ void FacetedSRPEffector::computeForceTorque(double callTime, double timeStep) {
     }
 
     // Compute the sun direction unit vector in spacecraft body frame components
-    Eigen::MRPd sigma_BN;
-    sigma_BN = (Eigen::Vector3d)this->hubSigma->getState();
+    Eigen::MRPd sigma_BN(this->hubSigma->getState().data());
     Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
     Eigen::Vector3d r_BN_N = this->hubPosition->getState();
     Eigen::Vector3d r_SB_B = dcm_BN * (r_SN_N - r_BN_N);

--- a/src/simulation/dynamics/igbmNoiseStateEffector/igbmNoiseStateEffector.cpp
+++ b/src/simulation/dynamics/igbmNoiseStateEffector/igbmNoiseStateEffector.cpp
@@ -106,7 +106,7 @@ void IgbmNoiseStateEffector::linkInStates(DynParamManager& /** states */)
 void IgbmNoiseStateEffector::computeDerivatives(double /** integTime */,
                                                 Eigen::Vector3d /** rDDot_BN_N */,
                                                 Eigen::Vector3d /** omegaDot_BN_B */,
-                                                Eigen::Vector3d /** sigma_BN */)
+                                                Eigen::MRPd /** sigma_BN */)
 {
     if (this->state == nullptr) {
         this->bskLogger.bskError("IgbmNoiseStateEffector::computeDerivatives called before registerStates.");

--- a/src/simulation/dynamics/igbmNoiseStateEffector/igbmNoiseStateEffector.h
+++ b/src/simulation/dynamics/igbmNoiseStateEffector/igbmNoiseStateEffector.h
@@ -79,7 +79,7 @@ public:
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override;
+                            Eigen::MRPd sigma_BN) override;
 
     /*!
      * @brief Set the mean level @f$\mu@f$ of the multiplicative factor @f$(1+\delta)@f$.

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -173,7 +173,7 @@ void LinearTranslationNDOFStateEffector::writeOutputStateMessages(uint64_t Curre
             // Logging the F frame is the body frame B of that object
             eigenVector3d2CArray(translatingBody->r_FcN_N, configLogMsg.r_BN_N);
             eigenVector3d2CArray(translatingBody->v_FcN_N, configLogMsg.v_BN_N);
-            eigenVector3d2CArray(translatingBody->sigma_FN, configLogMsg.sigma_BN);
+            eigenMRPd2CArray(translatingBody->sigma_FN, configLogMsg.sigma_BN);
             eigenVector3d2CArray(translatingBody->omega_FN_F, configLogMsg.omega_BN_B);
             this->translatingBodyConfigLogOutMsgs[i]->write(&configLogMsg, this->moduleID, CurrentClock);
         }
@@ -293,7 +293,7 @@ void LinearTranslationNDOFStateEffector::updateEffectorMassProps(double integTim
 
 /*! This method allows the TB state effector to give its contributions to the matrices needed for the back-sub
  method */
-void LinearTranslationNDOFStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void LinearTranslationNDOFStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // Find the DCM from N to B frames
     this->sigma_BN = sigma_BN;
@@ -417,7 +417,7 @@ void LinearTranslationNDOFStateEffector::computeBackSubContributions(BackSubMatr
 }
 
 /*! This method is used to find the derivatives for the TB stateEffector: rhoDDot and the kinematic derivative */
-void LinearTranslationNDOFStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void LinearTranslationNDOFStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     // Find rDDotLoc_BN_B
     const Eigen::Vector3d& rDDotLocal_BN_N = rDDot_BN_N;
@@ -467,7 +467,7 @@ void LinearTranslationNDOFStateEffector::computeTranslatingBodyInertialStates()
         // Compute the rotational properties
         Eigen::Matrix3d dcm_FN;
         dcm_FN = translatingBody->dcm_FB * this->dcm_BN;
-        translatingBody->sigma_FN = eigenMRPd2Vector3d(eigenC2MRP(dcm_FN));
+        translatingBody->sigma_FN = eigenC2MRP(dcm_FN);
         translatingBody->omega_FN_F = translatingBody->dcm_FB.transpose().transpose() * translatingBody->omega_FN_B;
 
         // Compute the translation properties

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -128,7 +128,7 @@ private:
     // Inertial properties
     Eigen::Vector3d r_FcN_N;            //!< [m] position vector of translating body's center of mass Fc relative to the inertial frame origin N
     Eigen::Vector3d v_FcN_N;            //!< [m/s] inertial velocity vector of Fc relative to inertial frame
-    Eigen::Vector3d sigma_FN;           //!< -- MRP attitude of frame S relative to inertial frame
+    Eigen::MRPd sigma_FN;               //!< -- MRP attitude of frame S relative to inertial frame
     Eigen::Vector3d omega_FN_F;         //!< [rad/s] inertial translating body frame angular velocity vector
 
     BSKLogger bskLogger;
@@ -192,7 +192,7 @@ private:
     void linkInStates(DynParamManager& states) final;
     void updateContributions(double integTime,
                              BackSubMatrices& backSubContr,
-                             Eigen::Vector3d sigma_BN,
+                             Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) final;
     void computeMRho(Eigen::MatrixXd& MRho);
@@ -203,7 +203,7 @@ private:
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) final;
+                            Eigen::MRPd sigma_BN) final;
     void updateEffectorMassProps(double integTime) final;
     void updateEnergyMomContributions(double integTime,
                                       Eigen::Vector3d& rotAngMomPntCContr_B,

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -219,7 +219,7 @@ void LinearTranslationOneDOFStateEffector::updateEffectorMassProps(double integT
 }
 
 void LinearTranslationOneDOFStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr,
-                                                               Eigen::Vector3d sigma_BN,
+                                                               Eigen::MRPd sigma_BN,
                                                                Eigen::Vector3d omega_BN_B,
                                                                Eigen::Vector3d g_N)
 {
@@ -293,8 +293,7 @@ void LinearTranslationOneDOFStateEffector::addPrescribedMotionCouplingContributi
     Eigen::Vector3d r_PB_B = (Eigen::Vector3d)*this->prescribedPositionProperty;
     Eigen::Vector3d rPrime_PB_B = (Eigen::Vector3d)*this->prescribedVelocityProperty;
     Eigen::Vector3d rPrimePrime_PB_B = (Eigen::Vector3d)*this->prescribedAccelerationProperty;
-    Eigen::MRPd sigma_PB;
-    sigma_PB = (Eigen::Vector3d)*this->prescribedAttitudeProperty;
+    Eigen::MRPd sigma_PB(this->prescribedAttitudeProperty->data());
     Eigen::Vector3d omega_PB_P = (Eigen::Vector3d)*this->prescribedAngVelocityProperty;
     Eigen::Vector3d omegaPrime_PB_P = (Eigen::Vector3d)*this->prescribedAngAccelerationProperty;
     Eigen::Matrix3d dcm_PB = sigma_PB.toRotationMatrix().transpose();
@@ -357,7 +356,7 @@ void LinearTranslationOneDOFStateEffector::addPrescribedMotionCouplingContributi
 void LinearTranslationOneDOFStateEffector::computeDerivatives(double integTime,
                                                               Eigen::Vector3d rDDot_BN_N,
                                                               Eigen::Vector3d omegaDot_BN_B,
-                                                              Eigen::Vector3d sigma_BN)
+                                                              Eigen::MRPd sigma_BN)
 {
 	Eigen::MRPd sigmaLocal_BN;
 	sigmaLocal_BN = sigma_BN;
@@ -394,7 +393,8 @@ void LinearTranslationOneDOFStateEffector::updateEnergyMomContributions(double i
 void LinearTranslationOneDOFStateEffector::computeTranslatingBodyInertialStates()
 {
     Eigen::Matrix3d dcm_FN = this->dcm_FB * this->dcm_BN;
-    *this->sigma_FN = eigenMRPd2Vector3d(eigenC2MRP(dcm_FN));
+    const Eigen::MRPd sigma_FN = eigenC2MRP(dcm_FN);
+    *this->sigma_FN = sigma_FN.coeffs();
     *this->omega_FN_F = this->dcm_FB.transpose() * this->omega_BN_B;
 
     this->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * this->r_FcB_B;

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
@@ -154,13 +154,13 @@ private:
     void updateEffectorMassProps(double integTime) override;
     void updateContributions(double integTime,
                              BackSubMatrices & backSubContr,
-                             Eigen::Vector3d sigma_BN,
+                             Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B) override;
     void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N,
-                            Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN) override;
+                            Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN) override;
     void UpdateState(uint64_t CurrentSimNanos) override;
 
     void computeTranslatingBodyInertialStates();

--- a/src/simulation/dynamics/meanRevertingNoiseStateEffector/meanRevertingNoiseStateEffector.cpp
+++ b/src/simulation/dynamics/meanRevertingNoiseStateEffector/meanRevertingNoiseStateEffector.cpp
@@ -83,10 +83,10 @@ void MeanRevertingNoiseStateEffector::linkInStates(DynParamManager& /** states *
 {
 }
 
-void MeanRevertingNoiseStateEffector::computeDerivatives(double /** integTime */,
-                                                         Eigen::Vector3d /** rDDot_BN_N */,
-                                                         Eigen::Vector3d /** omegaDot_BN_B */,
-                                                         Eigen::Vector3d /** sigma_BN */)
+void MeanRevertingNoiseStateEffector::computeDerivatives(double,
+                                                         Eigen::Vector3d,
+                                                         Eigen::Vector3d,
+                                                         Eigen::MRPd)
 {
     if (this->state == nullptr) {
         this->bskLogger.bskError("MeanRevertingNoiseStateEffector::computeDerivatives called before registerStates.");

--- a/src/simulation/dynamics/meanRevertingNoiseStateEffector/meanRevertingNoiseStateEffector.h
+++ b/src/simulation/dynamics/meanRevertingNoiseStateEffector/meanRevertingNoiseStateEffector.h
@@ -63,7 +63,7 @@ public:
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override;
+                            Eigen::MRPd sigma_BN) override;
 
     /*!
      * @brief Set the stationary standard deviation of the OU state.

--- a/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
+++ b/src/simulation/dynamics/msmForceTorque/msmForceTorque.cpp
@@ -134,7 +134,7 @@ void MsmForceTorque::readMessages()
 
         scStateInMsgsBuffer = this->scStateInMsgs.at(c)();
         this->r_BN_NList.at(c) = cArray2EigenVector3d(scStateInMsgsBuffer.r_BN_N);
-        this->sigma_BNList.at(c) = cArray2EigenVector3d(scStateInMsgsBuffer.sigma_BN);
+        this->sigma_BNList.at(c) = cArray2EigenMRPd(scStateInMsgsBuffer.sigma_BN);
     }
 }
 

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -110,8 +110,7 @@ void PrescribedMotionStateEffector::writeOutputStateMessages(uint64_t currentClo
         PrescribedRotationMsgPayload prescribedRotationBuffer = this->prescribedRotationOutMsg.zeroMsgPayload;
         eigenVector3d2CArray(this->omega_PM_P, prescribedRotationBuffer.omega_PM_P);
         eigenVector3d2CArray(this->omegaPrime_PM_P, prescribedRotationBuffer.omegaPrime_PM_P);
-        Eigen::Vector3d sigma_PM_loc = eigenMRPd2Vector3d(this->sigma_PM);
-        eigenVector3d2CArray(sigma_PM_loc, prescribedRotationBuffer.sigma_PM);
+        eigenMRPd2CArray(this->sigma_PM, prescribedRotationBuffer.sigma_PM);
         this->prescribedRotationOutMsg.write(&prescribedRotationBuffer, this->moduleID, currentClock);
     }
 
@@ -155,8 +154,7 @@ void PrescribedMotionStateEffector::linkInStates(DynParamManager& statesIn)
 void PrescribedMotionStateEffector::registerStates(DynParamManager& states)
 {
     this->sigma_PMState = states.registerState(3, 1, this->nameOfsigma_PMState);
-    Eigen::Vector3d sigma_PMInitMatrix = eigenMRPd2Vector3d(this->sigma_PM);
-    this->sigma_PMState->setState(sigma_PMInitMatrix);
+    this->sigma_PMState->setState(this->sigma_PM.coeffs());
 
     // Call method to register the prescribed motion properties
     registerProperties(states);
@@ -201,7 +199,7 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
     this->r_PM_M = this->rEpoch_PM_M + (this->rPrimeEpoch_PM_M * dt) + (0.5 * this->rPrimePrime_PM_M * dt * dt);
     this->rPrime_PM_M = this->rPrimeEpoch_PM_M + (this->rPrimePrime_PM_M * dt);
     this->omega_PM_P = this->omegaEpoch_PM_P + (this->omegaPrime_PM_P * dt);
-    this->sigma_PM = (Eigen::Vector3d)this->sigma_PMState->getStateReference();
+    this->sigma_PM = Eigen::MRPd(this->sigma_PMState->getStateReference().data());
 
     // Give the mass of the prescribed body to the effProps mass
     this->effProps.mEff = this->mass;
@@ -214,7 +212,8 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
 
     // Compute dcm_BP
     this->dcm_BP = this->dcm_BM * this->dcm_PM.transpose();
-    *this->sigma_PB = eigenMRPd2Vector3d(eigenC2MRP(this->dcm_BP.transpose()));
+    const Eigen::MRPd sigma_PB = eigenC2MRP(this->dcm_BP.transpose());
+    *this->sigma_PB = sigma_PB.coeffs();
 
     // Compute omega_PB_B
     this->omega_PM_B = this->dcm_BP * this->omega_PM_P;
@@ -319,7 +318,7 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
 */
 void PrescribedMotionStateEffector::updateContributions(double integTime,
                                                         BackSubMatrices & backSubContr,
-                                                        Eigen::Vector3d sigma_BN,
+                                                        Eigen::MRPd sigma_BN,
                                                         Eigen::Vector3d omega_BN_B,
                                                         Eigen::Vector3d g_N)
 {
@@ -333,7 +332,8 @@ void PrescribedMotionStateEffector::updateContributions(double integTime,
 
     // Update sigma_PN
     Eigen::Matrix3d dcm_PN = this->dcm_BP.transpose() * this->dcm_BN;
-    *this->sigma_PN = eigenMRPd2Vector3d(eigenC2MRP(dcm_PN));
+    Eigen::MRPd sigmaPNLoc = eigenC2MRP(dcm_PN);
+    *this->sigma_PN = sigmaPNLoc.coeffs();
 
     // Update omega_PN_P
     *this->omega_PN_P = *this->omega_PB_P + this->dcm_BP.transpose() * this->omega_BN_B;
@@ -362,7 +362,7 @@ void PrescribedMotionStateEffector::updateContributions(double integTime,
         backSubContr.vecTrans.setZero();
         backSubContr.vecRot.setZero();
 
-        (*it)->updateContributions(integTime, backSubContr, *this->sigma_PN, *this->omega_PN_P, g_N);
+        (*it)->updateContributions(integTime, backSubContr, sigmaPNLoc, *this->omega_PN_P, g_N);
         (*it)->addPrescribedMotionCouplingContributions(backSubContr);
 
         totMatrixA += this->dcm_BP * backSubContr.matrixA * this->dcm_BP.transpose();
@@ -408,10 +408,9 @@ void PrescribedMotionStateEffector::updateContributions(double integTime,
 void PrescribedMotionStateEffector::computeDerivatives(double integTime,
                                                        Eigen::Vector3d rDDot_BN_N,
                                                        Eigen::Vector3d omegaDot_BN_B,
-                                                       Eigen::Vector3d sigma_BN)
+                                                       Eigen::MRPd sigma_BN)
 {
-    Eigen::MRPd sigma_PM_loc;
-    sigma_PM_loc = (Eigen::Vector3d)this->sigma_PMState->getStateReference();
+    Eigen::MRPd sigma_PM_loc(this->sigma_PMState->getStateReference().data());
     this->sigma_PMState->setDerivative(0.25*sigma_PM_loc.Bmat()*this->omega_PM_P);
 
     // Loop through attached state effectors for compute derivatives
@@ -422,7 +421,8 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime,
 
         // Compute dcm_FN and sigma_FN
         Eigen::Matrix3d dcm_PN = this->dcm_BP.transpose() * this->dcm_BN;
-        *this->sigma_PN = eigenMRPd2Vector3d(eigenC2MRP(dcm_PN));
+        Eigen::MRPd sigmaPNLoc = eigenC2MRP(dcm_PN);
+        *this->sigma_PN = sigmaPNLoc.coeffs();
 
         // Compute omegaDot_PN_P
         Eigen::Vector3d omegaDot_PN_B = this->omegaPrime_PM_B + this->omega_BN_B.cross(this->omega_PM_B) + omegaDot_BN_B;
@@ -437,7 +437,7 @@ void PrescribedMotionStateEffector::computeDerivatives(double integTime,
 
         std::vector<StateEffector*>::iterator it;
         for(it = this->stateEffectors.begin(); it != this->stateEffectors.end(); it++) {
-            (*it)->computeDerivatives(integTime, rDDot_PN_N, omegaDot_PN_P, *this->sigma_PN);
+            (*it)->computeDerivatives(integTime, rDDot_PN_N, omegaDot_PN_P, sigmaPNLoc);
         }
     }
 }
@@ -508,7 +508,8 @@ void PrescribedMotionStateEffector::computePrescribedMotionInertialStates()
 {
     // Compute the effector's attitude with respect to the inertial frame
     Eigen::Matrix3d dcm_PN = (this->dcm_BP).transpose() * this->dcm_BN;
-    *this->sigma_PN = eigenMRPd2Vector3d(eigenC2MRP(dcm_PN));
+    const Eigen::MRPd sigma_PN = eigenC2MRP(dcm_PN);
+    *this->sigma_PN = sigma_PN.coeffs();
 
     // Compute the effector's inertial angular velocity
     *this->omega_PN_P = (this->dcm_BP).transpose() * this->omega_PN_B;
@@ -551,12 +552,11 @@ void PrescribedMotionStateEffector::UpdateState(uint64_t currentSimNanos)
         PrescribedRotationMsgPayload incomingPrescribedRotStates = this->prescribedRotationInMsg();
         this->omega_PM_P = cArray2EigenVector3d(incomingPrescribedRotStates.omega_PM_P);
         this->omegaPrime_PM_P = cArray2EigenVector3d(incomingPrescribedRotStates.omegaPrime_PM_P);
-        this->sigma_PM = cArray2EigenVector3d(incomingPrescribedRotStates.sigma_PM);
+        this->sigma_PM = cArray2EigenMRPd(incomingPrescribedRotStates.sigma_PM);
 
         // Save off the prescribed rotational states at each dynamics time step
         this->omegaEpoch_PM_P = cArray2EigenVector3d(incomingPrescribedRotStates.omega_PM_P);
-        Eigen::Vector3d sigma_PM_loc = cArray2EigenVector3d(incomingPrescribedRotStates.sigma_PM);
-        this->sigma_PMState->setState(sigma_PM_loc);
+        this->sigma_PMState->setState(this->sigma_PM.coeffs());
     }
 
     // Call the method to compute the effector's inertial states

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.h
@@ -67,13 +67,13 @@ public:
     void registerProperties(DynParamManager& states) override;       //!< Method for registering the prescribed motion properties
     void updateContributions(double integTime,
                              BackSubMatrices & backSubContr,
-                             Eigen::Vector3d sigma_BN,
+                             Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;          //!< Method for computing the effector's back-substitution contributions
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override;      //!< Method for effector to compute its state derivatives
+                            Eigen::MRPd sigma_BN) override;      //!< Method for effector to compute its state derivatives
     void updateEffectorMassProps(double integTime) override;         //!< Method for calculating the effector mass props and prop rates
     void updateEnergyMomContributions(double integTime,
                                       Eigen::Vector3d & rotAngMomPntCContr_B,

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -166,7 +166,7 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime)
     }
 }
 
-void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
 	Eigen::Vector3d omegaLoc_BN_B;
 	Eigen::Vector3d tempF;
@@ -184,7 +184,7 @@ void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMa
     gLocal_N = *this->g_N;
 
     //! - Find dcm_BN
-    sigmaBNLocal = (Eigen::Vector3d ) sigma_BN;
+    sigmaBNLocal = sigma_BN;
     dcm_NB = sigmaBNLocal.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
     //! - Map gravity to body frame
@@ -268,7 +268,7 @@ void ReactionWheelStateEffector::updateContributions(double integTime, BackSubMa
 	}
 }
 
-void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
 	Eigen::MatrixXd OmegasDot(this->numRW,1);
     Eigen::MatrixXd thetasDot(this->numRWJitter,1);
@@ -283,7 +283,7 @@ void ReactionWheelStateEffector::computeDerivatives(double integTime, Eigen::Vec
 	//! Grab necessarry values from manager
 	omegaDotBNLoc_B = omegaDot_BN_B;
 	rDDotBNLoc_N = rDDot_BN_N;
-	sigmaBNLocal = (Eigen::Vector3d ) sigma_BN;
+	sigmaBNLocal = sigma_BN;
 	dcm_NB = sigmaBNLocal.toRotationMatrix();
 	dcm_BN = dcm_NB.transpose();
 	rDDotBNLoc_B = dcm_BN*rDDotBNLoc_N;

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
@@ -51,9 +51,9 @@ public:
 	void registerStates(DynParamManager& states);
 	void linkInStates(DynParamManager& states);
     void writeOutputStateMessages(uint64_t integTimeNanos);
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);
     void updateEffectorMassProps(double integTime);  //!< -- Method for stateEffector to give mass contributions
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
     void Reset(uint64_t CurrentSimNanos);

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -119,9 +119,9 @@ void Spacecraft::writeOutputStateMessages(uint64_t clockTime)
     eigenMatrixXd2CArray(*this->inertialVelocityProperty, stateOut.v_BN_N);
     Eigen::MRPd sigmaLocal_BN;
     if (this->pointMassTranslationalOnly && this->hubSigma == nullptr) {
-        sigmaLocal_BN = this->hub.sigma_BNInit;
+        sigmaLocal_BN = Eigen::MRPd(this->hub.sigma_BNInit);
     } else {
-        sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
+        sigmaLocal_BN = Eigen::MRPd(this->hubSigma->getStateReference().data());
     }
     Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
     Eigen::Vector3d rLocal_CN_N = (*this->inertialPositionProperty) + dcm_NB*(*this->c_B);
@@ -168,7 +168,7 @@ void Spacecraft::readOptionalRefMsg()
         Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
         omega_BN_B = dcm_BN * omega_BN_N;
 
-        this->hubSigma->setState(eigenMRPd2Vector3d(sigma_BN));
+        this->hubSigma->setState(sigma_BN.coeffs());
         this->hubOmega_BN_B->setState(omega_BN_B);
     }
 
@@ -312,8 +312,7 @@ void Spacecraft::initializeDynamics()
         // - Edit r_BN_N and v_BN_N to take into account that point B and point C are not coincident
         // - Pulling the state from the hub at this time gives us r_CN_N
         Eigen::Vector3d rInit_BN_N = this->hubR_N->getStateReference();
-        Eigen::MRPd sigma_BN;
-        sigma_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
+        Eigen::MRPd sigma_BN(this->hubSigma->getStateReference().data());
         Eigen::Matrix3d dcm_NB = sigma_BN.toRotationMatrix();
         // - Substract off the center mass to leave r_BN_N
         rInit_BN_N -= dcm_NB*(*this->c_B);
@@ -479,14 +478,11 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     this->updateSCMassProps(integTimeSeconds);
 
     // - This is where gravity is computed (gravity needs to know c_B to calculated gravity about r_CN_N)
-    Eigen::MRPd sigmaBNLoc;
+    Eigen::MRPd sigmaBNLoc(this->hubSigma->getStateReference().data());
     Eigen::Matrix3d dcm_NB;
     Eigen::Vector3d cLocal_N;
 
-    Eigen::Vector3d sigmaState = this->hubSigma->getStateReference();
     Eigen::Vector3d omegaState = this->hubOmega_BN_B->getStateReference();
-
-    sigmaBNLoc = sigmaState;
     dcm_NB = sigmaBNLoc.toRotationMatrix();
     cLocal_N = dcm_NB*(*this->c_B);
     Eigen::Vector3d rLocal_CN_N = this->hubR_N->getStateReference() + dcm_NB*(*this->c_B);
@@ -519,7 +515,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
         this->backSubContributions.vecRot.setZero();
 
         // - Call the update contributions method for the stateEffectors and add in contributions to the hub matrices
-        (*it)->updateContributions(integTimeSeconds, this->backSubContributions, sigmaState, omegaState, *this->g_N);
+        (*it)->updateContributions(integTimeSeconds, this->backSubContributions, sigmaBNLoc, omegaState, *this->g_N);
         this->hub.hubBackSubMatrices.matrixA += this->backSubContributions.matrixA;
         this->hub.hubBackSubMatrices.matrixB += this->backSubContributions.matrixB;
         this->hub.hubBackSubMatrices.matrixC += this->backSubContributions.matrixC;
@@ -570,7 +566,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     this->hub.computeDerivatives(integTimeSeconds,
                                  this->hubV_N->getStateDerivReference(),
                                  this->hubOmega_BN_B->getStateDerivReference(),
-                                 sigmaState);
+                                 sigmaBNLoc);
 
     Eigen::Vector3d hubVDeriv = this->hubV_N->getStateDerivReference();
     Eigen::Vector3d hubOmegaDeriv = this->hubOmega_BN_B->getStateDerivReference();
@@ -578,7 +574,7 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     // - Loop through state effectors for compute derivatives
     for(it = states.begin(); it != states.end(); it++)
     {
-        (*it)->computeDerivatives(integTimeSeconds, hubVDeriv, hubOmegaDeriv, sigmaState);
+        (*it)->computeDerivatives(integTimeSeconds, hubVDeriv, hubOmegaDeriv, sigmaBNLoc);
     }
 }
 
@@ -604,7 +600,7 @@ void Spacecraft::preIntegration(uint64_t integrateToThisTimeNanos) {
     // - Get the angular rate, oldOmega_BN_B from the dyn manager
     this->oldOmega_BN_B = this->hubOmega_BN_B->getStateReference();
     // - Get center of mass, v_BN_N and dcm_NB from the dyn manager
-    oldSigma_BN = (Eigen::Vector3d) this->hubSigma->getStateReference();
+    oldSigma_BN = Eigen::MRPd(this->hubSigma->getStateReference().data());
     // - Finally find v_CN_N
     Eigen::Matrix3d oldDcm_NB = oldSigma_BN.toRotationMatrix(); // - dcm_NB before integration
     oldV_CN_N = oldV_BN_N + oldDcm_NB*(*this->cDot_B);
@@ -631,11 +627,8 @@ void Spacecraft::postIntegration(uint64_t integrateToThisTimeNanos) {
     // - Find v_CN_N after the integration for accumulated DV
     Eigen::Vector3d newV_BN_N = this->hubV_N->getStateReference(); // - V_BN_N after integration
     Eigen::Vector3d newV_CN_N;  // - V_CN_N after integration
-    Eigen::MRPd newSigma_BN;    // - Sigma_BN after integration
+    Eigen::MRPd newSigma_BN(this->hubSigma->getStateReference().data());    // - Sigma_BN after integration
     // - Get center of mass, v_BN_N and dcm_NB
-    Eigen::Vector3d sigmaBNLoc;
-    sigmaBNLoc = (Eigen::Vector3d) this->hubSigma->getStateReference();
-    newSigma_BN = sigmaBNLoc;
     Eigen::Matrix3d newDcm_NB = newSigma_BN.toRotationMatrix();  // - dcm_NB after integration
     newV_CN_N = newV_BN_N + newDcm_NB*(*this->cDot_B);
 
@@ -692,8 +685,7 @@ void Spacecraft::computeEnergyMomentum(double time)
     // - Grab values from state Manager
     Eigen::Vector3d rLocal_BN_N = hubR_N->getStateReference();
     Eigen::Vector3d rDotLocal_BN_N = hubV_N->getStateReference();
-    Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d ) hubSigma->getStateReference();
+    Eigen::MRPd sigmaLocal_BN(hubSigma->getStateReference().data());
 
     // - Find DCM's
     Eigen::Matrix3d dcmLocal_NB = sigmaLocal_BN.toRotationMatrix();

--- a/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
+++ b/src/simulation/dynamics/spacecraftSystem/spacecraftSystem.cpp
@@ -90,14 +90,13 @@ void SpacecraftUnit::writeOutputMessagesSC(uint64_t clockTime, int64_t moduleID)
     stateOut = this->scStateOutMsg.zeroMsgPayload;
     eigenMatrixXd2CArray(*this->inertialPositionProperty, stateOut.r_BN_N);
     eigenMatrixXd2CArray(*this->inertialVelocityProperty, stateOut.v_BN_N);
-    Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d) this->hubSigma->getState();
+    Eigen::MRPd sigmaLocal_BN(this->hubSigma->getState().data());
     Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
     Eigen::Vector3d rLocal_CN_N = (*this->inertialPositionProperty) + dcm_NB*(*this->c_B);
     Eigen::Vector3d vLocal_CN_N = (*this->inertialVelocityProperty) + dcm_NB*(*this->cDot_B);
     eigenVector3d2CArray(rLocal_CN_N, stateOut.r_CN_N);
     eigenVector3d2CArray(vLocal_CN_N, stateOut.v_CN_N);
-    eigenMatrixXd2CArray(this->hubSigma->getState(), stateOut.sigma_BN);
+    eigenMRPd2CArray(sigmaLocal_BN, stateOut.sigma_BN);
     eigenMatrixXd2CArray(this->hubOmega_BN_B->getState(), stateOut.omega_BN_B);
     eigenMatrixXd2CArray(this->dvAccum_CN_B, stateOut.TotalAccumDVBdy);
     stateOut.MRPSwitchCount = this->hub.MRPSwitchCount;
@@ -603,8 +602,7 @@ void SpacecraftSystem::updateSystemMassProps(double time)
 void SpacecraftSystem::initializeSCPosVelocity(SpacecraftUnit &spacecraft)
 {
     Eigen::Vector3d rInit_BN_N = spacecraft.hubR_N->getState();
-    Eigen::MRPd sigma_BN;
-    sigma_BN = (Eigen::Vector3d) spacecraft.hubSigma->getState();
+    Eigen::MRPd sigma_BN(spacecraft.hubSigma->getState().data());
     Eigen::Matrix3d dcm_NB = sigma_BN.toRotationMatrix();
     // - Substract off the center mass to leave r_BN_N
     rInit_BN_N -= dcm_NB*(*spacecraft.c_B);
@@ -657,11 +655,10 @@ void SpacecraftSystem::equationsOfMotionSC(double integTimeSeconds, double timeS
     this->updateSpacecraftMassProps(integTimeSeconds, spacecraft);
 
     // - This is where gravity is computed (gravity needs to know c_B to calculated gravity about r_CN_N)
-    Eigen::MRPd sigmaBNLoc;
+    Eigen::MRPd sigmaBNLoc(spacecraft.hubSigma->getState().data());
     Eigen::Matrix3d dcm_NB;
     Eigen::Vector3d cLocal_N;
 
-    sigmaBNLoc = (Eigen::Vector3d) spacecraft.hubSigma->getState();
     dcm_NB = sigmaBNLoc.toRotationMatrix();
     cLocal_N = dcm_NB*(*spacecraft.c_B);
     Eigen::Vector3d rLocal_CN_N = spacecraft.hubR_N->getState() + dcm_NB*(*spacecraft.c_B);
@@ -694,7 +691,7 @@ void SpacecraftSystem::equationsOfMotionSC(double integTimeSeconds, double timeS
         spacecraft.backSubMatricesContributions.vecRot.setZero();
 
         // - Call the update contributions method for the stateEffectors and add in contributions to the hub matrices
-        (*it)->updateContributions(integTimeSeconds, spacecraft.backSubMatricesContributions, spacecraft.hubSigma->getState(), spacecraft.hubOmega_BN_B->getState(), *spacecraft.g_N);
+        (*it)->updateContributions(integTimeSeconds, spacecraft.backSubMatricesContributions, sigmaBNLoc, spacecraft.hubOmega_BN_B->getState(), *spacecraft.g_N);
         spacecraft.hub.hubBackSubMatrices.matrixA += spacecraft.backSubMatricesContributions.matrixA;
         spacecraft.hub.hubBackSubMatrices.matrixB += spacecraft.backSubMatricesContributions.matrixB;
         spacecraft.hub.hubBackSubMatrices.matrixC += spacecraft.backSubMatricesContributions.matrixC;
@@ -742,12 +739,12 @@ void SpacecraftSystem::equationsOfMotionSC(double integTimeSeconds, double timeS
     spacecraft.hub.hubBackSubMatrices.vecRot += cLocal_B.cross(gravityForce_B) + spacecraft.sumTorquePntB_B;
 
     // - Compute the derivatives of the hub states before looping through stateEffectors
-    spacecraft.hub.computeDerivatives(integTimeSeconds, spacecraft.hubV_N->getStateDeriv(), spacecraft.hubOmega_BN_B->getStateDeriv(), spacecraft.hubSigma->getState());
+    spacecraft.hub.computeDerivatives(integTimeSeconds, spacecraft.hubV_N->getStateDeriv(), spacecraft.hubOmega_BN_B->getStateDeriv(), sigmaBNLoc);
 
     // - Loop through state effectors for compute derivatives
     for(it = spacecraft.states.begin(); it != spacecraft.states.end(); it++)
     {
-        (*it)->computeDerivatives(integTimeSeconds, spacecraft.hubV_N->getStateDeriv(), spacecraft.hubOmega_BN_B->getStateDeriv(), spacecraft.hubSigma->getState());
+        (*it)->computeDerivatives(integTimeSeconds, spacecraft.hubV_N->getStateDeriv(), spacecraft.hubOmega_BN_B->getStateDeriv(), sigmaBNLoc);
     }
 
     return;
@@ -770,11 +767,10 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
     this->updateSystemMassProps(integTimeSeconds);
 
     // - This is where gravity is computed (gravity needs to know c_B to calculated gravity about r_CN_N)
-    Eigen::MRPd sigmaBNLoc;
+    Eigen::MRPd sigmaBNLoc(this->primaryCentralSpacecraft.hubSigma->getState().data());
     Eigen::Matrix3d dcm_NB;
     Eigen::Vector3d cLocal_N;
 
-    sigmaBNLoc = (Eigen::Vector3d) this->primaryCentralSpacecraft.hubSigma->getState();
     dcm_NB = sigmaBNLoc.toRotationMatrix();
     cLocal_N = dcm_NB*(*this->primaryCentralSpacecraft.c_B);
     Eigen::Vector3d rLocal_CN_N = this->primaryCentralSpacecraft.hubR_N->getState() + dcm_NB*(*this->primaryCentralSpacecraft.c_B);
@@ -822,7 +818,7 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
         this->primaryCentralSpacecraft.backSubMatricesContributions.vecRot.setZero();
 
         // - Call the update contributions method for the stateEffectors and add in contributions to the hub matrices
-        (*it)->updateContributions(integTimeSeconds, this->primaryCentralSpacecraft.backSubMatricesContributions, this->primaryCentralSpacecraft.hubSigma->getState(), this->primaryCentralSpacecraft.hubOmega_BN_B->getState(), *this->primaryCentralSpacecraft.g_N);
+        (*it)->updateContributions(integTimeSeconds, this->primaryCentralSpacecraft.backSubMatricesContributions, sigmaBNLoc, this->primaryCentralSpacecraft.hubOmega_BN_B->getState(), *this->primaryCentralSpacecraft.g_N);
         this->primaryCentralSpacecraft.hub.hubBackSubMatrices.matrixA += this->primaryCentralSpacecraft.backSubMatricesContributions.matrixA;
         this->primaryCentralSpacecraft.hub.hubBackSubMatrices.matrixB += this->primaryCentralSpacecraft.backSubMatricesContributions.matrixB;
         this->primaryCentralSpacecraft.hub.hubBackSubMatrices.matrixC += this->primaryCentralSpacecraft.backSubMatricesContributions.matrixC;
@@ -846,7 +842,7 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
             this->primaryCentralSpacecraft.backSubMatricesContributions.vecRot.setZero();
 
             // - Call the update contributions method for the stateEffectors and add in contributions to the hub matrices
-            (*it)->updateContributions(integTimeSeconds, this->primaryCentralSpacecraft.backSubMatricesContributions, this->primaryCentralSpacecraft.hubSigma->getState(), this->primaryCentralSpacecraft.hubOmega_BN_B->getState(), *this->primaryCentralSpacecraft.g_N);
+            (*it)->updateContributions(integTimeSeconds, this->primaryCentralSpacecraft.backSubMatricesContributions, sigmaBNLoc, this->primaryCentralSpacecraft.hubOmega_BN_B->getState(), *this->primaryCentralSpacecraft.g_N);
             this->primaryCentralSpacecraft.hub.hubBackSubMatrices.matrixA += this->primaryCentralSpacecraft.backSubMatricesContributions.matrixA;
             this->primaryCentralSpacecraft.hub.hubBackSubMatrices.matrixB += this->primaryCentralSpacecraft.backSubMatricesContributions.matrixB;
             this->primaryCentralSpacecraft.hub.hubBackSubMatrices.matrixC += this->primaryCentralSpacecraft.backSubMatricesContributions.matrixC;
@@ -895,14 +891,14 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
     this->primaryCentralSpacecraft.hub.hubBackSubMatrices.vecRot += cLocal_B.cross(gravityForce_B) + this->primaryCentralSpacecraft.sumTorquePntB_B;
 
     // - Compute the derivatives of the hub states before looping through stateEffectors
-    this->primaryCentralSpacecraft.hub.computeDerivatives(integTimeSeconds, this->primaryCentralSpacecraft.hubV_N->getStateDeriv(), this->primaryCentralSpacecraft.hubOmega_BN_B->getStateDeriv(), this->primaryCentralSpacecraft.hubSigma->getState());
+    this->primaryCentralSpacecraft.hub.computeDerivatives(integTimeSeconds, this->primaryCentralSpacecraft.hubV_N->getStateDeriv(), this->primaryCentralSpacecraft.hubOmega_BN_B->getStateDeriv(), sigmaBNLoc);
 
     // - Need to figure out how to pass accelerations of rBDDot and omegaDot of the primary hub to the other hubs stateEffectors
 
     // - Loop through state effectors for compute derivatives
     for(it = this->primaryCentralSpacecraft.states.begin(); it != this->primaryCentralSpacecraft.states.end(); it++)
     {
-        (*it)->computeDerivatives(integTimeSeconds, this->primaryCentralSpacecraft.hubV_N->getStateDeriv(), this->primaryCentralSpacecraft.hubOmega_BN_B->getStateDeriv(), this->primaryCentralSpacecraft.hubSigma->getState());
+        (*it)->computeDerivatives(integTimeSeconds, this->primaryCentralSpacecraft.hubV_N->getStateDeriv(), this->primaryCentralSpacecraft.hubOmega_BN_B->getStateDeriv(), sigmaBNLoc);
     }
 
     // - Call this for all of the connected spacecraft
@@ -911,7 +907,7 @@ void SpacecraftSystem::equationsOfMotionSystem(double integTimeSeconds, double t
         // - Loop through state effectors for compute derivatives
         for(it = (*spacecraftConnectedIt)->states.begin(); it != (*spacecraftConnectedIt)->states.end(); it++)
         {
-            (*it)->computeDerivatives(integTimeSeconds, this->primaryCentralSpacecraft.hubV_N->getStateDeriv(), this->primaryCentralSpacecraft.hubOmega_BN_B->getStateDeriv(), this->primaryCentralSpacecraft.hubSigma->getState());
+            (*it)->computeDerivatives(integTimeSeconds, this->primaryCentralSpacecraft.hubV_N->getStateDeriv(), this->primaryCentralSpacecraft.hubOmega_BN_B->getStateDeriv(), sigmaBNLoc);
         }
     }
 
@@ -928,7 +924,7 @@ void SpacecraftSystem::findPriorStateInformation(SpacecraftUnit &spacecraft)
     // - Get the angular rate, oldOmega_BN_B from the dyn manager
     oldOmega_BN_B = spacecraft.hubOmega_BN_B->getState();
     // - Get center of mass, v_BN_N and dcm_NB from the dyn manager
-    oldSigma_BN = (Eigen::Vector3d) spacecraft.hubSigma->getState();
+    oldSigma_BN = Eigen::MRPd(spacecraft.hubSigma->getState().data());
     // - Finally find v_CN_N
     Eigen::Matrix3d oldDcm_NB = oldSigma_BN.toRotationMatrix(); // - dcm_NB before integration
     spacecraft.oldV_CN_N = spacecraft.oldV_BN_N + oldDcm_NB*(*spacecraft.cDot_B);
@@ -940,8 +936,7 @@ void SpacecraftSystem::findPriorStateInformation(SpacecraftUnit &spacecraft)
 void SpacecraftSystem::determineAttachedSCStates()
 {
     // Pull out primary spacecraft states
-    Eigen::MRPd sigmaPNLoc;
-    sigmaPNLoc = (Eigen::Vector3d) this->primaryCentralSpacecraft.hubSigma->getState();
+    Eigen::MRPd sigmaPNLoc(this->primaryCentralSpacecraft.hubSigma->getState().data());
     Eigen::Vector3d omegaPNLoc_P = this->primaryCentralSpacecraft.hubOmega_BN_B->getState();
     Eigen::Vector3d r_PNLocal_N = this->primaryCentralSpacecraft.hubR_N->getState();
     Eigen::Vector3d r_PNDotLocal_N = this->primaryCentralSpacecraft.hubV_N->getState();
@@ -958,10 +953,9 @@ void SpacecraftSystem::determineAttachedSCStates()
         double sigma_BNArray[3];
         eigenMatrix3d2CArray(dcm_BN, dcm_BNArray);
         C2MRP(RECAST3X3 dcm_BNArray, sigma_BNArray);
-        Eigen::Vector3d sigmaBNLoc;
-        sigmaBNLoc = cArray2EigenVector3d(sigma_BNArray);
+        Eigen::MRPd sigmaBNLoc = cArray2EigenMRPd(sigma_BNArray);
         // Set the MRP for the hub
-        (*spacecraftConnectedIt)->hubSigma->setState(sigmaBNLoc);
+        (*spacecraftConnectedIt)->hubSigma->setState(sigmaBNLoc.coeffs());
 
         // Now omega
         Eigen::Vector3d omegaBNLocal_B = (*spacecraftConnectedIt)->hub.dcm_BP*omegaPNLoc_P;
@@ -982,11 +976,8 @@ void SpacecraftSystem::calculateDeltaVandAcceleration(SpacecraftUnit &spacecraft
     // - Find v_CN_N after the integration for accumulated DV
     Eigen::Vector3d newV_BN_N = spacecraft.hubV_N->getState(); // - V_BN_N after integration
     Eigen::Vector3d newV_CN_N;  // - V_CN_N after integration
-    Eigen::MRPd newSigma_BN;    // - Sigma_BN after integration
+    Eigen::MRPd newSigma_BN(spacecraft.hubSigma->getState().data());    // - Sigma_BN after integration
     // - Get center of mass, v_BN_N and dcm_NB
-    Eigen::Vector3d sigmaBNLoc;
-    sigmaBNLoc = (Eigen::Vector3d) spacecraft.hubSigma->getState();
-    newSigma_BN = sigmaBNLoc;
     Eigen::Matrix3d newDcm_NB = newSigma_BN.toRotationMatrix();  // - dcm_NB after integration
     newV_CN_N = newV_BN_N + newDcm_NB*(*spacecraft.cDot_B);
 
@@ -1032,8 +1023,7 @@ void SpacecraftSystem::computeEnergyMomentumSC(double time, SpacecraftUnit &spac
     // - Grab values from state Manager
     Eigen::Vector3d rLocal_BN_N = spacecraft.hubR_N->getState();
     Eigen::Vector3d rDotLocal_BN_N = spacecraft.hubV_N->getState();
-    Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d ) spacecraft.hubSigma->getState();
+    Eigen::MRPd sigmaLocal_BN(spacecraft.hubSigma->getState().data());
 
     // - Find DCM's
     Eigen::Matrix3d dcmLocal_NB = sigmaLocal_BN.toRotationMatrix();
@@ -1111,8 +1101,7 @@ void SpacecraftSystem::computeEnergyMomentumSystem(double time)
     // - Grab values from state Manager
     Eigen::Vector3d rLocal_BN_N = this->primaryCentralSpacecraft.hubR_N->getState();
     Eigen::Vector3d rDotLocal_BN_N = this->primaryCentralSpacecraft.hubV_N->getState();
-    Eigen::MRPd sigmaLocal_BN;
-    sigmaLocal_BN = (Eigen::Vector3d ) this->primaryCentralSpacecraft.hubSigma->getState();
+    Eigen::MRPd sigmaLocal_BN(this->primaryCentralSpacecraft.hubSigma->getState().data());
 
     // - Find DCM's
     Eigen::Matrix3d dcmLocal_NB = sigmaLocal_BN.toRotationMatrix();

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
@@ -202,14 +202,14 @@ void SphericalPendulum::retrieveMassValue(double integTime)
 }
 
 /*! This method is for the FSP to add its contributions to the back-sub method */
-void SphericalPendulum::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void SphericalPendulum::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
 
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_BN;
     Eigen::Matrix3d dcm_BN;
     Eigen::Matrix3d dcm_NB;
-    sigmaLocal_BN = (Eigen::Vector3d ) sigma_BN;
+    sigmaLocal_BN = sigma_BN;
     dcm_NB = sigmaLocal_BN.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
 
@@ -294,13 +294,13 @@ void SphericalPendulum::updateContributions(double integTime, BackSubMatrices & 
 
 /*! This method is used to define the derivatives of the FSP. One is the trivial kinematic derivative and the other is
  derived using the back-sub method */
-void SphericalPendulum::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void SphericalPendulum::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
 
 	// - Find DCM
 	Eigen::MRPd sigmaLocal_BN;
 	Eigen::Matrix3d dcm_BN;
-	sigmaLocal_BN = (Eigen::Vector3d) sigma_BN;
+	sigmaLocal_BN = sigma_BN;
 	dcm_BN = (sigmaLocal_BN.toRotationMatrix()).transpose();
 
 	// - Set the derivative of l to lDot

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.h
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.h
@@ -90,10 +90,10 @@ public:
 	void updateEffectorMassProps(double integTime);  //!< -- Method for FSP to add its contributions to mass props
     void modifyStates(double integTime); //!<-- Method to force states modification during integration
     void retrieveMassValue(double integTime);
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
+    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
                                               double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
+    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
 };
 
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -337,7 +337,7 @@ void SpinningBodyNDOFStateEffector::computeInertiaProperties(std::shared_ptr<Spi
 
 void SpinningBodyNDOFStateEffector::updateContributions(double integTime,
                                                         BackSubMatrices& backSubContr,
-                                                        Eigen::Vector3d sigma_BN,
+                                                        Eigen::MRPd sigma_BN,
                                                         Eigen::Vector3d omega_BN_B,
                                                         Eigen::Vector3d g_N)
 {
@@ -567,7 +567,7 @@ void SpinningBodyNDOFStateEffector::computeBackSubVectors(BackSubMatrices &backS
     }
 }
 
-void SpinningBodyNDOFStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void SpinningBodyNDOFStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     Eigen::Vector3d rDDotLocal_BN_B = this->dcm_BN * rDDot_BN_N;
 
@@ -600,7 +600,8 @@ void SpinningBodyNDOFStateEffector::computeSpinningBodyInertialStates()
     for(auto& spinningBody: this->spinningBodyVec) {
         // Compute the rotational properties
         Eigen::Matrix3d dcm_SN = spinningBody->dcm_BS.transpose() * this->dcm_BN;
-        *spinningBody->sigma_SN = eigenMRPd2Vector3d(eigenC2MRP(dcm_SN));
+        const Eigen::MRPd sigma_SN = eigenC2MRP(dcm_SN);
+        *spinningBody->sigma_SN = sigma_SN.coeffs();
         *spinningBody->omega_SN_S = spinningBody->dcm_BS.transpose() * spinningBody->omega_SN_B;
 
         // Compute the translation properties

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
@@ -210,13 +210,13 @@ private:
     void computeDependentEffectors(BackSubMatrices& backSubContr, double integTime);
     void updateContributions(double integTime,
                              BackSubMatrices& backSubContr,
-                             Eigen::Vector3d sigma_BN,
+                             Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override;
+                            Eigen::MRPd sigma_BN) override;
     void updateEffectorMassProps(double integTime) override;
     void updateEnergyMomContributions(double integTime,
                                       Eigen::Vector3d& rotAngMomPntCContr_B,

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -251,7 +251,7 @@ void SpinningBodyOneDOFStateEffector::updateEffectorMassProps(double integTime)
  method */
 void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
                                                           BackSubMatrices & backSubContr,
-                                                          Eigen::Vector3d sigma_BN,
+                                                          Eigen::MRPd sigma_BN,
                                                           Eigen::Vector3d omega_BN_B,
                                                           Eigen::Vector3d g_N)
 {
@@ -338,8 +338,7 @@ void SpinningBodyOneDOFStateEffector::addPrescribedMotionCouplingContributions(B
     Eigen::Vector3d r_PB_B = (Eigen::Vector3d)*this->prescribedPositionProperty;
     Eigen::Vector3d rPrime_PB_B = (Eigen::Vector3d)*this->prescribedVelocityProperty;
     Eigen::Vector3d rPrimePrime_PB_B = (Eigen::Vector3d)*this->prescribedAccelerationProperty;
-    Eigen::MRPd sigma_PB;
-    sigma_PB = (Eigen::Vector3d)*this->prescribedAttitudeProperty;
+    Eigen::MRPd sigma_PB(this->prescribedAttitudeProperty->data());
     Eigen::Vector3d omega_PB_P = (Eigen::Vector3d)*this->prescribedAngVelocityProperty;
     Eigen::Vector3d omegaPrime_PB_P = (Eigen::Vector3d)*this->prescribedAngAccelerationProperty;
     Eigen::Matrix3d dcm_PB = sigma_PB.toRotationMatrix().transpose();
@@ -414,7 +413,7 @@ void SpinningBodyOneDOFStateEffector::addPrescribedMotionCouplingContributions(B
 void SpinningBodyOneDOFStateEffector::computeDerivatives(double integTime,
                                                          Eigen::Vector3d rDDot_BN_N,
                                                          Eigen::Vector3d omegaDot_BN_B,
-                                                         Eigen::Vector3d sigma_BN)
+                                                         Eigen::MRPd sigma_BN)
 {
     // Update dcm_BN
     this->sigma_BN = sigma_BN;
@@ -466,7 +465,8 @@ void SpinningBodyOneDOFStateEffector::computeSpinningBodyInertialStates()
     // inertial attitude
     Eigen::Matrix3d dcm_SN;
     dcm_SN = (this->dcm_BS).transpose() * this->dcm_BN;
-    *this->sigma_SN = eigenMRPd2Vector3d(eigenC2MRP(dcm_SN));
+    const Eigen::MRPd sigma_SN = eigenC2MRP(dcm_SN);
+    *this->sigma_SN = sigma_SN.coeffs();
     *this->omega_SN_S = (this->dcm_BS).transpose() * this->omega_SN_B;
 
     // inertial position vector

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
@@ -73,10 +73,10 @@ public:
     void registerProperties(DynParamManager& states) override;       //!< -- Method for registering the SB inertial properties
     void linkInPrescribedMotionProperties(DynParamManager& states) override;         //!< -- Method for getting access to prescribed motion properties
     void updateContributions(double integTime,
-                             BackSubMatrices& backSubContr, Eigen::Vector3d sigma_BN,
+                             BackSubMatrices& backSubContr, Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N) override;   //!< -- Method for back-substitution contributions
     void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N,
-                            Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN) override;                         //!< -- Method for SB to compute its derivatives
+                            Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN) override;                         //!< -- Method for SB to compute its derivatives
     void updateEffectorMassProps(double integTime) override;         //!< -- Method for giving the s/c the HRB mass props and prop rates
     void updateEnergyMomContributions(double integTime, Eigen::Vector3d& rotAngMomPntCContr_B,
                                       double& rotEnergyContr, Eigen::Vector3d omega_BN_B) override;         //!< -- Method for computing energy and momentum for SBs

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -344,7 +344,7 @@ void SpinningBodyTwoDOFStateEffector::updateEffectorMassProps(double integTime)
 
 /*! This method allows the SB state effector to give its contributions to the matrices needed for the back-sub
  method */
-void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::Vector3d sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // Find the DCM from N to B frames
     this->sigma_BN = sigma_BN;
@@ -521,8 +521,7 @@ void SpinningBodyTwoDOFStateEffector::addPrescribedMotionCouplingContributions(B
     Eigen::Vector3d r_PB_B = (Eigen::Vector3d)*this->prescribedPositionProperty;
     Eigen::Vector3d rPrime_PB_B = (Eigen::Vector3d)*this->prescribedVelocityProperty;
     Eigen::Vector3d rPrimePrime_PB_B = (Eigen::Vector3d)*this->prescribedAccelerationProperty;
-    Eigen::MRPd sigma_PB;
-    sigma_PB = (Eigen::Vector3d)*this->prescribedAttitudeProperty;
+    Eigen::MRPd sigma_PB(this->prescribedAttitudeProperty->data());
     Eigen::Vector3d omega_PB_P = (Eigen::Vector3d)*this->prescribedAngVelocityProperty;
     Eigen::Vector3d omegaPrime_PB_P = (Eigen::Vector3d)*this->prescribedAngAccelerationProperty;
     Eigen::Matrix3d dcm_PB = sigma_PB.toRotationMatrix().transpose();
@@ -644,7 +643,7 @@ void SpinningBodyTwoDOFStateEffector::addPrescribedMotionCouplingContributions(B
 }
 
 /*! This method is used to find the derivatives for the SB stateEffector: thetaDDot and the kinematic derivative */
-void SpinningBodyTwoDOFStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::Vector3d sigma_BN)
+void SpinningBodyTwoDOFStateEffector::computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN)
 {
     // Grab omegaDot_BN_B
     Eigen::Vector3d omegaDotLocal_BN_B;
@@ -693,8 +692,10 @@ void SpinningBodyTwoDOFStateEffector::computeSpinningBodyInertialStates()
     Eigen::Matrix3d dcm_S2N;
     dcm_S1N = (this->dcm_BS1).transpose() * this->dcm_BN;
     dcm_S2N = (this->dcm_BS2).transpose() * this->dcm_BN;
-    *this->sigma_S1N = eigenMRPd2Vector3d(eigenC2MRP(dcm_S1N));
-    *this->sigma_S2N = eigenMRPd2Vector3d(eigenC2MRP(dcm_S2N));
+    const Eigen::MRPd sigma_S1N = eigenC2MRP(dcm_S1N);
+    const Eigen::MRPd sigma_S2N = eigenC2MRP(dcm_S2N);
+    *this->sigma_S1N = sigma_S1N.coeffs();
+    *this->sigma_S2N = sigma_S2N.coeffs();
 
     // Convert the angular velocity to the corresponding frame
     *this->omega_S1N_S1 = dcm_BS1.transpose() * this->omega_S1N_B;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
@@ -92,13 +92,13 @@ public:
     void linkInPrescribedMotionProperties(DynParamManager& states) override;         //!< -- Method for getting access to prescribed motion properties
     void updateContributions(double integTime,
                              BackSubMatrices& backSubContr,
-                             Eigen::Vector3d sigma_BN,
+                             Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) override;  //!< -- Method for back-substitution contributions
     void computeDerivatives(double integTime,
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
-                            Eigen::Vector3d sigma_BN) override;                         //!< -- Method for SB to compute its derivatives
+                            Eigen::MRPd sigma_BN) override;                         //!< -- Method for SB to compute its derivatives
     void updateEffectorMassProps(double integTime) override;         //!< -- Method for giving the s/c the HRB mass props and prop rates
     void updateEnergyMomContributions(double integTime,
                                       Eigen::Vector3d& rotAngMomPntCContr_B,

--- a/src/simulation/environment/albedo/albedo.cpp
+++ b/src/simulation/environment/albedo/albedo.cpp
@@ -206,7 +206,7 @@ void Albedo::onUpdateBegin(const SCStatesMsgPayload&         scMsg,
                            uint64_t                          nanos)
 {
     this->r_BN_N       = Eigen::Vector3d(scMsg.r_BN_N);  // [m]
-    const Eigen::MRPd sigma_BN(Eigen::Vector3d(scMsg.sigma_BN));
+    const Eigen::MRPd sigma_BN(scMsg.sigma_BN);
     this->dcm_BN       = sigma_BN.toRotationMatrix().transpose(); // dcm_BN: rows are B axes expressed in N
     this->r_SN_N       = Eigen::Vector3d(sunMsg.PositionVector);  // [m]
     this->currentNanos = nanos;  // [ns]

--- a/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
+++ b/src/simulation/environment/ephemerisConverter/ephemerisConverter.cpp
@@ -71,7 +71,7 @@ void EphemerisConverter::addSpiceInputMsg(Message<SpicePlanetStateMsgPayload> *t
 void EphemerisConverter::convertEphemData(uint64_t clockNow)
 {
     Eigen::Matrix3d dcm_BN;
-    Eigen::Vector3d sigma_BN;
+    Eigen::MRPd sigma_BN;
     Eigen::Matrix3d dcm_BN_dot;
     Eigen::Matrix3d omega_tilde_BN_B_eigen;
     double omega_tilde_BN_B[3][3];
@@ -88,8 +88,8 @@ void EphemerisConverter::convertEphemData(uint64_t clockNow)
 
         /* Compute sigma_BN */
         dcm_BN = cArray2EigenMatrix3d(*this->spiceInBuffers.at(c).J20002Pfix);
-        sigma_BN = eigenMRPd2Vector3d(eigenC2MRP(dcm_BN));
-        eigenVector3d2CArray(sigma_BN, this->ephemOutBuffers.at(c).sigma_BN); //sigma_BN
+        sigma_BN = eigenC2MRP(dcm_BN);
+        eigenMRPd2CArray(sigma_BN, this->ephemOutBuffers.at(c).sigma_BN); //sigma_BN
 
         /* Compute omega_BN_B */
         dcm_BN_dot = cArray2EigenMatrix3d(*this->spiceInBuffers.at(c).J20002Pfix_dot);

--- a/src/simulation/environment/spacecraftChargingEquilibrium/spacecraftChargingEquilibrium.cpp
+++ b/src/simulation/environment/spacecraftChargingEquilibrium/spacecraftChargingEquilibrium.cpp
@@ -655,7 +655,7 @@ void SpacecraftChargingEquilibrium::readMessages()
     for (unsigned int c = 0; c < this->numSat; c++) {
         scStateInMsgsBuffer = this->scStateInMsgs.at(c)();
         this->r_BN_NList.at(c) = cArray2EigenVector3d(scStateInMsgsBuffer.r_BN_N);
-        this->sigma_BNList.at(c) = cArray2EigenVector3d(scStateInMsgsBuffer.sigma_BN);
+        this->sigma_BNList.at(c) = cArray2EigenMRPd(scStateInMsgsBuffer.sigma_BN);
     }
 }
 

--- a/src/simulation/forceTorque/cannonballDrag/cannonballDrag.cpp
+++ b/src/simulation/forceTorque/cannonballDrag/cannonballDrag.cpp
@@ -40,8 +40,7 @@ CannonballDrag::UpdateState(uint64_t CurrentSimNanos)
 
     // 'S' denotes the 'site' reference frame
     const auto siteStatePayload = this->referenceFrameStateInMsg();
-    Eigen::MRPd sigma_SN;
-    sigma_SN = Eigen::Map<const Eigen::Vector3d>(siteStatePayload.sigma_BN);
+    Eigen::MRPd sigma_SN(siteStatePayload.sigma_BN);
     const Eigen::Matrix3d dcm_SN = sigma_SN.toRotationMatrix().transpose();
 
     Eigen::Map<const Eigen::Vector3d> v_BN_N(siteStatePayload.v_BN_N);

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_integration.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_integration.py
@@ -41,6 +41,14 @@ XML_PATH = f"{TEST_FOLDER}/test_sat.xml"
 REFERENCE_DATA = f"{TEST_FOLDER}/test_sat_qpos_reference.txt"
 
 
+def _shortRotationQuaternion(quat):
+    """Return an equivalent quaternion with a nonnegative scalar component."""
+    quat = np.array(quat)
+    if quat[0] < 0.0:
+        quat = -quat
+    return quat
+
+
 def test_integration(showPlots: bool = False):
     """Tests that integration with RK4 in Basilisk is equal to integration
     with RK4 in MuJoCo.
@@ -118,7 +126,11 @@ def test_integration(showPlots: bool = False):
 
     # Assert that the final position absolute error is < 1e-14
     # Which is essentially floating point noise
-    assert result[check, 1:] == pytest.approx(ref[check, 1:], 0, 1e-14)
+    assert result[check, 1:4] == pytest.approx(ref[check, 1:4], 0, 1e-14)
+    assert _shortRotationQuaternion(result[check, 4:8]) == pytest.approx(
+        _shortRotationQuaternion(ref[check, 4:8]), 0, 1e-14
+    )
+    assert result[check, 8:] == pytest.approx(ref[check, 8:], 0, 1e-14)
 
     # Check the same as above, but use the message cube origin message
     cubeState = scene.getBody("cube").getOrigin().stateOutMsg.read()
@@ -127,7 +139,7 @@ def test_integration(showPlots: bool = False):
         cubeState.r_BN_N,
     )
     quat = rbk.MRP2EP(cubeState.sigma_BN)
-    assert ref[check, 4:8] == pytest.approx(quat)
+    assert _shortRotationQuaternion(ref[check, 4:8]) == pytest.approx(_shortRotationQuaternion(quat))
 
 
 # A torque-free single rigid body. With no external moment and a symmetric
@@ -183,7 +195,7 @@ def test_highOrderQuaternionConvergesFasterThanDefault():
     roughly 2^2 = 4.
     """
     omega = [0.4, -0.3, 0.8]  # rad/s, constant for a torque-free symmetric body
-    tf = 5.0
+    tf = 5.0  # [s]
 
     def attError(highOrder, dt, ref):
         q = _runFreeSpin(highOrder, dt, tf, omega)

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -149,7 +149,7 @@ void ImuSensor::readInputMessages()
     {
         this->StateCurrent = this->scStateInMsg();
     }
-    this->current_sigma_BN = cArray2EigenVector3d(this->StateCurrent.sigma_BN);
+    this->current_sigma_BN = cArray2EigenMRPd(this->StateCurrent.sigma_BN);
     this->current_omega_BN_B = cArray2EigenVector3d(this->StateCurrent.omega_BN_B);
     this->current_nonConservativeAccelpntB_B = cArray2EigenVector3d(this->StateCurrent.nonConservativeAccelpntB_B);
     this->current_omegaDot_BN_B = cArray2EigenVector3d(this->StateCurrent.omegaDot_BN_B);

--- a/src/simulation/thermal/sensorThermal/sensorThermal.cpp
+++ b/src/simulation/thermal/sensorThermal/sensorThermal.cpp
@@ -145,7 +145,7 @@ void SensorThermal::computeSunData()
     //! - Read Message data to eigen
     r_BN_N = cArray2EigenVector3d(this->stateCurrent.r_BN_N);
     r_SN_N = cArray2EigenVector3d(this->sunData.PositionVector);
-    sigma_BN = cArray2EigenVector3d(this->stateCurrent.sigma_BN);
+    sigma_BN = cArray2EigenMRPd(this->stateCurrent.sigma_BN);
 
     //! - Find sun heading unit vector
     r_SB_N = r_SN_N - r_BN_N;


### PR DESCRIPTION
* **Tickets addressed:** bsk-97
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR modernizes Eigen MRP support and moves selected attitude handling to `Eigen::MRPd` where the values semantically represent MRPs. The commits are organized as small library upgrades and then downstream usage updates, ending with a standalone release-note snippet.

Key changes include more robust `Eigen::MRPd` conversions, short-rotation quaternion/DCM handling, scalar casts for mapped MRP expressions, clearer assignment diagnostics, and expanded MRP unit test coverage. Dynamics attitude interfaces now pass MRP attitudes as `Eigen::MRPd` while preserving raw vector storage at state/message/SWIG boundaries.

## Verification
Validated with:

- `make -C dist3 test_avsEigenMRP`
- `make -C dist3 test_avsEigenSupport`
- `dist3/architecture/utilities/tests/test_avsEigenMRP`
- `dist3/architecture/utilities/tests/test_avsEigenSupport`
- `.venv/bin/pytest -q src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_integration.py`
- `git diff --check origin/develop...HEAD`

The MRP GoogleTest suite was expanded to cover constructors, maps, casts, assignment paths, DCM/AngleAxis conversion branch behavior, composition, shadow sets, `setFromTwoVectors()`, coefficient arithmetic, and small-vector handling.

## Documentation
Updated `avsEigenMRP.h` Doxygen comments to clarify MRP norm/normalization behavior, coefficient arithmetic, supported assignment paths, and helper internals. Added a release-note snippet documenting the `Eigen::MRPd` conversion updates and the `eigenMRPd2CArray()` signature change. Updated `AGENTS.md` review guidance to check for `Eigen::MRPd` use where appropriate.

## Future work
None