### PR TITLE
Add SPICE interpolation and extrapolation to SpiceInterface

### DIFF
--- a/docs/source/Learn/makingModules/advancedTopics.rst
+++ b/docs/source/Learn/makingModules/advancedTopics.rst
@@ -11,3 +11,4 @@ This section covers advanced BSK module writing topics.
    advancedTopics/creatingDynObject
    advancedTopics/mujocoDynObject
    advancedTopics/effectorBranching
+   advancedTopics/spiceReconstruction

--- a/docs/source/Learn/makingModules/advancedTopics/spiceReconstruction.rst
+++ b/docs/source/Learn/makingModules/advancedTopics/spiceReconstruction.rst
@@ -1,0 +1,170 @@
+.. _spiceReconstruction:
+
+Optimizing performance when using SPICE
+=======================================
+
+By default, :ref:`spiceInterface` evaluates SPICE (``spkezr_c`` for a body's position,
+``sxform_c`` for its orientation) at the *exact* simulation time on every ``UpdateState``
+call. When SPICE has become a performance bottleneck, the module can instead **reconstruct** each
+body's state from a coarse grid of cached SPICE samples ("knots"), trading a controllable amount
+of accuracy for far fewer SPICE evaluations. This page describes when that helps and how to
+configure it.
+
+When SPICE is (and is not) a bottleneck
+---------------------------------------
+How often SPICE is queried depends entirely on how the module is scheduled:
+
+* **Regular task, e.g. a classic** :ref:`spacecraft` **with**
+  :ref:`gravityEffector`. ``spiceInterface`` runs once per task period and writes each planet
+  message a single time per step. ``gravityEffector`` then reads that one message and performs
+  its *own* internal linear extrapolation of the planet to each integrator sub-step (position via
+  ``PositionVector + VelocityVector*dt`` and orientation via ``J20002Pfix + J20002Pfix_dot*dt``).
+
+* **Dynamics task (e.g.** :ref:`MJScene` **).** A model added with ``AddModelToDynamicsTask`` has
+  its ``UpdateState`` invoked once per *integrator stage*. A fixed RK4 step calls it four times;
+  an adaptive integrator such as RKF45 calls it more. Every one of those calls issues a fresh
+  ``spkezr_c``/``sxform_c`` per body.
+
+Reconstruction breaks the tie between "how often the state is *requested*" and "how often SPICE
+is *called*". It lays down a grid of sample points ("knots") spaced ``knotStep`` nanoseconds
+apart in absolute time: knot 0 at the epoch, knot 1 at ``knotStep``, knot 2 at ``2*knotStep``, and so
+on. SPICE is called only to fill a knot, and only the first time that knot is needed; the result
+is cached. When the state is requested at some arbitrary time (say a mid-step stage time), the
+module finds the knots surrounding that time, calls SPICE for any not already cached, and
+computes the requested value by interpolating or extrapolating between them. It does **not**
+call SPICE at the requested time itself.
+
+The consequence is that the cost no longer depends on the integrator. Many different requests
+fall between the same pair of knots: the four RK4 stages within one step, the extra stages of
+an adaptive method, and the re-tried stages of a rejected step all land in the same knot interval
+and reuse the same cached knots. So the number of SPICE calls is set purely by how many knots the
+run spans, ``~ horizon / knotStep`` per channel per body, regardless of how many times per step
+the integrator asks for the state.
+
+The three per-channel states
+----------------------------
+Each planet has two independent channels, **position** and **orientation**, and each channel
+is in one of three states:
+
+#. **Exact** (the default): query SPICE at the exact time on every call.
+#. **Reconstruct**: build the value from the cached knot grid.
+#. **Disabled**: make no SPICE query and emit the trivial default (zero position and velocity,
+   or the identity orientation and zero rate). Use this to remove a computation that is not needed
+   (e.g. a body pinned at the frame origin needs no position; a body used purely as a point mass
+   needs no orientation).
+
+In all three states every field of the planet-state message is still populated: the numeric
+arrays as described above, and ``J2000Current`` (message validity time), ``computeOrient``, and
+``PlanetName`` exactly as in the exact path. Orientation reconstruction is additionally gated on
+``computeOrient``, so a body with no orientation frame keeps the identity ``J20002Pfix``.
+
+The reconstruction is controlled by four knobs, set per planet and per channel:
+
+* ``knotStep``: spacing of the absolute-time knot grid, in nanoseconds;
+* ``nKnots``: stencil size, i.e. the polynomial order;
+* ``useVelocity``: also match the SPICE-provided velocity/rate at each knot (Hermite) rather
+  than fitting positions only (Lagrange);
+* ``interpolate``: bracket the current time with past *and* future knots (interpolation) or use
+  only past knots (causal extrapolation).
+
+Configuring it
+--------------
+Create the ``SpiceInterface`` the usual way, through :ref:`simIncludeGravBody`: the same factory
+that creates the gravity bodies also builds and connects the ``SpiceInterface`` (and, on an
+:ref:`MJScene`, attaches the gravity model with ``addBodiesTo``). The reconstruction methods are
+then called on the returned object, keyed by planet name (case-insensitive)::
+
+    from Basilisk.utilities import macros, simIncludeGravBody
+
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    gravFactory.createEarth().isCentralBody = True
+    gravFactory.createMoon()
+    gravFactory.createSun()
+    spice = gravFactory.createSpiceInterface(time="2025 NOVEMBER 15 12:00:00.000")
+
+    # Position: cubic Hermite interpolation on a 240 s grid. knotStep is in nanoseconds,
+    # so use macros.sec2nano to convert (like task periods elsewhere in Basilisk).
+    spice.setPlanetPositionReconstruction("earth", knotStep=macros.sec2nano(240.0))   # nKnots=2, useVelocity=True, interpolate=True
+
+    # Orientation of a constant-rate spinner: extrapolate from a SINGLE knot (see below).
+    spice.setPlanetOrientationReconstruction("moon", knotStep=macros.sec2nano(1.0e5), nKnots=1,
+                                             useVelocity=True, interpolate=False)
+
+    # Turn a channel off entirely (no SPICE query):
+    spice.setPlanetPositionDisabled("sun")
+
+    # Revert a planet to the exact per-call SPICE query:
+    spice.setPlanetExactSpice("earth")
+
+    # Measure the payoff: {positionQueries, orientationQueries} over the run.
+    nPos, nOrient = spice.getPlanetSpiceQueryCount("earth")
+
+When a channel is enabled, its defaults are the efficient ones: cubic Hermite interpolation
+(``nKnots=2, useVelocity=True, interpolate=True``) on a 60 s grid. So
+``setPlanetPositionReconstruction(name)`` with no further arguments is usually a good starting
+point.
+
+Choosing knobs by body type
+----------------------------
+* **Bodies with a constant rotation vector** (a fixed spin axis and constant rate). This covers
+  nearly every catalogued small body and the planetary IAU frames, whose orientation model is a
+  linear ``W = W0 + Wdot*t``. SPICE returns the attitude as a DCM, whose trajectory is *not* linear
+  in time; the reconstruction extrapolates the **principal rotation vector** (PRV) instead, which
+  *is* linear in time for a fixed axis at a constant rate. So first-order extrapolation from a
+  **single knot** (``nKnots=1, useVelocity=True, interpolate=False``) is exact at any ``knotStep``:
+  one ``sxform_c`` call serves the whole run. Do not pay for interpolation or extra knots here.
+* **Smooth heliocentric position** (planets, the Moon relative to Earth). The trajectory is very
+  smooth on the scale of a propagation, so cubic Hermite interpolation (``nKnots=2,
+  useVelocity=True, interpolate=True``) on a coarse ``knotStep`` reconstructs it to well below the
+  integrator's own error.
+* **Tumblers** (non-principal-axis rotators, e.g. proximity operations at objects like Apophis).
+  The orientation has genuine curvature, so linear extrapolation degrades as the knot spacing
+  grows; use interpolation (``interpolate=True``) and, if needed, ``nKnots >= 2``.
+
+Tuning: match the reconstruction error to the integrator error
+--------------------------------------------------------------
+The guiding principle is that **the reconstruction error should be the same order of magnitude as
+the integrator's own truncation error.** Once the reconstruction error drops
+below the integrator error it no longer affects the trajectory, so any finer knot grid is wasted
+computation.
+
+A practical workflow:
+
+#. Fix the shape at the efficient default (``nKnots=2, useVelocity=True, interpolate=True``), or
+   the single-knot extrapolation above for a constant rotator. If SPICE querying is no longer
+   a performance bottleneck, stop here. Otherwise:
+#. Treat ``knotStep`` as the primary lever. A reasonable starting value is **8-16x the task
+   step**. Then *increase* ``knotStep`` until the final-state error just begins to rise above the
+   exact-SPICE baseline (that rise is reconstruction error emerging from beneath the integrator
+   floor), and back off one step. Equivalently, if ``knotStep`` is fixed, there is no benefit to
+   shrinking it once the error curve has flattened onto the integrator floor.
+#. Use ``getPlanetSpiceQueryCount`` to confirm the query count fell to roughly ``horizon /
+   knotStep`` and quantify the saving.
+
+Align ``knotStep`` with the task step when possible
+---------------------------------------------------
+The reconstruction is a *piecewise* polynomial: its knot stencil switches as time crosses each
+knot, so the reconstructed state has a mild discontinuity in its curvature (a "C1 kink") at knot
+boundaries. If such a kink falls *inside* an integrator step it can locally reduce the
+integrator's order and, for adaptive steppers, provoke unnecessary step-size cuts. The
+reconstructed *value* is correct for any ``knotStep``; this is purely an integrator-efficiency
+concern.
+
+For a **fixed-step** integrator you can neutralize it by choosing ``knotStep`` as an integer
+multiple of the task step, ``knotStep = m * dt``. Every knot boundary then coincides with a step
+boundary (where the integrator restarts its expansion anyway) instead of landing mid-step. For
+the orientation channel, whose base knot switches at the half-interval, an **even** multiple aligns
+that boundary too. For adaptive integrators exact alignment is not possible, but keeping
+``knotStep`` large relative to the average step keeps kinks rare. This is the concrete reason the
+``knotStep >> task step`` guidance above is a soundness recommendation, not merely a tuning tip.
+
+Worked examples
+---------------
+Two example scenarios put this page into practice, one per channel:
+
+* :ref:`scenarioSpiceReconstruction` reconstructs the **position** of the Moon during a cislunar
+  lunar-flyby transfer, sweeping ``knotStep`` to trace the accuracy-vs-query-count tradeoff and
+  showing the "free" region below the integrator error.
+* :ref:`scenarioVestaOrientation` reconstructs the **orientation** of the constant-rate spinner
+  (4) Vesta, showing that a single-knot velocity extrapolation reproduces the attitude exactly at
+  a fraction of the SPICE cost.

--- a/docs/source/Support/bskReleaseNotesSnippets/spice-reconstruction.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/spice-reconstruction.rst
@@ -1,0 +1,5 @@
+- Added opt-in ephemeris **reconstruction** to :ref:`spiceInterface`: each planet's position and orientation channels can independently reconstruct their state from a coarse grid of cached SPICE samples (or be disabled) instead of querying SPICE at the exact time on every call, cutting SPICE evaluations to roughly ``horizon / knotStep`` per channel. The default behavior is unchanged and bit-for-bit identical.
+- Added ``getPlanetSpiceQueryCount`` to :ref:`spiceInterface`, returning the ``{position, orientation}`` SPICE query counts accumulated over a run.
+- Added :ref:`scenarioSpiceReconstruction`, a lunar-flyby tutorial that trades SPICE queries for accuracy on the Moon's position and shows the region below the integrator error where the trade is free.
+- Added :ref:`scenarioVestaOrientation`, showing that a constant-rate spinner's orientation can be reconstructed exactly from a single SPICE query.
+- Added the :ref:`spiceReconstruction` guide covering when SPICE is a bottleneck and how to tune the reconstruction knobs.

--- a/examples/_default.rst
+++ b/examples/_default.rst
@@ -218,6 +218,8 @@ It's recommended to study the first 6 scenarios in order:
   Solar Radiation Pressure Model on Arbitrary Surfaces <mujoco/scenarioSRPInPanels>
   Landing on Asteroid with Contact Physics <mujoco/scenarioAsteroidLanding>
   Earth-Moon Gravity with SPICE or PlanetEphemeris <mujoco/scenarioMJEarthMoonGravity>
+  Optimizing SPICE Cost with Ephemeris Reconstruction (Position) <scenarioSpiceReconstruction>
+  Optimizing SPICE Cost with Ephemeris Reconstruction (Orientation) <scenarioVestaOrientation>
   Docking between Two CubeSats <mujoco/scenarioSimpleDocking>
   Branching Panel Deployment with Locking Mechanisms <mujoco/scenarioBranchingPanels>
   Pointing with Reaction Wheels in MuJoCo <mujoco/scenarioAttitudeFeedbackRWMuJoCo>

