### PR TITLE
Split opNav into optional Basilisk wheel package

### DIFF
--- a/.github/scripts/build_optional_bsk_wheel.py
+++ b/.github/scripts/build_optional_bsk_wheel.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Build optional Basilisk component wheels from full-wheel deltas.
+
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import re
+import sys
+import zipfile
+from dataclasses import dataclass
+from email.parser import Parser
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_VERSION_FILE = REPO_ROOT / "docs/source/bskVersion.txt"
+BASE_DISTRIBUTION = "bsk"
+NATIVE_PAYLOAD_SUFFIXES = (".a", ".dll", ".dylib", ".lib", ".pyd", ".so")
+NATIVE_PAYLOAD_PREFIXES = ("bsk.libs/",)
+
+
+@dataclass(frozen=True)
+class OptionalComponent:
+    distribution: str
+    summary: str
+    description: str
+    cmake_include: str
+    support_files: tuple[tuple[str, re.Pattern[str]], ...] = ()
+
+
+COMPONENTS = {
+    "opnav": OptionalComponent(
+        distribution="bsk-opnav",
+        summary="Basilisk optical navigation extension modules",
+        description="Optional optical navigation extension modules for Basilisk.",
+        # Basilisk treats OpenCV-backed modules as optical navigation modules.
+        cmake_include="usingOpenCV",
+        support_files=(
+            (
+                "Windows dependency DLL",
+                re.compile(r"bsk\.libs/[^/]+-[0-9a-f]{32}\.dll"),
+            ),
+        ),
+    ),
+}
+
+MODULE_PACKAGE_ROOTS = {
+    REPO_ROOT / "src/fswAlgorithms": "Basilisk/fswAlgorithms",
+    REPO_ROOT / "src/simulation": "Basilisk/simulation",
+}
+
+
+def normalize_distribution_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "_", name).lower()
+
+
+def read_version(version_file: Path) -> str:
+    version = version_file.read_text(encoding="utf-8").strip()
+    if not version:
+        raise ValueError(f"Version file is empty: {version_file}")
+    return version
+
+
+def package_root_for_module(module_dir: Path) -> str:
+    for source_root, package_root in MODULE_PACKAGE_ROOTS.items():
+        try:
+            module_dir.relative_to(source_root)
+        except ValueError:
+            continue
+        return package_root
+
+    raise ValueError(f"Do not know Python package root for optional module: {module_dir}")
+
+
+def discover_cmake_include_modules(cmake_include: str) -> list[Path]:
+    include_pattern = re.compile(rf"include\s*\(\s*{re.escape(cmake_include)}\s*\)")
+    modules = []
+    for custom_cmake in (REPO_ROOT / "src").rglob("Custom.cmake"):
+        if include_pattern.search(custom_cmake.read_text(encoding="utf-8")):
+            modules.append(custom_cmake.parent)
+
+    if not modules:
+        raise ValueError(f"No Basilisk modules include {cmake_include!r}.")
+
+    return sorted(modules)
+
+
+def module_files_for_component(
+    component: OptionalComponent,
+    *,
+    include_libraries: bool = False,
+) -> tuple[tuple[str, re.Pattern[str]], ...]:
+    module_files = []
+    for module_dir in discover_cmake_include_modules(component.cmake_include):
+        target = module_dir.name
+        package_root = package_root_for_module(module_dir)
+        module_files.extend([
+            (
+                f"{target}.py",
+                re.compile(rf"{re.escape(package_root)}/{re.escape(target)}\.py"),
+            ),
+            (
+                f"_{target}",
+                re.compile(rf"{re.escape(package_root)}/_{re.escape(target)}\.(so|pyd)"),
+            ),
+        ])
+        if include_libraries:
+            module_files.append((
+                f"{target}.lib",
+                re.compile(rf"{re.escape(package_root)}/{re.escape(target)}\.lib"),
+            ))
+
+    return tuple(module_files)
+
+
+def expected_files_for_component(component: OptionalComponent) -> tuple[tuple[str, re.Pattern[str]], ...]:
+    return module_files_for_component(component)
+
+
+def allowed_files_for_component(component: OptionalComponent) -> tuple[tuple[str, re.Pattern[str]], ...]:
+    allowed_files = list(module_files_for_component(component, include_libraries=True))
+    allowed_files.extend(component.support_files)
+    return tuple(allowed_files)
+
+
+def optional_module_files_for_component(
+    component: OptionalComponent,
+) -> tuple[tuple[str, re.Pattern[str]], ...]:
+    return module_files_for_component(component, include_libraries=True)
+
+
+def find_dist_info_file(names: list[str], suffix: str) -> str:
+    matches = [name for name in names if name.endswith(f".dist-info/{suffix}")]
+    if len(matches) != 1:
+        raise ValueError(f"Expected one .dist-info/{suffix} file, found {len(matches)}.")
+    return matches[0]
+
+
+def read_metadata(archive: zipfile.ZipFile) -> dict[str, list[str]]:
+    metadata_name = find_dist_info_file(archive.namelist(), "METADATA")
+    raw_metadata = archive.read(metadata_name).decode("utf-8")
+    message = Parser().parsestr(raw_metadata)
+
+    metadata: dict[str, list[str]] = {}
+    for key, value in message.items():
+        metadata.setdefault(key, []).append(value)
+    return metadata
+
+
+def first_metadata_value(metadata: dict[str, list[str]], key: str) -> str | None:
+    values = metadata.get(key)
+    if not values:
+        return None
+    return values[0]
+
+
+def wheel_tag_suffix(wheel: Path, distribution: str, version: str) -> str:
+    prefix = f"{normalize_distribution_name(distribution)}-{version}-"
+    suffix = wheel.name.removesuffix(".whl")
+    if not suffix.startswith(prefix):
+        raise ValueError(
+            f"Wheel filename {wheel.name!r} does not start with expected prefix {prefix!r}."
+        )
+    return suffix[len(prefix):]
+
+
+def payload_names(archive: zipfile.ZipFile) -> set[str]:
+    return {
+        info.filename
+        for info in archive.infolist()
+        if not info.filename.endswith("/") and ".dist-info/" not in info.filename
+    }
+
+
+def archive_payload_digest(archive: zipfile.ZipFile, name: str) -> str:
+    return hashlib.sha256(archive.read(name)).hexdigest()
+
+
+def is_native_payload(name: str) -> bool:
+    normalized = name.lower()
+    return normalized.startswith(NATIVE_PAYLOAD_PREFIXES) or normalized.endswith(
+        NATIVE_PAYLOAD_SUFFIXES
+    )
+
+
+def warn_changed_native_payloads(changed: list[str]) -> None:
+    if not changed:
+        return
+
+    shown = changed[:10]
+    details = "\n  ".join(shown)
+    remaining = len(changed) - len(shown)
+    if remaining:
+        details += f"\n  ... {remaining} more"
+
+    print(
+        "warning: common native payload files differ between the base and "
+        f"component builds; continuing with {len(changed)} changed native files:\n"
+        f"  {details}",
+        file=sys.stderr,
+    )
+
+
+def validate_common_payloads(
+    base_archive: zipfile.ZipFile,
+    component_archive: zipfile.ZipFile,
+    base_payload: set[str],
+    component_payload: set[str],
+) -> None:
+    changed = []
+    for name in sorted(base_payload & component_payload):
+        base_digest = archive_payload_digest(base_archive, name)
+        component_digest = archive_payload_digest(component_archive, name)
+        if base_digest != component_digest:
+            changed.append(name)
+
+    native_changed = [name for name in changed if is_native_payload(name)]
+    non_native_changed = [name for name in changed if not is_native_payload(name)]
+    warn_changed_native_payloads(native_changed)
+
+    if non_native_changed:
+        details = "\n  ".join(non_native_changed)
+        raise ValueError(
+            "Component build changes non-native files that already exist in the base wheel:\n"
+            f"  {details}"
+        )
+
+
+def validate_delta(
+    base_payload: set[str],
+    component_payload: set[str],
+    component: OptionalComponent,
+) -> list[str]:
+    expected_files = expected_files_for_component(component)
+    allowed_files = allowed_files_for_component(component)
+    optional_module_files = optional_module_files_for_component(component)
+    optional_in_base = sorted(
+        name
+        for name in base_payload
+        if any(pattern.fullmatch(name) for _, pattern in optional_module_files)
+    )
+    if optional_in_base:
+        details = "\n  ".join(optional_in_base)
+        raise ValueError(f"Base wheel already contains optional files:\n  {details}")
+
+    delta = sorted(component_payload - base_payload)
+    unexpected = sorted(
+        name
+        for name in delta
+        if not any(pattern.fullmatch(name) for _, pattern in allowed_files)
+    )
+    if unexpected:
+        details = "\n  ".join(unexpected)
+        raise ValueError(f"Component wheel delta contains unexpected files:\n  {details}")
+
+    missing = [
+        label
+        for label, pattern in expected_files
+        if not any(pattern.fullmatch(name) for name in delta)
+    ]
+    if missing:
+        details = "\n  ".join(missing)
+        raise ValueError(f"Component wheel delta is missing expected files:\n  {details}")
+
+    return delta
+
+
+def digest_record(data: bytes) -> tuple[str, str]:
+    digest = hashlib.sha256(data).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded}", str(len(data))
+
+
+def add_bytes(
+    archive: zipfile.ZipFile,
+    records: list[tuple[str, str, str]],
+    name: str,
+    data: bytes,
+) -> None:
+    archive.writestr(name, data, compress_type=zipfile.ZIP_DEFLATED)
+    records.append((name, *digest_record(data)))
+
+
+def build_metadata(
+    base_metadata: dict[str, list[str]],
+    component: OptionalComponent,
+    version: str,
+    include_license_file: bool,
+) -> bytes:
+    lines = [
+        "Metadata-Version: 2.4",
+        f"Name: {component.distribution}",
+        f"Version: {version}",
+        f"Summary: {component.summary}",
+    ]
+
+    for field in ("Home-page", "License-Expression", "Requires-Python"):
+        value = first_metadata_value(base_metadata, field)
+        if value:
+            lines.append(f"{field}: {value}")
+
+    for value in base_metadata.get("Project-URL", []):
+        lines.append(f"Project-URL: {value}")
+    for value in base_metadata.get("Classifier", []):
+        lines.append(f"Classifier: {value}")
+
+    if include_license_file:
+        lines.append("License-File: LICENSE")
+
+    lines.extend([
+        f"Requires-Dist: {BASE_DISTRIBUTION}=={version}",
+        "Description-Content-Type: text/plain",
+        "",
+        component.description,
+        "",
+    ])
+    return "\n".join(lines).encode("utf-8")
+
+
+def build_wheel_file(
+    component_wheel: Path,
+    output_wheel: Path,
+    component: OptionalComponent,
+    base_metadata: dict[str, list[str]],
+    payload: list[str],
+    version: str,
+) -> None:
+    distribution = normalize_distribution_name(component.distribution)
+    dist_info = f"{distribution}-{version}.dist-info"
+    records: list[tuple[str, str, str]] = []
+
+    with zipfile.ZipFile(component_wheel) as source:
+        wheel_name = find_dist_info_file(source.namelist(), "WHEEL")
+        wheel_lines = source.read(wheel_name).decode("utf-8").splitlines()
+        wheel_metadata = [
+            line if not line.startswith("Generator: ") else "Generator: build_optional_bsk_wheel.py"
+            for line in wheel_lines
+        ]
+        wheel_data = ("\n".join(wheel_metadata) + "\n").encode("utf-8")
+
+        license_name = next(
+            (name for name in source.namelist() if name.endswith(".dist-info/licenses/LICENSE")),
+            None,
+        )
+        license_data = source.read(license_name) if license_name else None
+        metadata = build_metadata(
+            base_metadata,
+            component,
+            version,
+            include_license_file=license_data is not None,
+        )
+
+        with zipfile.ZipFile(output_wheel, "w", compression=zipfile.ZIP_DEFLATED) as output:
+            for name in payload:
+                add_bytes(output, records, name, source.read(name))
+
+            if license_data is not None:
+                add_bytes(output, records, f"{dist_info}/licenses/LICENSE", license_data)
+
+            add_bytes(output, records, f"{dist_info}/METADATA", metadata)
+            add_bytes(output, records, f"{dist_info}/WHEEL", wheel_data)
+            add_bytes(output, records, f"{dist_info}/top_level.txt", b"Basilisk\n")
+
+            record_name = f"{dist_info}/RECORD"
+            output_text = io.StringIO()
+            writer = csv.writer(output_text, lineterminator="\n")
+            for record in records:
+                writer.writerow(record)
+            writer.writerow((record_name, "", ""))
+            output.writestr(record_name, output_text.getvalue(), compress_type=zipfile.ZIP_DEFLATED)
+
+
+def build_optional_wheel(
+    component_name: str,
+    base_wheel: Path,
+    component_wheel: Path,
+    dest_dir: Path,
+    version_file: Path,
+) -> Path:
+    component = COMPONENTS[component_name]
+    version = read_version(version_file)
+
+    with zipfile.ZipFile(base_wheel) as base_archive, zipfile.ZipFile(component_wheel) as component_archive:
+        base_metadata = read_metadata(base_archive)
+        component_metadata = read_metadata(component_archive)
+
+        for metadata_name, metadata in (
+            ("base", base_metadata),
+            ("component", component_metadata),
+        ):
+            wheel_version = first_metadata_value(metadata, "Version")
+            if wheel_version != version:
+                raise ValueError(
+                    f"The {metadata_name} wheel version {wheel_version!r} does not match "
+                    f"{version_file}: {version!r}."
+                )
+
+        base_payload = payload_names(base_archive)
+        component_payload = payload_names(component_archive)
+        validate_common_payloads(
+            base_archive,
+            component_archive,
+            base_payload,
+            component_payload,
+        )
+        payload = validate_delta(base_payload, component_payload, component)
+
+    tag_suffix = wheel_tag_suffix(component_wheel, BASE_DISTRIBUTION, version)
+    output_name = f"{normalize_distribution_name(component.distribution)}-{version}-{tag_suffix}.whl"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    output_wheel = dest_dir / output_name
+    build_wheel_file(component_wheel, output_wheel, component, base_metadata, payload, version)
+    return output_wheel
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build an optional Basilisk component wheel from a full-wheel delta.",
+    )
+    parser.add_argument("--component", choices=sorted(COMPONENTS), required=True)
+    parser.add_argument("--base-wheel", type=Path, required=True)
+    parser.add_argument("--component-wheel", type=Path, required=True)
+    parser.add_argument("--dest-dir", type=Path, required=True)
+    parser.add_argument("--version-file", type=Path, default=DEFAULT_VERSION_FILE)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        output_wheel = build_optional_wheel(
+            args.component,
+            args.base_wheel,
+            args.component_wheel,
+            args.dest_dir,
+            args.version_file,
+        )
+    except Exception as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    print(output_wheel)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/generate_nightly_index.py
+++ b/.github/scripts/generate_nightly_index.py
@@ -16,28 +16,49 @@
 #
 
 import argparse
