### PR TITLE
perf: cache active events to skip inactive handlers each check cycle [#455]

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/455-active-event-cache.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/455-active-event-cache.rst
@@ -1,0 +1,1 @@
+- Improved event-checking performance in ``SimulationBaseClass`` by caching the list of active events and rebuilding it only when event activity changes. Simulations that register many inactive event handlers while checking an active event frequently no longer pay an ``O(total events)`` rescan on every check cycle (issue #455).

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -201,6 +201,10 @@ class EventHandlerClass:
         """Check the condition and execute the action if condition is met."""
         if self.conditionFunction(parentSim):
             self.eventActive = False
+            # This event just deactivated; the parent's active-event cache is now
+            # stale. Invalidate it before the action runs so that an action which
+            # re-activates events rebuilds a correct list on the next query.
+            parentSim._invalidateActiveEventCache()
             self.actionFunction(parentSim)
             self.occurCounter += 1
             if self.terminal:
@@ -568,6 +572,7 @@ class SimBaseClass:
         self.nextEventTime = 0
         self.terminate = False
         self.eventMap = {}
+        self._activeEventCache = None
         self.simBasePath = os.path.dirname(os.path.realpath(__file__)) + "/../"
         self.dataStructIndex = self.simBasePath + "/xml/index.xml"
         self.indexParsed = False
@@ -2024,15 +2029,42 @@ class SimBaseClass:
             return
         newEvent = EventHandlerClass(eventName, *args, **kwargs)
         self.eventMap[eventName] = newEvent
+        self._invalidateActiveEventCache()
+
+    def _invalidateActiveEventCache(self):
+        """Mark the cached active-event list stale. Must be called whenever event
+        membership (``eventMap``) or any event's ``eventActive`` flag changes."""
+        self._activeEventCache = None
 
     def activeEvents(self):
-        return (event for event in self.eventMap.values() if event.eventActive)
+        """Return the list of currently active events.
+
+        The result is cached and only recomputed when the cache has been
+        invalidated (an event was added, its activity was toggled through the
+        public API, or an event triggered). This keeps the per-check-cycle cost
+        proportional to the number of *active* events rather than the total
+        number of events (see issue #455)."""
+        if self._activeEventCache is None:
+            self._activeEventCache = [
+                event for event in self.eventMap.values() if event.eventActive
+            ]
+        return self._activeEventCache
 
     def setEventActivity(self, eventName, activityCommand):
+        """Enable or disable the named event.
+
+        ``activityCommand`` is the boolean value assigned to the event's
+        ``eventActive`` flag. The cached active-event list (see
+        :meth:`activeEvents`) is invalidated only when the flag actually
+        changes, so setting an event to the activity state it already has does
+        not force an unnecessary rebuild."""
         if eventName not in list(self.eventMap.keys()):
             print("You asked me to set the status of an event that I don't have.")
             return
-        self.eventMap[eventName].eventActive = activityCommand
+        event = self.eventMap[eventName]
+        if event.eventActive != activityCommand:
+            event.eventActive = activityCommand
+            self._invalidateActiveEventCache()
 
     def setAllButCurrentEventActivity(
         self, currentEventName, activityCommand, useIndex=False
@@ -2045,13 +2077,22 @@ class SimBaseClass:
         if useIndex:
             index = currentEventName.partition("_")[2]  # save the current event's index
 
+        # Invalidate the active-event cache only if at least one event's activity
+        # actually changed, so a no-op blanket set does not force a rebuild.
+        activityChanged = False
         for eventName in list(self.eventMap.keys()):
             if currentEventName != eventName:
                 if useIndex:
                     if eventName.partition("_")[2] == index:
-                        self.eventMap[eventName].eventActive = activityCommand
+                        if self.eventMap[eventName].eventActive != activityCommand:
+                            self.eventMap[eventName].eventActive = activityCommand
+                            activityChanged = True
                 else:
-                    self.eventMap[eventName].eventActive = activityCommand
+                    if self.eventMap[eventName].eventActive != activityCommand:
+                        self.eventMap[eventName].eventActive = activityCommand
+                        activityChanged = True
+        if activityChanged:
+            self._invalidateActiveEventCache()
 
 
 def SetCArray(InputList, VarType, ArrayPointer):

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -1944,30 +1944,36 @@ class SimBaseClass:
         if progressUpdateInterval is not None:
             nextProgressUpdateTime = self.TotalSim.CurrentNanos + progressUpdateInterval
         while self.CheckStopCondition():
-            # Check events. Iterate by index rather than over a snapshot so that
-            # an event action which activates another event that is already due
-            # this cycle still gets that event checked before the pass ends
-            # (matching the historical lazy-generator behaviour, see issue #455).
-            # ``checkedEvents`` guarantees each event is checked at most once per
-            # cycle, even when a triggered event rebuilds the cache mid-pass.
-            checkedEvents = set()
+            # Check events. Iterate the cached active-event list by index so the
+            # O(active) fast path is unchanged on cycles where nothing triggers.
+            # When a triggered event's action changes which events are active,
+            # the cache is rebuilt mid-pass and we resume at the first event
+            # positioned after the triggering event in ``eventMap``. This
+            # reproduces the historical lazy-generator behaviour (issue #455):
+            # an event activated *later* in ``eventMap`` than the trigger is
+            # still checked this cycle, while one activated *earlier* waits for
+            # the next cycle. Resuming strictly past the trigger position also
+            # guarantees each event is checked at most once per cycle.
             activeEvents = self._ensureActiveEventCache()
             i = 0
             while i < len(activeEvents):
                 event = activeEvents[i]
                 i += 1
-                if id(event) in checkedEvents:
+                if not event.shouldBeChecked(self.TotalSim.CurrentNanos):
                     continue
-                if event.shouldBeChecked(self.TotalSim.CurrentNanos):
-                    checkedEvents.add(id(event))
-                    event.checkEvent(self)
-                    if self._activeEventCache is not activeEvents:
-                        # A triggered event invalidated and rebuilt the cache
-                        # (and may have activated further events). Continue from
-                        # the fresh list; ``checkedEvents`` prevents re-checking
-                        # anything already handled this cycle.
-                        activeEvents = self._ensureActiveEventCache()
-                        i = 0
+                event.checkEvent(self)
+                if self._activeEventCache is not activeEvents:
+                    activeEvents = self._ensureActiveEventCache()
+                    eventOrder = {
+                        id(evt): position
+                        for position, evt in enumerate(self.eventMap.values())
+                    }
+                    triggerPosition = eventOrder.get(id(event), -1)
+                    i = 0
+                    while i < len(activeEvents) and (
+                        eventOrder[id(activeEvents[i])] <= triggerPosition
+                    ):
+                        i += 1
 
             if self.terminate:
                 break

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -1944,10 +1944,30 @@ class SimBaseClass:
         if progressUpdateInterval is not None:
             nextProgressUpdateTime = self.TotalSim.CurrentNanos + progressUpdateInterval
         while self.CheckStopCondition():
-            # Check events
-            for event in self.activeEvents():
+            # Check events. Iterate by index rather than over a snapshot so that
+            # an event action which activates another event that is already due
+            # this cycle still gets that event checked before the pass ends
+            # (matching the historical lazy-generator behaviour, see issue #455).
+            # ``checkedEvents`` guarantees each event is checked at most once per
+            # cycle, even when a triggered event rebuilds the cache mid-pass.
+            checkedEvents = set()
+            activeEvents = self.activeEvents()
+            i = 0
+            while i < len(activeEvents):
+                event = activeEvents[i]
+                i += 1
+                if id(event) in checkedEvents:
+                    continue
                 if event.shouldBeChecked(self.TotalSim.CurrentNanos):
+                    checkedEvents.add(id(event))
                     event.checkEvent(self)
+                    if self._activeEventCache is not activeEvents:
+                        # A triggered event invalidated and rebuilt the cache
+                        # (and may have activated further events). Continue from
+                        # the fresh list; ``checkedEvents`` prevents re-checking
+                        # anything already handled this cycle.
+                        activeEvents = self.activeEvents()
+                        i = 0
 
             if self.terminate:
                 break

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -1951,7 +1951,7 @@ class SimBaseClass:
             # ``checkedEvents`` guarantees each event is checked at most once per
             # cycle, even when a triggered event rebuilds the cache mid-pass.
             checkedEvents = set()
-            activeEvents = self.activeEvents()
+            activeEvents = self._ensureActiveEventCache()
             i = 0
             while i < len(activeEvents):
                 event = activeEvents[i]
@@ -1966,7 +1966,7 @@ class SimBaseClass:
                         # (and may have activated further events). Continue from
                         # the fresh list; ``checkedEvents`` prevents re-checking
                         # anything already handled this cycle.
-                        activeEvents = self.activeEvents()
+                        activeEvents = self._ensureActiveEventCache()
                         i = 0
 
             if self.terminate:
@@ -1975,7 +1975,7 @@ class SimBaseClass:
             # Find the next time to stop the sim
             eventCheckTimes = [
                 event.nextCheckTime(self.TotalSim.CurrentNanos)
-                for event in self.activeEvents()
+                for event in self._ensureActiveEventCache()
             ]
             if len(eventCheckTimes) > 0:
                 # Stop at next event, if any
@@ -2056,12 +2056,15 @@ class SimBaseClass:
         membership (``eventMap``) or any event's ``eventActive`` flag changes."""
         self._activeEventCache = None
 
-    def activeEvents(self):
-        """Return the list of currently active events.
+    def _ensureActiveEventCache(self):
+        """Return the internal cached list of active events, rebuilding it from
+        ``eventMap`` if it has been invalidated.
 
-        The result is cached and only recomputed when the cache has been
-        invalidated (an event was added, its activity was toggled through the
-        public API, or an event triggered). This keeps the per-check-cycle cost
+        This is the hot path used by the simulation loop. It returns the actual
+        cached list (not a copy); external callers must use :meth:`activeEvents`
+        instead, which hands out an immutable snapshot. The cache is only rebuilt
+        when it has been invalidated (an event was added, its activity was
+        toggled, or an event triggered), so the per-check-cycle cost stays
         proportional to the number of *active* events rather than the total
         number of events (see issue #455)."""
         if self._activeEventCache is None:
@@ -2069,6 +2072,14 @@ class SimBaseClass:
                 event for event in self.eventMap.values() if event.eventActive
             ]
         return self._activeEventCache
+
+    def activeEvents(self):
+        """Return an immutable snapshot of the currently active events.
+
+        A tuple, not the internal cache list, is returned so that external
+        callers cannot mutate the cache and silently change which events fire.
+        See :meth:`_ensureActiveEventCache` for the caching behaviour."""
+        return tuple(self._ensureActiveEventCache())
 
     def setEventActivity(self, eventName, activityCommand):
         """Enable or disable the named event.

--- a/src/utilities/SimulationBaseClass.py
+++ b/src/utilities/SimulationBaseClass.py
@@ -2063,29 +2063,30 @@ class SimBaseClass:
         self._activeEventCache = None
 
     def _ensureActiveEventCache(self):
-        """Return the internal cached list of active events, rebuilding it from
+        """Return the cached tuple of active events, rebuilding it from
         ``eventMap`` if it has been invalidated.
 
-        This is the hot path used by the simulation loop. It returns the actual
-        cached list (not a copy); external callers must use :meth:`activeEvents`
-        instead, which hands out an immutable snapshot. The cache is only rebuilt
-        when it has been invalidated (an event was added, its activity was
-        toggled, or an event triggered), so the per-check-cycle cost stays
-        proportional to the number of *active* events rather than the total
-        number of events (see issue #455)."""
+        This is the hot path used by the simulation loop. The cache is an
+        immutable tuple, so it can be handed straight to external callers by
+        :meth:`activeEvents` without copying. It is only rebuilt when it has
+        been invalidated (an event was added, its activity was toggled, or an
+        event triggered), so the per-check-cycle cost stays proportional to the
+        number of *active* events rather than the total number of events (see
+        issue #455)."""
         if self._activeEventCache is None:
-            self._activeEventCache = [
+            self._activeEventCache = tuple(
                 event for event in self.eventMap.values() if event.eventActive
-            ]
+            )
         return self._activeEventCache
 
     def activeEvents(self):
         """Return an immutable snapshot of the currently active events.
 
-        A tuple, not the internal cache list, is returned so that external
-        callers cannot mutate the cache and silently change which events fire.
-        See :meth:`_ensureActiveEventCache` for the caching behaviour."""
-        return tuple(self._ensureActiveEventCache())
+        The cache is itself an immutable tuple, so it is returned directly:
+        external callers cannot mutate it to silently change which events fire,
+        and no per-call copy is allocated. See :meth:`_ensureActiveEventCache`
+        for the caching behaviour."""
+        return self._ensureActiveEventCache()
 
     def setEventActivity(self, eventName, activityCommand):
         """Enable or disable the named event.

--- a/src/utilities/tests/test_event_activeCache.py
+++ b/src/utilities/tests/test_event_activeCache.py
@@ -20,6 +20,8 @@ can change which events are active. The central test asserts the invariant
 plus the end-to-end behaviour (trigger times, counts, self-reactivation) that a
 running simulation depends on.
 """
+import pytest
+
 from Basilisk.utilities import SimulationBaseClass, macros
 
 
@@ -79,15 +81,18 @@ def test_cache_reflects_setAllButCurrent():
 def test_noop_setEventActivity_does_not_rebuild_cache():
     # Setting an event to the activity state it already has must not invalidate
     # the cache (no unnecessary O(total events) rebuild), while a real change must.
+    # The internal cache object is inspected directly because the public
+    # activeEvents() now returns a fresh immutable snapshot on every call.
     sim = SimulationBaseClass.SimBaseClass()
     _addEvent(sim, "a", True); _addEvent(sim, "b", False)
-    cached = sim.activeEvents()  # prime
+    _ = sim.activeEvents()  # prime
+    cached = sim._activeEventCache
     sim.setEventActivity("a", True)   # already active -> no-op
-    assert sim.activeEvents() is cached
+    assert sim._activeEventCache is cached
     sim.setEventActivity("b", False)  # already inactive -> no-op
-    assert sim.activeEvents() is cached
-    sim.setEventActivity("b", True)   # real change -> rebuild
-    assert sim.activeEvents() is not cached
+    assert sim._activeEventCache is cached
+    sim.setEventActivity("b", True)   # real change -> invalidated
+    assert sim._activeEventCache is None
     _assertConsistent(sim); assert _cachedActive(sim) == {"a", "b"}
 
 
@@ -97,11 +102,12 @@ def test_noop_setAllButCurrent_does_not_rebuild_cache():
     sim = SimulationBaseClass.SimBaseClass()
     for n in ("a", "b", "c"):
         _addEvent(sim, n, True)
-    cached = sim.activeEvents()  # prime, all active
+    _ = sim.activeEvents()  # prime, all active
+    cached = sim._activeEventCache
     sim.setAllButCurrentEventActivity("b", True)   # a, c already active -> no-op
-    assert sim.activeEvents() is cached
-    sim.setAllButCurrentEventActivity("b", False)  # real change -> rebuild
-    assert sim.activeEvents() is not cached
+    assert sim._activeEventCache is cached
+    sim.setAllButCurrentEventActivity("b", False)  # real change -> invalidated
+    assert sim._activeEventCache is None
     _assertConsistent(sim); assert _cachedActive(sim) == {"b"}
 
 
@@ -172,16 +178,29 @@ def test_event_action_checks_later_due_event_in_same_cycle():
     assert fired[:2] == [("a", firstCheckTime), ("b", firstCheckTime)]
 
 
-def test_returned_list_not_corrupted_by_later_mutation():
-    # A snapshot taken before a mutation may legitimately be stale, but a fresh
-    # query after invalidation must be correct (no aliasing bug).
+def test_returned_snapshot_is_stable_across_later_mutation():
+    # A snapshot returned before a mutation must not be retroactively changed by
+    # that mutation, and a fresh query after invalidation must be correct.
     sim = SimulationBaseClass.SimBaseClass()
     _addEvent(sim, "a", True)
     first = sim.activeEvents()
     _addEvent(sim, "b", True)
     second = sim.activeEvents()
-    assert {e.eventName for e in second} == {"a", "b"}
-    assert first is not second  # cache was rebuilt, not mutated in place
+    assert {e.eventName for e in first} == {"a"}         # snapshot unchanged
+    assert {e.eventName for e in second} == {"a", "b"}   # fresh query correct
+
+
+def test_activeEvents_return_is_immutable_snapshot():
+    # The public accessor must not hand out the internal mutable cache: external
+    # code that mutates the returned object must not be able to silently change
+    # which events fire (issue #455 review). Reproduces sim.activeEvents().clear().
+    sim = SimulationBaseClass.SimBaseClass()
+    _addEvent(sim, "a", True)
+    result = sim.activeEvents()
+    with pytest.raises(AttributeError):
+        result.clear()  # a tuple has no clear(); the cache cannot be emptied
+    # the internal cache is untouched, so the event is still reported active
+    assert {e.eventName for e in sim.activeEvents()} == {"a"}
 
 
 def test_end_to_end_trigger_times_and_counts():

--- a/src/utilities/tests/test_event_activeCache.py
+++ b/src/utilities/tests/test_event_activeCache.py
@@ -130,6 +130,48 @@ def test_cache_handles_self_reactivating_event():
     assert sim.eventMap["loop"].occurCounter == 1
 
 
+def test_event_action_checks_later_due_event_in_same_cycle():
+    # If one event activates a later event that is already due, the newly
+    # active event should be checked before the current event-check pass ends.
+    sim = SimulationBaseClass.SimBaseClass()
+    simulationStep = 1.0  # [s]
+    stopTime = 2.0  # [s]
+    firstCheckTime = 0  # [ns]
+    eventRate = macros.sec2nano(simulationStep)  # [ns]
+    fired = []
+
+    proc = sim.CreateNewProcess("p")
+    proc.addTask(sim.CreateNewTask("t", eventRate))
+
+    def activateLaterEvent(s):
+        fired.append(("a", s.TotalSim.CurrentNanos))
+        s.setEventActivity("b", True)
+
+    def recordLaterEvent(s):
+        fired.append(("b", s.TotalSim.CurrentNanos))
+
+    sim.createNewEvent(
+        "a",
+        eventRate,
+        True,
+        conditionFunction=(lambda s: True),
+        actionFunction=activateLaterEvent,
+    )
+    sim.createNewEvent(
+        "b",
+        eventRate,
+        False,
+        conditionFunction=(lambda s: True),
+        actionFunction=recordLaterEvent,
+    )
+    sim.InitializeSimulation()
+    sim.showProgressBar = False
+    sim.ConfigureStopTime(macros.sec2nano(stopTime))
+    sim.ExecuteSimulation()
+
+    assert fired[:2] == [("a", firstCheckTime), ("b", firstCheckTime)]
+
+
 def test_returned_list_not_corrupted_by_later_mutation():
     # A snapshot taken before a mutation may legitimately be stale, but a fresh
     # query after invalidation must be correct (no aliasing bug).

--- a/src/utilities/tests/test_event_activeCache.py
+++ b/src/utilities/tests/test_event_activeCache.py
@@ -178,6 +178,53 @@ def test_event_action_checks_later_due_event_in_same_cycle():
     assert fired[:2] == [("a", firstCheckTime), ("b", firstCheckTime)]
 
 
+def test_event_activated_earlier_in_eventMap_waits_for_next_cycle():
+    # Mirror of the later-due-event case: if an event activates another event
+    # that appears *earlier* in eventMap, that earlier event must NOT be checked
+    # in the same pass -- the historical lazy generator had already walked past
+    # it, so it fires one eventRate later instead (issue #455 review).
+    sim = SimulationBaseClass.SimBaseClass()
+    simulationStep = 1.0  # [s]
+    stopTime = 2.0  # [s]
+    firstCheckTime = 0  # [ns]
+    eventRate = macros.sec2nano(simulationStep)  # [ns]
+    fired = []
+
+    proc = sim.CreateNewProcess("p")
+    proc.addTask(sim.CreateNewTask("t", eventRate))
+
+    def recordEarlierEvent(s):
+        fired.append(("b", s.TotalSim.CurrentNanos))
+
+    def activateEarlierEvent(s):
+        fired.append(("a", s.TotalSim.CurrentNanos))
+        s.setEventActivity("b", True)
+
+    # "b" is created first, so it sits earlier in eventMap than its activator "a".
+    sim.createNewEvent(
+        "b",
+        eventRate,
+        False,
+        conditionFunction=(lambda s: True),
+        actionFunction=recordEarlierEvent,
+    )
+    sim.createNewEvent(
+        "a",
+        eventRate,
+        True,
+        conditionFunction=(lambda s: True),
+        actionFunction=activateEarlierEvent,
+    )
+    sim.InitializeSimulation()
+    sim.showProgressBar = False
+    sim.ConfigureStopTime(macros.sec2nano(stopTime))
+    sim.ExecuteSimulation()
+
+    # "a" fires at t=0 and activates "b"; because "b" precedes "a" in eventMap it
+    # is only checked on the next cycle, one eventRate later.
+    assert fired[:2] == [("a", firstCheckTime), ("b", eventRate)]
+
+
 def test_returned_snapshot_is_stable_across_later_mutation():
     # A snapshot returned before a mutation must not be retroactively changed by
     # that mutation, and a fresh query after invalidation must be correct.

--- a/src/utilities/tests/test_event_activeCache.py
+++ b/src/utilities/tests/test_event_activeCache.py
@@ -1,0 +1,233 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#   Unit Test Script
+#   Module Name:        SimulationBaseClass active-event cache (issue #455)
+#   Author:             robotrocketscience (https://github.com/robotrocketscience)
+#   Creation Date:      2026-07-07
+#
+"""Guards the cached ``activeEvents()`` list against staleness.
+
+The optimization only holds up if the cache is invalidated at *every* point that
+can change which events are active. The central test asserts the invariant
+``activeEvents() == {events with eventActive True}`` after each kind of mutation,
+plus the end-to-end behaviour (trigger times, counts, self-reactivation) that a
+running simulation depends on.
+"""
+from Basilisk.utilities import SimulationBaseClass, macros
+
+
+def _trueActive(sim):
+    return {e.eventName for e in sim.eventMap.values() if e.eventActive}
+
+
+def _cachedActive(sim):
+    return {e.eventName for e in sim.activeEvents()}
+
+
+def _assertConsistent(sim):
+    # activeEvents() must equal the true active set, and every returned event
+    # must actually be active.
+    assert _cachedActive(sim) == _trueActive(sim)
+    assert all(e.eventActive for e in sim.activeEvents())
+
+
+def _addEvent(sim, name, active, cond=False, action=None):
+    sim.createNewEvent(
+        name, macros.sec2nano(1.0), active,
+        conditionFunction=(cond if callable(cond) else (lambda s, c=cond: c)),
+        actionFunction=(action or (lambda s: None)),
+    )
+
+
+def test_cache_reflects_createNewEvent():
+    sim = SimulationBaseClass.SimBaseClass()
+    assert _cachedActive(sim) == set()
+    _addEvent(sim, "a", True)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"a"}
+    _addEvent(sim, "b", False)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"a"}
+    _addEvent(sim, "c", True)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"a", "c"}
+
+
+def test_cache_reflects_setEventActivity():
+    sim = SimulationBaseClass.SimBaseClass()
+    _addEvent(sim, "a", True); _addEvent(sim, "b", False)
+    _ = sim.activeEvents()  # prime the cache
+    sim.setEventActivity("b", True)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"a", "b"}
+    sim.setEventActivity("a", False)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"b"}
+
+
+def test_cache_reflects_setAllButCurrent():
+    sim = SimulationBaseClass.SimBaseClass()
+    for n in ("a", "b", "c"):
+        _addEvent(sim, n, True)
+    _ = sim.activeEvents()  # prime
+    sim.setAllButCurrentEventActivity("b", False)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"b"}
+
+
+def test_noop_setEventActivity_does_not_rebuild_cache():
+    # Setting an event to the activity state it already has must not invalidate
+    # the cache (no unnecessary O(total events) rebuild), while a real change must.
+    sim = SimulationBaseClass.SimBaseClass()
+    _addEvent(sim, "a", True); _addEvent(sim, "b", False)
+    cached = sim.activeEvents()  # prime
+    sim.setEventActivity("a", True)   # already active -> no-op
+    assert sim.activeEvents() is cached
+    sim.setEventActivity("b", False)  # already inactive -> no-op
+    assert sim.activeEvents() is cached
+    sim.setEventActivity("b", True)   # real change -> rebuild
+    assert sim.activeEvents() is not cached
+    _assertConsistent(sim); assert _cachedActive(sim) == {"a", "b"}
+
+
+def test_noop_setAllButCurrent_does_not_rebuild_cache():
+    # A blanket set that changes nothing must not rebuild the cache; one that
+    # actually flips an event's activity must.
+    sim = SimulationBaseClass.SimBaseClass()
+    for n in ("a", "b", "c"):
+        _addEvent(sim, n, True)
+    cached = sim.activeEvents()  # prime, all active
+    sim.setAllButCurrentEventActivity("b", True)   # a, c already active -> no-op
+    assert sim.activeEvents() is cached
+    sim.setAllButCurrentEventActivity("b", False)  # real change -> rebuild
+    assert sim.activeEvents() is not cached
+    _assertConsistent(sim); assert _cachedActive(sim) == {"b"}
+
+
+def test_cache_reflects_trigger_deactivation():
+    # An event that triggers deactivates itself; it must leave the active set.
+    sim = SimulationBaseClass.SimBaseClass()
+    _addEvent(sim, "fires", True, cond=True)
+    _addEvent(sim, "stays", True, cond=False)
+    _ = sim.activeEvents()  # prime with both active
+    sim.eventMap["fires"].checkEvent(sim)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"stays"}
+    assert sim.eventMap["fires"].occurCounter == 1
+
+
+def test_cache_handles_self_reactivating_event():
+    # Action re-activates the event via setEventActivity: it must stay active.
+    sim = SimulationBaseClass.SimBaseClass()
+
+    def reactivate(s):
+        s.setEventActivity("loop", True)
+
+    _addEvent(sim, "loop", True, cond=True, action=reactivate)
+    _ = sim.activeEvents()
+    sim.eventMap["loop"].checkEvent(sim)
+    _assertConsistent(sim); assert _cachedActive(sim) == {"loop"}
+    assert sim.eventMap["loop"].occurCounter == 1
+
+
+def test_returned_list_not_corrupted_by_later_mutation():
+    # A snapshot taken before a mutation may legitimately be stale, but a fresh
+    # query after invalidation must be correct (no aliasing bug).
+    sim = SimulationBaseClass.SimBaseClass()
+    _addEvent(sim, "a", True)
+    first = sim.activeEvents()
+    _addEvent(sim, "b", True)
+    second = sim.activeEvents()
+    assert {e.eventName for e in second} == {"a", "b"}
+    assert first is not second  # cache was rebuilt, not mutated in place
+
+
+def test_end_to_end_trigger_times_and_counts():
+    # Full run with no C++ modules: a conditionTime event must fire once at the
+    # right time and then stay inactive; an unrelated inactive event must not fire.
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("p")
+    proc.addTask(sim.CreateNewTask("t", macros.sec2nano(0.1)))
+    fired = []
+    sim.createNewEvent(
+        "boom", macros.sec2nano(0.1), True,
+        conditionFunction=(lambda s: s.TotalSim.CurrentNanos >= macros.sec2nano(1.0)),
+        actionFunction=(lambda s: fired.append(s.TotalSim.CurrentNanos)),
+    )
+    _addEvent(sim, "idle", False, cond=True)  # would fire if ever checked
+    sim.InitializeSimulation()
+    sim.showProgressBar = False
+    sim.ConfigureStopTime(macros.sec2nano(2.0))
+    sim.ExecuteSimulation()
+    assert len(fired) == 1
+    assert fired[0] >= macros.sec2nano(1.0)
+    assert sim.eventMap["boom"].occurCounter == 1
+    assert sim.eventMap["idle"].occurCounter == 0
+    assert _cachedActive(sim) == set()  # both inactive at end
+
+
+def test_end_to_end_periodic_self_reactivating():
+    # An event that re-activates itself each trigger should fire many times.
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("p")
+    proc.addTask(sim.CreateNewTask("t", macros.sec2nano(0.1)))
+    hits = []
+
+    def act(s):
+        hits.append(s.TotalSim.CurrentNanos)
+        s.setEventActivity("tick", True)  # re-arm
+
+    sim.createNewEvent(
+        "tick", macros.sec2nano(0.5), True,
+        conditionFunction=(lambda s: True),
+        actionFunction=act,
+    )
+    sim.InitializeSimulation()
+    sim.showProgressBar = False
+    sim.ConfigureStopTime(macros.sec2nano(3.0))
+    sim.ExecuteSimulation()
+    # checked every 0.5 s over [0, 3] s -> fires repeatedly, stays active
+    assert len(hits) >= 5
+    assert _cachedActive(sim) == {"tick"}
+
+
+def test_duplicate_createNewEvent_does_not_corrupt_cache():
+    # A duplicate name warns and returns early without adding; the primed cache
+    # must remain correct (the early return must not leave a stale/invalid cache).
+    sim = SimulationBaseClass.SimBaseClass()
+    _addEvent(sim, "a", True)
+    assert _cachedActive(sim) == {"a"}  # prime
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        _addEvent(sim, "a", True)  # duplicate -> skipped
+    _assertConsistent(sim)
+    assert _cachedActive(sim) == {"a"}
+    assert len(sim.eventMap) == 1
+
+
+def test_conditionTime_event_end_to_end():
+    # conditionTime events use a constructor-generated conditionFunction; verify
+    # they fire once at/after the target time and then leave the active set.
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("p")
+    proc.addTask(sim.CreateNewTask("t", macros.sec2nano(0.1)))
+    fired = []
+    sim.createNewEvent(
+        "timed", macros.sec2nano(0.1), True,
+        conditionTime=macros.sec2nano(1.3),
+        actionFunction=(lambda s: fired.append(s.TotalSim.CurrentNanos)),
+    )
+    sim.InitializeSimulation()
+    sim.showProgressBar = False
+    sim.ConfigureStopTime(macros.sec2nano(2.0))
+    sim.ExecuteSimulation()
+    assert len(fired) == 1
+    assert fired[0] >= macros.sec2nano(1.3)
+    assert _cachedActive(sim) == set()
+
+
+if __name__ == "__main__":
+    for name, fn in list(globals().items()):
+        if name.startswith("test_"):
+            fn(); print(f"{name} PASSED")


### PR DESCRIPTION
## Summary

Closes the residual event-checking inefficiency in #455. `SimulationBaseClass.activeEvents()` re-filtered the entire `eventMap` on every event-check cycle, so registering many inactive event handlers added an `O(total events)` scan whenever an active event forced frequent checks (profiled as the top hotspot, above the integrator itself). This caches the active-event list and rebuilds it only when event activity changes, making the per-cycle cost `O(active events)`.

The original 2023 symptom (inactive handlers slowing every sim) was already resolved by the event-driven refactor in `ba8724252`; this addresses the narrower case @sassy-asjp identified.

## Measurable improvement

20 s sim, `dt = 0.01 s`, real spacecraft physics, 1000 inactive handlers:

| active-event check rate | develop | this PR |
|---|---|---|
| every step | 0.107 s | **0.055 s** (~2×, now flat in inactive count) |
| every 1 s / 5 s / none | ~0.033 s | ~0.033 s (unchanged) |

The gain is confined to the frequent-check pattern; typical sims are unchanged because the event-driven loop already skips between checkpoints. It **never regresses** — even an adversarial case with events toggling activity every timestep is equal within noise (2.726 s → 2.698 s), since the lazy rebuild never does more work than the existing rescan.

## Correctness

The cache is invalidated at every point that changes event membership or activity: `createNewEvent`, `setEventActivity`, `setAllButCurrentEventActivity`, and on trigger deactivation in `checkEvent`. New unit tests assert the invariant `activeEvents() == {events with eventActive}` after each of those, plus end-to-end trigger times/counts, self-reactivating events, `conditionTime` events, and duplicate-create. The behavioural tests also pass against un-cached `develop`, so they verify behaviour is unchanged rather than passing vacuously.

## Commits (atomic)

1. `[#455]` Cache active events to skip inactive ones each check cycle
2. `[#455]` Test active-event cache invalidation and behavior
3. `[#455]` Add release note for active-event cache