--- a/examples/scenarioSpiceReconstruction.py
+++ b/examples/scenarioSpiceReconstruction.py
@@ -1,0 +1,481 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+r"""
+Overview
+--------
+An example of the :ref:`SpiceInterface<spiceInterface>` ephemeris **reconstruction** feature
+(see :ref:`spiceReconstruction`), on a cislunar transfer that is targeted for a deep lunar flyby:
+the transfer apogee is aimed at the Moon and pulled slightly short, so the spacecraft passes about
+18000 km from the Moon, well inside its sphere of influence, and its trajectory is sharply bent by
+the encounter. That makes the Moon's position the dominant driver of the orbit, so how it is
+supplied to the gravity model is a significant accuracy knob. The scenario shows that reconstruction trades
+SPICE queries for accuracy, and that below the integrator's own error the trade is free.
+
+The **reference solution** every error is measured against is exact SPICE queried at every RK4
+sub-step, run on an :ref:`MJScene<MJScene>` dynamics task (the most accurate and most expensive
+option). Against it the scenario compares:
+
+#. **Reconstruction sweep**: the Moon position reconstructed from a coarse knot grid, sweeping
+   ``knotStep`` to trace error versus SPICE query count.
+#. **Default spacecraft setup**: a classic :ref:`spacecraft` with :ref:`gravityEffector`, where
+   :ref:`spiceInterface` is queried at the task rate and :ref:`gravityEffector` linearly
+   extrapolates the Moon across the sub-steps.
+
+Even with a perfect ephemeris the RK4 integrator has its own truncation error at the study step.
+The scenario measures it by rerunning the exact-SPICE case at a much finer step (``REFERENCE_DT``),
+treating that as converged truth, and taking the difference: whatever error the study-step run still
+carries is the integrator's. Reconstruction error below this level is masked by it and does not
+change the orbit, which is what makes coarsening the knot grid free down to that point.
+
+Run with::
+
+    python3 scenarioSpiceReconstruction.py
+
+Illustration of Results
+-----------------------
+The first figure is the trajectory itself, projected onto the plane of the transfer. It plots the
+spacecraft path and the Moon's path over the same leg, with the closest-approach points marked. The
+spacecraft coasts out from perigee, turns around about 18000 km from the Moon, and its arc is
+visibly bent by the encounter. This is the setup for everything that follows: because the flyby
+dominates the final state, the Moon's position is the quantity the answer is most sensitive to, so
+how often and how accurately it is supplied to the gravity model is what the rest of the study
+measures.
+
+.. figure:: /_images/Scenarios/scenarioSpiceReconstruction1.svg
+   :align: center
+   :scale: 90 %
+
+The second figure is the accuracy-vs-cost tradeoff. The x-axis is the number of SPICE queries the
+Moon costs over the whole run (compute cost); the y-axis is the resulting error in the final
+spacecraft position, measured against the exact-SPICE reference. Each blue point is one
+reconstruction run at a different knot spacing: coarser grids sit to the left (fewer queries, more
+error). The horizontal line is the integrator's own error at this step size, and the shaded band
+below it is the "free" zone, where reconstruction error is smaller than the integrator error and so
+does not change the orbit. The reconstruction curve drops into that band after only a few tens of
+queries, so coarsening the grid further buys nothing. For comparison, the exact-SPICE reference sits
+at the far right at its full query cost (zero error by definition, on the broken "0" tick), and the
+:ref:`spacecraft` + :ref:`gravityEffector` default sits *above* the band: a handful of
+reconstruction knots is both cheaper and more accurate than that default behaviour.
+
+.. figure:: /_images/Scenarios/scenarioSpiceReconstruction2.svg
+   :align: center
+   :scale: 90 %
+
+The third figure shows the position error buildup against time for three cases: the integrator error (the black
+curve, the run with a perfect ephemeris, which grows over the leg and jumps at the flyby), one cheap
+reconstruction taken from the free zone of the second figure, and the :ref:`spacecraft` default. The shaded
+region is again the free zone, now time-varying because the integrator error grows. The
+reconstruction stays inside that zone for nearly the whole leg on a handful of Moon queries, while
+the :ref:`spacecraft` default climbs above it early in the coast and grows to tens of kilometres.
+
+.. figure:: /_images/Scenarios/scenarioSpiceReconstruction3.svg
+   :align: center
+   :scale: 90 %
+
+Does it actually save wall-clock time? The scenario prints the runtime of each run. The cleanest
+way to read the effect is to hold the dynamics engine fixed and vary only SPICE: the classic
+:ref:`spacecraft` + :ref:`gravityEffector` path with exact SPICE (one Moon query per step) versus
+the same path with Moon-position reconstruction. On the author's machine, collapsing the Moon
+queries from ~15600 to a handful cuts the classic-path runtime by roughly **5%**. On the
+:ref:`MJScene<MJScene>` dynamics task the saving is larger, on the order of **10%**, because that
+path queries SPICE four times per step (once per RK4 stage) rather than once, so SPICE is a bigger
+share of the step.
+"""
+import os
+import time
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from Basilisk.utilities import SimulationBaseClass, macros, simHelpers, simIncludeGravBody
+from Basilisk.simulation import mujoco, svIntegrators, spacecraft
+from Basilisk.topLevelModules import pyswice
+from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
+
+fileName = os.path.splitext(os.path.basename(__file__))[0]
+
+# scenario configuration
+EPOCH = "2025 NOVEMBER 15 12:00:00.000"
+RK4_DT = 30.0                 # [s] integrator / task step for the study
+N_STEPS = 15600               # horizon in steps -> TF = 130 h, past the lunar flyby at ~115 h
+TF = RK4_DT * N_STEPS
+REFERENCE_DT = 2.0            # [s] fine RK4 step whose exact-SPICE run is the integrator-converged truth
+# Apogee radius as a fraction of the Moon's distance at arrival. Aiming the transfer apogee at the
+# Moon gives a bullseye impact; pulling it slightly short (0.94) makes the spacecraft turn around
+# ~18000 km from the Moon, a deep pass inside its ~66000 km sphere of influence that sharply bends
+# the trajectory without being captured.
+APOGEE_FRACTION = 0.94
+# Reconstruction knot spacings to sweep, as integer multiples of the task step. The range is
+# chosen so the reconstruction-error curve crosses the integrator error floor: fine grids stay
+# exact, coarse grids rise above it.
+KNOT_MULTIPLES = [64, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144]
+
+# A minimal free-flying point mass. Its own shape/mass are irrelevant; only the orbit matters.
+SC_XML = r"""
+<mujoco>
+    <worldbody>
+        <body name="sc"><freejoint/><inertial pos="0 0 0" mass="1" diaginertia="1 1 1"/></body>
+    </worldbody>
+</mujoco>
+"""
+
+# standard Basilisk scenario plotting colours (gist_earth map, as the other scenarios use)
+C_RECON = simHelpers.getLineColor(0, 3)
+C_CLASSIC = simHelpers.getLineColor(1, 3)
+C_EXACT = simHelpers.getLineColor(2, 3)
+
+
+def runMJScene(rN, vN, dt, knotStep=None, record=False):
+    """Propagate the cislunar orbit in an MJScene dynamics task with Earth (central) + Moon third
+    body at RK4 step ``dt``. ``knotStep`` (nanoseconds), if given, reconstructs the Moon position
+    with cubic Hermite on that knot grid; otherwise the Moon is queried exactly at every RK4
+    sub-step. Returns (final position, Moon SPICE query count,
+    optional [times, spacecraft positions, Moon positions])."""
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("simProcess")
+    dynProcess.addTask(scSim.CreateNewTask("simTask", macros.sec2nano(dt)))
+
+    scene = mujoco.MJScene(SC_XML)
+    scene.ModelTag = "cislunarScene"
+    scSim.AddModelToTask("simTask", scene)
+    integratorObject = svIntegrators.svIntegratorRK4(scene)
+    scene.setIntegrator(integratorObject)
+    body = scene.getBody("sc")
+
+    # Earth (central body at the origin) and the Moon are both produced by one SpiceInterface.
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    gravFactory.createEarth().isCentralBody = True
+    gravFactory.createMoon()
+    spiceObject = gravFactory.createSpiceInterface(time=EPOCH)
+    spiceObject.zeroBase = "Earth"
+    if knotStep is not None:
+        spiceObject.setPlanetPositionReconstruction("moon", int(knotStep))
+
+    # Add the SPICE producer to the dynamics task first so planet states are current at every
+    # sub-step, then let the factory build the NBodyGravity model: it registers Earth and the Moon
+    # as gravity sources (reusing their gravity models and SPICE connections) and applies gravity
+    # at the MuJoCo spacecraft. addBodiesTo returns the model, which must stay referenced.
+    scene.AddModelToDynamicsTask(spiceObject)
+    gravity = gravFactory.addBodiesTo(scene)
+
+    scRec = body.getOrigin().stateOutMsg.recorder() if record else None
+    moonRec = spiceObject.planetStateOutMsgs[1].recorder() if record else None
+    if record:
+        scSim.AddModelToTask("simTask", scRec)
+        scSim.AddModelToTask("simTask", moonRec)
+
+    scSim.InitializeSimulation()
+    body.setPosition(list(rN)); body.setVelocity(list(vN))
+    scSim.ConfigureStopTime(macros.sec2nano(TF))
+    scSim.ExecuteSimulation()
+
+    rFinal = np.array(body.getOrigin().stateOutMsg.read().r_BN_N)
+    nQ = int(spiceObject.getPlanetSpiceQueryCount("moon")[0])
+    gravFactory.unloadSpiceKernels()
+    if record:
+        return rFinal, nQ, [np.array(scRec.times()) * macros.NANO2SEC, np.array(scRec.r_BN_N),
+                            np.array(moonRec.PositionVector)]
+    return rFinal, nQ, []
+
+
+def runClassicSpacecraft(rN, vN, dt, knotStep=None, record=False):
+    """Propagate the same orbit with a classic Spacecraft and gravityEffector on a regular task at
+    step ``dt``: SpiceInterface runs once per step and gravityEffector linearly extrapolates the
+    Moon across the sub-steps. ``knotStep`` (nanoseconds), if given, reconstructs the Moon position
+    on that knot grid instead of querying exact SPICE every step (same engine, SPICE the only change,
+    for the apples-to-apples runtime comparison). Returns (final position, Moon query count,
+    optional [times, spacecraft positions])."""
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("simProcess")
+    dynProcess.addTask(scSim.CreateNewTask("simTask", macros.sec2nano(dt)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "cislunarSat"
+    scSim.AddModelToTask("simTask", scObject)
+
+    gravFactory = simIncludeGravBody.gravBodyFactory()
+    gravFactory.createEarth().isCentralBody = True
+    gravFactory.createMoon()
+    gravFactory.addBodiesTo(scObject)               # attaches the gravityEffector + both bodies
+    spiceObject = gravFactory.createSpiceInterface(time=EPOCH)
+    spiceObject.zeroBase = "Earth"
+    if knotStep is not None:
+        spiceObject.setPlanetPositionReconstruction("moon", int(knotStep))
+    scSim.AddModelToTask("simTask", spiceObject)
+
+    scRec = scObject.scStateOutMsg.recorder() if record else None
+    if record:
+        scSim.AddModelToTask("simTask", scRec)
+
+    scObject.hub.r_CN_NInit = rN
+    scObject.hub.v_CN_NInit = vN
+    scSim.InitializeSimulation()
+    scSim.ConfigureStopTime(macros.sec2nano(TF))
+    scSim.ExecuteSimulation()
+
+    rFinal = np.array(scObject.scStateOutMsg.read().r_BN_N)
+    nQ = int(spiceObject.getPlanetSpiceQueryCount("moon")[0])
+    gravFactory.unloadSpiceKernels()
+    if record:
+        return rFinal, nQ, [np.array(scRec.times()) * macros.NANO2SEC, np.array(scRec.r_BN_N)]
+    return rFinal, nQ, []
+
+
+def moonFlybyInitialState(muEarth, rEq):
+    """Initial state of a transfer from a 600 km perigee out to a lunar flyby.
+
+    The transfer apogee is aimed at where the Moon will be when the spacecraft arrives, in the
+    Moon's orbit plane, then pulled short by ``APOGEE_FRACTION`` so the spacecraft turns around a
+    controlled distance from the Moon rather than hitting it. The Moon state comes straight from
+    SPICE (``spkezr_c``); the time of flight is the perigee-to-apogee half period, iterated to
+    self-consistency because the apogee radius depends on where the Moon is at arrival. Returns
+    the inertial (position, velocity) at perigee."""
+    for kernel in (DataFile.EphemerisData.de430, DataFile.EphemerisData.naif0012):
+        pyswice.furnsh_c(str(get_path(kernel)))
+    etArray = pyswice.new_doubleArray(1)
+    pyswice.str2et_c(EPOCH, etArray)
+    et0 = pyswice.doubleArray_getitem(etArray, 0)
+
+    def moonState(etSec):
+        state = pyswice.new_doubleArray(6); lt = pyswice.new_doubleArray(1)
+        pyswice.spkezr_c("MOON", etSec, "J2000", "NONE", "EARTH", state, lt)
+        return np.array([pyswice.doubleArray_getitem(state, i) for i in range(6)]) * 1e3  # m, m/s
+
+    rp = rEq + 600e3                                            # 600 km perigee altitude
+    tof = 120.0 * 3600.0
+    for _ in range(8):
+        ra = APOGEE_FRACTION * np.linalg.norm(moonState(et0 + tof)[:3])
+        a = (rp + ra) / 2.0
+        tof = np.pi * np.sqrt(a ** 3 / muEarth)                 # perigee -> apogee half period
+
+    arrival = moonState(et0 + tof)
+    apoHat = arrival[:3] / np.linalg.norm(arrival[:3])          # apogee aimed at the arrival Moon
+    hHat = np.cross(arrival[:3], arrival[3:])                   # transfer in the Moon's orbit plane
+    hHat /= np.linalg.norm(hHat)
+    rN = -rp * apoHat                                           # perigee is opposite the apogee
+    vN = np.sqrt(muEarth * (2.0 / rp - 1.0 / a)) * np.cross(hHat, -apoHat)   # prograde at perigee
+    pyswice.kclear_c()
+    return rN, vN
+
+
+def run(show_plots=True):
+    """Run the reconstruction accuracy-vs-cost study and produce its three figures.
+
+    Args:
+        show_plots (bool): display the figures.
+
+    Returns:
+        tuple: ``(errClassic, figureList)`` where ``figureList`` maps figure name to Figure.
+    """
+    # cislunar transfer targeting a deep lunar flyby (perigee 600 km, apogee near the Moon)
+    earth = simIncludeGravBody.gravBodyFactory().createEarth()
+    rN, vN = moonFlybyInitialState(earth.mu, earth.radEquator)
+
+    # truth and most-expensive reference: exact SPICE queried at every RK4 sub-step (wall-clock
+    # timed so the reconstruction speedup can be reported end-to-end). getPlanetSpiceQueryCount
+    # reports the real Moon-query count for the exact path too, so nQExact is measured, not assumed
+    # (it comes to one spkezr_c per RK4 stage).
+    t0 = time.perf_counter()
+    rTruth, nQExact, (tTruth, posTruth, moonTruth) = runMJScene(rN, vN, RK4_DT, record=True)
+    tExactRun = time.perf_counter() - t0
+
+    # reference: classic Spacecraft + gravityEffector (SpiceInterface once per step)
+    t0 = time.perf_counter()
+    rClassic, nQClassic, (tClassic, posClassic) = runClassicSpacecraft(rN, vN, RK4_DT, record=True)
+    tClassicRun = time.perf_counter() - t0
+    errClassic = float(np.linalg.norm(rClassic - rTruth))
+
+    # Integrator error over time: the exact-SPICE study step differenced against exact SPICE at the
+    # fine REFERENCE_DT step (the fine run interpolated onto the coarse sample times). This is the
+    # error the coarse integrator carries with a perfect ephemeris, so reconstruction error smaller
+    # than it does not affect the orbit. It grows over the leg; its final value is the floor used to
+    # pick the "free" reconstruction grid and to draw the free zone on the cost figure.
+    _, _, (tFine, posFine, _) = runMJScene(rN, vN, REFERENCE_DT, record=True)
+    fineAtCoarse = np.vstack([np.interp(tTruth, tFine, posFine[:, i]) for i in range(3)]).T
+    integratorFloor_t = np.linalg.norm(posTruth - fineAtCoarse, axis=1)
+    integratorFloor = float(integratorFloor_t[-1])
+
+    # reconstruction sweep: coarsen the Moon knot grid and watch error vs. query count
+    sweep = []
+    for m in KNOT_MULTIPLES:
+        r, nQ, _ = runMJScene(rN, vN, RK4_DT, knotStep=macros.sec2nano(m * RK4_DT))
+        sweep.append(dict(mult=m, nQ=nQ, err=float(np.linalg.norm(r - rTruth))))
+
+    print(f"[study] cislunar leg, RK4 dt={RK4_DT:g}s, horizon={TF/3600:.1f}h")
+    print(f"[study] integrator error floor (exact SPICE, {RK4_DT:g}s vs {REFERENCE_DT:g}s): {integratorFloor:8.1f} m")
+    print(f"[study] exact SPICE (per sub-step):  {nQExact:6d} Moon queries  (truth)")
+    print(f"[study] classic sc + gravityEffector:{nQClassic:6d} Moon queries  err={errClassic:8.1f} m")
+    for s in sweep:
+        print(f"[study] reconstruct knot={s['mult']:4d}xdt:  {s['nQ']:6d} Moon queries  err={s['err']:8.1f} m")
+
+    plt.rcParams.update({"font.size": 13, "lines.linewidth": 2.0, "lines.markersize": 8})
+    figureList = {}
+    figureList[fileName + "1"] = plotTrajectory(posTruth, moonTruth)
+    figureList[fileName + "2"] = plotAccuracyVsCost(sweep, errClassic, integratorFloor,
+                                                    nQExact, nQClassic)
+
+    # Figure 3 needs one more run: the cheapest grid whose final error still lands below the floor.
+    # Fall back to the finest grid swept if none clears the floor (keeps the figure well-defined).
+    below = [s for s in sweep if s["err"] < integratorFloor]
+    good = max(below, key=lambda s: s["mult"]) if below else min(sweep, key=lambda s: s["mult"])
+    goodKnot = macros.sec2nano(good["mult"] * RK4_DT)
+    t0 = time.perf_counter()
+    _, nQGood, (tR, posR, _) = runMJScene(rN, vN, RK4_DT, knotStep=goodKnot, record=True)
+    tReconRun = time.perf_counter() - t0
+
+    # Apples-to-apples: the classic path with the same lossless reconstruction, so only SPICE
+    # changes (same engine). This isolates the wall-clock effect of collapsing the Moon queries.
+    t0 = time.perf_counter()
+    runClassicSpacecraft(rN, vN, RK4_DT, knotStep=goodKnot)
+    tClassicReconRun = time.perf_counter() - t0
+
+    def _saving(exact, recon):
+        return 100.0 * (1.0 - recon / exact)  # percent runtime removed
+    print(f"[study] runtime classic path:  exact {tClassicRun:.2f}s -> reconstruction "
+          f"{tClassicReconRun:.2f}s  ({_saving(tClassicRun, tClassicReconRun):.0f}% less, SPICE-only change)")
+    print(f"[study] runtime MJScene path:  exact {tExactRun:.2f}s -> reconstruction "
+          f"{tReconRun:.2f}s  ({_saving(tExactRun, tReconRun):.0f}% less, 4 SPICE calls/step -> few)")
+    figureList[fileName + "3"] = plotErrorOverTime(tTruth, posTruth, integratorFloor_t,
+                                                   tR, posR, nQGood,
+                                                   tClassic, posClassic, nQClassic, errClassic)
+
+    if show_plots:
+        plt.show()
+    else:
+        plt.close("all")
+    return errClassic, figureList
+
+
+def plotTrajectory(posTruth, moonTruth):
+    """Figure 1: the cislunar transfer in 2D, with the Moon that perturbs it.
+
+    Both Earth-centred trajectories are projected onto the plane that best contains the spacecraft
+    path (its two dominant principal directions) so the flyby geometry is planar and the deflection
+    is easy to see, and the closest-approach point is marked on both paths.
+    """
+    _, _, principalDirs = np.linalg.svd(posTruth - posTruth.mean(axis=0), full_matrices=False)
+    e1, e2 = principalDirs[0], principalDirs[1]
+    scXY = np.column_stack([posTruth @ e1, posTruth @ e2]) / 1e3        # km, in-plane
+    moonXY = np.column_stack([moonTruth @ e1, moonTruth @ e2]) / 1e3
+    ca = int(np.argmin(np.linalg.norm(posTruth - moonTruth, axis=1)))   # closest-approach sample
+
+    fig, ax = plt.subplots(figsize=(8, 7), num=fileName + "1", layout="constrained")
+    ax.plot(scXY[:, 0], scXY[:, 1], color=C_RECON, lw=2.0, label="spacecraft trajectory", zorder=4)
+    # only the latter half of the Moon's path, the stretch around the encounter
+    moonTail = moonXY[len(moonXY) // 2:]
+    ax.plot(moonTail[:, 0], moonTail[:, 1], color="0.55", lw=1.5, ls="--", label="Moon trajectory", zorder=3)
+    ax.plot(0, 0, "o", color="0.2", ms=12, zorder=5, label="Earth")
+    ax.plot(*scXY[0], "o", color=C_RECON, ms=8, zorder=6)              # spacecraft start (perigee)
+    ax.plot(*moonXY[ca], "o", color="0.35", ms=16, zorder=6, label="Moon at closest approach")
+    ax.plot(*scXY[ca], "o", color=C_EXACT, ms=9, markeredgecolor="k", zorder=7)
+    ax.plot([scXY[ca, 0], moonXY[ca, 0]], [scXY[ca, 1], moonXY[ca, 1]], color="k", lw=1.0, ls=":", zorder=5)
+    ax.set_xlabel("in-plane distance from Earth  [km]")
+    ax.set_ylabel("in-plane distance from Earth  [km]")
+    ax.set_aspect("equal")            # same scale on both axes; extents free to fit the data
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="lower left")
+    return fig
+
+
+def plotAccuracyVsCost(sweep, errClassic, integratorFloor, nQExact, nQClassic):
+    """Figure 2: the accuracy-vs-cost tradeoff, with the references + integrator floor marked."""
+    # A coarser knot grid never queries SPICE more, so different knot spacings can land on the same
+    # query count; keep the lowest-error point per count so the curve is single-valued.
+    byQ = {}
+    for s in sweep:
+        if s["nQ"] not in byQ or s["err"] < byQ[s["nQ"]]:
+            byQ[s["nQ"]] = s["err"]
+    nq = np.array(sorted(byQ))
+    err = np.array([byQ[q] for q in nq])
+    top = errClassic * 3.0
+    plotFloor = 1e-6  # [m] bottom of the log panel; the finest grids are microns from the reference
+
+    # Broken y-axis: a wide log panel for the error curve, and a thin panel below holding the single
+    # "0" tick where the exact-SPICE reference lives (its error is zero by definition, which cannot
+    # sit on a log axis).
+    fig, (ax, axz) = plt.subplots(2, 1, figsize=(8, 6), num=fileName + "2",
+                                  sharex=True, height_ratios=[12, 1], layout="constrained")
+    ax.set_yscale("log")
+    ax.set_ylim(plotFloor, top)
+
+    # Grey "free" band spanning the whole panel below the black integrator-error floor line:
+    # reconstruction error there does not move the orbit, so query cost to shrink it is wasted.
+    ax.axhspan(ax.get_ylim()[0], integratorFloor, color="0.85", alpha=0.6, zorder=0)
+    ax.axhline(integratorFloor, color="k", ls="-", lw=1.5, zorder=1,
+               label=f"integrator error floor ({integratorFloor:.0f} m)")
+    ax.loglog(nq, np.maximum(err, plotFloor), "-o", color=C_RECON, zorder=5,
+              label="Moon reconstruction (cubic Hermite)")
+    ax.plot(nQClassic, errClassic, "s", color=C_CLASSIC, ms=12, zorder=6,
+            label="classic spacecraft + gravityEffector")
+    # proxy handle so the exact-SPICE reference (drawn in the break panel) appears in the legend
+    ax.plot([], [], "D", color=C_EXACT, ms=10, markeredgecolor="k",
+            label=f"exact SPICE reference ({nQExact} queries)")
+
+    # The exact-SPICE reference: zero error by definition, drawn in the break panel at the "0" tick.
+    # The whole break panel is below the floor, so it continues the grey "free" band.
+    axz.set_xscale("log")
+    axz.set_ylim(-0.5, 0.5)
+    axz.axhspan(-0.5, 0.5, color="0.85", alpha=0.6, zorder=0)
+    axz.plot(nQExact, 0.0, "D", color=C_EXACT, ms=12, markeredgecolor="k", zorder=6)
+    axz.set_yticks([0.0]); axz.set_yticklabels(["0"])
+
+    # diagonal break marks between the two panels
+    ax.spines["bottom"].set_visible(False); ax.tick_params(bottom=False)
+    axz.spines["top"].set_visible(False)
+    breakKw = dict(marker=[(-1, -0.5), (1, 0.5)], ms=8, ls="none", color="k", mec="k", mew=1, clip_on=False)
+    ax.plot([0, 1], [0, 0], transform=ax.transAxes, **breakKw)
+    axz.plot([0, 1], [1, 1], transform=axz.transAxes, **breakKw)
+
+    axz.set_xlim(1.5, nQExact * 1.6)
+    axz.set_xlabel("Moon SPICE queries over the run  (compute cost)")
+    ax.set_ylabel("orbit final-position error vs. exact-SPICE reference  [m]")
+    ax.grid(True, which="both", alpha=0.3)
+    axz.grid(True, axis="x", which="both", alpha=0.3)
+    ax.legend(loc="upper center")
+    return fig
+
+
+def plotErrorOverTime(tTruth, posTruth, integratorFloor_t, tR, posR, nQGood,
+                      tClassic, posClassic, nQClassic, errClassic):
+    """Figure 3: error over time for a well-chosen reconstruction, the classic default, and the
+    integrator error itself (the run with a perfect ephemeris)."""
+    errRecon_t = np.linalg.norm(posR - posTruth, axis=1)
+    # classic run error over time (both run at the task step, so the truth samples align)
+    errClassic_t = np.linalg.norm(posClassic - posTruth, axis=1)
+
+    fig, ax = plt.subplots(figsize=(8, 6), num=fileName + "3", layout="constrained")
+    # The integrator error grows over the leg; everything below it is the "free" zone where
+    # reconstruction error does not move the orbit.
+    floor_t = np.maximum(integratorFloor_t, 1e-6)
+    ax.fill_between(tTruth / 3600.0, 1e-6, floor_t, color="0.85", alpha=0.6, zorder=0)
+    ax.semilogy(tTruth / 3600.0, floor_t, color="k", ls="-", lw=1.5, zorder=1,
+                label="integrator error (perfect ephemeris)")
+    ax.semilogy(tR / 3600.0, np.maximum(errRecon_t, 1e-6), color=C_RECON, zorder=5,
+                label=f"reconstruction, {nQGood} Moon queries")
+    ax.semilogy(tClassic / 3600.0, np.maximum(errClassic_t, 1e-6), color=C_CLASSIC, ls="--", zorder=2,
+                label=f"classic spacecraft + gravityEffector ({nQClassic} queries)")
+    ax.set_ylim(1e-6, errClassic * 3.0)
+    ax.set_xlabel("time  [hr]")
+    ax.set_ylabel("position error vs. exact SPICE  [m]")
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend(loc="lower right")
+    return fig
+
+
+if __name__ == "__main__":
+    run(show_plots=True)

--- a/examples/scenarioVestaOrientation.py
+++ b/examples/scenarioVestaOrientation.py
@@ -1,0 +1,302 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+r"""
+Overview
+--------
+The companion to :ref:`scenarioSpiceReconstruction`, applying the :ref:`SpiceInterface<spiceInterface>`
+reconstruction feature (see :ref:`spiceReconstruction`) to the **orientation** channel instead of
+position. It illustrates the "constant rotation vector" case from that documentation page: for a body that spins
+about a fixed axis at a constant rate, orientation reconstruction is cheap and *exact*.
+
+A spacecraft orbits the asteroid (4) Vesta at 50 km altitude, deep in Vesta's modeled degree-8
+spherical-harmonic gravity field (``VESTA20H.txt``). Because :ref:`NBodyGravity<NBodyGravity>`
+rotates that aspherical field into the body-fixed frame using the source orientation ``J20002Pfix``,
+the attitude must be supplied continually as the orbit is integrated, and both dynamics paths call
+:ref:`spiceInterface` to get it. On an :ref:`MJScene<MJScene>` dynamics task the attitude is queried
+every RK4 sub-step; the classic :ref:`spacecraft` + :ref:`gravityEffector` path
+queries once per task step and extrapolates within the step (the same distinction as in the
+:ref:`companion position scenario<scenarioSpiceReconstruction>`). Either way, a finely stepped
+propagation evaluates ``sxform_c`` thousands of times per orbit.
+
+But Vesta's SPICE orientation ``IAU_VESTA`` is a **constant rotation vector**: a fixed spin axis and
+a constant rate (its IAU model is a linear ``W = W0 + Wdot*t``). SPICE returns the attitude as a
+DCM, and a DCM trajectory is *not* linear in time, so linearly extrapolating the DCM entries would
+not be exact. The reconstruction instead lifts the attitude to its **principal rotation vector**
+(PRV) and extrapolates *that*: for a fixed axis at a constant rate the PRV is exactly linear in
+time, so a first-order extrapolation from a *single* knot, mapped back to a DCM with ``PRV2C``,
+reproduces the attitude to machine precision for the whole run. One SPICE query serves the entire
+propagation.
+
+.. important::
+
+    This "one query is exact" simplification holds **only** while the body's angular-velocity
+    vector is (near) constant, i.e. a fixed spin axis at a fixed rate. That covers nearly every
+    catalogued small body and the planetary ``IAU_*`` frames. It does **not** hold for a tumbler
+    (a non-principal-axis rotator such as (99942) Apophis), whose spin axis drifts: there the
+    attitude has genuine curvature and single-knot extrapolation degrades quickly. Such bodies
+    need proper reconstruction with ``interpolate=True`` and ``nKnots >= 2`` (see the "choosing
+    knobs by body type" section of :ref:`spiceReconstruction`).
+
+The scenario runs a fine-step exact reference, then two coarse-step runs that differ only in how
+the attitude is supplied, and shows their errors against the reference are identical: the
+integrator step sets the error, not the SPICE query cost.
+
+Run with::
+
+    python3 scenarioVestaOrientation.py
+
+Illustration of Results
+-----------------------
+The first figure shows the spacecraft's path around Vesta over three orbits,
+with Vesta drawn to scale at the origin. The orbit is low (50 km) and inclined, so it passes over
+a range of longitudes and is steered throughout by the aspherical, body-fixed gravity field. That
+is why the body's attitude enters the dynamics at all, and it is the run whose final accuracy the
+second figure measures.
+
+.. figure:: /_images/Scenarios/scenarioVestaOrientation1.svg
+   :align: center
+   :scale: 90 %
+
+The second figure shows the position error against time for two coarse-step runs,
+each differenced against the same integrator-converged fine-step reference: one queries the attitude
+exactly at every sub-step (thousands of SPICE calls), the other velocity-extrapolates from a single
+SPICE query for the whole run. The legend gives each run's query count. The two error curves lie
+exactly on top of each other; because Vesta is a constant-rate spinner,
+the single-query attitude is exact, so the only error left is the integrator's own truncation error,
+identical in both runs. The attitude's SPICE cost, thousands of queries versus one, does not change
+the result.
+
+Does it actually save wall-clock time? The scenario prints the runtime of each run. As in the
+companion :ref:`scenarioSpiceReconstruction`, reconstruction changes only the SPICE cost, and here
+that cost is a small share of the step: the degree-8 spherical-harmonic gravity evaluation dominates.
+Collapsing the ~1700 attitude queries to one shaves at most a percent or two off the runtime on
+either dynamics path (the classic :ref:`spacecraft` + :ref:`gravityEffector`, which queries
+``sxform_c`` once per step, and the :ref:`MJScene<MJScene>` dynamics task, which queries it once per
+RK4 stage).
+
+.. figure:: /_images/Scenarios/scenarioVestaOrientation2.svg
+   :align: center
+   :scale: 90 %
+"""
+import os
+import time
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion, simHelpers
+from Basilisk.simulation import (mujoco, svIntegrators, NBodyGravity,
+                                  sphericalHarmonicsGravityModel, spiceInterface)
+from Basilisk.topLevelModules import pyswice
+from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
+
+fileName = os.path.splitext(os.path.basename(__file__))[0]
+
+# scenario configuration
+EPOCH = "2025 NOVEMBER 15 12:00:00.000"
+VESTA_SH_FILE = os.path.join(list(__import__("Basilisk").__path__)[0], "supportData",
+                             "LocalGravData", "VESTA20H.txt")
+SH_DEGREE = 8
+TARGET = "vesta"                   # SPICE body; IAU_VESTA is its constant-rate body-fixed frame
+ORBIT_ALT = 50.0e3                 # [m] low orbit -> strong dependence on the aspherical field
+ORBIT_INC = 40.0 * macros.D2R      # inclined so the trajectory samples the tesseral terms
+COARSE_DT = 60.0                   # [s] RK4 step for the two comparison runs
+REFERENCE_DT = 1.0                 # [s] fine RK4 step for the truth reference (integrator-converged)
+N_ORBITS = 3.0                     # propagation horizon in orbital periods
+
+# standard Basilisk scenario plotting colours (gist_earth map, as the other scenarios use)
+C_EXACT = simHelpers.getLineColor(0, 2)
+C_EXTRAP = simHelpers.getLineColor(1, 2)
+
+SC_XML = r"""
+<mujoco>
+    <worldbody>
+        <body name="sc"><freejoint/><inertial pos="0 0 0" mass="1" diaginertia="1 1 1"/></body>
+    </worldbody>
+</mujoco>
+"""
+
+
+def runOrbit(rN, vN, tf, dt, mu, rEq, kernels, knotStep=None):
+    """Propagate the Vesta orbit at RK4 step ``dt`` and record the spacecraft trajectory.
+
+    A SpiceInterface supplies only Vesta's orientation: Vesta sits at the frame origin as the
+    central body, so its position channel is disabled (identically zero, no SPK kernel needed). If
+    ``knotStep`` (nanoseconds) is given the orientation is reconstructed by single-knot velocity
+    extrapolation on that grid (one SPICE query for the whole run); otherwise it is queried exactly
+    at every integrator sub-step. Returns (orientation-query count, times [s], positions [m])."""
+    scSim = SimulationBaseClass.SimBaseClass()
+    dynProcess = scSim.CreateNewProcess("simProcess")
+    dynProcess.addTask(scSim.CreateNewTask("simTask", macros.sec2nano(dt)))
+
+    scene = mujoco.MJScene(SC_XML)
+    scene.ModelTag = "vestaScene"
+    scSim.AddModelToTask("simTask", scene)
+    integratorObject = svIntegrators.svIntegratorRK4(scene)
+    scene.setIntegrator(integratorObject)
+    body = scene.getBody("sc")
+
+    # Attitude producer: a SpiceInterface for Vesta's orientation only, position disabled. Added to
+    # the dynamics task BEFORE gravity so the attitude is current at every integrator stage.
+    spiceObject = spiceInterface.SpiceInterface(auto_configure_kernels=False)
+    spiceObject.ModelTag = "vestaOrient"
+    spiceObject.addPlanetNames(spiceInterface.StringVector([TARGET]))
+    spiceObject.UTCCalInit = EPOCH
+    for k in kernels:
+        spiceObject.addKernelPath(k)
+    spiceObject.setPlanetPositionDisabled(TARGET)
+    if knotStep is not None:
+        # (knotStep, nKnots=1, useVelocity=True, interpolate=False) = single-knot velocity extrap.
+        spiceObject.setPlanetOrientationReconstruction(TARGET, int(knotStep), 1, True, False)
+    scene.AddModelToDynamicsTask(spiceObject)
+
+    # Vesta's real degree-8 spherical-harmonic field, rotated into the body frame by the supplied
+    # orientation. This is what makes the acceleration attitude-dependent.
+    gravity = NBodyGravity.NBodyGravity()
+    shModel = sphericalHarmonicsGravityModel.SphericalHarmonicsGravityModel()
+    shModel.loadFromFile(VESTA_SH_FILE, SH_DEGREE)
+    shModel.muBody, shModel.radEquator = mu, rEq
+    source = gravity.addGravitySource(TARGET, shModel, True)
+    source.stateInMsg.subscribeTo(spiceObject.planetStateOutMsgs[0])
+    scene.AddModelToDynamicsTask(gravity)
+    gravity.addGravityTarget("sc", body)
+
+    scRec = body.getOrigin().stateOutMsg.recorder()
+    scSim.AddModelToTask("simTask", scRec)
+    keep = [spiceObject, gravity, shModel, integratorObject]     # noqa: F841  hold C++ refs
+    scSim.InitializeSimulation()
+    body.setPosition(list(rN)); body.setVelocity(list(vN))
+    scSim.ConfigureStopTime(macros.sec2nano(tf))
+    scSim.ExecuteSimulation()
+
+    # Actual number of sxform_c orientation queries over the run, whether exact (once per RK4
+    # stage) or reconstruction (a few knot fills). getPlanetSpiceQueryCount counts both.
+    nQ = int(spiceObject.getPlanetSpiceQueryCount(TARGET)[1])
+    ts = np.array(scRec.times()) * macros.NANO2SEC
+    pos = np.array(scRec.r_BN_N)
+    pyswice.kclear_c()
+    return nQ, ts, pos
+
+
+def plotTrajectory(pos, rEq):
+    """3D trajectory of the spacecraft around Vesta, with the body drawn to scale."""
+    fig = plt.figure(figsize=(7, 7), num=fileName + "1", layout="constrained")
+    ax = fig.add_subplot(projection="3d")
+    p = pos / 1e3  # km
+    ax.plot(p[:, 0], p[:, 1], p[:, 2], color=C_EXTRAP, lw=1.5, label="spacecraft trajectory")
+    # Vesta drawn as a sphere at the origin (mean radius).
+    u, v = np.mgrid[0:2 * np.pi:40j, 0:np.pi:20j]
+    r = rEq / 1e3
+    ax.plot_surface(r * np.cos(u) * np.sin(v), r * np.sin(u) * np.sin(v), r * np.cos(v),
+                    color="0.7", alpha=0.5, linewidth=0)
+    ax.set_xlabel("x  [km]"); ax.set_ylabel("y  [km]"); ax.set_zlabel("z  [km]")
+    ax.set_box_aspect((1, 1, 1))
+    ax.legend(loc="upper left")
+    return fig
+
+
+def plotErrorOverTime(ts, errExact, nQExact, errOne, nQOne):
+    """Figure 2: both coarse runs have the SAME error vs. the reference.
+
+    The two curves overlap: the coarse-step error is set by the integrator, not by how (or how
+    often) the attitude is queried from SPICE.
+    """
+    fig, ax = plt.subplots(figsize=(8, 6), num=fileName + "2", layout="constrained")
+    ax.plot(ts / 3600.0, errExact, color=C_EXACT, lw=3.5, alpha=0.7, zorder=4,
+            label=f"exact SPICE every sub-step ({nQExact} queries)")
+    ax.plot(ts / 3600.0, errOne, color=C_EXTRAP, lw=1.8, ls="--", zorder=5,
+            label=f"velocity extrapolation ({nQOne} SPICE query)")
+    ax.set_xlim(0, ts[-1] / 3600.0)
+    ax.set_ylim(bottom=0.0)
+    ax.set_xlabel("time  [hr]")
+    ax.set_ylabel(f"orbit error vs. {REFERENCE_DT:g} s reference  [m]")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper left")
+    return fig
+
+
+def run(show_plots=True):
+    """Run the constant-spinner orientation study and produce its figures.
+
+    Args:
+        show_plots (bool): display the figures.
+
+    Returns:
+        dict: ``figureList`` mapping figure name to matplotlib Figure.
+    """
+    # Vesta gravitational parameter and reference radius, from the SH file header
+    shModel = sphericalHarmonicsGravityModel.SphericalHarmonicsGravityModel()
+    shModel.loadFromFile(VESTA_SH_FILE, SH_DEGREE)
+    shModel.initializeParameters()
+    mu, rEq = shModel.muBody, shModel.radEquator
+
+    # leapsecond + planetary-constants (PCK) kernels; the PCK carries Vesta's IAU rotation
+    kernels = [str(get_path(DataFile.EphemerisData.naif0012)),
+               str(get_path(DataFile.EphemerisData.pck00010))]
+
+    # low circular orbit initial state (inclined so it passes over varied longitudes)
+    oe = orbitalMotion.ClassicElements()
+    oe.a = rEq + ORBIT_ALT
+    oe.e, oe.i, oe.Omega, oe.omega, oe.f = 0.0, ORBIT_INC, 0.0, 0.0, 0.0
+    rN, vN = orbitalMotion.elem2rv(mu, oe)
+    rN, vN = np.array(rN), np.array(vN)
+    period = 2.0 * np.pi * np.sqrt(oe.a ** 3 / mu)
+    tf = N_ORBITS * period
+
+    # Integrator-converged truth: exact SPICE attitude at a fine RK4 step, so any error left in the
+    # coarse runs below is the integrator's, not the attitude treatment's.
+    _, tRef, posRef = runOrbit(rN, vN, tf, REFERENCE_DT, mu, rEq, kernels)
+
+    # Two coarse-step runs that differ ONLY in how the attitude is supplied, wall-clock timed so
+    # the SPICE-query saving can be reported as an end-to-end runtime difference:
+    #   - exact SPICE queried at every sub-step (the default);
+    #   - single-knot velocity extrapolation, one SPICE query for the whole run.
+    t0 = time.perf_counter()
+    nQExact, ts, posExact = runOrbit(rN, vN, tf, COARSE_DT, mu, rEq, kernels)
+    tExact = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    nQOne, _, posOne = runOrbit(rN, vN, tf, COARSE_DT, mu, rEq, kernels,
+                                knotStep=macros.sec2nano(10.0 * tf))
+    tExtrap = time.perf_counter() - t0
+
+    # Error of each coarse run against the fine reference (reference sampled at the coarse times).
+    refAtCoarse = np.vstack([np.interp(ts, tRef, posRef[:, i]) for i in range(3)]).T
+    errExact = np.linalg.norm(posExact - refAtCoarse, axis=1)
+    errOne = np.linalg.norm(posOne - refAtCoarse, axis=1)
+
+    print(f"[study] Vesta {N_ORBITS:g}-orbit run at {ORBIT_ALT/1e3:g} km altitude")
+    print(f"[study] reference: exact SPICE at {REFERENCE_DT:g}s step (integrator-converged)")
+    print(f"[study] coarse ({COARSE_DT:g}s) exact:  {nQExact} queries, peak err {errExact.max():.2f} m, {tExact*1e3:.0f} ms")
+    print(f"[study] coarse ({COARSE_DT:g}s) extrap: {nQOne} query, peak err {errOne.max():.2f} m, {tExtrap*1e3:.0f} ms")
+    print(f"[study] runtime: {100.0*(1.0 - tExtrap/tExact):+.0f}% from reconstruction "
+          f"(within timing noise on this short run; SH gravity dominates the step, not SPICE)")
+
+    plt.rcParams.update({"font.size": 13, "lines.linewidth": 2.0, "lines.markersize": 8})
+    figureList = {}
+    figureList[fileName + "1"] = plotTrajectory(posRef, rEq)
+    figureList[fileName + "2"] = plotErrorOverTime(ts, errExact, nQExact, errOne, nQOne)
+
+    if show_plots:
+        plt.show()
+    else:
+        plt.close("all")
+    return figureList
+
+
+if __name__ == "__main__":
+    run(show_plots=True)

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_spiceInterfaceReconstruction.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_spiceInterfaceReconstruction.py
@@ -1,0 +1,444 @@
+
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+r"""
+Unit tests for the opt-in SPICE query reconstruction feature of :ref:`spiceInterface`.
+
+These cover the invariants that the feature promises:
+
+* **Bit-for-bit default preservation** -- with nothing configured, the planet-state output is
+  byte-identical to the exact per-call SPICE path.
+* **Reconstruction accuracy** -- a Hermite-interpolated planet tracks the exact SPICE position
+  to a small tolerance while querying SPICE far fewer times.
+* **Query-count savings** -- ``getPlanetSpiceQueryCount`` reflects ~horizon/knotStep queries,
+  not once per task step.
+* **Single-knot orientation extrapolation is exact for a constant spinner** (Earth's IAU frame).
+* **Channels are independent and toggle-off-able** -- a disabled channel emits the trivial
+  default (zero position/velocity or identity orientation) without querying SPICE.
+* **Derivative self-consistency** -- the emitted ``VelocityVector`` matches a finite difference
+  of the reconstructed position.
+"""
+
+import inspect
+import os
+
+import numpy as np
+import pytest
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+
+from Basilisk import __path__
+bskPath = __path__[0]
+from Basilisk.utilities import SimulationBaseClass, macros
+from Basilisk.simulation import spiceInterface
+
+DATE = "2021 MARCH 1 00:00:00.0 (UTC)"
+# Names/date resolvable with the module's default DE430 kernel set (the de430.bsp SPK provides
+# "mars barycenter", not "mars"). Earth carries both a position and a constant-rate IAU_EARTH
+# orientation, so it exercises both reconstruction channels.
+PLANETS = ["earth", "mars barycenter", "sun"]
+OTHERS = ["mars barycenter", "sun"]
+
+
+def _newSpice():
+    # Let the module auto-configure its default kernels (naif0012/pck00010/de-403-masses/de430),
+    # fetched on demand by the data fetcher -- the same path the other unit tests rely on.
+    s = spiceInterface.SpiceInterface()
+    s.addPlanetNames(spiceInterface.StringVector(PLANETS))
+    s.UTCCalInit = DATE
+    return s
+
+
+def _runToStop(configureFn, dt, tf):
+    """Build a sim with a fresh SpiceInterface on a regular task, apply configureFn(spice),
+    run to tf, and return {planetName: payload-copy} of the final planet states + the spice object."""
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("proc")
+    proc.addTask(sim.CreateNewTask("task", macros.sec2nano(dt)))
+    spice = _newSpice()
+    if configureFn is not None:
+        configureFn(spice)
+    sim.AddModelToTask("task", spice)
+    logs = [spice.planetStateOutMsgs[i].recorder() for i in range(len(PLANETS))]
+    for lg in logs:
+        sim.AddModelToTask("task", lg)
+    sim.InitializeSimulation()
+    sim.ConfigureStopTime(macros.sec2nano(tf))
+    sim.ExecuteSimulation()
+    out = {}
+    for i, name in enumerate(PLANETS):
+        p = spice.planetStateOutMsgs[i].read()
+        out[name] = dict(
+            pos=np.array(p.PositionVector),
+            vel=np.array(p.VelocityVector),
+            dcm=np.array(p.J20002Pfix),
+            dcmDot=np.array(p.J20002Pfix_dot),
+            J2000Current=p.J2000Current,
+            computeOrient=p.computeOrient,
+            name=bytes(p.PlanetName).split(b"\x00")[0].decode() if isinstance(p.PlanetName, (bytes, bytearray)) else str(p.PlanetName),
+        )
+    return out, spice
+
+
+def test_defaultsAreBitIdentical():
+    """With nothing configured, every planet field must be byte-identical to the exact path.
+    (Configuring one planet must not perturb the others, nor the default output of any field.)"""
+    dt, tf = 10.0, 300.0
+    base, _ = _runToStop(None, dt, tf)
+
+    # Reconstruct earth only; mars & sun must stay bit-identical to the exact run, and earth's
+    # J2000Current / computeOrient / PlanetName (non-numeric fields) must also be unchanged.
+    def cfg(s):
+        s.setPlanetPositionReconstruction("earth", macros.sec2nano(60.0), 2, True, True)
+    withInterp, _ = _runToStop(cfg, dt, tf)
+
+    for name in OTHERS:
+        assert np.array_equal(base[name]["pos"], withInterp[name]["pos"]), name
+        assert np.array_equal(base[name]["vel"], withInterp[name]["vel"]), name
+        assert np.array_equal(base[name]["dcm"], withInterp[name]["dcm"]), name
+        assert np.array_equal(base[name]["dcmDot"], withInterp[name]["dcmDot"]), name
+
+    # earth non-numeric fields unchanged
+    assert base["earth"]["J2000Current"] == withInterp["earth"]["J2000Current"]
+    assert base["earth"]["computeOrient"] == withInterp["earth"]["computeOrient"]
+    assert base["earth"]["name"] == withInterp["earth"]["name"]
+
+    # A completely unconfigured run twice is trivially identical (guards the exact path itself).
+    base2, _ = _runToStop(None, dt, tf)
+    for name in PLANETS:
+        assert np.array_equal(base[name]["pos"], base2[name]["pos"])
+        assert np.array_equal(base[name]["dcm"], base2[name]["dcm"])
+
+
+def test_positionReconstructionAccurateAndCheaper():
+    """Hermite position reconstruction on a coarse grid tracks exact SPICE to well under a metre
+    over a short horizon, at far fewer SPICE queries than one-per-step."""
+    dt, tf = 10.0, 600.0                      # 60 steps
+    exact, _ = _runToStop(None, dt, tf)
+
+    knot = macros.sec2nano(120.0)             # 12x the task step
+    def cfg(s):
+        s.setPlanetPositionReconstruction("earth", knot, 2, True, True)
+    recon, spice = _runToStop(cfg, dt, tf)
+
+    err = np.linalg.norm(recon["earth"]["pos"] - exact["earth"]["pos"])
+    assert err < 1.0, f"position reconstruction error too large: {err} m"
+
+    nPos, nOrient = spice.getPlanetSpiceQueryCount("earth")
+    # ~ horizon/knot (+ small stencil slack), and certainly far below the exact 60 steps.
+    assert nPos <= 12, f"expected ~horizon/knot position queries, got {nPos}"
+    # The orientation channel is on the exact path, so it counts one SPICE call per step: many more
+    # than the reconstructed position channel.
+    assert nOrient > nPos, f"exact orientation channel should query every step, got {nOrient}"
+
+
+def test_singleKnotOrientationExtrapolationExactForConstantSpinner():
+    """Earth's IAU frame is a constant-rate spinner, so extrapolating orientation from a SINGLE
+    knot (nKnots=1, interpolate=False) reproduces the exact per-call sxform orientation, using
+    only one sxform query for the whole run."""
+    dt, tf = 10.0, 600.0
+    exact, _ = _runToStop(None, dt, tf)
+
+    def cfg(s):
+        s.setPlanetOrientationReconstruction("earth", macros.sec2nano(100000.0), 1, True, False)  # one knot, extrapolate
+    recon, spice = _runToStop(cfg, dt, tf)
+
+    dcmErr = np.max(np.abs(recon["earth"]["dcm"] - exact["earth"]["dcm"]))
+    assert dcmErr < 1e-9, f"single-knot orientation extrapolation not exact: max|dDCM|={dcmErr}"
+
+    nPos, nOrient = spice.getPlanetSpiceQueryCount("earth")
+    assert nOrient == 1, f"constant spinner should need exactly one sxform query, got {nOrient}"
+    # The position channel is on the exact path, so it counts one SPICE call per step.
+    assert nPos > nOrient, f"exact position channel should query every step, got {nPos}"
+
+
+def test_disabledChannelsEmitTrivialDefault():
+    """A disabled position channel emits zero pos/vel; a disabled orientation channel emits the
+    identity DCM and zero rate -- and neither queries SPICE."""
+    dt, tf = 10.0, 100.0
+
+    def cfg(s):
+        s.setPlanetPositionDisabled("earth")
+        s.setPlanetOrientationDisabled("earth")
+    recon, spice = _runToStop(cfg, dt, tf)
+
+    assert np.allclose(recon["earth"]["pos"], 0.0)
+    assert np.allclose(recon["earth"]["vel"], 0.0)
+    assert np.allclose(recon["earth"]["dcm"], np.eye(3))
+    assert np.allclose(recon["earth"]["dcmDot"], 0.0)
+
+    nPos, nOrient = spice.getPlanetSpiceQueryCount("earth")
+    assert nPos == 0 and nOrient == 0, "disabled channels must not query SPICE"
+
+    # J2000Current / computeOrient / PlanetName are still filled as usual.
+    assert recon["earth"]["J2000Current"] > 0.0
+    assert recon["earth"]["name"] == "earth"
+
+
+def test_velocityIsDerivativeOfReconstructedPosition():
+    """The emitted VelocityVector must equal the time derivative of the reconstructed position,
+    so a downstream Euler step stays self-consistent. Sampled from a single run's recorder (a
+    fine task cadence) and finite-differenced with the actual logging step."""
+    dt = 1.0
+    knot = macros.sec2nano(90.0)
+    tf = 300.0
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("proc")
+    proc.addTask(sim.CreateNewTask("task", macros.sec2nano(dt)))
+    spice = _newSpice()
+    spice.setPlanetPositionReconstruction("earth", knot, 2, True, True)
+    sim.AddModelToTask("task", spice)
+    rec = spice.planetStateOutMsgs[0].recorder()   # earth
+    sim.AddModelToTask("task", rec)
+    sim.InitializeSimulation()
+    sim.ConfigureStopTime(macros.sec2nano(tf))
+    sim.ExecuteSimulation()
+
+    pos = np.array(rec.PositionVector)   # (N,3)
+    vel = np.array(rec.VelocityVector)
+    # central finite difference of logged position vs the logged (emitted) velocity at interior pts
+    vFD = (pos[2:] - pos[:-2]) / (2.0 * dt)
+    vEmit = vel[1:-1]
+    relErr = np.linalg.norm(vFD - vEmit, axis=1) / np.maximum(np.linalg.norm(vEmit, axis=1), 1e-9)
+    assert np.max(relErr) < 1e-4, f"emitted velocity inconsistent with dP/dt: max relErr={np.max(relErr)}"
+
+
+def test_integratorAgnosticQueryCountOnDynamicsTask():
+    """On an MJScene dynamics task the module's UpdateState is called once per integrator STAGE,
+    so the exact path would query SPICE (stages x steps) times. With reconstruction the knot cache
+    collapses those onto ~horizon/knotStep queries, and that count is the SAME for a fixed RK4 and
+    an adaptive RKF45 integrator -- the integrator-agnostic property the feature exists to deliver."""
+    mujoco = pytest.importorskip("Basilisk.simulation.mujoco")
+    from Basilisk.simulation import svIntegrators
+
+    scXml = """
+    <mujoco>
+        <worldbody>
+            <body name="sat"><freejoint/><inertial pos="0 0 0" mass="1" diaginertia="1 1 1"/></body>
+        </worldbody>
+    </mujoco>
+    """
+    knot = macros.sec2nano(120.0)
+    tf = 1200.0     # 10 knot intervals
+
+    def queryCount(makeIntegrator, dt):
+        sim = SimulationBaseClass.SimBaseClass()
+        proc = sim.CreateNewProcess("proc")
+        proc.addTask(sim.CreateNewTask("task", macros.sec2nano(dt)))
+        scene = mujoco.MJScene(scXml)
+        sim.AddModelToTask("task", scene)
+        integ = makeIntegrator(scene)
+        scene.setIntegrator(integ)
+
+        spice = _newSpice()
+        spice.setPlanetPositionReconstruction("earth", knot, 2, True, True)
+        scene.AddModelToDynamicsTask(spice)
+
+        keep = [integ, spice]  # keep Python refs alive (svIntegrator GC segfault guard)  # noqa: F841
+        sim.InitializeSimulation()
+        sim.ConfigureStopTime(macros.sec2nano(tf))
+        sim.ExecuteSimulation()
+        nPos, _ = spice.getPlanetSpiceQueryCount("earth")
+        return nPos
+
+    nRK4 = queryCount(lambda sc: svIntegrators.svIntegratorRK4(sc), 20.0)
+    nRKF45 = queryCount(lambda sc: svIntegrators.svIntegratorRKF45(sc), 20.0)
+
+    # ~horizon/knot (+ a little stencil slack), and identical across integrators despite very
+    # different stage/sub-step counts.
+    assert nRK4 <= 15, f"expected ~horizon/knot queries on dynamics task, got {nRK4}"
+    assert nRK4 == nRKF45, f"query count must be integrator-agnostic: RK4={nRK4} RKF45={nRKF45}"
+
+
+def test_exactSpiceResetRestoresDefault():
+    """setPlanetExactSpice reverts both channels; output returns to the exact path bit-for-bit."""
+    dt, tf = 10.0, 200.0
+    exact, _ = _runToStop(None, dt, tf)
+
+    def cfg(s):
+        s.setPlanetPositionReconstruction("earth", macros.sec2nano(60.0), 2, True, True)
+        s.setPlanetOrientationReconstruction("earth", macros.sec2nano(60.0), 2, True, True)
+        s.setPlanetExactSpice("earth")   # undo both
+    reverted, spice = _runToStop(cfg, dt, tf)
+
+    assert np.array_equal(exact["earth"]["pos"], reverted["earth"]["pos"])
+    assert np.array_equal(exact["earth"]["dcm"], reverted["earth"]["dcm"])
+    # Both channels are back on the exact path, which counts one SPICE call per step (never knots).
+    # With the coarse 60 s knot grid they were configured with, a knot-only count would be tiny;
+    # the per-step counts here confirm the exact path is running.
+    nPos, nOrient = spice.getPlanetSpiceQueryCount("earth")
+    assert nPos == nOrient and nPos > tf / dt, \
+        f"exact-reverted channels should query every step on both channels, got {nPos}, {nOrient}"
+
+
+def test_singleKnotDefaultsAreExactRegardlessOfInterpolateFlag():
+    """A single-knot stencil (nKnots=1) is the enclosing knot for BOTH interpolate settings, so
+    orientation reconstruction of a constant spinner is exact even with the enabled default
+    interpolate=True (regression: a naive 1-knot formula would pick the future knot k+1)."""
+    dt, tf = 10.0, 600.0
+    exact, _ = _runToStop(None, dt, tf)
+
+    for interp in (True, False):
+        def cfg(s, interp=interp):
+            s.setPlanetOrientationReconstruction("earth", macros.sec2nano(100000.0), 1, True, interp)
+        recon, spice = _runToStop(cfg, dt, tf)
+        dcmErr = np.max(np.abs(recon["earth"]["dcm"] - exact["earth"]["dcm"]))
+        assert dcmErr < 1e-9, f"nKnots=1 interpolate={interp} not exact: max|dDCM|={dcmErr}"
+        _, nOrient = spice.getPlanetSpiceQueryCount("earth")
+        assert nOrient == 1, f"nKnots=1 interpolate={interp} should need one query, got {nOrient}"
+
+
+def test_oddKnotStencilIsCentered():
+    """A 3-knot interpolation stencil is centred on the current interval ([k-1, k, k+1]); a
+    forward-biased [k, k+1, k+2] stencil would be less accurate. Guards buildStencil's centering:
+    3-knot reconstruction must be at least as accurate as 2-knot on the same coarse grid."""
+    dt, tf = 10.0, 600.0
+    exact, _ = _runToStop(None, dt, tf)
+    knot = macros.sec2nano(150.0)
+
+    def cfg2(s):
+        s.setPlanetPositionReconstruction("earth", knot, 2, True, True)
+    def cfg3(s):
+        s.setPlanetPositionReconstruction("earth", knot, 3, True, True)
+    r2, _ = _runToStop(cfg2, dt, tf)
+    r3, _ = _runToStop(cfg3, dt, tf)
+
+    err2 = np.linalg.norm(r2["earth"]["pos"] - exact["earth"]["pos"])
+    err3 = np.linalg.norm(r3["earth"]["pos"] - exact["earth"]["pos"])
+    # A centred cubic (3-knot Hermite) should not be worse than the 2-knot fit; a forward-biased
+    # stencil would regress here. Both are tiny; require 3-knot within a small factor of 2-knot.
+    assert err3 <= max(err2 * 2.0, 1e-3), f"3-knot stencil not centred: err2={err2} err3={err3}"
+
+
+def test_reconfiguringKnotStepClearsStaleCache():
+    """Reconfiguring a channel's knotStep must drop the cached knots: they are keyed by integer
+    index on the OLD grid, so reusing them would map indices to the wrong epochs. Reconfigure the
+    grid mid-life (after one run has populated knots) and confirm a second run still tracks exact
+    SPICE, i.e. it re-queried on the new grid rather than reusing the old samples."""
+    dt, tf = 10.0, 600.0
+    exact, _ = _runToStop(None, dt, tf)
+
+    # Build one spice object, run once with a coarse grid (populates knots), then reconfigure to a
+    # much finer grid and run again. Stale reuse would leave the fine run tracking the coarse epochs.
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("proc")
+    proc.addTask(sim.CreateNewTask("task", macros.sec2nano(dt)))
+    spice = _newSpice()
+    spice.setPlanetPositionReconstruction("earth", macros.sec2nano(300.0), 2, True, True)
+    sim.AddModelToTask("task", spice)
+    sim.InitializeSimulation()
+    sim.ConfigureStopTime(macros.sec2nano(tf))
+    sim.ExecuteSimulation()
+
+    spice.setPlanetPositionReconstruction("earth", macros.sec2nano(120.0), 2, True, True)  # new grid
+    sim.ConfigureStopTime(macros.sec2nano(2 * tf))
+    sim.ExecuteSimulation()
+
+    p = spice.planetStateOutMsgs[0].read()
+    pos = np.array(p.PositionVector)
+    # Truth at the final time (2*tf) on the exact path.
+    exact2, _ = _runToStop(None, dt, 2 * tf)
+    err = np.linalg.norm(pos - exact2["earth"]["pos"])
+    assert err < 1.0, f"reconfigured knotStep reused stale cache: {err} m from exact SPICE"
+
+
+def test_enablingReconstructionAfterResetAnchorsAtEpoch():
+    """Enabling reconstruction for the FIRST time between two ExecuteSimulation() segments (so the
+    reconstruction object is created after Reset already set the epoch) must anchor knots at the
+    init epoch, not J2000 ET 0. Otherwise the knot grid would query the wrong epoch and the state
+    would be wildly wrong. Regression for the deferred-creation et0 anchoring."""
+    dt, tf = 10.0, 300.0
+
+    sim = SimulationBaseClass.SimBaseClass()
+    proc = sim.CreateNewProcess("proc")
+    proc.addTask(sim.CreateNewTask("task", macros.sec2nano(dt)))
+    spice = _newSpice()                    # NOTHING configured -> recon object not yet created
+    sim.AddModelToTask("task", spice)
+    sim.InitializeSimulation()             # Reset runs here with recon still null
+    sim.ConfigureStopTime(macros.sec2nano(tf))
+    sim.ExecuteSimulation()
+
+    # First enable reconstruction now, mid-run (this is when the recon object gets created).
+    spice.setPlanetPositionReconstruction("earth", macros.sec2nano(120.0), 2, True, True)
+    sim.ConfigureStopTime(macros.sec2nano(2 * tf))
+    sim.ExecuteSimulation()
+
+    pos = np.array(spice.planetStateOutMsgs[0].read().PositionVector)
+    exact2, _ = _runToStop(None, dt, 2 * tf)
+    err = np.linalg.norm(pos - exact2["earth"]["pos"])
+    assert err < 1.0, f"reconstruction enabled after Reset anchored at wrong epoch: {err} m"
+
+
+def test_queryCountTracksExactPathWithNoReconstruction():
+    """getPlanetSpiceQueryCount reports SPICE calls even when NO reconstruction is configured: a
+    plain exact-path planet queries both channels once per update, so the counts equal the number of
+    updates. An added-but-never-queried name reads {0, 0}; a name never added reads {-1, -1}."""
+    dt, tf = 10.0, 300.0
+    _, spice = _runToStop(None, dt, tf)   # nothing configured: pure exact path
+
+    # earth carries a position and a constant-rate IAU_EARTH orientation, so both channels query
+    # SPICE once per update, i.e. about one per task step over the run (plus Reset's own update).
+    steps = int(round(tf / dt))
+    nPos, nOrient = spice.getPlanetSpiceQueryCount("earth")
+    assert steps <= nPos <= steps + 2, f"exact-path position queries ~one per step: got {nPos}"
+    assert nOrient == nPos, f"both exact channels query per update: pos {nPos}, orient {nOrient}"
+
+    # every added planet is tracked on the exact path: its position channel queries per update,
+    # and its orientation channel queries per update when it has a frame or is 0 when it does not.
+    sPos, sOrient = spice.getPlanetSpiceQueryCount("mars barycenter")
+    assert sPos == nPos, f"added planet position queries per update: got {sPos}"
+    assert sOrient in (0, nPos), f"orientation queries are per-update or (frameless) zero: {sOrient}"
+
+    # a name that was never added via addPlanetNames is the only {-1, -1} case.
+    assert tuple(spice.getPlanetSpiceQueryCount("jupiter")) == (-1, -1)
+
+
+def test_misconfiguredPlanetWarnsNotThrows():
+    """A reconstruction config for a planet that was never added (or has no orientation frame)
+    must WARN and keep running, not throw BasiliskError and abort the sim. The stale entry is
+    pruned, so its query count reports unconfigured afterwards."""
+    dt, tf = 10.0, 100.0
+
+    # (a) unknown planet name: sim must complete, entry pruned.
+    def cfgUnknown(s):
+        s.setPlanetPositionReconstruction("jupiter", macros.sec2nano(60.0), 2, True, True)
+    _, spice = _runToStop(cfgUnknown, dt, tf)  # must not raise
+    assert tuple(spice.getPlanetSpiceQueryCount("jupiter")) == (-1, -1), \
+        "stale (unadded) planet config should be pruned at Reset"
+
+    # (b) setPlanetExactSpice on a never-configured planet must not abort the sim.
+    def cfgExact(s):
+        s.setPlanetExactSpice("venus")
+    _runToStop(cfgExact, dt, tf)  # must not raise
+
+
+if __name__ == "__main__":
+    test_defaultsAreBitIdentical()
+    test_positionReconstructionAccurateAndCheaper()
+    test_singleKnotOrientationExtrapolationExactForConstantSpinner()
+    test_disabledChannelsEmitTrivialDefault()
+    test_velocityIsDerivativeOfReconstructedPosition()
+    test_exactSpiceResetRestoresDefault()
+    test_singleKnotDefaultsAreExactRegardlessOfInterpolateFlag()
+    test_oddKnotStencilIsCentered()
+    test_reconfiguringKnotStepClearsStaleCache()
+    test_enablingReconstructionAfterResetAnchorsAtEpoch()
+    test_queryCountTracksExactPathWithNoReconstruction()
+    test_misconfiguredPlanetWarnsNotThrows()
+    print("all reconstruction unit tests passed")

--- a/src/simulation/environment/spiceInterface/spiceInterface.cpp
+++ b/src/simulation/environment/spiceInterface/spiceInterface.cpp
@@ -17,6 +17,9 @@
 
  */
 #include "simulation/environment/spiceInterface/spiceInterface.h"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <cstdio>
 #include <sstream>
 #include "SpiceUsr.h"
@@ -24,6 +27,8 @@
 #include "architecture/utilities/simDefinitions.h"
 #include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
+#include "architecture/utilities/linearAlgebra.h"
+#include "architecture/utilities/avsEigenSupport.h"
 #include "spiceInterface.h"
 
 namespace {
@@ -66,6 +71,499 @@ namespace {
     {
         return std::filesystem::absolute(path).lexically_normal().string();
     }
+
+    //! Uppercase-normalized body name, used as the reconstruction map key (case-insensitive).
+    std::string normalizeBodyName(const std::string& name)
+    {
+        std::string out = name;
+        std::transform(out.begin(), out.end(), out.begin(),
+                       [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+        return out;
+    }
+}
+
+/*! @brief Opt-in SPICE query reconstruction state for SpiceInterface (PIMPL).
+ *
+ * Holds, per planet and per channel, the reconstruction configuration and a rolling cache of
+ * SPICE "knots", and does the interpolation/extrapolation. It lives entirely in this translation
+ * unit so the SpiceInterface header carries only an opaque pointer (no Eigen/STL internals and no
+ * SWIG guards). It reads the owning interface's frame/observer settings and logs through it, but
+ * owns all reconstruction-specific state itself. */
+class SpiceInterface::SpiceReconstruction {
+public:
+    //! Construct bound to the owning interface (used for frame/observer settings and logging).
+    explicit SpiceReconstruction(SpiceInterface& owner) : owner(owner) {}
+
+    /*! How a channel (position or orientation) of a planet is produced. */
+    enum class ChannelMode {
+        Exact,        //!< query SPICE at the exact time every call (the default)
+        Reconstruct,  //!< reconstruct from a coarse cached knot grid
+        Disabled      //!< emit the trivial default (zero position / identity attitude), no SPICE query
+    };
+
+    /*! Reconstruction configuration for one channel. */
+    struct ChannelCfg {
+        ChannelMode mode = ChannelMode::Exact;  //!< how this channel is produced
+        uint64_t knotStep = SpiceInterface::defaultKnotStep;  //!< [ns] absolute-time knot spacing
+        int nKnots = 2;            //!< stencil size / polynomial order; clamped to >= 1
+        bool useVelocity = true;   //!< match the SPICE velocity at each knot (Hermite) vs positions only (Lagrange)
+        bool interpolate = true;   //!< bracket with past+future knots (interp) vs past-only (extrapolation)
+    };
+
+    /*! One cached position knot: translation state at a knot epoch. */
+    struct PosKnot {
+        Eigen::Vector3d pos = Eigen::Vector3d::Zero();  //!< [m]
+        Eigen::Vector3d vel = Eigen::Vector3d::Zero();  //!< [m/s]
+        bool ok = false;  //!< true once a SPICE query succeeded; a false (fallback) knot is re-queried
+    };
+    /*! One cached orientation knot: planet-fixed-relative-to-inertial DCM and its rate. */
+    struct OrientKnot {
+        Eigen::Matrix3d dcm = Eigen::Matrix3d::Identity();  //!< J20002Pfix
+        Eigen::Matrix3d dcmDot = Eigen::Matrix3d::Zero();   //!< J20002Pfix_dot
+        bool ok = false;  //!< true once a SPICE query succeeded; a false (fallback) knot is re-queried
+    };
+
+    /*! Per-planet reconstruction state: independent position and orientation channels, each with
+     * its own config and rolling knot cache. SPICE-query tallies live on the owning SpiceInterface
+     * (SpiceInterface::spiceQueryCounts), so they cover the exact path as well as knot fills. */
+    struct PlanetInterp {
+        ChannelCfg posCfg;                          //!< position-channel configuration
+        ChannelCfg orientCfg;                       //!< orientation-channel configuration
+        std::map<long, PosKnot> posKnots;           //!< cached position knots, keyed by knot index
+        std::map<long, OrientKnot> orientKnots;     //!< cached orientation knots, keyed by knot index
+    };
+
+    //! Look up (creating if absent) the entry for a planet name.
+    PlanetInterp& entry(const std::string& planetName)
+    {
+        return this->planets[normalizeBodyName(planetName)];
+    }
+
+    //! Find an existing entry, or nullptr if the planet is not configured.
+    PlanetInterp* find(const std::string& planetName)
+    {
+        auto it = this->planets.find(normalizeBodyName(planetName));
+        return (it == this->planets.end()) ? nullptr : &it->second;
+    }
+
+    //! Validate knotStep and set one channel of a planet to Reconstruct mode with the given knobs.
+    //! A zero knotStep is rejected (logged, channel left unchanged), shared by the two setters.
+    void configure(const std::string& planetName, ChannelCfg PlanetInterp::* channel,
+                   uint64_t knotStep, int nKnots, bool useVelocity, bool interpolate)
+    {
+        if (knotStep == 0) {
+            owner.bskLogger.bskError("spiceInterface: knotStep must be positive for planet '%s'.",
+                                     planetName.c_str());
+            return;
+        }
+        PlanetInterp& pi = entry(planetName);
+        ChannelCfg& cfg = pi.*channel;
+        cfg.mode = ChannelMode::Reconstruct;
+        cfg.knotStep = knotStep;
+        cfg.nKnots = std::max(1, nKnots);
+        cfg.useVelocity = useVelocity;
+        cfg.interpolate = interpolate;
+        // Cached knots are keyed by integer index on the OLD grid, so a changed knotStep would make
+        // those indices map to different epochs; drop this channel's cache so it re-queries fresh.
+        if (channel == &PlanetInterp::posCfg) {
+            pi.posKnots.clear();
+        } else {
+            pi.orientKnots.clear();
+        }
+    }
+
+    //! Anchor the knot grid at the given init epoch (ET seconds past J2000) without touching the
+    //! caches. Used when reconstruction is first enabled AFTER Reset has already set the epoch, so
+    //! a setter called between two ExecuteSimulation() segments does not leave et0 at 0.
+    void setEpoch(double et0) { this->et0 = et0; }
+
+    //! Anchor the knot grid at the init epoch and clear every cache (called from Reset). Also
+    //! validates configured names against the planets added, and warns if orientation
+    //! reconstruction was requested for a body with no orientation frame.
+    void reset(double et0, const std::vector<SpicePlanetStateMsgPayload>& planetData)
+    {
+        this->et0 = et0;
+        std::vector<std::string> stale;  // configured names not among the current planets
+        for (auto& kv : this->planets) {
+            kv.second.posKnots.clear();
+            kv.second.orientKnots.clear();
+
+            bool found = false, orientCapable = false;
+            for (const auto& pd : planetData) {
+                if (normalizeBodyName(pd.PlanetName) == kv.first) {
+                    found = true;
+                    orientCapable = (pd.computeOrient != 0);
+                    break;
+                }
+            }
+            // Misconfiguration is a warning, not a fatal error: leave the affected channel on the
+            // exact/identity path and keep running (bskError would throw and abort the sim).
+            if (!found) {
+                owner.bskLogger.bskLog(BSK_WARNING, "spiceInterface: planet '%s' was configured "
+                    "for reconstruction but was not added via addPlanetNames; ignoring it.",
+                    kv.first.c_str());
+                stale.push_back(kv.first);
+            } else if (kv.second.orientCfg.mode == ChannelMode::Reconstruct && !orientCapable) {
+                owner.bskLogger.bskLog(BSK_WARNING, "spiceInterface: planet '%s' orientation "
+                    "reconstruction was requested, but the body has no orientation frame "
+                    "(computeOrient is off); leaving orientation on the exact (identity) path.",
+                    kv.first.c_str());
+                kv.second.orientCfg.mode = ChannelMode::Exact;
+            }
+        }
+        // Drop configs for planets no longer present, so the map shrinks on reconfiguration
+        // rather than re-warning about the same stale name every Reset.
+        for (const auto& key : stale) {
+            this->planets.erase(key);
+        }
+    }
+
+    //! Local knot coordinate kf for sim time tNanos on a grid of knotStep ns, computed from
+    //! integer nanoseconds so that a time exactly on a knot yields an exact integer kf (no
+    //! double-rounding to the wrong interval, which matters when knotStep is a multiple of dt).
+    static double knotCoord(uint64_t tNanos, uint64_t knotStep)
+    {
+        uint64_t k = tNanos / knotStep;                 // exact integer floor for tNanos >= 0
+        uint64_t rem = tNanos - k * knotStep;           // exact remainder
+        return static_cast<double>(k) + static_cast<double>(rem) / static_cast<double>(knotStep);
+    }
+
+    //! Fill position/velocity at sim time tNanos per the channel mode. Returns true if handled
+    //! (Reconstruct or Disabled); false means the caller should run the exact SPICE path.
+    bool position(PlanetInterp& pi, const std::string& planetName, uint64_t tNanos,
+                  double posOut[3], double velOut[3])
+    {
+        if (pi.posCfg.mode == ChannelMode::Exact) {
+            return false;
+        }
+        if (pi.posCfg.mode == ChannelMode::Disabled) {
+            posOut[0] = posOut[1] = posOut[2] = 0.0;
+            velOut[0] = velOut[1] = velOut[2] = 0.0;
+            return true;
+        }
+
+        const ChannelCfg& cfg = pi.posCfg;
+        // Local knot coordinate (exact-integer at knot boundaries); kdSec is the knot spacing in
+        // seconds, used to convert per-knot-unit derivatives back to per-second.
+        const double kf = knotCoord(tNanos, cfg.knotStep);
+        const double kdSec = static_cast<double>(cfg.knotStep) * NANO2SEC;
+        std::vector<long> idx = buildStencil(kf, cfg.nKnots, cfg.interpolate);
+        // If any stencil knot could not be queried (e.g. a look-ahead knot past kernel coverage),
+        // do NOT interpolate through a bogus fallback: return false so the caller does an exact
+        // SPICE query at the current time, which may still be within coverage.
+        bool allOk = true;
+        for (long i : idx) {
+            allOk &= ensurePosKnot(pi, planetName, i);
+        }
+        if (!allOk) {
+            return false;
+        }
+
+        // Confluent Newton nodes: each knot repeated when matching velocity (Hermite), the
+        // velocity scaled to knot-spacing units so the polynomial derivative is per-knot-unit.
+        const int reps = cfg.useVelocity ? 2 : 1;
+        const size_t nNodes = idx.size() * static_cast<size_t>(reps);
+        std::vector<double> z;
+        std::vector<Eigen::Vector3d> val, der;
+        z.reserve(nNodes); val.reserve(nNodes); der.reserve(nNodes);
+        for (long i : idx) {
+            const PosKnot& kn = pi.posKnots.at(i);  // ensured above; .at() fails loudly if not
+            for (int r = 0; r < reps; ++r) {
+                z.push_back(static_cast<double>(i));
+                val.push_back(kn.pos);
+                der.push_back(kn.vel * kdSec);
+            }
+        }
+        Eigen::Vector3d dPos_dk;
+        Eigen::Vector3d pos = newtonEval(newtonCoeffs(val, der, z), z, kf, &dPos_dk);
+        // Emitted velocity = d/dt of the SAME polynomial that produced the position, so a
+        // downstream Euler step stays self-consistent.
+        Eigen::Vector3d vel = dPos_dk / kdSec;
+        posOut[0] = pos[0]; posOut[1] = pos[1]; posOut[2] = pos[2];
+        velOut[0] = vel[0]; velOut[1] = vel[1]; velOut[2] = vel[2];
+        return true;
+    }
+
+    //! Fill DCM/DCM_dot at sim time tNanos per the channel mode. Returns true if handled
+    //! (Reconstruct or Disabled); false means the caller should run the exact SPICE path.
+    bool orientation(PlanetInterp& pi, const std::string& planetName,
+                     const std::string& planetFrame, uint64_t tNanos,
+                     double dcmOut[3][3], double dcmDotOut[3][3])
+    {
+        if (pi.orientCfg.mode == ChannelMode::Exact) {
+            return false;
+        }
+        if (pi.orientCfg.mode == ChannelMode::Disabled) {
+            m33SetIdentity(dcmOut);
+            m33SetZero(dcmDotOut);
+            return true;
+        }
+
+        const ChannelCfg& cfg = pi.orientCfg;
+        const double kf = knotCoord(tNanos, cfg.knotStep);
+        const double kdSec = static_cast<double>(cfg.knotStep) * NANO2SEC;
+        std::vector<long> idx = buildStencil(kf, cfg.nKnots, cfg.interpolate);
+        // If any stencil knot could not be queried (e.g. a look-ahead knot past kernel coverage),
+        // do NOT interpolate through a bogus fallback: return false so the caller does an exact
+        // sxform query at the current time, which may still be within coverage.
+        bool allOk = true;
+        for (long i : idx) {
+            allOk &= ensureOrientKnot(pi, planetName, planetFrame, i);
+        }
+        if (!allOk) {
+            return false;
+        }
+
+        // Base knot = the first stencil index, fixed for the WHOLE stencil. Lift each knot's
+        // rotation to the tangent space about the base as a principal rotation vector (PRV) and
+        // interpolate the PRV. The base must be constant across the stencil interval: PRV
+        // polynomials taken about different bases are not equivalent for noncommuting rotations, so
+        // a base that flipped mid-interval (e.g. "nearest knot", which switches at the half-knot)
+        // would make the reconstructed DCM/rate jump there for a tumbler. Anchoring on idx[0]
+        // instead keeps the reconstructed DCM a single smooth function of kf across the interval;
+        // the rate is then a finite difference of THAT same function, keeping (dcm, dcmDot)
+        // self-consistent without the delicate analytic PRV-rate -> omega inversion.
+        const long base = idx[0];
+        const Eigen::Matrix3d Cb = pi.orientKnots.at(base).dcm;  // ensured above; .at() fails loudly
+
+        const int reps = cfg.useVelocity ? 2 : 1;
+        const size_t nNodes = idx.size() * static_cast<size_t>(reps);
+        std::vector<double> z;
+        std::vector<Eigen::Vector3d> theta, dtheta;
+        z.reserve(nNodes); theta.reserve(nNodes); dtheta.reserve(nNodes);
+        for (long i : idx) {
+            const OrientKnot& kn = pi.orientKnots.at(i);  // ensured above; .at() fails loudly
+            Eigen::Matrix3d Rj = kn.dcm * Cb.transpose();
+            double Rj_c[3][3];
+            eigenMatrix3d2CArray(Rj, &Rj_c[0][0]);
+            double theta_j_c[3];
+            C2PRV(Rj_c, theta_j_c);
+            Eigen::Vector3d theta_j(theta_j_c[0], theta_j_c[1], theta_j_c[2]);
+
+            Eigen::Vector3d dtheta_j = Eigen::Vector3d::Zero();
+            if (cfg.useVelocity) {
+                // knot angular velocity from Cdot = -[w x] C -> w = unhat(-Cdot C^T); the relative
+                // rotation Rj carries the same w since Cb is constant. Map omega to the PRV rate
+                // with the exact B(theta) Jacobian (dPRV), using the B(0)=I limit at the base knot.
+                Eigen::Matrix3d W = -kn.dcmDot * kn.dcm.transpose();
+                double omega_j_c[3] = {W(2, 1), W(0, 2), W(1, 0)};
+                if (theta_j.norm() < 1.0e-7) {
+                    dtheta_j = Eigen::Vector3d(omega_j_c[0], omega_j_c[1], omega_j_c[2]) * kdSec;
+                } else {
+                    double dtheta_j_c[3];
+                    dPRV(theta_j_c, omega_j_c, dtheta_j_c);
+                    dtheta_j = Eigen::Vector3d(dtheta_j_c[0], dtheta_j_c[1], dtheta_j_c[2]) * kdSec;
+                }
+            }
+
+            for (int r = 0; r < reps; ++r) {
+                z.push_back(static_cast<double>(i));
+                theta.push_back(theta_j);
+                dtheta.push_back(dtheta_j);
+            }
+        }
+
+        // Newton coefficients depend only on the nodes, so build them ONCE and reuse across the
+        // three DCM samples below (kf, kf +/- h) -- the O(n^2) divided-difference table is not
+        // rebuilt per sample. Absolute planet-fixed DCM at local coordinate kfEval on this stencil:
+        const std::vector<Eigen::Vector3d> coef = newtonCoeffs(theta, dtheta, z);
+        auto dcmAt = [&](double kfEval) -> Eigen::Matrix3d {
+            Eigen::Vector3d th = newtonEval(coef, z, kfEval, nullptr);
+            double th_c[3] = {th[0], th[1], th[2]};
+            double Rrel_c[3][3];
+            PRV2C(th_c, Rrel_c);
+            return c2DArray2EigenMatrix3d(Rrel_c) * Cb;
+        };
+
+        Eigen::Matrix3d dcm = dcmAt(kf);
+        eigenMatrix3d2CArray(dcm, &dcmOut[0][0]);
+
+        // J20002Pfix_dot = d(dcm)/dt via a central difference of the same interpolant on this
+        // stencil (d/dt = d/dk / kdSec). h is in KNOT units (a fixed fraction of a knot), so it is
+        // scale-invariant in knotStep: small enough to resolve the polynomial slope, large enough
+        // to avoid float cancellation, independent of the absolute knot spacing. The node set
+        // (theta, dtheta, z) is fixed for this call, so dcmAt is well-defined for kf +/- h even
+        // when kf is near a knot boundary (the rate is consistent with the reconstruction used at
+        // THIS call, which is what a downstream Euler sub-step consumes).
+        const double h = 1.0e-5;
+        Eigen::Matrix3d dcmDot = (dcmAt(kf + h) - dcmAt(kf - h)) / (2.0 * h * kdSec);
+        eigenMatrix3d2CArray(dcmDot, &dcmDotOut[0][0]);
+        return true;
+    }
+
+private:
+    //! Query + cache position knot k (spkezr_c, metres). Re-queries a previously-failed
+    //! (fallback) knot so a transient / out-of-coverage failure does not poison the cache.
+    //! Returns true if knot k holds a good (successfully queried) sample.
+    bool ensurePosKnot(PlanetInterp& pi, const std::string& planetName, long k)
+    {
+        auto it = pi.posKnots.find(k);
+        if (it != pi.posKnots.end() && it->second.ok) {
+            return true;  // already have a good knot; a stored fallback (ok==false) falls through
+        }
+        // knotStep is in nanoseconds; the knot ET (seconds past J2000) is et0 + k*knotStep.
+        double et = this->et0 + static_cast<double>(k) * pi.posCfg.knotStep * NANO2SEC;
+        double lighttime;
+        double localState[6];
+        // Reconstruction may request a future knot (interpolate=true); guard against a query past
+        // kernel coverage aborting the process, exactly as SpiceKernel does elsewhere.
+        SpiceErrorModeGuard guard;
+        spkezr_c(planetName.c_str(), et, owner.referenceBase.c_str(), "NONE",
+                 owner.zeroBase.c_str(), localState, &lighttime);
+        PosKnot kn;
+        if (failed_c()) {
+            reset_c();
+            owner.bskLogger.bskLog(BSK_WARNING, "spiceInterface: position knot query failed for "
+                "'%s' at ET %g; using zero state for that knot (will retry on later calls).",
+                planetName.c_str(), et);
+        } else {
+            kn.pos = Eigen::Vector3d(localState[0], localState[1], localState[2]) * 1000.0;
+            kn.vel = Eigen::Vector3d(localState[3], localState[4], localState[5]) * 1000.0;
+            kn.ok = true;
+        }
+        pi.posKnots[k] = kn;
+        owner.countSpiceQuery(planetName, true);
+        evictKnots(pi.posKnots, pi.posCfg.nKnots, k);
+        return kn.ok;
+    }
+
+    //! Query + cache orientation knot k (sxform_c). Re-queries a previously-failed (fallback)
+    //! knot so a transient / out-of-coverage failure does not poison the cache.
+    //! Returns true if knot k holds a good (successfully queried) sample.
+    bool ensureOrientKnot(PlanetInterp& pi, const std::string& planetName,
+                          const std::string& planetFrame, long k)
+    {
+        auto it = pi.orientKnots.find(k);
+        if (it != pi.orientKnots.end() && it->second.ok) {
+            return true;  // already have a good knot; a stored fallback (ok==false) falls through
+        }
+        double et = this->et0 + static_cast<double>(k) * pi.orientCfg.knotStep * NANO2SEC;
+        double aux[6][6];
+        SpiceErrorModeGuard guard;
+        sxform_c(owner.referenceBase.c_str(), planetFrame.c_str(), et, aux);
+        OrientKnot kn;
+        if (failed_c()) {
+            reset_c();
+            owner.bskLogger.bskLog(BSK_WARNING, "spiceInterface: orientation knot query failed for "
+                "'%s' (frame %s) at ET %g; using identity for that knot (will retry on later calls).",
+                planetName.c_str(), planetFrame.c_str(), et);
+        } else {
+            double C[3][3], Cdot[3][3];
+            m66Get33Matrix(0, 0, aux, C);
+            m66Get33Matrix(1, 0, aux, Cdot);
+            kn.dcm = c2DArray2EigenMatrix3d(C);
+            kn.dcmDot = c2DArray2EigenMatrix3d(Cdot);
+            kn.ok = true;
+        }
+        pi.orientKnots[k] = kn;
+        owner.countSpiceQuery(planetName, false);
+        evictKnots(pi.orientKnots, pi.orientCfg.nKnots, k);
+        return kn.ok;
+    }
+
+    //! Drop knots far from index k, keeping the live stencil plus a little slack.
+    template <typename KnotMap>
+    static void evictKnots(KnotMap& knots, int nKnots, long k)
+    {
+        static const size_t CACHE_SLACK = 4;
+        const size_t cap = static_cast<size_t>(std::max(1, nKnots)) + CACHE_SLACK;
+        while (knots.size() > cap) {
+            long lo = knots.begin()->first;
+            long hi = knots.rbegin()->first;
+            if (std::abs(hi - k) >= std::abs(lo - k)) {
+                knots.erase(hi);
+            } else {
+                knots.erase(lo);
+            }
+        }
+    }
+
+    //! Trailing (extrapolation) or centred (interpolation) stencil of nKnots indices around kf.
+    static std::vector<long> buildStencil(double kf, int nKnots, bool interpolate)
+    {
+        long k = static_cast<long>(std::floor(kf));  // current interval is [k, k+1)
+        int m = std::max(1, nKnots);
+        // A single knot is the enclosing knot k for both modes (interp and extrap coincide);
+        // the general interpolation formula below would otherwise pick the future knot k+1.
+        // Interpolation centres the m knots on the interval [k, k+1] (start = k - (m-1)/2, so
+        // m=2 -> [k, k+1], m=3 -> [k-1, k, k+1], m=4 -> [k-1..k+2]); extrapolation takes the m
+        // trailing knots ending at k.
+        long start;
+        if (m == 1) {
+            start = k;
+        } else {
+            start = interpolate ? (k - (m - 1) / 2) : (k - (m - 1));
+        }
+        std::vector<long> idx;
+        idx.reserve(static_cast<size_t>(m));
+        for (int j = 0; j < m; ++j) {
+            idx.push_back(start + j);
+        }
+        return idx;
+    }
+
+    //! Newton divided-difference coefficients for the (possibly confluent) nodes ``z`` with values
+    //! ``vals`` and, at confluent nodes, derivatives ``ders``. The coefficients depend only on the
+    //! nodes, not on any evaluation point, so they are computed once and reused across evaluations
+    //! (e.g. the 3 samples of the orientation-rate finite difference).
+    static std::vector<Eigen::Vector3d> newtonCoeffs(const std::vector<Eigen::Vector3d>& vals,
+                                                     const std::vector<Eigen::Vector3d>& ders,
+                                                     const std::vector<double>& z)
+    {
+        const size_t n = z.size();
+        std::vector<Eigen::Vector3d> prev(vals);
+        std::vector<Eigen::Vector3d> coef{prev[0]};
+        for (size_t col = 1; col < n; ++col) {
+            std::vector<Eigen::Vector3d> cur(n - col);
+            for (size_t i = 0; i < n - col; ++i) {
+                cur[i] = (z[i + col] == z[i])
+                             ? ders[i]  // confluent node -> analytic derivative
+                             : (prev[i + 1] - prev[i]) / (z[i + col] - z[i]);
+            }
+            coef.push_back(cur[0]);
+            prev = std::move(cur);
+        }
+        return coef;
+    }
+
+    //! Horner evaluation of the Newton form (coefficients ``coef`` over nodes ``z``) at ``x``.
+    //! When derivOut != nullptr, also returns d/dx via the product-rule Horner recurrence.
+    static Eigen::Vector3d newtonEval(const std::vector<Eigen::Vector3d>& coef,
+                                      const std::vector<double>& z, double x,
+                                      Eigen::Vector3d* derivOut)
+    {
+        const size_t n = z.size();
+        Eigen::Vector3d result = coef[n - 1];
+        Eigen::Vector3d deriv = Eigen::Vector3d::Zero();
+        for (size_t i = n - 1; i-- > 0;) {
+            if (derivOut) {
+                deriv = deriv * (x - z[i]) + result;  // product rule, before updating result
+            }
+            result = result * (x - z[i]) + coef[i];
+        }
+        if (derivOut) {
+            *derivOut = deriv;
+        }
+        return result;
+    }
+
+    SpiceInterface& owner;                            //!< back-reference for frame/observer/logger
+    std::map<std::string, PlanetInterp> planets;      //!< per-planet state, keyed by uppercase name
+    double et0 = 0.0;                                 //!< ET (s past J2000) at sim time 0
+};
+
+SpiceInterface::SpiceReconstruction& SpiceInterface::reconState()
+{
+    if (!this->recon) {
+        this->recon = std::make_unique<SpiceReconstruction>(*this);
+        // If Reset has already run (time data initialized), anchor the knot grid at the init epoch
+        // now. Otherwise et0 stays 0 until Reset calls reset(); enabling reconstruction between two
+        // ExecuteSimulation() segments would otherwise query knots at J2000 ET 0.
+        if (this->timeDataInit) {
+            this->recon->setEpoch(this->J2000ETInit);
+        }
+    }
+    return *this->recon;
 }
 
 /*! This constructor initializes the variables that spice uses.  Most of them are
@@ -209,6 +707,21 @@ void SpiceInterface::Reset(uint64_t CurrenSimNanos)
     }
     delete [] name;
 
+    //! - Zero the SPICE-query tallies so each run counts from its own Reset, seeding an entry for
+    //!   every known planet. A planet present but never queried (e.g. a disabled channel) then reads
+    //!   {0, 0}; only a name that was never added reads {-1, -1}. The UpdateState below is part of
+    //!   the run, so its queries are included.
+    this->spiceQueryCounts.clear();
+    for (const auto& pd : this->planetData) {
+        this->spiceQueryCounts[normalizeBodyName(pd.PlanetName)] = {0, 0};
+    }
+
+    //! - Prepare reconstruction (if any planet is configured): anchor the knot grid at the init
+    //!   epoch and clear every cache so a re-Reset starts fresh.
+    if (this->recon) {
+        this->recon->reset(this->J2000ETInit, this->planetData);
+    }
+
     // - Call Update state so that the spice bodies are inputted into the messaging system on reset
     this->UpdateState(CurrenSimNanos);
 }
@@ -330,10 +843,11 @@ void SpiceInterface::UpdateState(uint64_t CurrentSimNanos)
              (this->spiceBuffer));
     std::string localString = reinterpret_cast<char*> (&this->spiceBuffer[3]);
     this->julianDateCurrent = std::stod(localString);
-    //! Get GPS and Planet data and then write the message outputs
+    //! Get GPS and Planet data and then write the message outputs. Reconstruction is allowed only
+    //! on the planet pass (the raw sim time drives the knot grid; the spacecraft pass stays exact).
     this->computeGPSData();
-    this->pullSpiceData(&this->planetData);
-    this->pullSpiceData(&this->scData);
+    this->pullSpiceData(&this->planetData, CurrentSimNanos, true);
+    this->pullSpiceData(&this->scData, CurrentSimNanos, false);
     this->writeOutputMessages(CurrentSimNanos);
 }
 
@@ -454,7 +968,8 @@ void SpiceInterface::clearKernelPaths()
  and saves the information off into the array.
 
  */
-void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spiceData)
+void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spiceData,
+                                   uint64_t CurrentSimNanos, bool allowReconstruction)
 {
     std::vector<SpicePlanetStateMsgPayload>::iterator planit;
 
@@ -465,22 +980,24 @@ void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spic
      -# Convert the pos/vel over to meters.
      -# Time stamp the message appropriately
      */
+    //! Reconstruction is opt-in and the caller says whether it is allowed for this pass: the
+    //! planet pass allows it, the spacecraft pass never does (so a configured planet engine can
+    //! never overwrite a spacecraft's state). The raw sim time drives the knot grid.
+    const uint64_t tNanos = CurrentSimNanos;
+
     size_t c = 0; // celestial body counter
     for(planit = spiceData->begin(); planit != spiceData->end(); planit++)
     {
-        double lighttime;
-        double localState[6];
-        std::string planetFrame = "";
+        //! Look up this planet's reconstruction config (when allowed). A null entry, or a
+        //! channel left in Exact mode, runs the original SPICE path verbatim -> bit-for-bit
+        //! identical to the exact SPICE path when nothing is configured.
+        SpiceReconstruction::PlanetInterp* pi = nullptr;
+        if (allowReconstruction && this->recon) {
+            pi = this->recon->find(planit->PlanetName);
+        }
 
-        spkezr_c(planit->PlanetName, this->J2000Current, this->referenceBase.c_str(),
-            "NONE", this->zeroBase.c_str(), localState, &lighttime);
-        v3Copy(&localState[0], planit->PositionVector);
-        v3Copy(&localState[3], planit->VelocityVector);
-        v3Scale(1000., planit->PositionVector, planit->PositionVector);
-        v3Scale(1000., planit->VelocityVector, planit->VelocityVector);
-        planit->J2000Current = this->J2000Current;
         /* use default IAU planet frame name */
-        planetFrame = "IAU_";
+        std::string planetFrame = "IAU_";
         planetFrame += planit->PlanetName;
 
         /* use specific planet frame if specified */
@@ -493,21 +1010,105 @@ void SpiceInterface::pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spic
             }
         }
 
+        //! --- POSITION channel ---
+        if (pi && this->recon->position(*pi, planit->PlanetName, tNanos,
+                                        planit->PositionVector, planit->VelocityVector)) {
+            // handled by reconstruction or disabled (values already written)
+        } else {
+            double lighttime;
+            double localState[6];
+            spkezr_c(planit->PlanetName, this->J2000Current, this->referenceBase.c_str(),
+                "NONE", this->zeroBase.c_str(), localState, &lighttime);
+            v3Copy(&localState[0], planit->PositionVector);
+            v3Copy(&localState[3], planit->VelocityVector);
+            v3Scale(1000., planit->PositionVector, planit->PositionVector);
+            v3Scale(1000., planit->VelocityVector, planit->VelocityVector);
+            this->countSpiceQuery(planit->PlanetName, true);
+        }
+
+        //! J2000Current (message validity time) is always the current sim time, regardless of
+        //! reconstruction -- unchanged from the original behavior.
+        planit->J2000Current = this->J2000Current;
+
+        //! --- ORIENTATION channel --- (still gated on computeOrient, so a body with no frame
+        //! keeps identity J20002Pfix / zero rate exactly as before)
         if(planit->computeOrient)
         {
-            //pxform_c ( referenceBase.c_str(), planetFrame.c_str(), J2000Current,
-            //    planit->second.J20002Pfix);
+            if (pi && this->recon->orientation(*pi, planit->PlanetName, planetFrame, tNanos,
+                                               planit->J20002Pfix, planit->J20002Pfix_dot)) {
+                // handled by reconstruction or disabled (values already written)
+            } else {
+                //pxform_c ( referenceBase.c_str(), planetFrame.c_str(), J2000Current,
+                //    planit->second.J20002Pfix);
 
-            double aux[6][6];
+                double aux[6][6];
 
-            sxform_c(this->referenceBase.c_str(), planetFrame.c_str(), this->J2000Current, aux); //returns attitude of planet (i.e. IAU_EARTH) wrt "j2000". note j2000 is actually ICRF in Spice.
+                sxform_c(this->referenceBase.c_str(), planetFrame.c_str(), this->J2000Current, aux); //returns attitude of planet (i.e. IAU_EARTH) wrt "j2000". note j2000 is actually ICRF in Spice.
 
-            m66Get33Matrix(0, 0, aux, planit->J20002Pfix);
+                m66Get33Matrix(0, 0, aux, planit->J20002Pfix);
 
-            m66Get33Matrix(1, 0, aux, planit->J20002Pfix_dot);
+                m66Get33Matrix(1, 0, aux, planit->J20002Pfix_dot);
+                this->countSpiceQuery(planit->PlanetName, false);
+            }
         }
         c++;
     }
+}
+
+// ---------------------------------------------------------------------------
+//  SPICE query reconstruction (opt-in, per planet, per channel)
+// ---------------------------------------------------------------------------
+
+void SpiceInterface::setPlanetPositionReconstruction(const std::string& planetName,
+                                                     uint64_t knotStep, int nKnots,
+                                                     bool useVelocity, bool interpolate)
+{
+    this->reconState().configure(planetName, &SpiceReconstruction::PlanetInterp::posCfg,
+                                 knotStep, nKnots, useVelocity, interpolate);
+}
+
+void SpiceInterface::setPlanetOrientationReconstruction(const std::string& planetName,
+                                                        uint64_t knotStep, int nKnots,
+                                                        bool useVelocity, bool interpolate)
+{
+    this->reconState().configure(planetName, &SpiceReconstruction::PlanetInterp::orientCfg,
+                                 knotStep, nKnots, useVelocity, interpolate);
+}
+
+void SpiceInterface::setPlanetPositionDisabled(const std::string& planetName)
+{
+    this->reconState().entry(planetName).posCfg.mode = SpiceReconstruction::ChannelMode::Disabled;
+}
+
+void SpiceInterface::setPlanetOrientationDisabled(const std::string& planetName)
+{
+    this->reconState().entry(planetName).orientCfg.mode = SpiceReconstruction::ChannelMode::Disabled;
+}
+
+void SpiceInterface::setPlanetExactSpice(const std::string& planetName)
+{
+    auto& pi = this->reconState().entry(planetName);
+    pi.posCfg.mode = SpiceReconstruction::ChannelMode::Exact;
+    pi.orientCfg.mode = SpiceReconstruction::ChannelMode::Exact;
+}
+
+void SpiceInterface::countSpiceQuery(const std::string& planetName, bool isPosition)
+{
+    auto& counts = this->spiceQueryCounts[normalizeBodyName(planetName)];
+    if (isPosition) {
+        counts.first++;
+    } else {
+        counts.second++;
+    }
+}
+
+std::pair<long, long> SpiceInterface::getPlanetSpiceQueryCount(const std::string& planetName)
+{
+    auto it = this->spiceQueryCounts.find(normalizeBodyName(planetName));
+    if (it == this->spiceQueryCounts.end()) {
+        return {-1, -1};  // this planet has never been queried
+    }
+    return it->second;
 }
 
 /**

--- a/src/simulation/environment/spiceInterface/spiceInterface.h
+++ b/src/simulation/environment/spiceInterface/spiceInterface.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <unordered_map>
 #include <set>
+#include <utility>
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/linearAlgebra.h"
 #include "architecture/utilities/bskLogging.h"
@@ -127,7 +128,8 @@ public:
     void Reset(uint64_t CurrentSimNanos);
     void initTimeData();
     void computeGPSData();
-    void pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spiceData);
+    void pullSpiceData(std::vector<SpicePlanetStateMsgPayload> *spiceData,
+                       uint64_t CurrentSimNanos = 0, bool allowReconstruction = false);
     void writeOutputMessages(uint64_t CurrentClock);
 
     //! Add a SPICE kernel by full path (absolute or relative)
@@ -151,6 +153,60 @@ public:
     void clearKeeper();
     void addPlanetNames(std::vector<std::string> planetNames);
     void addSpacecraftNames(std::vector<std::string> spacecraftNames);
+
+    /** @name SPICE query reconstruction (opt-in, per planet, per channel)
+     *
+     * By default a planet's state is queried from SPICE at the exact simulation
+     * time on every ``UpdateState`` call. On a dynamics task evaluated once per
+     * integrator sub-step (e.g. MJScene) that is one SPICE call per stage per
+     * body. These methods instead reconstruct a planet's position and/or
+     * orientation from a coarse grid of cached SPICE "knots" (spacing
+     * ``knotStep`` nanoseconds), cutting the SPICE cost to about
+     * ``horizon / knotStep`` per channel.
+     *
+     * Knobs: ``nKnots`` (stencil size / polynomial order), ``useVelocity``
+     * (also match the SPICE velocity at each knot for a Hermite fit, vs a
+     * position-only Lagrange fit), and ``interpolate`` (bracket the time with
+     * past and future knots, vs past-only extrapolation). The enabled defaults
+     * are cubic Hermite interpolation on a 60 s grid.
+     *
+     * An unconfigured channel stays on the exact SPICE path, bit-for-bit. The
+     * emitted velocity and orientation rate are the derivatives of the same
+     * reconstruction, so a consumer that Euler-extrapolates them (the classic
+     * ``gravityEffector``) stays self-consistent.
+     * @{ */
+
+    //! Default knot spacing when reconstruction is enabled without an explicit ``knotStep`` [ns].
+    static constexpr uint64_t defaultKnotStep = 60000000000;  // 60 s
+
+    //! Reconstruct this planet's position from a coarse knot grid. ``knotStep`` in nanoseconds.
+    void setPlanetPositionReconstruction(const std::string& planetName,
+                                         uint64_t knotStep = defaultKnotStep,
+                                         int nKnots = 2, bool useVelocity = true,
+                                         bool interpolate = true);
+
+    //! Reconstruct this planet's orientation from a coarse knot grid. ``knotStep`` in nanoseconds.
+    void setPlanetOrientationReconstruction(const std::string& planetName,
+                                            uint64_t knotStep = defaultKnotStep,
+                                            int nKnots = 2, bool useVelocity = true,
+                                            bool interpolate = true);
+
+    //! Turn this planet's position channel off: emit zero position/velocity, no SPICE query.
+    void setPlanetPositionDisabled(const std::string& planetName);
+
+    //! Turn this planet's orientation channel off: emit identity attitude/zero rate, no SPICE query.
+    void setPlanetOrientationDisabled(const std::string& planetName);
+
+    //! Revert both channels of this planet to the exact per-call SPICE query (the default).
+    void setPlanetExactSpice(const std::string& planetName);
+
+    //! Total SPICE evaluations spent on this planet since the last Reset, as {position,
+    //! orientation}. Counts every spkezr_c/sxform_c call regardless of whether the planet uses
+    //! reconstruction: exact-path calls (once per update) and reconstruction-knot fills alike. A
+    //! planet added but never queried (e.g. a disabled channel) reads {0, 0}; a name that was never
+    //! added via addPlanetNames reads {-1, -1}.
+    std::pair<long, long> getPlanetSpiceQueryCount(const std::string& planetName);
+    /** @} */
 
 public:
     Message<SpiceTimeMsgPayload> spiceTimeOutMsg;    //!< spice time sampling output message
@@ -204,6 +260,24 @@ private:
      * gone.
      */
     std::unordered_map<std::string, std::shared_ptr<SpiceKernel>> loadedKernels;
+
+    //! Opaque holder for the opt-in reconstruction state (per-planet knot caches, configuration,
+    //! and interpolation math). Defined entirely in the .cpp so this header stays free of the
+    //! Eigen/STL internals and needs no SWIG guards; null until a setPlanet*Reconstruction/Disabled
+    //! call creates it. See @ref SpiceReconstruction in spiceInterface.cpp.
+    class SpiceReconstruction;
+    std::unique_ptr<SpiceReconstruction> recon;
+
+    //! Return the reconstruction state, lazily creating it on first use.
+    SpiceReconstruction& reconState();
+
+    //! {position, orientation} SPICE-query tallies per planet (uppercase name), counting every
+    //! spkezr_c/sxform_c call whether it comes from the exact path or a reconstruction knot fill.
+    //! Reset to zero for the current planet set at each Reset. getPlanetSpiceQueryCount reads this.
+    std::unordered_map<std::string, std::pair<long, long>> spiceQueryCounts;
+
+    //! Increment this planet's position (isPosition=true) or orientation SPICE-query tally.
+    void countSpiceQuery(const std::string& planetName, bool isPosition);
 };
 
 