+import re
 from pathlib import Path
 
 
-def _package_index(wheels: list[Path]) -> str:
+def _normalize_project_name(project_name: str) -> str:
+    return re.sub(r"[-_.]+", "-", project_name).lower()
+
+
+def _wheel_project_name(wheel: Path) -> str:
+    parts = wheel.name.removesuffix(".whl").split("-")
+    if len(parts) < 5:
+        raise ValueError(f"Unexpected wheel filename: {wheel.name}")
+    return _normalize_project_name(parts[0])
+
+
+def _package_index(project_name: str, wheels: list[Path]) -> str:
     links = "\n".join(f'  <a href="{w.name}">{w.name}</a><br/>' for w in wheels)
     return (
         "<!DOCTYPE html>\n"
-        "<html><head><title>Links for bsk</title></head><body>\n"
-        "<h1>Links for bsk</h1>\n"
+        f"<html><head><title>Links for {project_name}</title></head><body>\n"
+        f"<h1>Links for {project_name}</h1>\n"
         f"{links}\n"
         "</body></html>\n"
     )
 
 
-def _root_index() -> str:
+def _root_index(project_names: list[str]) -> str:
+    links = "\n".join(f'  <a href="{name}/">{name}</a><br/>' for name in project_names)
     return (
         "<!DOCTYPE html>\n"
         "<html><head><title>Simple Index</title></head><body>\n"
         "<h1>Simple Index</h1>\n"
-        '  <a href="bsk/">bsk</a><br/>\n'
+        f"{links}\n"
         "</body></html>\n"
     )
