### PR TITLE
Remove Numba cache artifacts during clean builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,10 +6,9 @@ import shlex
 import subprocess
 import sys
 from datetime import datetime
-from typing import Optional, Callable
 from glob import glob
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import importlib.metadata
 from packaging.requirements import Requirement
@@ -18,7 +17,6 @@ from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 from conan.tools.microsoft import is_msvc
 from conan.tools.files import copy
-from pathlib import Path
 
 sys.path.insert(1, './src/utilities/')
 import makeDraftModule
@@ -69,6 +67,67 @@ def is_running_virtual_env():
 required_conan_version = ">=2.0.5"
 
 PY_LIMITED_API_PY39  = "0x03090000"  # cp39-abi3
+NUMBA_CACHE_SEARCH_DIRS = ("src", "docs/source", "examples")
+NUMBA_CACHE_DIR_NAME = "__pycache__"
+NUMBA_CACHE_FILE_PATTERNS = ("*.nbc", "*.nbi")
+
+
+def get_basilisk_numba_model_cache_dir() -> Optional[Path]:
+    """Return Basilisk's generated Numba model cache directory."""
+    try:
+        from platformdirs import user_cache_dir
+    except ImportError:
+        return None
+    return Path(user_cache_dir("basilisk")) / "numba_model"
+
+
+def clean_numba_cache_artifacts(root: Optional[Path] = None,
+                                user_cache_dir: Optional[Path] = None,
+                                print_fn: Optional[Callable[[str], None]] = print) -> tuple[int, bool]:
+    """Remove Numba disk-cache artifacts that can outlive a clean build."""
+    root_path = Path.cwd() if root is None else Path(root)
+    removed_cache_files = 0
+
+    for search_dir in NUMBA_CACHE_SEARCH_DIRS:
+        search_path = root_path / search_dir
+        if not search_path.exists():
+            continue
+        for cache_dir in search_path.rglob(NUMBA_CACHE_DIR_NAME):
+            if not cache_dir.is_dir():
+                continue
+            for pattern in NUMBA_CACHE_FILE_PATTERNS:
+                for cache_file in cache_dir.glob(pattern):
+                    try:
+                        cache_file.unlink()
+                        removed_cache_files += 1
+                    except FileNotFoundError:
+                        continue
+
+    cache_dir = (
+        get_basilisk_numba_model_cache_dir()
+        if user_cache_dir is None
+        else Path(user_cache_dir)
+    )
+    cache_dir_existed = False
+    removed_user_cache = False
+    if cache_dir is not None and cache_dir.exists():
+        cache_dir_existed = True
+        shutil.rmtree(cache_dir, ignore_errors=True)
+        removed_user_cache = not cache_dir.exists()
+
+    if print_fn is not None:
+        print_fn(f"Removed {removed_cache_files} in-repo Numba cache file(s).")
+        if cache_dir is None:
+            print_fn("Basilisk Numba model cache path unavailable; platformdirs is not installed.")
+        elif removed_user_cache:
+            print_fn(f"Removed Basilisk Numba model cache: {cache_dir}")
+        elif cache_dir_existed:
+            print_fn(f"Unable to fully remove Basilisk Numba model cache: {cache_dir}")
+        else:
+            print_fn(f"No Basilisk Numba model cache found at: {cache_dir}")
+
+    return removed_cache_files, removed_user_cache
+
 
 def resolve_py_limited_api(opt_value: Optional[str]) -> str:
     """Use explicit --pyLimitedAPI if provided, else cp39."""
@@ -230,6 +289,7 @@ class BasiliskConan(ConanFile):
             distPath = os.path.join(root, "dist3")
             if os.path.exists(distPath):
                 shutil.rmtree(distPath, ignore_errors=True)
+            clean_numba_cache_artifacts(Path(root))
         if self.settings.get_safe("build_type") == "Debug":
             print(warningColor + "Build type is set to Debug. Performance will be significantly lower." + endColor)
 

--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -65,7 +65,8 @@ The script accepts the following options to customize this process.
     * - ``clean``
       -
       - None
-      - If flag is set, this forces the distribution folder ``dist3`` to be deleted to create a fresh setup and build
+      - If flag is set, this deletes the distribution folder ``dist3`` and Basilisk Numba cache
+        artifacts to create a fresh setup and build
     * - ``buildProject``
       - Boolean
       - True