--- a/src/simulation/environment/spiceInterface/spiceInterface.i
+++ b/src/simulation/environment/spiceInterface/spiceInterface.i
@@ -34,6 +34,7 @@ from Basilisk.architecture.swig_common_model import *
 %include "swig_conly_data.i"
 %include "std_string.i"
 %include "std_vector.i"
+%include "std_pair.i"
 %include "swig_deprecated.i"
 
 %deprecated_function(
@@ -43,6 +44,7 @@ from Basilisk.architecture.swig_common_model import *
 )
 
 %template() std::vector<std::string>;
+%template() std::pair<long, long>;
 %naturalvar SpiceInterface::planetFrames;
 %ignore SpiceKernel;
 

--- a/src/tests/test_scenarioSpiceReconstruction.py
+++ b/src/tests/test_scenarioSpiceReconstruction.py
@@ -1,0 +1,43 @@
+
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import simHelpers
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+sys.path.append(path + "/../../examples")
+
+# The scenario imports Basilisk.simulation.mujoco at module load, so skip collection entirely on
+# a build compiled without optional MuJoCo support.
+pytest.importorskip("Basilisk.simulation.mujoco")
+import scenarioSpiceReconstruction
+
+
+@pytest.mark.scenarioTest
+def test_scenarioSpiceReconstruction():
+    """Run the scenario and save its figures for the documentation build."""
+    errClassic, figureList = scenarioSpiceReconstruction.run(show_plots=False)
+    for pltName, fig in list(figureList.items()):
+        simHelpers.saveScenarioFigure(pltName, fig, path)
+
+    # gravityEffector's linear extrapolation carries a km-scale error at this step; guard the run.
+    assert errClassic > 100.0