+
+
+def _group_wheels_by_project(wheels: list[Path]) -> dict[str, list[Path]]:
+    grouped_wheels: dict[str, list[Path]] = {}
+    for wheel in wheels:
+        project_name = _wheel_project_name(wheel)
+        grouped_wheels.setdefault(project_name, []).append(wheel)
+    return grouped_wheels
 
 
 def main() -> None:
@@ -50,16 +71,24 @@ def main() -> None:
     if not wheels:
         raise SystemExit(f"No wheels found in {args.wheels_dir}")
 
-    pkg_dir = args.output_dir / "bsk"
-    pkg_dir.mkdir(parents=True, exist_ok=True)
+    grouped_wheels = _group_wheels_by_project(wheels)
+    project_names = sorted(grouped_wheels)
 
-    (pkg_dir / "index.html").write_text(_package_index(wheels))
-    (args.output_dir / "index.html").write_text(_root_index())
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "index.html").write_text(_root_index(project_names))
 
-    for whl in wheels:
-        (pkg_dir / whl.name).write_bytes(whl.read_bytes())
+    for project_name in project_names:
+        pkg_dir = args.output_dir / project_name
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        project_wheels = sorted(grouped_wheels[project_name])
+        (pkg_dir / "index.html").write_text(_package_index(project_name, project_wheels))
+        for wheel in project_wheels:
+            (pkg_dir / wheel.name).write_bytes(wheel.read_bytes())
 