--- a/docs/source/Build/installBuildConan.rst
+++ b/docs/source/Build/installBuildConan.rst
@@ -55,7 +55,8 @@ Note that the option names for groupings of Basilisk modules are the same as wit
     * - ``-o clean``
       - Boolean
       - False
-      - Delete the distribution folder before configuring to yield a fresh build
+      - Delete the distribution folder and Basilisk Numba cache artifacts before configuring to yield
+        a fresh build
     * - ``-o buildProject``
       - Boolean
       - True

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -15,6 +15,8 @@ Version |release| (July 7, 2026)
   for Basilisk and compatible plugins. If source builds fail with SWIG 4.4.0 or emit
   ``builtin type swigvarlink has no __module__ attribute`` warnings, upgrade to SWIG 4.4.1 or a newer
   supported 4.x release.
+- ``python conanfile.py --clean`` now removes Basilisk Numba cache artifacts in addition to ``dist3``,
+  preventing clean source builds from reusing stale compiled Numba objects after API changes.
 
 Version 2.11.0 (July 7, 2026)
 -----------------------------

--- a/docs/source/Support/bskReleaseNotesSnippets/1469-clean-numba-cache.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1469-clean-numba-cache.rst
@@ -1,0 +1,1 @@
+- ``python conanfile.py --clean`` now removes Basilisk Numba cache artifacts in addition to ``dist3``, preventing stale compiled Numba objects from surviving clean source builds.

--- a/src/tests/test_conan_clean.py
+++ b/src/tests/test_conan_clean.py
@@ -1,0 +1,70 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+"""Tests for Basilisk build-clean helpers."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+pytest.importorskip("conan")
+
+
+def test_clean_numba_cache_artifacts(tmp_path, monkeypatch):
+    """Ensure clean builds remove repo and user Numba cache artifacts."""
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(repo_root)
+    monkeypatch.syspath_prepend(str(repo_root))
+    conanfile = importlib.import_module("conanfile")
+
+    cache_files = [
+        tmp_path / "src" / "module" / "__pycache__" / "state.nbc",
+        tmp_path / "src" / "module" / "__pycache__" / "state.nbi",
+        tmp_path / "docs" / "source" / "codeSamples" / "__pycache__" / "sample.nbc",
+        tmp_path / "examples" / "__pycache__" / "scenario.nbi",
+    ]
+    retained_files = [
+        tmp_path / "src" / "module" / "__pycache__" / "state.pyc",
+        tmp_path / "src" / "module" / "reference.nbc",
+        tmp_path / "docs" / "source" / "codeSamples" / "sample.py",
+        tmp_path / "docs" / "source" / "codeSamples" / "reference.nbi",
+        tmp_path / "examples" / "scenario_data.nbc",
+    ]
+    for path in cache_files + retained_files:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("cache", encoding="utf-8")
+
+    user_cache_dir = tmp_path / "user-cache" / "basilisk" / "numba_model"
+    user_cache_file = user_cache_dir / "nbm_test.py"
+    user_cache_dir.mkdir(parents=True)
+    user_cache_file.write_text("cache", encoding="utf-8")
+
+    removed_files, removed_user_cache = conanfile.clean_numba_cache_artifacts(
+        tmp_path,
+        user_cache_dir,
+        print_fn=None,
+    )
+
+    assert removed_files == len(cache_files)
+    assert removed_user_cache is True
+    assert not user_cache_dir.exists()
+    for path in cache_files:
+        assert not path.exists()
+    for path in retained_files:
+        assert path.exists()


### PR DESCRIPTION
- **Tickets addressed:** #1469 
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

Extend `python conanfile.py --clean` to remove stale Numba build artifacts in addition to `dist3`.

The clean operation now removes:

- `.nbc` and `.nbi` files beneath `src`, `docs/source`, and `examples`
- Basilisk's generated Numba model cache under the platform-specific user cache directory

The commits are organized by implementation, unit test, documentation, and release-note update.

## Verification

Added `src/tests/test_conan_clean.py` to verify that:

- Repository Numba cache files are removed
- The Basilisk user Numba cache directory is removed
- Unrelated `.py` and `.pyc` files are retained

The focused test passes:

`pytest -q src/tests/test_conan_clean.py`

All pre-commit and commit-message hooks also pass. A full clean build is being tested separately.

## Documentation

Updated both build guides to describe the expanded `--clean` behavior:

- `docs/source/Build/installBuild.rst`
- `docs/source/Build/installBuildConan.rst`

Also updated `bskKnownIssues.rst` and added a release-note snippet for the user-visible build behavior change.

## Future work

None identified.