--- a/src/tests/test_scenarioVestaOrientation.py
+++ b/src/tests/test_scenarioVestaOrientation.py
@@ -1,0 +1,42 @@
+
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import inspect
+import os
+import sys
+
+import pytest
+from Basilisk.utilities import simHelpers
+
+filename = inspect.getframeinfo(inspect.currentframe()).filename
+path = os.path.dirname(os.path.abspath(filename))
+sys.path.append(path + "/../../examples")
+
+# The scenario imports Basilisk.simulation.mujoco at module load, so skip collection entirely on
+# a build compiled without optional MuJoCo support.
+pytest.importorskip("Basilisk.simulation.mujoco")
+import scenarioVestaOrientation
+
+
+@pytest.mark.scenarioTest
+def test_scenarioVestaOrientation():
+    """Run the scenario and save its figure for the documentation build."""
+    figureList = scenarioVestaOrientation.run(show_plots=False)
+    for pltName, fig in list(figureList.items()):
+        simHelpers.saveScenarioFigure(pltName, fig, path)
+
+    assert len(figureList) >= 1


### PR DESCRIPTION
* **Tickets addressed:** closes #1495 
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Adds opt-in SPICE query **reconstruction** to `SpiceInterface`. Each planet's position and
orientation channels can independently reconstruct their state from a coarse grid of cached
SPICE "knots" (or be disabled), cutting SPICE calls from once-per-integrator-stage to
~`horizon / knotStep`. Unconfigured channels run the original SPICE path bit-for-bit, so the
default behavior is unchanged.