-    print(f"Index generated with {len(wheels)} wheel(s) in {args.output_dir}")
+    print(
+        f"Index generated with {len(wheels)} wheel(s) across "
+        f"{len(project_names)} package(s) in {args.output_dir}"
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/run_optional_bsk_wheel_test.py
+++ b/.github/scripts/run_optional_bsk_wheel_test.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Generate and test optional Basilisk component wheels.
+
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+from build_optional_bsk_wheel import COMPONENTS, DEFAULT_VERSION_FILE, build_optional_wheel
+from test_optional_bsk_wheels import find_one_wheel, test_optional_wheels
+
+
+def reset_output_directory(directory: Path, protected_directories: tuple[Path, ...]) -> None:
+    resolved_directory = directory.resolve()
+    protected = {path.resolve() for path in protected_directories}
+    protected.update((Path.cwd().resolve(), Path.home().resolve()))
+    if resolved_directory in protected or resolved_directory == resolved_directory.parent:
+        raise ValueError(f"Refusing to clean protected output directory: {directory}")
+
+    if directory.exists() and not directory.is_dir():
+        raise ValueError(f"Output path is not a directory: {directory}")
+
+    if directory.exists():
+        shutil.rmtree(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+
+
+def copy_wheel_to_wheelhouse(wheel: Path, wheelhouse: Path) -> Path:
+    wheelhouse.mkdir(parents=True, exist_ok=True)
+    destination = wheelhouse / wheel.name
+    if wheel.resolve() != destination.resolve():
+        shutil.copy2(wheel, destination)
+    return destination
+
+
+def assemble_test_wheelhouse(base_wheel: Path, optional_wheel: Path, wheelhouse: Path) -> None:
+    copy_wheel_to_wheelhouse(base_wheel, wheelhouse)
+    copy_wheel_to_wheelhouse(optional_wheel, wheelhouse)
+
+
+def run_optional_wheel_test(
+    component_name: str,
+    base_wheel_dir: Path,
+    component_wheel_dir: Path,
+    optional_wheel_dir: Path,
+    test_wheelhouse: Path,
+    version_file: Path,
+) -> None:
+    base_wheel = find_one_wheel(base_wheel_dir, "bsk-*.whl")
+    component_wheel = find_one_wheel(component_wheel_dir, "bsk-*.whl")
+    print(f"Base wheel input: {base_wheel}", flush=True)
+    print(f"Component wheel input: {component_wheel}", flush=True)
+
+    protected_directories = (base_wheel_dir, component_wheel_dir)
+    reset_output_directory(optional_wheel_dir, protected_directories)
+    reset_output_directory(test_wheelhouse, protected_directories)
+
+    optional_wheel = build_optional_wheel(
+        component_name,
+        base_wheel,
+        component_wheel,
+        optional_wheel_dir,
+        version_file,
+    )
+    print(f"Generated optional wheel: {optional_wheel}", flush=True)
+
+    assemble_test_wheelhouse(base_wheel, optional_wheel, test_wheelhouse)
+    test_optional_wheels(test_wheelhouse)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an optional Basilisk wheel and test local installs.",
+    )
+    parser.add_argument("--component", choices=sorted(COMPONENTS), required=True)
+    parser.add_argument("--base-wheel-dir", type=Path, required=True)
+    parser.add_argument("--component-wheel-dir", type=Path, required=True)
+    parser.add_argument("--optional-wheel-dir", type=Path, required=True)
+    parser.add_argument("--test-wheelhouse", type=Path, required=True)
+    parser.add_argument("--version-file", type=Path, default=DEFAULT_VERSION_FILE)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        run_optional_wheel_test(
+            args.component,
+            args.base_wheel_dir,
+            args.component_wheel_dir,
+            args.optional_wheel_dir,
+            args.test_wheelhouse,
+            args.version_file,
+        )
+    except Exception as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_optional_bsk_wheels.py
+++ b/.github/scripts/test_optional_bsk_wheels.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Test optional Basilisk wheels in isolated virtual environments.
+
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+
+
+CORE_IMPORTS = [
+    "Basilisk.architecture.messaging",
+    "Basilisk.utilities.SimulationBaseClass",
+    "Basilisk.simulation.spacecraft",
+    "Basilisk.fswAlgorithms.mrpFeedback",
+    "Basilisk.simulation.mujoco",
+    "Basilisk.simulation.thrOnTimeToForce",
+]
+OPNAV_IMPORTS = [
+    "Basilisk.simulation.camera",
+    "Basilisk.fswAlgorithms.centerRadiusCNN",
+    "Basilisk.fswAlgorithms.houghCircles",
+    "Basilisk.fswAlgorithms.limbFinding",
+]
+
+
+def venv_python(venv_path: Path) -> Path:
+    if os.name == "nt":
+        return venv_path / "Scripts/python.exe"
+    return venv_path / "bin/python"
+
+
+def run(command: list[str | Path], *, env: dict[str, str] | None = None) -> None:
+    print("+", " ".join(str(part) for part in command), flush=True)
+    subprocess.run([str(part) for part in command], check=True, env=env)
+
+
+def find_one_wheel(wheelhouse: Path, pattern: str) -> Path:
+    matches = sorted(wheelhouse.glob(pattern))
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one wheel matching {pattern!r}, found {len(matches)}.")
+    return matches[0]
+
+
+def create_venv(parent: Path, name: str) -> Path:
+    venv_path = parent / name
+    shutil.rmtree(venv_path, ignore_errors=True)
+    venv.EnvBuilder(with_pip=True).create(venv_path)
+    return venv_path
+
+
+def import_check_script(required: list[str], missing: list[str]) -> str:
+    return f"""
+import importlib
+import importlib.util
+import sys
+
+required = {required!r}
+missing = {missing!r}
+
+import Basilisk
+print("Basilisk:", Basilisk.__file__)
+
+for name in required:
+    module = importlib.import_module(name)
+    print("OK import", name, "->", getattr(module, "__file__", "<builtin>"))
+
+for name in missing:
+    if importlib.util.find_spec(name) is not None:
+        raise SystemExit(f"unexpected optional module present: {{name}}")
+    print("EXPECTED missing", name)
+"""
+
+
+def run_import_check(
+    python: Path,
+    *,
+    required: list[str],
+    missing: list[str],
+    env: dict[str, str],
+) -> None:
+    run([python, "-c", import_check_script(required, missing)], env=env)
+
+
+def install_extra(python: Path, wheelhouse: Path, extra: str) -> None:
+    run([
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--no-index",
+        "--find-links",
+        wheelhouse,
+        f"bsk[{extra}]",
+    ])
+
+
+def test_optional_wheels(wheelhouse: Path) -> None:
+    base_wheel = find_one_wheel(wheelhouse, "bsk-*.whl")
+    opnav_wheel = find_one_wheel(wheelhouse, "bsk_opnav-*.whl")
+    print(f"Testing base wheel: {base_wheel}")
+    print(f"Testing opNav wheel: {opnav_wheel}")
+
+    with tempfile.TemporaryDirectory(prefix="bsk-optional-wheel-test-") as tmp_dir_name:
+        tmp_dir = Path(tmp_dir_name)
+        test_env = os.environ.copy()
+        test_env["MPLBACKEND"] = "Agg"
+        test_env["MPLCONFIGDIR"] = str(tmp_dir / "matplotlib")
+
+        venv_path = create_venv(tmp_dir, "install")
+        python = venv_python(venv_path)
+
+        run([python, "-m", "pip", "install", base_wheel])
+        run_import_check(
+            python,
+            required=CORE_IMPORTS,
+            missing=OPNAV_IMPORTS,
+            env=test_env,
+        )
+
+        install_extra(python, wheelhouse, "opnav")
+        run([python, "-m", "pip", "show", "bsk", "bsk-opnav"])
+        run_import_check(
+            python,
+            required=CORE_IMPORTS + OPNAV_IMPORTS,
+            missing=[],
+            env=test_env,
+        )
+
+        run([python, "-m", "pip", "uninstall", "-y", "bsk-opnav"])
+        run_import_check(
+            python,
+            required=CORE_IMPORTS,
+            missing=OPNAV_IMPORTS,
+            env=test_env,
+        )
+
+        install_extra(python, wheelhouse, "all")
+        run([python, "-m", "pip", "show", "bsk", "bsk-opnav"])
+        run_import_check(
+            python,
+            required=CORE_IMPORTS + OPNAV_IMPORTS,
+            missing=[],
+            env=test_env,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Test optional Basilisk wheels.")
+    parser.add_argument("--wheelhouse", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        test_optional_wheels(args.wheelhouse)
+    except Exception as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -30,22 +30,67 @@ jobs:
       - name: Setup system dependencies
         uses: ./.github/actions/setup
 
-      - name: Build wheels
+      - name: Build core bsk wheel
         uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: wheelhouse-core
         env:
-          CONAN_ARGS: "--opNav True --mujoco True ${{ matrix.extra-conan-args }}"
+          CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
           CIBW_TEST_SKIP: "*"
+
+      - name: Free runner disk before opNav Linux wheel
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        shell: bash
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af || true
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Build opNav-enabled bsk wheel
+        uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: wheelhouse-opnav-full
+        env:
+          CONAN_ARGS: "--opNav True --mujoco True --clean ${{ matrix.extra-conan-args }}"
+          CIBW_TEST_SKIP: "*"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+
+      - name: Generate and test optional wheel installs
+        shell: bash
+        run: >
+          python .github/scripts/run_optional_bsk_wheel_test.py
+          --component opnav
+          --base-wheel-dir wheelhouse-core
+          --component-wheel-dir wheelhouse-opnav-full
+          --optional-wheel-dir wheelhouse-optional
+          --test-wheelhouse wheelhouse-test
+
+      - name: Prepare nightly wheels
+        shell: bash
+        run: |
+          mkdir -p wheelhouse-nightly
+          cp wheelhouse-core/*.whl wheelhouse-nightly/
+          cp wheelhouse-optional/*.whl wheelhouse-nightly/
 
       - name: Upload wheels
         uses: actions/upload-artifact@v6
         with:
           name: nightly-wheels-${{ matrix.os }}
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse-nightly/*.whl
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: build-wheels
-    if: ${{ always() && needs.build-wheels.result == 'failure' }}
+    needs: [build-wheels, publish-index]
+    if: ${{ always() && (needs.build-wheels.result == 'failure' || needs.publish-index.result == 'failure') }}
     runs-on: ubuntu-24.04
     permissions: {}
 
@@ -92,8 +137,8 @@ jobs:
 
   publish-index:
     name: Publish Nightly Index
-    needs: build-wheels
-    if: ${{ github.ref_name == 'develop' }}
+    needs: [build-wheels]
+    if: ${{ (github.ref_name == 'develop' || github.event_name == 'workflow_dispatch') && needs.build-wheels.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -106,7 +151,7 @@ jobs:
           sparse-checkout: .github/scripts
 
       - name: Download all wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: nightly-wheels-*
           merge-multiple: true
@@ -124,6 +169,7 @@ jobs:
           keep_files: false
 
       - name: Checkout gh-pages branch
+        if: ${{ github.ref_name == 'develop' }}
         uses: actions/checkout@v5
         with:
           ref: gh-pages
@@ -131,6 +177,7 @@ jobs:
           path: gh-pages-site
 
       - name: Trim gh-pages history
+        if: ${{ github.ref_name == 'develop' }}
         shell: bash
         working-directory: gh-pages-site
         run: |

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-wheels:
-    name: Build Basilisk Wheels
+    name: Build Basilisk Wheels (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -57,17 +57,62 @@ jobs:
       - name: Setup system dependencies
         uses: ./.github/actions/setup
 
-      - name: Build wheels
+      - name: Build core bsk wheel
         uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: wheelhouse-core
         env:
-          CONAN_ARGS: "--opNav True --mujoco True ${{ matrix.extra-conan-args }}"
+          CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
           CIBW_TEST_SKIP: "*"
+
+      - name: Free runner disk before opNav Linux wheel
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        shell: bash
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af || true
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Build opNav-enabled bsk wheel
+        uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: wheelhouse-opnav-full
+        env:
+          CONAN_ARGS: "--opNav True --mujoco True --clean ${{ matrix.extra-conan-args }}"
+          CIBW_TEST_SKIP: "*"
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+
+      - name: Generate and test optional wheel installs
+        shell: bash
+        run: >
+          python .github/scripts/run_optional_bsk_wheel_test.py
+          --component opnav
+          --base-wheel-dir wheelhouse-core
+          --component-wheel-dir wheelhouse-opnav-full
+          --optional-wheel-dir wheelhouse-optional
+          --test-wheelhouse wheelhouse-test
+
+      - name: Prepare publish wheels
+        shell: bash
+        run: |
+          mkdir -p wheelhouse-publish
+          cp wheelhouse-core/*.whl wheelhouse-publish/
+          cp wheelhouse-optional/*.whl wheelhouse-publish/
 
       - name: Upload wheels
         uses: actions/upload-artifact@v6
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse-publish/*.whl
 
   make_sdist:
     name: Make SDist
@@ -103,7 +148,7 @@ jobs:
           python-version: 3.14
 
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: cibw-sdist
           path: dist
@@ -119,14 +164,14 @@ jobs:
       id-token: write
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: cibw-wheels-*
           merge-multiple: true
           path: dist
 
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: cibw-sdist
           path: dist

--- a/.github/workflows/test-optional-wheels.yml
+++ b/.github/workflows/test-optional-wheels.yml
@@ -1,9 +1,6 @@
 name: Test Optional Wheels
 
 on:
-  push:
-    branches:
-      - feature/fix_v2_11_0
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-optional-wheels.yml
+++ b/.github/workflows/test-optional-wheels.yml
@@ -1,0 +1,198 @@
+name: Test Optional Wheels
+
+on:
+  push:
+    branches:
+      - feature/fix_v2_11_0
+  workflow_dispatch:
+
+jobs:
+  test-opnav-wheels:
+    name: Test opNav Wheels (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-26
+          - ubuntu-24.04-arm
+          - windows-2025-vs2026
+        include:
+          - os: windows-2025-vs2026
+            extra-conan-args: --generator Ninja
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Remove runner-provided Microsoft apt sources
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.sources
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.sources
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
+
+      - name: Build core bsk wheel
+        uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: wheelhouse-core
+        env:
+          CIBW_BUILD: "cp314-*"
+          CIBW_TEST_SKIP: "*"
+          CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
+
+      - name: Build opNav-enabled bsk wheel
+        uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: wheelhouse-opnav-full
+        env:
+          CIBW_BUILD: "cp314-*"
+          CIBW_TEST_SKIP: "*"
+          CONAN_ARGS: "--opNav True --mujoco True --clean ${{ matrix.extra-conan-args }}"
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Generate and test optional wheel installs
+        shell: bash
+        run: >
+          python .github/scripts/run_optional_bsk_wheel_test.py
+          --component opnav
+          --base-wheel-dir wheelhouse-core
+          --component-wheel-dir wheelhouse-opnav-full
+          --optional-wheel-dir wheelhouse-optional
+          --test-wheelhouse wheelhouse-test
+
+      - name: Upload wheel artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: optional-wheel-test-${{ matrix.os }}
+          path: |
+            wheelhouse-core/*.whl
+            wheelhouse-opnav-full/*.whl
+            wheelhouse-optional/*.whl
+
+  build-opnav-linux-x64-wheels:
+    name: Build opNav Wheel Input (${{ matrix.wheel-kind }}, ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - wheel-kind: core
+            output-dir: wheelhouse-core
+            conan-args: --opNav False --mujoco True --clean
+            needs_disk_cleanup: false
+          - wheel-kind: opnav-full
+            output-dir: wheelhouse-opnav-full
+            conan-args: --opNav True --mujoco True --clean
+            needs_disk_cleanup: true
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Remove runner-provided Microsoft apt sources
+        shell: bash
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.sources
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.sources
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
+
+      - name: Free runner disk for heavy optional Linux wheel
+        if: ${{ runner.os == 'Linux' && matrix.needs_disk_cleanup }}
+        shell: bash
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af || true
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Build ${{ matrix.wheel-kind }} bsk wheel
+        uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: ${{ matrix.output-dir }}
+        env:
+          CIBW_BUILD: "cp314-*"
+          CIBW_TEST_SKIP: "*"
+          CONAN_ARGS: "${{ matrix.conan-args }}"
+
+      - name: Upload wheel input
+        uses: actions/upload-artifact@v6
+        with:
+          name: optional-wheel-test-ubuntu-24.04-${{ matrix.wheel-kind }}
+          path: ${{ matrix.output-dir }}/*.whl
+
+  test-opnav-wheels-linux-x64:
+    name: Test opNav Wheels (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    needs: build-opnav-linux-x64-wheels
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+
+      - name: Remove runner-provided Microsoft apt sources
+        shell: bash
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.sources
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.sources
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Download core wheel input
+        uses: actions/download-artifact@v6
+        with:
+          name: optional-wheel-test-ubuntu-24.04-core
+          path: wheelhouse-core
+
+      - name: Download opNav-enabled wheel input
+        uses: actions/download-artifact@v6
+        with:
+          name: optional-wheel-test-ubuntu-24.04-opnav-full
+          path: wheelhouse-opnav-full
+
+      - name: Generate and test optional wheel installs
+        shell: bash
+        run: >
+          python .github/scripts/run_optional_bsk_wheel_test.py
+          --component opnav
+          --base-wheel-dir wheelhouse-core
+          --component-wheel-dir wheelhouse-opnav-full
+          --optional-wheel-dir wheelhouse-optional
+          --test-wheelhouse wheelhouse-test
+
+      - name: Upload wheel artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: optional-wheel-test-ubuntu-24.04
+          path: |
+            wheelhouse-core/*.whl
+            wheelhouse-opnav-full/*.whl
+            wheelhouse-optional/*.whl

--- a/README.md
+++ b/README.md
@@ -20,17 +20,26 @@ The easiest way to get started with Basilisk is to install the prebuilt wheel
 from [PyPI](https://pypi.org/project/bsk/):
 
 ```bash
-pip install bsk
+pip install "bsk[all]"
 ```
 
-This installs the latest stable version with all standard features
-(e.g. optical navigation and MuJoCo). See the [install](docs/source/Install.rst)
-docs for supported platforms and additional details about the wheels.
+This installs the latest stable version with the core Basilisk wheel and all
+optional Basilisk component wheels. MuJoCo is included in the core wheel, while
+optical navigation is installed through the optional component package. See the
+[install](docs/source/Install.rst) docs for supported platforms and additional
+details about the wheels.
+
+If you need a smaller installation and do not use optional Basilisk components,
+install only the core wheel:
+
+```bash
+pip install bsk
+```
 
 If you also want the optional Python dependencies used by example scripts, install:
 
 ```bash
-pip install "bsk[examples]"
+pip install "bsk[all,examples]"
 ```
 
 #### Build from Source
@@ -80,7 +89,7 @@ web page documentation site, they are listed and discussed in the [integrated ex
 The documentation lists the scenarios in an order that facilitates learning basic BSK features. The python scripts
 are stored in the repository under `basilisk/examples`. A good start would be to run `scenarioBasicOrbit.py`.
 
-If you downloaded Basilisk through `pip install bsk`, then you can download all examples to the local folder using the command line `bskExamples`.
+If you downloaded Basilisk through `pip install "bsk[all]"`, then you can download all examples to the local folder using the command line `bskExamples`.
 
 To play with the tutorials, it is suggested the user makes a copy of these tutorial files, and use the copies in order
 to learn, test and experiment. Copy the folder `basilisk/examples` into a

--- a/docs/source/Build.rst
+++ b/docs/source/Build.rst
@@ -8,10 +8,13 @@ most users the precompiled version available on PyPI is sufficient. See the
 :ref:`Install Instructions <bskInstall>` for more information.
 
 .. note::
-   To use custom C++ modules, Basilisk must be built from source.
-   The prebuilt PyPI wheels are designed for most users and include all standard
-   features, but they do not yet support linking external C++ modules.
-   We're actively exploring ways to enable this in future releases.
+   To use the legacy ``ExternalModules`` path that compiles custom modules into
+   the Basilisk package, Basilisk must be built from source with
+   ``pathToExternalModules``.
+   The recommended prebuilt PyPI install, ``pip install "bsk[all]"``, is designed
+   for most users and includes all optional Basilisk component wheels. For
+   out-of-tree C++ modules that do not need to live inside
+   ``Basilisk.ExternalModules``, use :ref:`Basilisk plugins <writingPlugins>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/Install.rst
+++ b/docs/source/Install.rst
@@ -5,17 +5,19 @@ Install
 
 Basilisk can be installed either from `PyPI <https://pypi.org/project/bsk/>`_ as
 a prebuilt wheel or built locally from source.
-The prebuilt wheels include all build options, such as optical navigation
-and MuJoCo dynamics, but do **not** support linking external C++ modules, as
-this requires rebuilding Basilisk.
+The recommended prebuilt installation uses the ``all`` extra so ``pip`` installs
+the core Basilisk wheel plus all optional Basilisk component wheels. MuJoCo
+dynamics are included in the core wheel, while optical navigation is provided by
+the optional ``bsk-opnav`` package. Prebuilt wheels can be used with
+:ref:`Basilisk plugins <writingPlugins>` for out-of-tree C++ modules, but they
+cannot be modified in place to include legacy ``ExternalModules`` through the
+``pathToExternalModules`` build option.
 
-If you want to use custom C++ modules, or prefer smaller install sizes by
-excluding unused features, you must build Basilisk from source.
-See the :ref:`Building from Source <bskInstall-build>` for more information.
-
-.. note::
-   We are currently investigating ways to allow users to link external C++
-   modules while using the prebuilt PyPI wheel. Stay tuned!
+If you want to use legacy ``ExternalModules`` or native build options not
+covered by the published package extras, you must build Basilisk from source. If
+you prefer a smaller prebuilt install and do not need optional Basilisk
+components, use the core ``bsk`` package variant described below. See the
+:ref:`Building from Source <bskInstall-build>` for more information.
 
 
 The easiest way to install Basilisk is using ``pip`` to install the prebuilt
@@ -23,28 +25,35 @@ package from PyPI. Run:
 
 .. code-block:: bash
 
-   pip install bsk
+   pip install "bsk[all]"
+
+The most common install variants are:
+
+- ``bsk``: core Basilisk wheel only
+- ``bsk[opnav]``: core Basilisk plus optical navigation components
+- ``bsk[all]``: recommended install with all optional Basilisk components
 
 If you also want the optional Python packages used by example scripts, install:
 
 .. code-block:: bash
 
-   pip install "bsk[examples]"
+   pip install "bsk[all,examples]"
 
 Or, if using `uv <https://docs.astral.sh/uv/>`_ (a modern Python package manager):
 
 .. code-block:: bash
 
-   uv pip install bsk
+   uv pip install "bsk[all]"
 
-This installs the latest stable version of Basilisk and all dependencies.
+This installs the latest stable version of Basilisk and all recommended
+dependencies.
 To install a specific version, run:
 
 .. code-block:: bash
 
-   pip install bsk==<version>
+   pip install "bsk[all]==<version>"
 
-Replace ``<version>`` with the desired release number, e.g. ``2.9.0``.
+Replace ``<version>`` with the desired release number, e.g. ``2.11.0``.
 
 Container images are also available for users who prefer Docker-based
 workflows. See :ref:`bskContainers` for registry locations, tags, and
@@ -85,7 +94,7 @@ nightly wheels are pre-release versions:
      --index-url https://avslab.github.io/basilisk/nightly/ \
      --extra-index-url https://pypi.org/simple/ \
      --pre \
-     bsk
+     "bsk[all]"
 
 Because nightly wheels are built from the ``develop`` branch and carry the same
 version string until ``bskVersion.txt`` changes, pip may report
@@ -100,7 +109,7 @@ force an overwrite of whatever is currently installed, add
      --extra-index-url https://pypi.org/simple/ \
      --pre \
      --upgrade --force-reinstall --no-cache-dir \
-     bsk
+     "bsk[all]"
 
 .. warning::
 

--- a/docs/source/Learn.rst
+++ b/docs/source/Learn.rst
@@ -19,7 +19,7 @@ Finally, there is the source-code itself.  That is always the ultimate guide to 
 
 .. note::
 
-    If you downloaded Basilisk through ``pip install bsk``, then you can download all examples
+    If you downloaded Basilisk through ``pip install "bsk[all]"``, then you can download all examples
     to the local folder using the command line ``bskExamples``.
 
 

--- a/docs/source/Plugins/installing.rst
+++ b/docs/source/Plugins/installing.rst
@@ -24,7 +24,14 @@ For example, if a plugin is published to PyPI as ``my-atm-plugin``:
     pip install my-atm-plugin
 
 This installs the plugin and pulls in Basilisk as a dependency
-automatically.  Once installed, use it like any built-in Basilisk module:
+automatically.  To ensure optional Basilisk components are available, install
+the recommended Basilisk extra explicitly:
+
+.. code-block:: bash
+
+    pip install "bsk[all]" <plugin-name>
+
+Once installed, use the plugin like any built-in Basilisk module:
 
 .. code-block:: python
 
@@ -48,7 +55,7 @@ The plugin's documentation should state which Basilisk version it targets:
 
 .. code-block:: bash
 
-    pip install "bsk==2.9.1" "my-plugin"
+    pip install "bsk[all]==2.11.0" "my-plugin"
 
 If the installed Basilisk version does not match what the plugin was compiled
 against, CMake will error at configure time with an error message.
@@ -69,6 +76,6 @@ If you want to **build** a plugin rather than just use one, you also need
 
     pip install bsk-sdk
 
-``bsk-sdk`` version numbers track Basilisk — ``bsk-sdk==2.9.1`` contains
-headers from Basilisk ``v2.9.1``.  See :ref:`writingPlugins` to get
+``bsk-sdk`` version numbers track Basilisk — ``bsk-sdk==2.11.0`` contains
+headers from Basilisk ``v2.11.0``.  See :ref:`writingPlugins` to get
 started building your own plugin.

--- a/docs/source/Plugins/overview.rst
+++ b/docs/source/Plugins/overview.rst
@@ -43,7 +43,7 @@ all of Basilisk every time you make a change.
    * - Distributable via ``pip install``
      - **Yes**
      - No
-   * - Works with ``pip install bsk``
+   * - Works with ``pip install "bsk[all]"``
      - **Yes**
      - No
    * - Portable across machines/environments
@@ -65,12 +65,12 @@ Why Write a Plugin?
 
 .. tip::
 
-    ``pip install bsk`` + ``pip install bsk-sdk`` is all you need.
+    ``pip install "bsk[all]"`` + ``pip install bsk-sdk`` is all you need.
     No cloning. No building Basilisk from source. Ever.
 
 - **No Basilisk source checkout required.** Install Basilisk and the SDK
   from PyPI and start writing your module immediately.  Upgrading Basilisk
-  is a single ``pip install --upgrade bsk``.
+  is a single ``pip install --upgrade "bsk[all]"``.
 
 - **Compile only your code.** Plugin builds take seconds, not minutes.
   You never wait on a full Basilisk recompile to test a one-line change.
@@ -106,7 +106,7 @@ CMake helpers needed to compile out-of-tree modules.
               fillcolor="#dce8fb"]
       sdk    [label="bsk-sdk\n(BSK headers · SWIG interfaces · CMake helpers)",
               fillcolor="#d4edda"]
-      bsk    [label="Basilisk: pip install bsk",
+      bsk    [label="Basilisk: pip install bsk[all]",
               fillcolor="#fff3cd"]
 
       plugin -> sdk [label="  compiles against  "]
@@ -192,12 +192,12 @@ Version Compatibility
 ---------------------
 
 A plugin wheel is compiled against a specific version of the BSK headers.
-``bsk-sdk`` version numbers track Basilisk:  ``bsk-sdk==2.9.1`` contains
-headers from Basilisk ``v2.9.1``.  If the installed Basilisk version does
+``bsk-sdk`` version numbers track Basilisk:  ``bsk-sdk==2.11.0`` contains
+headers from Basilisk ``v2.11.0``.  If the installed Basilisk version does
 not match, CMake will error at configure time with a clear message.
 
 Always install matching versions:
 
 .. code-block:: bash
 
-    pip install "bsk==2.9.1" "bsk-sdk==2.9.1"
+    pip install "bsk[all]==2.11.0" "bsk-sdk==2.11.0"

--- a/docs/source/Plugins/writing.rst
+++ b/docs/source/Plugins/writing.rst
@@ -22,7 +22,7 @@ A complete working example is in the
 Prerequisites
 -------------
 
-- Basilisk installed: ``pip install bsk``
+- Basilisk installed: ``pip install "bsk[all]"``
 - The SDK: ``pip install bsk-sdk``
 - CMake ≥ 3.26 and a C++17 compiler (same requirement as Basilisk itself)
 - ``scikit-build-core`` and ``build``: ``pip install scikit-build-core build``

--- a/docs/source/Support/Developer/releaseGuide.rst
+++ b/docs/source/Support/Developer/releaseGuide.rst
@@ -23,18 +23,18 @@ The high level steps to release a new version of Basilisk are as follows:
 #. Push branch to origin and do a PR.
 #. Merge ``develop`` into ``master``
 #. Add release tag ``v2.X.Y`` to ``master``
-#. Create a Release on GitHub
+#. When BSK wheels are successfully deployed, create a Release on GitHub
 
 To prepare ``develop`` for the next beta cycle:
 
 #. Create ``beta_X_Y`` branch
 #. Modify the version number in ``docs/source/bskVersion.txt``
-   to reflect the new beta cycle such as ``v2_X_Y_beta``.
+   to reflect the new beta cycle such as ``v2.X.Y.beta``.
 #. Update ``docs/source/Support/bskReleaseNotes.rst``
    and ``docs/source/Support/bskKnownIssues.rst`` files to next beta cycle
 #. Make PR and push to ``develop``
 #. Manually run the ``Nightly Wheels`` workflow using the ``workflow_dispatch``
-   trigger after merging the beta branch so the nightly package index is
+   trigger after merging the beta branch so the nightly wheels are
    republished on GitHub Pages.
 
 
@@ -145,8 +145,8 @@ After pushing the release tag, create a new release on GitHub:
 #. Select “Draft new Release”
 #. Select correct tag ``v2.X.Y`` on ``master``
 #. Add title “Basilisk v2.X.Y”
-#. Add release notes
-#. Remove all ``:ref:`` statements from release notes
+#. Add release notes manually or using the auto-generation option
+#. Remove all ``:ref:`` statements, if needed, from release notes
 #. Bottom of page, press “Publish Release” button
 
 This will make the release official and provide users with information about the new version.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -110,7 +110,7 @@ Version 2.10.0 (April 2, 2026)
   Basilisk with Python 3.13 or above, we automatically default to using the newer cp313 ABI.
 - The :ref:`simpleAntenna` module raises a warning for each of the following messages not being connected: ``sunInMsg``, ``planetInMsg``, ``sunEclipseInMsg``, even for ground based antennas.
   These messages are not relevant for ground based antennas and the warning should therefore not be risen for an antenna on ground.
-- If you install Basilisk via ``pip install bsk``, note that the ``basilisk/supportData`` folder does not
+- If you install Basilisk via ``pip``, note that the ``basilisk/supportData`` folder does not
   exist in your folder.  Simulation script importing directly using a local file path to ``supportData``
   will not work.  Rather, ``pooch`` is being used to manage data which puts the data files into a
   cache folder on your system.  See :ref:`bskPrinciples-6a` on how to get a file data path and import it.

--- a/docs/source/Support/bskReleaseNotes.rst
+++ b/docs/source/Support/bskReleaseNotes.rst
@@ -20,7 +20,6 @@ Basilisk Release Notes
     - spacecraft charging related modules
     - support effector branching for additional state and dynamic effectors
     - More effector and sensor fault modeling
-    - `pip`-based installation and pre-compiled releases
     - integrating the `MuJoCo <https://mujoco.org>`_ library as an alternate dynamics engine
 
 Version |release| (July 7, 2026)
@@ -29,6 +28,8 @@ Version |release| (July 7, 2026)
 ..
    .. include:: bskReleaseNotesSnippets/_compiled_latest.rst
 
+- Split off the ``opNav`` build from the core BSK distribution wheels to reduce the wheel file size to be less than 100Mb.
+  Updated documentation to discuss how to use ``pip`` install with ``opNav`` modules.
 - Refactored the :ref:`motorThermal` unit test to validate the module against analytically derived temperatures instead of a stored vector of regression "truth" values. The test now drives the module with a stand-alone reaction wheel state message and isolates each term of the heat balance (dissipation, motor power inefficiency, and friction) in separate scenarios, comparing the recorded temperatures to the closed-form heat-balance recurrence.
 - Fixed Monte Carlo nested dispersion paths and randomized ``RNGSeed`` application.
 - Tuned :ref:`scenarioMonteCarloAttRW` dispersions to show subtler run-to-run variations without saturated response.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ examples = [
   'scipy==1.17.1; python_version >= "3.11"',
   'numba',
 ]
+opnav = [
+  "bsk-opnav",
+]
+all = [
+  "bsk-opnav",
+]
 
 [tool.cibuildwheel]
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ if _parse_version_prefix(setuptools_version) < (77, 0, 3):
 # See https://github.com/pypa/setuptools/issues/3896
 import shlex
 import os
+import shutil
 USER_CONAN_ARGS = shlex.split(os.getenv("CONAN_ARGS") or "")
 #-------------------------------------------------------------------------------
 
@@ -128,8 +129,12 @@ class BuildConanExtCommand(Command, SubCommand):
                             "Please install via `python conanfile.py` instead!")
 
         # Refresh `build_py` to ensure it can find the newly generated packages.
+        # Remove stale package output from previous wheel variants before build_py
+        # copies the current Conan build into place.
         build_py = self.reinitialize_command("build_py")
         build_py.ensure_finalized()
+        for package_root in {pkg.split(".")[0] for pkg in self.distribution.packages}:
+            shutil.rmtree(Path(build_py.build_lib, package_root), ignore_errors=True)
 
 
 # XXX: Forcibly override build to run ConanExtension builder before build_py.

--- a/src/architecture/messaging/CMakeLists.txt
+++ b/src/architecture/messaging/CMakeLists.txt
@@ -148,26 +148,30 @@ add_custom_target(swigtrick DEPENDS ${CMAKE_BINARY_DIR}/Basilisk/architecture/me
 generate_messages(msgPayloadDefCpp "False")
 generate_messages(msgPayloadDefC "True")
 
-# Verify the central SysModel copy restriction while keeping Recorder explicitly copyable.
-add_executable(test_recorder_copy_contract _UnitTest/test_recorder_copy_contract.cpp)
-target_sources(test_recorder_copy_contract PRIVATE ${CMAKE_SOURCE_DIR}/architecture/_GeneralModuleFiles/sys_model.cpp)
-target_link_libraries(test_recorder_copy_contract GTest::gtest_main)
-target_link_libraries(test_recorder_copy_contract ArchitectureUtilities)
-target_link_libraries(test_recorder_copy_contract ModuleIdGenerator)
+set(recorder_copy_contract_test_source
+    "${CMAKE_CURRENT_SOURCE_DIR}/_UnitTest/test_recorder_copy_contract.cpp")
+if(EXISTS "${recorder_copy_contract_test_source}")
+  # Verify the central SysModel copy restriction while keeping Recorder explicitly copyable.
+  add_executable(test_recorder_copy_contract "${recorder_copy_contract_test_source}")
+  target_sources(test_recorder_copy_contract PRIVATE ${CMAKE_SOURCE_DIR}/architecture/_GeneralModuleFiles/sys_model.cpp)
+  target_link_libraries(test_recorder_copy_contract GTest::gtest_main)
+  target_link_libraries(test_recorder_copy_contract ArchitectureUtilities)
+  target_link_libraries(test_recorder_copy_contract ModuleIdGenerator)
 
-# Windows test discovery runs the executable from this folder, so copy the required DLL beside it first.
-if(WIN32)
-  add_custom_command(
-    TARGET test_recorder_copy_contract
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:ModuleIdGenerator>
-            $<TARGET_FILE_DIR:test_recorder_copy_contract>)
-endif()
+  # Windows test discovery runs the executable from this folder, so copy the required DLL beside it first.
+  if(WIN32)
+    add_custom_command(
+      TARGET test_recorder_copy_contract
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_FILE:ModuleIdGenerator>
+              $<TARGET_FILE_DIR:test_recorder_copy_contract>)
+  endif()
 
-# Apple-silicon Xcode builds cannot reliably run the test during the build, so defer discovery to CTest.
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND CMAKE_GENERATOR STREQUAL "Xcode")
-  gtest_discover_tests(test_recorder_copy_contract DISCOVERY_MODE PRE_TEST)
-else()
-  gtest_discover_tests(test_recorder_copy_contract)
+  # Apple-silicon Xcode builds cannot reliably run the test during the build, so defer discovery to CTest.
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND CMAKE_GENERATOR STREQUAL "Xcode")
+    gtest_discover_tests(test_recorder_copy_contract DISCOVERY_MODE PRE_TEST)
+  else()
+    gtest_discover_tests(test_recorder_copy_contract)
+  endif()
 endif()


### PR DESCRIPTION
* **Tickets addressed:** #1468
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR splits the opNav-enabled Basilisk payload out of the core `bsk` wheel into a companion `bsk-opnav` wheel. The core wheel still includes standard Basilisk functionality and MuJoCo support, while opNav modules are installed through the `opnav`/`all` package extras:

- `pip install bsk`: core Basilisk wheel
- `pip install "bsk[opnav]"`: core plus opNav
- `pip install "bsk[all]"`: recommended install with all optional Basilisk components

The implementation adds tooling to build an opNav-enabled wheel, derive the opNav-only payload from the difference against the core wheel, and validate that shared payload files do not silently change between builds. The release and nightly wheel workflows now build, test, and publish both `bsk` and `bsk-opnav`. The nightly simple index was also updated to publish each distribution under its own normalized package directory so pip can resolve `bsk-opnav` through the nightly index.

Commits are organized by topic: sdist guard fix, optional-wheel tooling, CI validation workflow, release/nightly publishing integration, installation docs, release notes, nightly index fix, and cleanup of the heavy optional-wheel workflow trigger.

## Verification
Validated locally and on GitHub Actions:

- Built and tested split core/opNav wheels locally on macOS.
- Ran the manual cross-platform optional-wheel workflow on GitHub Actions.
- Published `bsk==2.11.0rc1` and `bsk-opnav==2.11.0rc1` to TestPyPI.
- Verified clean TestPyPI installs:
  - `pip install bsk==2.11.0rc1`
  - `pip install "bsk[all]==2.11.0rc1"`
- Confirmed core-only install imports core Basilisk and MuJoCo modules, while opNav modules are absent.
- Confirmed `bsk[all]` install imports core, MuJoCo, and opNav modules.
- Verified the corrected nightly simple-index layout locally using real nightly wheel artifacts.

Automated validation was added through `.github/scripts/test_optional_bsk_wheels.py` and the manual `Test Optional Wheels` workflow. The workflow is intentionally manual-only because it is expensive and duplicates much of the release/nightly wheel build path.

## Documentation
Updated installation and plugin-facing documentation to describe the new package extras and the recommended `pip install "bsk[all]"` path. Updated release documentation to describe RC/TestPyPI routing and wheel validation expectations. Added release-note coverage for the split-wheel packaging change.

Updated documents include:

- `docs/source/Install.rst`
- `docs/source/Build.rst`
- `docs/source/Learn.rst`
- `docs/source/Plugins/*.rst`
- `docs/source/Support/Developer/releaseGuide.rst`
- `docs/source/Support/bskReleaseNotesSnippets/`

## Future work
A future cleanup should refactor the wheel build flow so the core and opNav wheels can be produced more cleanly and with less duplicate build time. The current implementation is intentionally conservative for the v2.11 release, but the longer-term goal should be to avoid rebuilding large portions of Basilisk multiple times when generating related wheel artifacts.