### PR TITLE
Fix nightly optional-wheel build metadata mismatch

### DIFF
--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build core bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: wheelhouse-core
         env:
@@ -53,7 +53,7 @@ jobs:
           df -h
 
       - name: Build opNav-enabled bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: wheelhouse-opnav-full
         env:

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build core bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: wheelhouse-core
         env:
@@ -80,7 +80,7 @@ jobs:
           df -h
 
       - name: Build opNav-enabled bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: wheelhouse-opnav-full
         env:

--- a/.github/workflows/test-optional-wheels.yml
+++ b/.github/workflows/test-optional-wheels.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build core bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: wheelhouse-core
         env:
@@ -44,7 +44,7 @@ jobs:
           CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
 
       - name: Build opNav-enabled bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: wheelhouse-opnav-full
         env:
@@ -123,7 +123,7 @@ jobs:
           df -h
 
       - name: Build ${{ matrix.wheel-kind }} bsk wheel
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           output-dir: ${{ matrix.output-dir }}
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ CMakeCache.txt
 .DS_Store
 dist/
 dist3/
+/wheelhouse*/
 .pytest_cache
 docs/html
 docs/build

--- a/docs/source/Support/bskReleaseNotesSnippets/nightly-optional-wheel-build-info.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/nightly-optional-wheel-build-info.rst
@@ -1,0 +1,1 @@
+- Fixed nightly optional-wheel packaging failures caused by wheel build output changing the recorded source-dirty state between core and extension builds.


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

Ignore root-level `wheelhouse*` build-output directories so the core and opNav-enabled wheel builds record the same source-dirty state. This prevents the generated `Basilisk/_buildInfoData.py` files from differing and allows optional-wheel packaging to complete.

The PR contains one focused commit covering the ignore rule and its release-note snippet.

## Verification

- Confirmed all wheelhouse paths used by the nightly, publish, and optional-wheel workflows are ignored.
- Created a probe file under `wheelhouse-core` and verified it did not appear in `git status --porcelain --untracked-files=normal`.
- Ran the relevant pre-commit checks successfully.
- Ran `git diff --check` successfully.

No automated test was added because the change is limited to Git ignore behavior and was directly validated with `git check-ignore` and `git status`. The Nightly Wheels workflow will be manually triggered for full matrix validation.

## Documentation

No existing documentation was invalidated. Added a release-note snippet documenting the optional-wheel packaging fix.

## Future work

Manually trigger the Nightly Wheels workflow and confirm that optional-wheel generation succeeds on Linux x86-64, Linux ARM64, macOS, and Windows.