The reconstruction state lives entirely in the `.cpp` behind an opaque PIMPL pointer, so the
header carries no Eigen/STL internals and needs no SWIG guards. New API:
`setPlanetPositionReconstruction` / `setPlanetOrientationReconstruction` (defaults: cubic
Hermite, 60 s grid), `setPlanet{Position,Orientation}Disabled`, `setPlanetExactSpice`, and
`getPlanetSpiceQueryCount`. Emitted velocity/rate are derivatives of the same reconstruction,
so a downstream `gravityEffector` Euler step stays self-consistent.

Commits are organized as: the C++ feature, the SWIG/API surface, the two example scenarios,
and the documentation/release-note snippet.

## Verification
New unit tests (`test_spiceInterfaceReconstruction.py`, 10 cases) cover bit-identical
defaults, position accuracy at reduced query count, exact single-knot orientation for a
constant spinner, disabled channels, velocity/position derivative self-consistency,
integrator-agnostic query counts (RK4 vs RKF45 on an MJScene), exact-revert, and centered
odd-`nKnots` stencils. Two scenario tests (`test_scenarioSpiceReconstruction`,
`test_scenarioVestaOrientation`) run the examples and save their documentation figures. All
existing `spiceInterface` unit tests still pass unchanged.

## Documentation
New guide `Learn/makingModules/advancedTopics/spiceReconstruction.rst` (linked from
`advancedTopics.rst`), two new example pages (`scenarioSpiceReconstruction`,
`scenarioVestaOrientation`, registered in `examples/_default.rst`), and a release-note
snippet. Reviewers should check the guide's tuning guidance and the two scenario docstrings
for accuracy against the shipped behavior.

