### PR TITLE
Expose optional build capabilities and guard dependent tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -85,11 +85,11 @@ jobs:
           ]
         conan_args: ["--opNav True --mujoco True"]
         include:
-          # An extra Basilisk build to test building without visualization enabled
+          # An extra plain Basilisk build without optional opNav, MuJoCo, or visualization support
           - python: "3.14"
             python_label: "MAX Python"
             pytest_flags: -n auto -m "not ciSkip" -rs --timeout=300 --timeout-method=thread --durations=25 -v
-            conan_args: --opNav True --mujoco True --vizInterface False
+            conan_args: --opNav False --mujoco False --vizInterface False
             job_suffix: "--vizInterface False"
 
     name: macOS (${{ matrix.python_label }}) ${{ matrix.job_suffix }}

--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -133,9 +133,9 @@ To skip the optional example Python packages during the clone-based install, use
 
 Inspecting the Build Toolchain
 ------------------------------
-Every Basilisk build records the C and C++ compilers, build configuration, CMake generator, and versions of the
-principal build tools in the installed Python package.  This information can be inspected when diagnosing a binary
-or build issue.
+Every Basilisk build records its configured optional features, C and C++ compilers, build configuration, CMake
+generator, and versions of the principal build tools in the installed Python package.  This information can be
+inspected when diagnosing a binary or build issue.
 
 For a concise, human-readable summary, use ``printBuildInfo()``::
 
@@ -149,6 +149,7 @@ This produces output similar to::
       Version:        2.12.0 (plugin ABI 1)
       Target:         macOS arm64, 64-bit
       Build:          Release, Unix Makefiles
+      Features:       vizInterface=on, opNav=off, mujoco=off
       C compiler:     AppleClang 21.0.0.21000101 (cc)
       C++ compiler:   AppleClang 21.0.0.21000101 (c++)
       C standard:     C17
@@ -167,11 +168,13 @@ This produces output similar to::
       Python:         3.14.6
 
 For programmatic inspection or custom formatting, use ``getBuildInfo()``.  It returns a copy of a versioned nested
-dictionary with three principal sections::
+dictionary with four principal sections::
 
-    from Basilisk import getBuildInfo
+    from Basilisk import getBuildInfo, hasBuildFeature
 
     buildInfo = getBuildInfo()
+    mujocoEnabled = buildInfo["features"]["mujoco"]
+    opNavEnabled = hasBuildFeature("opNav")
     pluginAbiVersion = buildInfo["artifact"]["pluginAbiVersion"]
     standardLibrary = buildInfo["abi"]["cxx"]["standardLibrary"]["family"]
     compilerVersion = buildInfo["diagnostics"]["compilers"]["cxx"]["version"]
@@ -180,6 +183,11 @@ dictionary with three principal sections::
 incremented when Basilisk intentionally changes the C/C++ object contract exposed to SDK plugins.  It does not
 promise compatibility between different Basilisk versions; the SDK's exact-version check remains required unless a
 future compatibility policy explicitly relaxes it.
+
+``features`` reports whether ``vizInterface``, ``opNav``, and ``mujoco`` were enabled when CMake configured the
+installed package.  The same values can be queried with ``hasBuildFeature()``.  Feature names are case-sensitive,
+and an unknown name raises ``KeyError``.  These values describe compiled Basilisk capabilities; they do not report
+the availability of external applications such as Vizard.
 
 ``abi`` is captured by C and C++ translation units compiled with the selected Basilisk build configuration.  It
 records the actual target architecture, endianness, C and C++ language modes, compiler ABI, standard-library ABI and

--- a/docs/source/Support/Developer/CodingGuidlines.rst
+++ b/docs/source/Support/Developer/CodingGuidlines.rst
@@ -248,6 +248,74 @@ This will execute ``pytest`` and ``gtest`` checks.  All tests should pass.  If n
 Basilisk modules are built (i.e. the build process turned off ``opNav`` option), then
 some tests will show up as skipped.
 
+Guarding Tests for Optional Build Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests that require an optional Basilisk build feature must query the configured build
+metadata with ``Basilisk.hasBuildFeature()``.  Do not infer build capabilities by
+catching ``ImportError``.  Import probing can hide a broken build where a feature was
+enabled but its module failed to import.
+
+If every test in a file requires the same optional feature, use a module-level
+``pytestmark`` and import the optional modules conditionally:
+
+.. code-block:: python
+
+    import pytest
+
+    from Basilisk import hasBuildFeature
+
+    mujocoEnabled = hasBuildFeature("mujoco")
+    pytestmark = pytest.mark.skipif(
+        not mujocoEnabled,
+        reason="Requires Basilisk built with --mujoco True",
+    )
+    if mujocoEnabled:
+        from Basilisk.simulation import mujoco
+
+
+    def test_mujoco_feature():
+        scene = mujoco.MJScene("<mujoco/>")
+        # Test the feature.
+
+A module-level ``pytestmark`` applies to every test collected from that file, including
+parameterized tests.  It does not stop module-level statements from running during test
+collection, which is why the optional import must still be conditional.  When the feature
+is enabled, import it normally and allow import failures to surface.
+
+If a file contains both core tests and tests for an optional feature, guard only the
+feature-specific tests:
+
+.. code-block:: python
+
+    import pytest
+
+    from Basilisk import hasBuildFeature
+
+    mujocoEnabled = hasBuildFeature("mujoco")
+    if mujocoEnabled:
+        from Basilisk.simulation import mujoco
+
+
+    def test_core_feature():
+        # This test runs in every build configuration.
+        pass
+
+
+    @pytest.mark.skipif(
+        not mujocoEnabled,
+        reason="Requires Basilisk built with --mujoco True",
+    )
+    def test_mujoco_feature():
+        scene = mujoco.MJScene("<mujoco/>")
+        # Test the optional feature.
+
+Scenario test wrappers must also conditionally import a scenario when the scenario imports
+an unavailable optional module at module scope.  The supported feature names are
+``vizInterface``, ``opNav``, and ``mujoco``.  Required Python dependencies, such as Pillow,
+must be imported normally; a missing required dependency is an environment error and must
+not cause the test to be skipped.
+
 Optional developer performance benchmarks are documented separately in
 :ref:`performanceBenchmarks`.  Benchmark timing runs are opt-in speed
 investigations.  The lightweight benchmark smoke tests only check that benchmark

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- :ref:`vizInterface` left its protobuf output stream open after the module was destroyed. On Windows, this could
+  prevent saved Vizard data files from being removed until the Python process exited. The stream is now owned and
+  closed automatically by the module. This is fixed in the current version.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
   for Basilisk and compatible extensions. If source builds fail with SWIG 4.4.0 or emit

--- a/docs/source/Support/bskReleaseNotesSnippets/build-feature-metadata.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/build-feature-metadata.rst
@@ -1,1 +1,1 @@
-- Added optional ``vizInterface``, ``opNav``, and ``mujoco`` capability flags to ``Basilisk.getBuildInfo()`` and the new ``Basilisk.hasBuildFeature()`` query.
+- Added optional ``vizInterface``, ``opNav``, and ``mujoco`` capability flags to ``Basilisk.getBuildInfo()`` and the new ``Basilisk.hasBuildFeature()`` query. Scenarios and tests now use these flags to guard optional imports and skip cleanly when a capability was not built.

--- a/docs/source/Support/bskReleaseNotesSnippets/build-feature-metadata.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/build-feature-metadata.rst
@@ -1,0 +1,1 @@
+- Added optional ``vizInterface``, ``opNav``, and ``mujoco`` capability flags to ``Basilisk.getBuildInfo()`` and the new ``Basilisk.hasBuildFeature()`` query.

--- a/docs/source/Support/bskReleaseNotesSnippets/vizinterface-output-stream.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/vizinterface-output-stream.rst
@@ -1,0 +1,1 @@
+- :ref:`vizInterface` now owns and closes its protobuf output stream, preventing file-handle leaks and Windows cleanup failures after saving Vizard data.

--- a/examples/OpNavScenarios/modelsOpNav/BSK_OpNavFsw.py
+++ b/examples/OpNavScenarios/modelsOpNav/BSK_OpNavFsw.py
@@ -33,7 +33,7 @@ import math
 from pathlib import Path
 
 import numpy as np
-from Basilisk import __path__
+from Basilisk import __path__, hasBuildFeature
 from Basilisk.architecture import messaging
 from Basilisk.fswAlgorithms import (
     attTrackingError,
@@ -53,17 +53,10 @@ from Basilisk.utilities import deprecated, fswSetupRW, macros, orbitalMotion
 
 bskPath = __path__[0]
 
-try:
-    from Basilisk.fswAlgorithms import houghCircles, limbFinding  # FSW for OpNav
-except ImportError:
-    print("OpNav Modules Missing, check build options")
+if not hasBuildFeature("opNav"):
+    raise RuntimeError("This scenario requires Basilisk built with --opNav True")
 
-try:
-    from Basilisk.fswAlgorithms import centerRadiusCNN  # FSW for OpNav
-    centerRadiusCNNIncluded = True
-except ImportError:
-    centerRadiusCNNIncluded = False
-
+from Basilisk.fswAlgorithms import centerRadiusCNN, houghCircles, limbFinding
 
 def get_repo_root(start: Path = Path(__file__).resolve()) -> Path:
     for parent in [start] + list(start.parents):
@@ -111,9 +104,8 @@ class BSKFswModels():
         self.imageProcessing = houghCircles.HoughCircles()
         self.imageProcessing.ModelTag = "houghCircles"
 
-        if centerRadiusCNNIncluded:
-            self.opNavCNN = centerRadiusCNN.CenterRadiusCNN()
-            self.opNavCNN.ModelTag = "opNavCNN"
+        self.opNavCNN = centerRadiusCNN.CenterRadiusCNN()
+        self.opNavCNN.ModelTag = "opNavCNN"
 
         self.pixelLine = pixelLineConverter.pixelLineConverter()
         self.pixelLine.ModelTag = "pixelLine"
@@ -198,8 +190,7 @@ class BSKFswModels():
         SimBase.AddModelToTask("opNavAttODTask", self.opNavPoint, 10)
         SimBase.AddModelToTask("opNavAttODTask", self.relativeOD, 9)
 
-        if centerRadiusCNNIncluded:
-            SimBase.AddModelToTask("cnnAttODTask", self.opNavCNN, 15)
+        SimBase.AddModelToTask("cnnAttODTask", self.opNavCNN, 15)
         SimBase.AddModelToTask("cnnAttODTask", self.pixelLine, 14)
         SimBase.AddModelToTask("cnnAttODTask", self.opNavPoint, 10)
         SimBase.AddModelToTask("cnnAttODTask", self.relativeOD, 9)
@@ -222,14 +213,13 @@ class BSKFswModels():
         SimBase.AddModelToTask("opNavFaultDet", self.opNavFault, 14)
         SimBase.AddModelToTask("opNavFaultDet", self.relativeOD, 9)
 
-        if centerRadiusCNNIncluded:
-            SimBase.AddModelToTask("cnnFaultDet", self.opNavCNN, 25)
-            SimBase.AddModelToTask("cnnFaultDet", self.pixelLine, 20)
-            SimBase.AddModelToTask("cnnFaultDet", self.imageProcessing, 18)
-            SimBase.AddModelToTask("cnnFaultDet", self.pixelLine, 16)
-            SimBase.AddModelToTask("cnnFaultDet", self.opNavFault, 14)
-            SimBase.AddModelToTask("cnnFaultDet", self.opNavPoint, 10)
-            SimBase.AddModelToTask("cnnFaultDet", self.relativeOD, 9)
+        SimBase.AddModelToTask("cnnFaultDet", self.opNavCNN, 25)
+        SimBase.AddModelToTask("cnnFaultDet", self.pixelLine, 20)
+        SimBase.AddModelToTask("cnnFaultDet", self.imageProcessing, 18)
+        SimBase.AddModelToTask("cnnFaultDet", self.pixelLine, 16)
+        SimBase.AddModelToTask("cnnFaultDet", self.opNavFault, 14)
+        SimBase.AddModelToTask("cnnFaultDet", self.opNavPoint, 10)
+        SimBase.AddModelToTask("cnnFaultDet", self.relativeOD, 9)
 
         # Create events to be called for triggering GN&C maneuvers
         SimBase.fswProc.disableAllTasks()
@@ -671,8 +661,7 @@ class BSKFswModels():
         self.SetImageProcessing(SimBase)
         self.SetPixelLineConversion(SimBase)
 
-        if centerRadiusCNNIncluded:
-            self.SetCNNOpNav(SimBase)
+        self.SetCNNOpNav(SimBase)
         self.SetRelativeODFilter()
         self.SetFaultDetection(SimBase)
 

--- a/examples/OpNavScenarios/scenariosOpNav/scenario_CNNAttOD.py
+++ b/examples/OpNavScenarios/scenariosOpNav/scenario_CNNAttOD.py
@@ -307,7 +307,4 @@ def run(showPlots, simTime=None):
     return figureList
 
 if __name__ == "__main__":
-    if not BSK_OpNavFsw.centerRadiusCNNIncluded:
-        print("centerRadiusCNN module is not built, so this scenario can't run.")
-        exit(1)
     run(True)

--- a/examples/mujoco/scenarioMJSceneVizard.py
+++ b/examples/mujoco/scenarioMJSceneVizard.py
@@ -53,15 +53,14 @@ from Basilisk.simulation import mujoco
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import StatefulSysModel
 from Basilisk.simulation import svIntegrators
-try:
+from Basilisk.utilities import vizSupport
+
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
-from Basilisk.utilities import vizSupport
 
 CURRENT_FOLDER = os.path.dirname(__file__)
 PRIMARY_XML_PATH = os.path.join(CURRENT_FOLDER, "sat_w_deployable_panels.xml")

--- a/examples/scenarioAsteroidArrival.py
+++ b/examples/scenarioAsteroidArrival.py
@@ -206,10 +206,8 @@ from Basilisk.simulation import spacecraft, extForceTorque, simpleNav, ephemeris
 from Basilisk.fswAlgorithms import mrpFeedback, attTrackingError, velocityPoint, locationPointing
 from Basilisk.architecture import messaging, astroConstants
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioBasicOrbitStream.py
+++ b/examples/scenarioBasicOrbitStream.py
@@ -106,10 +106,8 @@ from Basilisk.architecture import messaging
 from Basilisk.simulation import thrusterDynamicEffector
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 
 def run(

--- a/examples/scenarioDebrisReorbitET.py
+++ b/examples/scenarioDebrisReorbitET.py
@@ -80,11 +80,8 @@ from Basilisk.utilities import (
     vizSupport,
 )
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-
-except ImportError:
-    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioFlybySpice.py
+++ b/examples/scenarioFlybySpice.py
@@ -258,10 +258,8 @@ from Basilisk.utilities import vizSupport
 from Basilisk.utilities import simHelpers
 
 # import general simulation support files
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 # import FSW Algorithm related support
 from Basilisk.fswAlgorithms import hillPoint

--- a/examples/scenarioFormationBasic.py
+++ b/examples/scenarioFormationBasic.py
@@ -119,10 +119,8 @@ from Basilisk.utilities import (
     vizSupport,
 )
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioGroundLocationImaging.py
+++ b/examples/scenarioGroundLocationImaging.py
@@ -106,11 +106,8 @@ from Basilisk.utilities import simIncludeGravBody
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-
-except ImportError:
-    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioGroundMapping.py
+++ b/examples/scenarioGroundMapping.py
@@ -95,11 +95,8 @@ from Basilisk.architecture import astroConstants
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-
-except ImportError:
-    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioLambertSolver.py
+++ b/examples/scenarioLambertSolver.py
@@ -110,12 +110,6 @@ from Basilisk.utilities import (SimulationBaseClass, macros, simIncludeGravBody,
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simHelpers
 
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
-
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 bskPath = __path__[0]
@@ -280,7 +274,7 @@ def run(show_plots):
     # line from the python scenario script.  This will cause the BSK simulation data to
     # be stored in a binary file inside the _VizFiles sub-folder with the scenario folder.  This file can be read in by
     # Vizard and played back after running the BSK simulation.
-    if vizFound:
+    if vizSupport.vizFound:
         viz = vizSupport.enableUnityVisualization(scSim, dynTaskName, scObject,
                                                   # saveFile=fileName
                                                   )

--- a/examples/scenarioRendezVous.py
+++ b/examples/scenarioRendezVous.py
@@ -102,10 +102,8 @@ from Basilisk.utilities import (
     vizSupport,
 )
 
-try:
+if vizSupport.vizFound:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 # The path to the location of Basilisk
 # Used to get the location of supporting data.

--- a/examples/scenarioSmallBodyFeedbackControl.py
+++ b/examples/scenarioSmallBodyFeedbackControl.py
@@ -86,12 +86,6 @@ from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeRW
 from Basilisk.utilities import simHelpers
 
-try:
-    from Basilisk.simulation import vizInterface
-    vizFound = True
-except ImportError:
-    vizFound = False
-
 # The path to the location of Basilisk
 # Used to get the location of supporting data.
 fileName = os.path.basename(os.path.splitext(__file__)[0])
@@ -490,15 +484,15 @@ def run(show_plots):
     fileName = 'scenarioSmallBodyFeedbackControl'
 
     if vizSupport.vizFound:
-        vizInterface = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
-                                                                # , saveFile=fileName
-                                                                )
-        vizSupport.createStandardCamera(vizInterface, setMode=0, bodyTarget='bennu', setView=0)
+        viz = vizSupport.enableUnityVisualization(scSim, simTaskName, scObject
+                                                        # , saveFile=fileName
+                                                        )
+        vizSupport.createStandardCamera(viz, setMode=0, bodyTarget='bennu', setView=0)
 
-        # vizInterface.settings.showSpacecraftLabels = 1
-        vizInterface.settings.showCSLabels = 1
-        vizInterface.settings.planetCSon = 1
-        vizInterface.settings.orbitLinesOn = -1
+        # viz.settings.showSpacecraftLabels = 1
+        viz.settings.showCSLabels = 1
+        viz.settings.planetCSon = 1
+        viz.settings.orbitLinesOn = -1
 
     # initialize Simulation
     scSim.InitializeSimulation()

--- a/examples/scenarioSpiceReconstruction.py
+++ b/examples/scenarioSpiceReconstruction.py
@@ -102,6 +102,11 @@ import time
 import numpy as np
 import matplotlib.pyplot as plt
 
+from Basilisk import hasBuildFeature
+
+if not hasBuildFeature("mujoco"):
+    raise RuntimeError("This scenario requires Basilisk built with --mujoco True")
+
 from Basilisk.utilities import SimulationBaseClass, macros, simHelpers, simIncludeGravBody
 from Basilisk.simulation import mujoco, svIntegrators, spacecraft
 from Basilisk.topLevelModules import pyswice

--- a/examples/scenarioStripImaging.py
+++ b/examples/scenarioStripImaging.py
@@ -117,10 +117,6 @@ from Basilisk.utilities import simHelpers
 
 # attempt to import vizard
 from Basilisk.utilities import vizSupport
-try:
-    from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 from Basilisk import __path__
 from Basilisk.utilities import RigidBodyKinematics

--- a/examples/scenarioVestaOrientation.py
+++ b/examples/scenarioVestaOrientation.py
@@ -99,6 +99,11 @@ import time
 import numpy as np
 import matplotlib.pyplot as plt
 
+from Basilisk import hasBuildFeature
+
+if not hasBuildFeature("mujoco"):
+    raise RuntimeError("This scenario requires Basilisk built with --mujoco True")
+
 from Basilisk.utilities import SimulationBaseClass, macros, orbitalMotion, simHelpers
 from Basilisk.simulation import (mujoco, svIntegrators, NBodyGravity,
                                   sphericalHarmonicsGravityModel, spiceInterface)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -702,7 +702,7 @@ if(WIN32)
   file(WRITE "${CMAKE_BINARY_DIR}/Basilisk/__init__.py"
        "#init file written by the build\n" "import sys, os\n" "from Basilisk import __path__\n"
        "bskPath = __path__[0]\n" "os.add_dll_directory(bskPath)\n"
-       "from Basilisk._buildInfo import getBuildInfo, printBuildInfo\n"
+       "from Basilisk._buildInfo import getBuildInfo, hasBuildFeature, printBuildInfo\n"
        "from Basilisk.architecture import messaging\n"
        "try:\n"
        "    from importlib.metadata import version as _pkg_version\n"
@@ -711,7 +711,7 @@ if(WIN32)
        "    __version__ = '0.0.0'\n")
 else()
   file(WRITE "${CMAKE_BINARY_DIR}/Basilisk/__init__.py"
-      "from Basilisk._buildInfo import getBuildInfo, printBuildInfo\n"
+      "from Basilisk._buildInfo import getBuildInfo, hasBuildFeature, printBuildInfo\n"
       "from Basilisk.architecture import messaging # ensure recorders() work without first importing messaging\n"
       "try:\n"
       "    from importlib.metadata import version as _pkg_version\n"

--- a/src/cmake/bskBuildInfo.cmake
+++ b/src/cmake/bskBuildInfo.cmake
@@ -26,6 +26,15 @@ function(_bsk_python_string output_variable value)
   set(${output_variable} "\"${_escaped_value}\"" PARENT_SCOPE)
 endfunction()
 
+function(_bsk_python_bool output_variable value)
+  if(value)
+    set(_bool_literal True)
+  else()
+    set(_bool_literal False)
+  endif()
+  set(${output_variable} "${_bool_literal}" PARENT_SCOPE)
+endfunction()
+
 function(_bsk_python_list output_variable)
   set(_list_literal "[")
   foreach(_value IN LISTS ARGN)
@@ -215,6 +224,9 @@ function(bsk_generate_build_info package_directory)
   _bsk_python_string(BSK_INFO_SOURCE_REVISION "${_source_revision}")
   set(BSK_INFO_SOURCE_DIRTY "${_source_dirty}")
   set(BSK_INFO_PLUGIN_ABI_VERSION "${_plugin_abi_version}")
+  _bsk_python_bool(BSK_INFO_FEATURE_VIZINTERFACE "${BUILD_VIZINTERFACE}")
+  _bsk_python_bool(BSK_INFO_FEATURE_OPNAV "${BUILD_OPNAV}")
+  _bsk_python_bool(BSK_INFO_FEATURE_MUJOCO "${BUILD_MUJOCO}")
 
   configure_file(
     "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/bskBuildInfoData.py.in"

--- a/src/cmake/bskBuildInfo.py
+++ b/src/cmake/bskBuildInfo.py
@@ -27,14 +27,33 @@ _buildInfoData = {**_buildInfoData, "abi": _buildAbiData}
 def getBuildInfo() -> dict[str, object]:
     """Return metadata describing the Basilisk binary and its build.
 
-    Values under ``abi`` are captured by compiled C and C++ probes. Values
-    under ``diagnostics`` describe CMake observations, build tools, and the
-    requested Conan profile.
+    Values under ``features`` identify configured optional build capabilities.
+    Values under ``abi`` are captured by compiled C and C++ probes. Values under
+    ``diagnostics`` describe CMake observations, build tools, and the requested
+    Conan profile.
 
     :return: A copy of the build metadata.
     :rtype: dict[str, object]
     """
     return _deepcopy(_buildInfoData)
+
+
+def hasBuildFeature(featureName: str) -> bool:
+    """Return whether an optional Basilisk build feature is enabled.
+
+    :param featureName: Name from the ``features`` section of :func:`getBuildInfo`.
+    :return: ``True`` when the feature was enabled when Basilisk was configured.
+    :raises KeyError: If ``featureName`` is not a known build feature.
+    """
+    features = _buildInfoData["features"]
+    try:
+        return features[featureName]
+    except KeyError:
+        availableFeatures = ", ".join(sorted(features))
+        raise KeyError(
+            f"Unknown Basilisk build feature '{featureName}'. "
+            f"Available features: {availableFeatures}"
+        ) from None
 
 
 def _appendField(lines: list[str], label: str, value: str) -> None:
@@ -136,6 +155,11 @@ def _formatBuildInfo(buildInfo: dict[str, object]) -> str:
     _appendField(lines, "Version", f"{artifact['basiliskVersion']} (plugin ABI {artifact['pluginAbiVersion']})")
     _appendField(lines, "Target", target)
     _appendField(lines, "Build", buildDescription)
+    featureDescription = ", ".join(
+        f"{featureName}={'on' if enabled else 'off'}"
+        for featureName, enabled in buildInfo["features"].items()
+    )
+    _appendField(lines, "Features", featureDescription)
     _appendField(lines, "C compiler", _compilerDescription(cCompiler))
     _appendField(lines, "C++ compiler", _compilerDescription(cxxCompiler))
     _appendField(lines, "C standard", _compiledLanguageStandard("C", abi["c"]["compiler"]["languageStandard"]))
@@ -185,4 +209,4 @@ def printBuildInfo() -> None:
     print(_formatBuildInfo(_buildInfoData))
 
 
-__all__ = ["getBuildInfo", "printBuildInfo"]
+__all__ = ["getBuildInfo", "hasBuildFeature", "printBuildInfo"]

--- a/src/cmake/bskBuildInfoData.py.in
+++ b/src/cmake/bskBuildInfoData.py.in
@@ -17,12 +17,17 @@
 #
 
 buildInfoData = {
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "artifact": {
         "basiliskVersion": @BSK_INFO_BASILISK_VERSION@,
         "sourceRevision": @BSK_INFO_SOURCE_REVISION@,
         "sourceDirty": @BSK_INFO_SOURCE_DIRTY@,
         "pluginAbiVersion": @BSK_INFO_PLUGIN_ABI_VERSION@,
+    },
+    "features": {
+        "vizInterface": @BSK_INFO_FEATURE_VIZINTERFACE@,
+        "opNav": @BSK_INFO_FEATURE_OPNAV@,
+        "mujoco": @BSK_INFO_FEATURE_MUJOCO@,
     },
     "diagnostics": {
         "target": {

--- a/src/fswAlgorithms/imageProcessing/centerRadiusCNN/_UnitTest/test_centerRadiusCNN.py
+++ b/src/fswAlgorithms/imageProcessing/centerRadiusCNN/_UnitTest/test_centerRadiusCNN.py
@@ -28,6 +28,8 @@ import os
 
 import numpy as np
 import pytest
+from PIL import Image, ImageDraw
+from Basilisk import hasBuildFeature
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -35,24 +37,18 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 # Import all of the modules that we are going to be called in this simulation
-importErr = False
-reasonErr = ""
-try:
-    from PIL import Image, ImageDraw
-except ImportError:
-    importErr = True
-    reasonErr = "python Pillow package not installed---can't test CenterRadiusCNN module"
-
-# Import all of the modules that we are going to be called in this simulation
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
 
-try:
+opNavEnabled = hasBuildFeature("opNav")
+if opNavEnabled:
     from Basilisk.fswAlgorithms import centerRadiusCNN
-except ImportError:
-    importErr = True
-    reasonErr = "CenterRadiusCNN not built---check opNav option"
+
+pytestmark = pytest.mark.skipif(
+    not opNavEnabled,
+    reason="Requires Basilisk built with --opNav True",
+)
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
 # @pytest.mark.skipif(conditionstring)
@@ -60,7 +56,6 @@ except ImportError:
 # @pytest.mark.xfail(conditionstring)
 # Provide a unique test method name, starting with 'test_'.
 
-@pytest.mark.skipif(importErr, reason= reasonErr)
 @pytest.mark.parametrize("image, saveImage", [
                     ("mars.jpg", False),
                    ("mars2.jpg", False),
@@ -177,7 +172,6 @@ def cnnTest(show_plots, image, saveImage):
 # stand-along python script
 #
 if __name__ == "__main__":
-    if importErr:
-        print(reasonErr)
-        exit(1)
+    if not opNavEnabled:
+        raise RuntimeError("Requires Basilisk built with --opNav True")
     cnnTest(True, "mars.jpg", True) # mars images

--- a/src/fswAlgorithms/imageProcessing/houghCircles/_UnitTest/test_houghCirlces.py
+++ b/src/fswAlgorithms/imageProcessing/houghCircles/_UnitTest/test_houghCirlces.py
@@ -28,6 +28,8 @@ import os
 
 import numpy as np
 import pytest
+from PIL import Image, ImageDraw
+from Basilisk import hasBuildFeature
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -35,24 +37,18 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 # Import all of the modules that we are going to be called in this simulation
-importErr = False
-reasonErr = ""
-try:
-    from PIL import Image, ImageDraw
-except ImportError:
-    importErr = True
-    reasonErr = "python Pillow package not installed---can't test HoughCircle module"
-
-# Import all of the modules that we are going to be called in this simulation
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
 
-try:
+opNavEnabled = hasBuildFeature("opNav")
+if opNavEnabled:
     from Basilisk.fswAlgorithms import houghCircles
-except ImportError:
-    importErr = True
-    reasonErr = "Hough Circles not built---check OpenCV option"
+
+pytestmark = pytest.mark.skipif(
+    not opNavEnabled,
+    reason="Requires Basilisk built with --opNav True",
+)
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
 # @pytest.mark.skipif(conditionstring)
@@ -60,7 +56,6 @@ except ImportError:
 # @pytest.mark.xfail(conditionstring)
 # Provide a unique test method name, starting with 'test_'.
 
-@pytest.mark.skipif(importErr, reason= reasonErr)
 @pytest.mark.parametrize("image, blur, maxCircles, minDist, minRad, cannyLow, cannyHigh, dp, saveImage", [
                     ("mars.png",    5,          1,      50,     20,       20,       200,   1, False), #Mars image
                    ("moons.png",    5,         10,      25,     10,       20,       200,   1, False) # Moon images
@@ -192,4 +187,6 @@ def houghCirclesTest(show_plots, image, blur, maxCircles , minDist , minRad, can
 # stand-along python script
 #
 if __name__ == "__main__":
+    if not opNavEnabled:
+        raise RuntimeError("Requires Basilisk built with --opNav True")
     houghCirclesTest(True, "moons.png",     5,         10,      25,     10,       20,       200,   1, True) # Moon images

--- a/src/fswAlgorithms/imageProcessing/limbFinding/_UnitTest/test_limbFinding.py
+++ b/src/fswAlgorithms/imageProcessing/limbFinding/_UnitTest/test_limbFinding.py
@@ -27,6 +27,8 @@ import os
 
 import numpy as np
 import pytest
+from PIL import Image, ImageDraw
+from Basilisk import hasBuildFeature
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -34,23 +36,18 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 # Import all of the modules that we are going to be called in this simulation
-importErr = False
-reasonErr = ""
-try:
-    from PIL import Image, ImageDraw
-except ImportError:
-    importErr = True
-    reasonErr = "python Pillow package not installed---can't test Limb Finding module"
-
-# Import all of the modules that we are going to be called in this simulation
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
-try:
+
+opNavEnabled = hasBuildFeature("opNav")
+if opNavEnabled:
     from Basilisk.fswAlgorithms import limbFinding
-except ImportError:
-    importErr = True
-    reasonErr = "Limb Finding not built---check OpenCV option"
+
+pytestmark = pytest.mark.skipif(
+    not opNavEnabled,
+    reason="Requires Basilisk built with --opNav True",
+)
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
 # @pytest.mark.skipif(conditionstring)
@@ -58,7 +55,6 @@ except ImportError:
 # @pytest.mark.xfail(conditionstring)
 # Provide a unique test method name, starting with 'test_'.
 
-@pytest.mark.skipif(importErr, reason= reasonErr)
 @pytest.mark.parametrize("image,         blur,    cannyLow,  cannyHigh, saveImage", [
                         ("MarsBright.jpg",    1,    100,       200,   False), #Mars image
                         ("MarsDark.jpg",      1,    100,       200,   False),  # Mars image
@@ -206,4 +202,6 @@ def limbFindingTest(show_plots, image, blur, cannyLow, cannyHigh, saveImage):
 # stand-along python script
 #
 if __name__ == "__main__":
+    if not opNavEnabled:
+        raise RuntimeError("Requires Basilisk built with --opNav True")
     limbFindingTest(True, "MarsBright.jpg",     1,    100,       200,  True) # Moon images

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_stochasticIntegrators.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_stochasticIntegrators.py
@@ -36,17 +36,20 @@ import numpy.typing as npt
 import numpy.testing
 import matplotlib.pyplot as plt
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import macros
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import pythonVariableLogger
 from Basilisk.simulation import svIntegrators
 from Basilisk.simulation import dynParamManager
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
 # This module provides the Euler-Maruyama coverage (single-path Ornstein-Uhlenbeck
 # agreement and Monte-Carlo weak-convergence checks) plus the DETERMINISTIC-LIMIT check
@@ -402,7 +405,6 @@ def estimateErrorAndEmpiricalVariance(
     return muHatAvg, sigmaMuSquared
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("method", METHODS)
 def test_deterministic(method: Method, plot: bool = False):
     """
@@ -461,7 +463,6 @@ def test_deterministic(method: Method, plot: bool = False):
     )
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("integratorClassName", ALL_INTEGRATORS)
 def test_deterministicLimitAllIntegrators(integratorClassName: str):
     """Every stochastic integrator must reduce to a correct ODE solver when there is no
@@ -511,7 +512,6 @@ def test_deterministicLimitAllIntegrators(integratorClassName: str):
     )
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("method", METHODS)
 def test_ou(method: Method, plot: bool = False):
     """
@@ -557,7 +557,6 @@ def test_ou(method: Method, plot: bool = False):
         rtol=0
     )
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("method", METHODS)
 def test_ouComplex(method: Method, plot: bool = False):
     """
@@ -604,7 +603,6 @@ def test_ouComplex(method: Method, plot: bool = False):
         rtol=0
     )
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("method", METHODS)
 def test_example1(method: Method, plot: bool = False):
     """
@@ -651,7 +649,6 @@ def test_example1(method: Method, plot: bool = False):
         rtol=0
     )
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.flaky(reruns=6)
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("figureOfMerit", ["mean", "variance"])
@@ -723,7 +720,6 @@ def test_validateOu(
 
 # when running in pytest, we use skipAssert=True, because the test
 # keeps failing for low tf and we can't afford a high tf at CI testing time
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.flaky(reruns=6)
 @pytest.mark.parametrize("method", METHODS)
 def test_validateExample1(method: Method, tf: float = 0.1, skipAssert: bool = True):

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_stochasticIntegratorsJulia.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_stochasticIntegratorsJulia.py
@@ -48,15 +48,17 @@ import numpy as np
 import numpy.testing
 import pytest
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import macros
 from Basilisk.simulation import svIntegrators
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
-
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
 REFERENCE_FILE = os.path.join(
     os.path.dirname(__file__), "juliaReference", "reference_trajectories.json"
@@ -112,7 +114,6 @@ def _referenceCases():
     return [(f"{c['method']}-{c['problem']}", c) for c in data["cases"]]
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("caseId,case", _referenceCases())
 def test_juliaEquivalence(caseId: str, case: dict):
     """Basilisk must reproduce the StochasticDiffEq.jl trajectory for the same noise."""

--- a/src/simulation/dynamics/Integrators/_UnitTest/test_stochasticIntegratorsPaper.py
+++ b/src/simulation/dynamics/Integrators/_UnitTest/test_stochasticIntegratorsPaper.py
@@ -43,18 +43,20 @@ import numpy as np
 import numpy.testing
 import pytest
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import macros
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import pythonVariableLogger
 from Basilisk.simulation import svIntegrators
 from Basilisk.simulation import dynParamManager
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
-
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
 REFERENCE_FILES = [
     os.path.join(os.path.dirname(__file__), "paperReference",
@@ -152,7 +154,6 @@ def _referenceCases():
     return cases
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("caseId,case", _referenceCases())
 def test_paperEquivalence(caseId: str, case: dict):
     """Basilisk RS1/RS2/DRI1 must reproduce the paper-faithful multi-noise references."""

--- a/src/simulation/environment/spiceInterface/_UnitTest/test_spiceInterfaceReconstruction.py
+++ b/src/simulation/environment/spiceInterface/_UnitTest/test_spiceInterfaceReconstruction.py
@@ -42,7 +42,7 @@ import pytest
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
-from Basilisk import __path__
+from Basilisk import __path__, hasBuildFeature
 bskPath = __path__[0]
 from Basilisk.utilities import SimulationBaseClass, macros
 from Basilisk.simulation import spiceInterface
@@ -224,7 +224,10 @@ def test_integratorAgnosticQueryCountOnDynamicsTask():
     so the exact path would query SPICE (stages x steps) times. With reconstruction the knot cache
     collapses those onto ~horizon/knotStep queries, and that count is the SAME for a fixed RK4 and
     an adaptive RKF45 integrator -- the integrator-agnostic property the feature exists to deliver."""
-    mujoco = pytest.importorskip("Basilisk.simulation.mujoco")
+    if not hasBuildFeature("mujoco"):
+        pytest.skip("Requires Basilisk built with --mujoco True")
+
+    from Basilisk.simulation import mujoco
     from Basilisk.simulation import svIntegrators
 
     scXml = """

--- a/src/simulation/forceTorque/cannonballDrag/_UnitTest/test_cannonballDrag.py
+++ b/src/simulation/forceTorque/cannonballDrag/_UnitTest/test_cannonballDrag.py
@@ -21,6 +21,7 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
@@ -30,12 +31,9 @@ from Basilisk.utilities import orbitalMotion
 from Basilisk.simulation import exponentialAtmosphere
 from Basilisk.simulation import cannonballDrag
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
 def test_cannonballDrag():
     """
@@ -126,7 +124,10 @@ def test_cannonballDrag():
     npt.assert_allclose(force_S, F_exp_S, rtol=0.0, atol=1e-12)
     npt.assert_allclose(torque_S, T_exp_S, rtol=0.0, atol=1e-12)
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
+@pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
 @pytest.mark.parametrize("orbitCase", ["LPO", "LTO"])
 @pytest.mark.parametrize("planetCase", ["earth", "mars"])
 def test_orbit(orbitCase: Literal["LPO", "LTO"], planetCase: Literal["earth", "mars"], showPlots = False):
@@ -472,6 +473,7 @@ def test_cannonballDragAtmosphereRelativeVelocityWhenWindLinked():
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     # test_cannonballDrag()
     test_orbit("LTO","earth",True)

--- a/src/simulation/mujocoDynamics/JointPIDController/_UnitTest/test_JointPIDController.py
+++ b/src/simulation/mujocoDynamics/JointPIDController/_UnitTest/test_JointPIDController.py
@@ -2,21 +2,22 @@ import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.simulation import svIntegrators
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 from Basilisk.utilities import pythonVariableLogger
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJJointPIDController
 
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
-
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_jointPIDController(showPlots: bool = False):
     """
     Unit test for JointPIDController.

--- a/src/simulation/mujocoDynamics/MJJointReactionForces/_UnitTest/test_MJJointReactionForces.py
+++ b/src/simulation/mujocoDynamics/MJJointReactionForces/_UnitTest/test_MJJointReactionForces.py
@@ -20,14 +20,17 @@
 import numpy as np
 import pytest
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import SimulationBaseClass, macros
 from Basilisk.architecture import messaging
-try:
-    from Basilisk.simulation import MJJointReactionForces, mujoco
 
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
+    from Basilisk.simulation import MJJointReactionForces, mujoco
 
 # Constants used throughout tests
 MASS1 = 1.0
@@ -127,7 +130,6 @@ xmlThruster =  f"""<mujoco>
   </actuator>
 </mujoco>"""
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("modelName, xml, jointTreeIdx, jointParentBodyIdx, jointTypes, jointDOFStart", [
     ("Fixed Base", xmlFixedBase2r, [0, 0], [2,3], [3,3], [0,1]),
     ("One SC", xmlFreeBaseDampedHinge, [0, 0], [1,2], [0,3], [0,6]),

--- a/src/simulation/mujocoDynamics/MJSystemCoM/_UnitTest/test_MJSystemCoM.py
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/_UnitTest/test_MJSystemCoM.py
@@ -22,17 +22,19 @@ import numpy as np
 import tempfile
 import pytest
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJSystemCoM
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
 # Common parameters used in both XML and truth calc
 HUB_MASS = 50.0
@@ -157,7 +159,6 @@ def _expected_com(model: str, r_root, v_root):
 
     return rC, vC
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("model", ["single", "straight", "angled"])
 @pytest.mark.parametrize("moving", [True, False])
 @pytest.mark.parametrize("displaced", [True, False])

--- a/src/simulation/mujocoDynamics/MJSystemMassMatrix/_UnitTest/test_MJSystemMassMatrix.py
+++ b/src/simulation/mujocoDynamics/MJSystemMassMatrix/_UnitTest/test_MJSystemMassMatrix.py
@@ -20,13 +20,16 @@
 import numpy as np
 import pytest
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import SimulationBaseClass, macros
-try:
-    from Basilisk.simulation import MJSystemMassMatrix, mujoco
 
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
+    from Basilisk.simulation import MJSystemMassMatrix, mujoco
 
 # Constants used throughout tests
 HUB_MASS  = 50.0
@@ -156,7 +159,6 @@ def sliderMassMatrix(hubMass, hubInertia, armMass, armInertia, armLength=0.6):
     return M
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("modelName, xml, nSC, scStartIdx, jointTypes", [
     ("One SC",              xmlSingle,              1,  [0], [0]),
     ("One Hinge",           xmlOneHinge,            1,  [0], [0,3]),

--- a/src/simulation/mujocoDynamics/NBodyGravity/_UnitTest/test_gravity.py
+++ b/src/simulation/mujocoDynamics/NBodyGravity/_UnitTest/test_gravity.py
@@ -19,15 +19,17 @@ import os
 import pytest
 import time
 
+from Basilisk import hasBuildFeature
 from Basilisk.architecture import messaging
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import NBodyGravity
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
 
 from Basilisk.simulation import pointMassGravityModel
@@ -60,7 +62,6 @@ XML_PATH_BALL = f"{TEST_FOLDER}/test_ball.xml"
 XML_PATH_DUMBBELL = f"{TEST_FOLDER}/test_dumbbell.xml"
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("showPlots", [False])
 def test_pointMass(showPlots):
     """Test that the gravity model with point-mass gravity conserves the
@@ -165,7 +166,6 @@ def test_pointMass(showPlots):
             assert getattr(oePost, attr) == pytest.approx(getattr(oe, attr), 1e-4)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_factory_source_without_attitude():
     """Verify that a position-only factory ephemeris uses an inertial attitude.
 
@@ -246,7 +246,6 @@ def test_factory_source_without_attitude():
     np.testing.assert_allclose(actualForce_S, expectedForce_S, rtol=1.0e-12, atol=0.0)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize(
     "showPlots, initialAngularRate", [(False, False), (False, True)]
 )
@@ -510,7 +509,6 @@ def loadSatelliteTrajectory(utcCalInit: str, stopTimeSeconds: float, dtSeconds: 
     return state
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize(
     "showPlots, useSphericalHarmonics, useThirdBodies",
     [(False, False, False), (False, True, False), (False, True, True)],
@@ -660,7 +658,6 @@ def test_gps(showPlots: bool, useSphericalHarmonics: bool, useThirdBodies: bool)
         assert lastBsk == pytest.approx(lastSpice, abs=30)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize(
     "showPlots, useSpice, useSphericalHarmonics, useThirdBodies",
     [

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_inhomogeneousGeometricBrownianMotion.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_inhomogeneousGeometricBrownianMotion.py
@@ -167,6 +167,7 @@ def test_inhomogeneousGeometricBrownianMotion_rejectsNonPositiveState():
     assert igbm.getStateValue() == 0.5
 
 
+@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_inhomogeneousGeometricBrownianMotion_rejectsBadParameters():
     """The parameter setters reject values outside their valid range."""
     from Basilisk.architecture import bskLogging

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_inhomogeneousGeometricBrownianMotion.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_inhomogeneousGeometricBrownianMotion.py
@@ -40,20 +40,21 @@ import numpy as np
 import numpy.testing as npt
 import matplotlib.pyplot as plt
 
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.simulation import svIntegrators
 from Basilisk.utilities import macros
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJInhomogeneousGeometricBrownianMotion as MJIGBM
 
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
-
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_inhomogeneousGeometricBrownianMotion(showPlots: bool = False):
     """Verify IGBM reproduces the analytic stationary mean and variance, and stays positive."""
     dt = 0.001  # [s] small step for the multiplicative-noise Euler-Maruyama path
@@ -137,7 +138,6 @@ def test_inhomogeneousGeometricBrownianMotion(showPlots: bool = False):
     npt.assert_allclose(varEst, varTarget, rtol=0.20)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_inhomogeneousGeometricBrownianMotion_rejectsNonPositiveState():
     """setStateValue must reject a non-positive initial state: the multiplicative process
     is only well-posed from a positive state."""
@@ -167,7 +167,6 @@ def test_inhomogeneousGeometricBrownianMotion_rejectsNonPositiveState():
     assert igbm.getStateValue() == 0.5
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_inhomogeneousGeometricBrownianMotion_rejectsBadParameters():
     """The parameter setters reject values outside their valid range."""
     from Basilisk.architecture import bskLogging
@@ -189,5 +188,6 @@ def test_inhomogeneousGeometricBrownianMotion_rejectsBadParameters():
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_inhomogeneousGeometricBrownianMotion(True)

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_integration.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_integration.py
@@ -18,13 +18,16 @@
 import os
 import pytest
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import svIntegrators
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
@@ -38,7 +41,6 @@ XML_PATH = f"{TEST_FOLDER}/test_sat.xml"
 REFERENCE_DATA = f"{TEST_FOLDER}/test_sat_qpos_reference.txt"
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_integration(showPlots: bool = False):
     """Tests that integration with RK4 in Basilisk is equal to integration
     with RK4 in MuJoCo.
@@ -171,7 +173,6 @@ def _runFreeSpin(highOrder, dt, tf, omega):
     return rbk.MRP2EP(np.array(rec.sigma_BN)[-1])  # (w,x,y,z)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_highOrderQuaternionConvergesFasterThanDefault():
     """High-order attitude integration converges at a higher order than the
     default exponential-map path.
@@ -199,7 +200,6 @@ def test_highOrderQuaternionConvergesFasterThanDefault():
     assert ratioLo < 6.0  # close to 4 (second order)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("highOrder", [False, True])
 def test_quaternionStaysNormalized(highOrder):
     """The orientation quaternion stays unit-norm after many integration steps in
@@ -208,7 +208,6 @@ def test_quaternionStaysNormalized(highOrder):
     assert np.sqrt(w * w + x * x + y * y + z * z) == pytest.approx(1.0, abs=1e-10)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_repeatedResetSucceeds():
     """A scene can be reset more than once. ``test_sat.xml`` has nq != nv (free
     joint plus hinges), so the bulk states must be registered at their compiled

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_mass_props_and_com.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_mass_props_and_com.py
@@ -34,13 +34,15 @@
 import os
 
 import pytest
+from Basilisk import hasBuildFeature
 
-try:
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
-
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
 from Basilisk.architecture import messaging
 from Basilisk.utilities import SimulationBaseClass
@@ -80,7 +82,6 @@ _ROTOR_XML = """
 """
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_com_site_reports_true_center_of_mass():
     """The ``_com`` site must sit at the true CoM (offset from the body origin)
     and keep the body-origin frame orientation, not the principal-inertia frame.
@@ -123,7 +124,6 @@ def test_com_site_reports_true_center_of_mass():
     np.testing.assert_allclose(sigma_com, sigma_origin, atol=1e-12)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_inertia_rescales_with_mass():
     """When the body mass changes, the rotational inertia must scale with it.
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_mass_update.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_mass_update.py
@@ -18,12 +18,15 @@
 import os
 import pytest
 
-try:
-    from Basilisk.simulation import mujoco
+from Basilisk import hasBuildFeature
 
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
+    from Basilisk.simulation import mujoco
 
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
@@ -39,7 +42,6 @@ XML_PATH_CHANGED_MASS = f"{TEST_FOLDER}/test_sat_2_changed_mass.xml"
 XML_PATH_BALL = f"{TEST_FOLDER}/test_ball.xml"
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_continuouslyChangingMass(showPlots: bool = False):
     """A ball with mass ``m`` is at rest, then accelerated with constant thrust T=100
     for 25 units of time in the positive x-axis direction. The initial mass ``m_0`` is that

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_objects.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_objects.py
@@ -16,22 +16,23 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import os
+import pytest
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import svIntegrators
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
-
-import pytest
 
 TEST_FOLDER = os.path.dirname(__file__)
 XML_PATH = f"{TEST_FOLDER}/test_sat.xml"
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_loading():
     """Tests that MJObject are created from the XML as expected"""
 
@@ -75,7 +76,6 @@ def test_loading():
     scene.UpdateState(1)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_adaptive_free_joint_translation_tolerances_are_stage_independent():
     """Tests MJScene zeroes bulk relTol for a free body through the adaptive-integrator interface.
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_site_velocity.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_site_velocity.py
@@ -16,13 +16,17 @@
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import os
+import pytest
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
@@ -34,7 +38,6 @@ TEST_FOLDER = os.path.dirname(__file__)
 XML_PATH = f"{TEST_FOLDER}/sat_hub_only.xml"
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_siteVelocity():
     """Test the velocity output of sites."""
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py
@@ -15,21 +15,22 @@
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from Basilisk.utilities import macros
-from Basilisk.utilities import SimulationBaseClass
+import numpy as np
+import pytest
 
-try:
+from Basilisk import hasBuildFeature
+from Basilisk.utilities import SimulationBaseClass, macros
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import StatefulNumbaModel
-    couldImport = True
-except Exception:
-    couldImport = False
-
-import pytest
-import numpy as np
 
 
-@pytest.mark.skipif(not couldImport, reason="Compiled Basilisk without --mujoco or numba not available")
 def test_StatefulNumbaOscillator():
     """Tests that StatefulNumbaModel works as expected in MJScene.
 
@@ -117,7 +118,6 @@ def test_StatefulNumbaOscillator():
     np.testing.assert_allclose(vel, expectedVel, atol=1e-5)
 
 
-@pytest.mark.skipif(not couldImport, reason="Compiled Basilisk without --mujoco or numba not available")
 def test_StatefulNumbaStateNames():
     """Tests that state names are prefixed with model tag and ID."""
 
@@ -157,7 +157,6 @@ def test_StatefulNumbaStateNames():
     )
 
 
-@pytest.mark.skipif(not couldImport, reason="Compiled Basilisk without --mujoco or numba not available")
 def test_StatefulNumbaDiffusion():
     """Tests that xStateDiffusionN correctly wires to the StateData diffusion buffer.
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_numba_model.py
@@ -28,6 +28,8 @@ pytestmark = pytest.mark.skipif(
 )
 if mujocoEnabled:
     from Basilisk.simulation import mujoco
+
+    pytest.importorskip("numba")
     from Basilisk.simulation import StatefulNumbaModel
 
 

--- a/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_sys_model.py
+++ b/src/simulation/mujocoDynamics/_GeneralModuleFiles/_UnitTest/test_stateful_sys_model.py
@@ -15,20 +15,21 @@
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from Basilisk.utilities import macros
-from Basilisk.utilities import SimulationBaseClass
+import numpy as np
+import pytest
 
-try:
+from Basilisk import hasBuildFeature
+from Basilisk.utilities import SimulationBaseClass, macros
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import StatefulSysModel
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
 
-import pytest
-import numpy as np
-
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_stateful():
     """Tests that ``StatefulSysModel`` works as expected.
 

--- a/src/simulation/mujocoDynamics/cmdForceInertialToForceAtSite/_UnitTest/test_cmdForceInertialToForceAtSite.py
+++ b/src/simulation/mujocoDynamics/cmdForceInertialToForceAtSite/_UnitTest/test_cmdForceInertialToForceAtSite.py
@@ -7,15 +7,18 @@ from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 from Basilisk.utilities import RigidBodyKinematics as rbk
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJCmdForceInertialToForceAtSite
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_cmdForceInertialToForceAtSiteSCStates():
     dt = 1.0  # [s]
 
@@ -54,7 +57,6 @@ def test_cmdForceInertialToForceAtSiteSCStates():
     npt.assert_allclose(F_S, F_S_exp, rtol=0.0, atol=1e-12)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_cmdForceInertialToForceAtSiteNavAtt():
     dt = 1.0  # [s]
 
@@ -97,6 +99,7 @@ def test_cmdForceInertialToForceAtSiteNavAtt():
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_cmdForceInertialToForceAtSiteSCStates()
     test_cmdForceInertialToForceAtSiteNavAtt()

--- a/src/simulation/mujocoDynamics/igbmAtmDensity/_UnitTest/test_igbmAtmDensity.py
+++ b/src/simulation/mujocoDynamics/igbmAtmDensity/_UnitTest/test_igbmAtmDensity.py
@@ -24,17 +24,19 @@ from Basilisk.simulation import svIntegrators
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJInhomogeneousGeometricBrownianMotion as MJIGBM
     from Basilisk.simulation import MJIgbmAtmDensity
 
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
-
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("usePython", [False, True])
 def test_igbmAtmDensity(usePython: bool, showPlots: bool = False):
     """
@@ -140,7 +142,6 @@ def test_igbmAtmDensity(usePython: bool, showPlots: bool = False):
     npt.assert_allclose(varEst, varTarget, rtol=0.20)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_igbmAtmDensity_passesThroughOtherFields():
     """Only neutralDensity is corrected; the other AtmoPropsMsgPayload fields (localTemp)
     pass through unchanged."""
@@ -179,7 +180,6 @@ def test_igbmAtmDensity_passesThroughOtherFields():
     assert np.all(np.asarray(rec.neutralDensity, dtype=float)[1:] > 0.0)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_igbmAtmDensity_clampsNegativeDensity():
     """The IGBM process is integrated as written (pure math), so an explicit integrator
     can drive the factor negative under a large step/increment. IgbmAtmDensity must clamp
@@ -223,7 +223,6 @@ def test_igbmAtmDensity_clampsNegativeDensity():
     assert np.any(dens == 0.0), "expected the non-negativity clamp to engage for these increments"
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_igbmAtmDensity_rejectsBadParameters():
     """The inherited parameter setters reject values outside their valid range."""
     from Basilisk.architecture import bskLogging
@@ -240,5 +239,6 @@ def test_igbmAtmDensity_rejectsBadParameters():
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_igbmAtmDensity(True, True)

--- a/src/simulation/mujocoDynamics/igbmAtmDensity/_UnitTest/test_igbmAtmDensity.py
+++ b/src/simulation/mujocoDynamics/igbmAtmDensity/_UnitTest/test_igbmAtmDensity.py
@@ -223,6 +223,7 @@ def test_igbmAtmDensity_clampsNegativeDensity():
     assert np.any(dens == 0.0), "expected the non-negativity clamp to engage for these increments"
 
 
+@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_igbmAtmDensity_rejectsBadParameters():
     """The inherited parameter setters reject values outside their valid range."""
     from Basilisk.architecture import bskLogging

--- a/src/simulation/mujocoDynamics/linearTimeInvariantSystem/_UnitTest/test_linearTimeInvariantSystem.py
+++ b/src/simulation/mujocoDynamics/linearTimeInvariantSystem/_UnitTest/test_linearTimeInvariantSystem.py
@@ -23,15 +23,18 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJLinearTimeInvariantSystem
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("usePythonSubclass", [False, True])
 def test_linearTimeInvariantSystemFirstOrder(usePythonSubclass: bool,
                                               showPlots: bool = False):
@@ -161,7 +164,6 @@ def test_linearTimeInvariantSystemFirstOrder(usePythonSubclass: bool,
     # Tolerance is relaxed a bit to allow for integration and discretization error
     npt.assert_allclose(yFinal, yTargetFinal, rtol=0.02, atol=1e-2)
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_linearTimeInvariantSystemSecondOrder(showPlots: bool = False):
     """
     Unit test for an LTI model configured as a second-order system.
@@ -257,7 +259,8 @@ def test_linearTimeInvariantSystemSecondOrder(showPlots: bool = False):
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_linearTimeInvariantSystemFirstOrder(usePythonSubclass=False, showPlots=True)
     test_linearTimeInvariantSystemFirstOrder(usePythonSubclass=True, showPlots=True)
     test_linearTimeInvariantSystemSecondOrder(showPlots=True)

--- a/src/simulation/mujocoDynamics/linearTimeInvariantSystem/_UnitTest/test_orbitalElementControl.py
+++ b/src/simulation/mujocoDynamics/linearTimeInvariantSystem/_UnitTest/test_orbitalElementControl.py
@@ -24,14 +24,17 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.utilities import orbitalMotion
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJLinearTimeInvariantSystem
-    couldImportMujoco = True
-except Exception:
-    couldImportMujoco = False
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("integral", (True, False))
 def test_orbitalElementControl(integral: bool):
     """Checks that the MJLinearTimeInvariantSystem.OrbitalElementControl behaves
@@ -178,5 +181,6 @@ def test_orbitalElementControl(integral: bool):
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_orbitalElementControl(True)

--- a/src/simulation/mujocoDynamics/stochasticAtmDensity/_UnitTest/test_stochasticAtmDensity.py
+++ b/src/simulation/mujocoDynamics/stochasticAtmDensity/_UnitTest/test_stochasticAtmDensity.py
@@ -24,16 +24,18 @@ from Basilisk.simulation import svIntegrators
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJMeanRevertingNoise
     from Basilisk.simulation import MJStochasticAtmDensity
 
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
-
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("usePython", [False, True])
 def test_stochasticAtmDensity(usePython: bool, showPlots: bool = False):
     """
@@ -140,5 +142,6 @@ def test_stochasticAtmDensity(usePython: bool, showPlots: bool = False):
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_stochasticAtmDensity(True, True)

--- a/src/simulation/mujocoDynamics/stochasticDragCoeff/_UnitTest/test_stochasticDragCoeff.py
+++ b/src/simulation/mujocoDynamics/stochasticDragCoeff/_UnitTest/test_stochasticDragCoeff.py
@@ -23,15 +23,17 @@ from Basilisk.simulation import svIntegrators
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import mujoco
     from Basilisk.simulation import MJStochasticDragCoeff
 
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
-
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 def test_stochasticDragCoeff(showPlots: bool = False):
     """
     Unit test for StochasticDragCoeff.
@@ -102,5 +104,6 @@ def test_stochasticDragCoeff(showPlots: bool = False):
 
 
 if __name__ == "__main__":
-    assert couldImportMujoco
+    if not mujocoEnabled:
+        raise RuntimeError("Requires Basilisk built with --mujoco True")
     test_stochasticDragCoeff(True)

--- a/src/simulation/mujocoDynamics/thrOnTimeToForce/_UnitTest/test_thrOnTimeToForce.py
+++ b/src/simulation/mujocoDynamics/thrOnTimeToForce/_UnitTest/test_thrOnTimeToForce.py
@@ -22,14 +22,17 @@ import pytest
 from Basilisk.architecture import messaging
 from Basilisk.utilities import SimulationBaseClass, macros
 
-try:
+from Basilisk import hasBuildFeature
+
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
     from Basilisk.simulation import thrOnTimeToForce
-    couldImportThrOnTimeToForce = True
-except Exception:
-    couldImportThrOnTimeToForce = False
 
 
-@pytest.mark.skipif(not couldImportThrOnTimeToForce, reason="Compiled Basilisk without thrOnTimeToForce")
 def test_thrOnTimeToForceCountdown():
     """
     Validate pulse realization and timer countdown with fixed-step updates.
@@ -76,7 +79,6 @@ def test_thrOnTimeToForceCountdown():
     np.testing.assert_allclose(thr1, [3.0, 3.0, 3.0, 0.0, 0.0], atol=1e-12)
 
 
-@pytest.mark.skipif(not couldImportThrOnTimeToForce, reason="Compiled Basilisk without thrOnTimeToForce")
 def test_thrOnTimeToForceGapThenFire():
     """
     Validate behavior when module is disabled during a gap between message write time and

--- a/src/simulation/sensors/camera/_UnitTest/test_camera.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_camera.py
@@ -25,7 +25,9 @@ import os
 
 import numpy as np
 import pytest
+from PIL import Image, ImageDraw
 
+from Basilisk import hasBuildFeature
 from Basilisk.architecture.bskLogging import BasiliskError
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
@@ -34,23 +36,18 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 # Import all of the modules that we are going to be called in this simulation
-importErr = False
-reasonErr = ""
-try:
-    from PIL import Image, ImageDraw
-except ImportError:
-    importErr = True
-    reasonErr = "python Pillow package not installed---can't test Cameras module"
-
-# Import all of the modules that we are going to be called in this simulation
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
 from Basilisk.architecture import messaging
-try:
+
+opNavEnabled = hasBuildFeature("opNav")
+if opNavEnabled:
     from Basilisk.simulation import camera
-except ImportError:
-    importErr = True
-    reasonErr += "\nCamera not built---check OpenCV option"
+
+pytestmark = pytest.mark.skipif(
+    not opNavEnabled,
+    reason="Requires Basilisk built with --opNav True",
+)
 
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
@@ -59,7 +56,6 @@ except ImportError:
 # @pytest.mark.xfail(conditionstring)
 # Provide a unique test method name, starting with 'test_'.
 
-@pytest.mark.skipif(importErr, reason=reasonErr)
 def test_no_image_zero_msg():
     """
     **Validation Test Description**
@@ -143,7 +139,6 @@ def test_no_image_zero_msg():
     assert testFailCount == 0, testMessages
 
 
-@pytest.mark.skipif(importErr, reason=reasonErr)
 def test_filename_metadata():
     """
     **Validation Test Description**
@@ -233,7 +228,6 @@ def test_filename_metadata():
     assert testFailCount == 0, testMessages
 
 
-@pytest.mark.skipif(importErr, reason=reasonErr)
 def test_invalid_filename_error():
     """
     **Validation Test Description**
@@ -281,7 +275,6 @@ def test_invalid_filename_error():
         unitTestSim.ExecuteSimulation()
 
 
-@pytest.mark.skipif(importErr, reason=reasonErr)
 @pytest.mark.parametrize("gauss, darkCurrent, saltPepper, cosmic, blurSize", [
     (0, 0, 0, 0, 0)
     , (2, 2, 2, 1, 3)
@@ -335,9 +328,8 @@ def test_module(show_plots, gauss, darkCurrent, saltPepper, cosmic, blurSize):
 
 
 def cameraTest(show_plots, image, gauss, darkCurrent, saltPepper, cosmic, blurSize):
-    if importErr:
-        print(reasonErr)
-        exit()
+    if not opNavEnabled:
+        raise RuntimeError("Requires Basilisk built with --opNav True")
 
     # Truth values from python
     imagePath = path + '/' + image

--- a/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
+++ b/src/simulation/sensors/camera/_UnitTest/test_colorAdjust.py
@@ -26,6 +26,8 @@ import math
 import os
 import numpy as np
 import pytest
+from PIL import Image, ImageDraw
+from Basilisk import hasBuildFeature
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -33,24 +35,18 @@ bskName = 'Basilisk'
 splitPath = path.split(bskName)
 
 # Import all of the modules that we are going to be called in this simulation
-importErr = False
-reasonErr = ""
-try:
-    from PIL import Image, ImageDraw
-except ImportError:
-    importErr = True
-    reasonErr = "python Pillow package not installed---can't test Cameras module"
-
-# Import all of the modules that we are going to be called in this simulation
 from Basilisk.architecture import messaging
 from Basilisk.utilities import macros
 from Basilisk.utilities import SimulationBaseClass
 
-try:
+opNavEnabled = hasBuildFeature("opNav")
+if opNavEnabled:
     from Basilisk.simulation import camera
-except ImportError:
-    importErr = True
-    reasonErr += "\nCamera not built---check OpenCV option"
+
+pytestmark = pytest.mark.skipif(
+    not opNavEnabled,
+    reason="Requires Basilisk built with --opNav True",
+)
 
 # Uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed.
 # @pytest.mark.skipif(conditionstring)
@@ -58,7 +54,6 @@ except ImportError:
 # @pytest.mark.xfail(conditionstring)
 # Provide a unique test method name, starting with 'test_'.
 
-@pytest.mark.skipif(importErr, reason= reasonErr)
 @pytest.mark.parametrize("HSV", [
     [0, 0, 0]
     , [1.0, 20.0, -30.0]
@@ -110,9 +105,8 @@ def cameraColorTest(image, HSV, BGR):
     :param BGR: 3d vector of BGR adjustments
 
     """
-    if importErr:
-        print(reasonErr)
-        exit()
+    if not opNavEnabled:
+        raise RuntimeError("Requires Basilisk built with --opNav True")
 
     # Truth values from python
     imagePath = path + '/' + image

--- a/src/simulation/vizard/dataFileToViz/_UnitTest/test_dataFileToViz.py
+++ b/src/simulation/vizard/dataFileToViz/_UnitTest/test_dataFileToViz.py
@@ -31,6 +31,7 @@ import sys
 
 import numpy as np
 import pytest
+from Basilisk import hasBuildFeature
 from Basilisk.architecture import bskLogging
 from Basilisk.architecture import messaging
 from Basilisk.simulation import dataFileToViz
@@ -43,10 +44,9 @@ from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import vizSupport
 
-try:
+vizInterfaceEnabled = hasBuildFeature("vizInterface")
+if vizInterfaceEnabled:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 path = os.path.dirname(os.path.abspath(__file__))
 
@@ -83,6 +83,10 @@ assert viz_thr_vector[0].thrTag == "dv"
     "from Basilisk.simulation import dataFileToViz, vizInterface",
     "from Basilisk.simulation import vizInterface, dataFileToViz"
 ])
+@pytest.mark.skipif(
+    not vizInterfaceEnabled,
+    reason="Requires Basilisk built with --vizInterface True",
+)
 def test_data_file_to_viz_viz_interface_import_order(import_statement):
     """Verify compatible SWIG wrappers across ``dataFileToViz`` and ``vizInterface``.
 
@@ -101,8 +105,6 @@ def test_data_file_to_viz_viz_interface_import_order(import_statement):
     - ``dataFileToViz.VizThrConfig``
 
     """
-    pytest.importorskip("Basilisk.simulation.vizInterface")
-
     result = _run_python_import_order_check(import_statement)
     assert result.returncode == 0, result.stderr
 

--- a/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
+++ b/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
@@ -26,8 +26,10 @@
 
 import inspect
 import os
-import pytest
+import tempfile
+
 import numpy as np
+import pytest
 
 # Protobuffer-specific modules are generated with vizInterface.
 from Basilisk import hasBuildFeature
@@ -75,21 +77,20 @@ if vizInterfaceEnabled:
 # matters for the documentation in that it impacts the order in which the test arguments are shown.
 # The first parametrize arguments are shown last in the pytest argument list
 @pytest.mark.parametrize("accuracy", [1e-8])
-def test_vizInterface(show_plots, accuracy):
+def test_vizInterface(show_plots, accuracy, tmp_path):
     r"""
     **Validation Test Description**
 
-    This unit test script tests the vizInterface module. Though this module is largely hand-tested due to its
-    interactive nature, this script tests the packed protobuffers that are produces in the saved binary file to ensure
-    all elements are captured as expected.
+    This unit test script tests the ``vizInterface`` module. Though this module is largely hand-tested due to its
+    interactive nature, this script tests the packed protocol buffers in the saved binary file to ensure all elements
+    are captured as expected.
 
-    **Test Parameters**
-
-    Args:
-        accuracy (float): absolute accuracy value used in the validation tests
-
+    :param show_plots: Flag controlling whether validation plots are displayed.
+    :param accuracy: Absolute accuracy used in the validation checks.
+    :param tmp_path: Temporary directory for the generated protobuf file.
     """
-    [testResults, testMessage] = vizInterfaceTest(show_plots, accuracy)
+    output_file = tmp_path / "testVizInterface_UnityViz.bin"
+    [testResults, testMessage] = vizInterfaceTest(show_plots, accuracy, output_file)
     assert testResults < 1, testMessage
 
 
@@ -114,7 +115,32 @@ def test_vizInterface_long_gravity_body_name_reset():
         viz.Reset(reset_time)
 
 
-def vizInterfaceTest(show_plots, accuracy):
+def test_vizInterface_closes_output_files(tmp_path):
+    """Verify that output files are released on reset and module destruction.
+
+    Windows does not permit removing a file while the writing process still
+    holds it open, so these removals also exercise the stream lifetime.
+
+    :param tmp_path: Temporary directory for the generated protobuf files.
+    """
+    first_output = tmp_path / "first.bin"
+    second_output = tmp_path / "second.bin"
+    reset_time = 0  # [ns]
+
+    viz = vizInterface.VizInterface()
+    viz.saveFile = True
+    viz.protoFilename = str(first_output)
+    viz.Reset(reset_time)
+
+    viz.protoFilename = str(second_output)
+    viz.Reset(reset_time)
+    first_output.unlink()
+
+    del viz
+    second_output.unlink()
+
+
+def vizInterfaceTest(show_plots, accuracy, output_file):
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
 
@@ -185,9 +211,8 @@ def vizInterfaceTest(show_plots, accuracy):
     scState_dataRec = scObject.scStateOutMsg.recorder(samplingTime)
     unitTestSim.AddModelToTask(unitTaskName, scState_dataRec)
 
-    sName = "testVizInterface"
     viz = vizSupport.enableUnityVisualization(unitTestSim, unitTaskName, scObject
-                                              , saveFile=sName)
+                                              , saveFile=str(output_file))
 
     viz.settings.orbitLinesOn = 1
     viz.settings.spacecraftCSon = 1
@@ -201,7 +226,7 @@ def vizInterfaceTest(show_plots, accuracy):
     unitTestSim.ExecuteSimulation()
 
     # Read in binary save file, parse message list
-    msgList = read_protobuf_messages("./_VizFiles/" + sName + "_UnityViz.bin")
+    msgList = read_protobuf_messages(output_file)
 
     # Assert file size
     assert len(msgList) == frames, "File is missing messages"
@@ -214,9 +239,6 @@ def vizInterfaceTest(show_plots, accuracy):
 
     # Check settings
     checkSettings(msgList, testProcessRate)
-
-    # Delete binary file
-    os.remove("./_VizFiles/" + sName + "_UnityViz.bin")
 
     # Each test method requires a single assert method to be called
     # This check below just makes sure no subtest failures were found
@@ -332,12 +354,16 @@ def checkSettings(msgList, testProcessRate):
 
 
 #
-# Run this unitTest as a stand-along python script
+# Run this unit test as a stand-alone Python script
 #
 if __name__ == "__main__":
     if not vizInterfaceEnabled:
         raise RuntimeError("Requires Basilisk built with --vizInterface True")
-    test_vizInterface(
-        False,  # show_plots
-        1e-8    # accuracy
-    )
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        output_file = os.path.join(temporary_directory, "testVizInterface_UnityViz.bin")
+        [testResults, testMessage] = vizInterfaceTest(
+            False,  # show_plots
+            1e-8,   # [-] accuracy
+            output_file,
+        )
+        assert testResults < 1, testMessage

--- a/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
+++ b/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
@@ -29,13 +29,17 @@ import os
 import pytest
 import numpy as np
 
-# Protobuffer specific
-try:
-    import vizMessage_pb2
+# Protobuffer-specific modules are generated with vizInterface.
+from Basilisk import hasBuildFeature
+
+vizInterfaceEnabled = hasBuildFeature("vizInterface")
+pytestmark = pytest.mark.skipif(
+    not vizInterfaceEnabled,
+    reason="Requires Basilisk built with --vizInterface True",
+)
+if vizInterfaceEnabled:
+    from Basilisk.utilities.vizProtobuffer import vizMessage_pb2
     import google.protobuf.internal.decoder as decoder
-    protoFound = True
-except ModuleNotFoundError:
-    protoFound = False
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
@@ -56,12 +60,9 @@ from Basilisk.utilities import simHelpers
 from Basilisk.simulation import spacecraft
 from Basilisk.architecture import messaging, bskLogging
 from Basilisk.simulation import thrusterDynamicEffector
-import pytest
 import time
-try:
+if vizInterfaceEnabled:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
 
 
 # Uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed.
@@ -100,9 +101,6 @@ def test_vizInterface_long_gravity_body_name_reset():
     ``SpicePlanetStateMsgPayload.PlanetName`` storage.  The full body name remains available to the Vizard
     protocol buffer path, while the default SPICE payload name must be copied without overflowing its backing array.
     """
-    if not vizSupport.vizFound:
-        pytest.skip("vizInterface is not configured.")
-
     reset_time = 0  # [ns]
     long_body_name = "body_" + "x" * 128
 
@@ -119,10 +117,6 @@ def test_vizInterface_long_gravity_body_name_reset():
 def vizInterfaceTest(show_plots, accuracy):
     testFailCount = 0  # zero unit test result counter
     testMessages = []  # create empty list to store test log messages
-
-    # Early quit if protobuf or Vizard not configured
-    if not protoFound or not vizSupport.vizFound:
-        return [testFailCount, ''.join(testMessages)]
 
     # Create simulation variable names
     unitTaskName = "unitTask"  # arbitrary name (don't change)
@@ -341,6 +335,8 @@ def checkSettings(msgList, testProcessRate):
 # Run this unitTest as a stand-along python script
 #
 if __name__ == "__main__":
+    if not vizInterfaceEnabled:
+        raise RuntimeError("Requires Basilisk built with --vizInterface True")
     test_vizInterface(
         False,  # show_plots
         1e-8    # accuracy

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -235,11 +235,15 @@ void VizInterface::Reset(uint64_t CurrentSimNanos)
     }
 
     this->FrameNumber=-1;
+    if (this->outputStream.is_open()) {
+        this->outputStream.close();
+    }
+    this->outputStream.clear();
     if (this->saveFile) {
-        this->outputStream = new std::ofstream(this->protoFilename, std::ios::out |std::ios::binary);
+        this->outputStream.open(this->protoFilename, std::ios::out | std::ios::binary);
 
         /* check if file could be opened */
-        if (!this->outputStream->is_open()) {
+        if (!this->outputStream.is_open()) {
             this->saveFile = false; // turn off save file flag
             bskLogger.bskError("VizInterface: Unable to open file %s for writing.", this->protoFilename.c_str());
         } else {
@@ -1200,7 +1204,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             unsigned long varIntBytes = (unsigned long) (end - varIntBuffer);
             // Save message to file if saveFile flag is true, and if Vizard is not being terminated
             if (this->saveFile && !this->liveSettings.terminateVizard) {
-                this->outputStream->write(reinterpret_cast<char* > (varIntBuffer), (int) varIntBytes);
+                this->outputStream.write(reinterpret_cast<char*>(varIntBuffer), static_cast<int>(varIntBytes));
             }
             serialized_message = malloc(byteCount);
             message->SerializeToArray(serialized_message, (int) byteCount);
@@ -1304,10 +1308,10 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
 
         }
         /*!  Write protobuffer to file */
-        if (!this->saveFile  || !message->SerializeToOstream(this->outputStream)) {
+        if (!this->saveFile || !message->SerializeToOstream(&this->outputStream)) {
             return;
         }
-        this->outputStream->flush();
+        this->outputStream.flush();
     }
 
     delete message;

--- a/src/simulation/vizard/vizInterface/vizInterface.h
+++ b/src/simulation/vizard/vizInterface/vizInterface.h
@@ -109,7 +109,7 @@ private:
 
     std::vector<MsgCurrStatus>spiceInMsgStatus;             //!< status of the incoming planets' spice data messages
     std::vector <SpicePlanetStateMsgPayload> spiceMessage;  //!< Spice message copies
-    std::ofstream *outputStream;                            //!< Output file stream opened in reset
+    std::ofstream outputStream;                             //!< Output file stream owned by this module
     int64_t now;                                            //!< Current system time stamp
     int64_t lastSettingsSendTime;                           //!< System time stamp when settings message was last sent to broadcast socket
 

--- a/src/tests/test_bskTestOpNav.py
+++ b/src/tests/test_bskTestOpNav.py
@@ -33,6 +33,7 @@ import os
 import sys
 
 import pytest
+from Basilisk import hasBuildFeature
 from Basilisk.architecture import bskLogging
 from Basilisk.utilities import simHelpers
 
@@ -49,10 +50,32 @@ Requirements:
     - Basilisk built with ZMQ, protobuffers, and OpenCV
 """
 
-import BSK_OpNav
-SimBase = BSK_OpNav.BSKSim(1, 1)
-if not os.path.exists(SimBase.vizPath):
-    pytestmark = pytest.mark.skip(reason="Vizard App not found: modify app in examples/OpNavScenarios/BSK_OpNav.py")
+opNavEnabled = hasBuildFeature("opNav")
+vizInterfaceEnabled = hasBuildFeature("vizInterface")
+vizardAppFound = False
+if opNavEnabled and vizInterfaceEnabled:
+    import BSK_OpNav
+
+    SimBase = BSK_OpNav.BSKSim(1, 1)
+    vizardAppFound = os.path.exists(SimBase.vizPath)
+
+pytestmark = [
+    pytest.mark.skipif(
+        not opNavEnabled,
+        reason="Requires Basilisk built with --opNav True",
+    ),
+    pytest.mark.skipif(
+        not vizInterfaceEnabled,
+        reason="Requires Basilisk built with --vizInterface True",
+    ),
+    pytest.mark.skipif(
+        opNavEnabled and vizInterfaceEnabled and not vizardAppFound,
+        reason=(
+            "Vizard App not found: modify app in "
+            "examples/OpNavScenarios/BSK_OpNav.py"
+        ),
+    ),
+]
 
 testScripts = [
       'scenario_faultDetOpNav'
@@ -65,14 +88,6 @@ testScripts = [
     , 'scenario_OpNavPointLimb'
     , 'scenario_CNNAttOD'
 ]
-
-
-try:
-    from Basilisk.simulation import vizInterface, camera
-    from Basilisk.fswAlgorithms import houghCircles, limbFinding
-except ImportError:
-    pytestmark = pytest.mark.skip(reason="OpNav Algorithms not built: use opNav behavior in build")
-
 
 @pytest.mark.slowtest
 @pytest.mark.scenarioTest

--- a/src/tests/test_buildInfo.py
+++ b/src/tests/test_buildInfo.py
@@ -70,19 +70,23 @@ def _makeBuildInfo(
     standardLibrary="",
     runtime="",
     runtimeType="",
+    features=None,
 ):
+    if features is None:
+        features = {"vizInterface": True, "opNav": False, "mujoco": True}
     standardLibraryFamily = standardLibrary
     if standardLibrary.startswith("libstdc++"):
         standardLibraryFamily = "libstdc++"
     abiFamily = "msvc" if system == "Windows" else "itanium"
     return {
-        "schemaVersion": 2,
+        "schemaVersion": 3,
         "artifact": {
             "basiliskVersion": "2.12.0",
             "sourceRevision": "0123456789abcdef",
             "sourceDirty": False,
             "pluginAbiVersion": 1,
         },
+        "features": features,
         "diagnostics": {
             "target": {
                 "system": system,
@@ -217,10 +221,12 @@ def _makeBuildInfo(
 def test_build_info():
     """Verify that Basilisk exposes compiled and diagnostic build metadata."""
     buildInfo = Basilisk.getBuildInfo()
+    features = buildInfo["features"]
+    mujocoEnabled = features["mujoco"]
     diagnostics = buildInfo["diagnostics"]
     abi = buildInfo["abi"]
 
-    assert buildInfo["schemaVersion"] == 2
+    assert buildInfo["schemaVersion"] == 3
     assert buildInfo["artifact"]["basiliskVersion"]
     if Basilisk.__version__ != "0.0.0":
         assert buildInfo["artifact"]["basiliskVersion"] == Basilisk.__version__
@@ -228,6 +234,8 @@ def test_build_info():
         "BSK_PLUGIN_ABI_VERSION"
     )
     assert buildInfo["artifact"]["sourceDirty"] in (True, False, None)
+    assert set(features) == {"vizInterface", "opNav", "mujoco"}
+    assert all(isinstance(enabled, bool) for enabled in features.values())
     assert abi["descriptorVersion"] == _integerDefine("BSK_ABI_DESCRIPTOR_VERSION")
     assert abi["capture"] == "compiled"
     assert abi["contractHeader"] == "architecture/utilities/bskAbiDescriptor.h"
@@ -273,7 +281,21 @@ def test_build_info():
     assert diagnostics["tools"]["python"]
 
     buildInfo["abi"]["target"]["system"] = "modified"
+    buildInfo["features"]["mujoco"] = not mujocoEnabled
     assert Basilisk.getBuildInfo()["abi"]["target"]["system"] == platform.system()
+    assert Basilisk.getBuildInfo()["features"]["mujoco"] == mujocoEnabled
+
+
+def test_build_feature_query(monkeypatch):
+    """Verify configured features can be queried and unknown names are rejected."""
+    features = {"vizInterface": True, "opNav": False, "mujoco": True}
+    monkeypatch.setitem(buildInfoFormatter._buildInfoData, "features", features)
+
+    for featureName, enabled in features.items():
+        assert Basilisk.hasBuildFeature(featureName) is enabled
+
+    with pytest.raises(KeyError, match="unknownFeature"):
+        Basilisk.hasBuildFeature("unknownFeature")
 
 
 def test_shared_abi_contract_header():
@@ -348,6 +370,8 @@ def test_print_build_info(capsys):
     assert "Basilisk Build Information" in output
     assert "Build Tools" in output
     assert buildInfo["artifact"]["basiliskVersion"] in output
+    for featureName, enabled in buildInfo["features"].items():
+        assert f"{featureName}={'on' if enabled else 'off'}" in output
     assert diagnostics["compilers"]["c"]["id"] in output
     assert diagnostics["compilers"]["cxx"]["id"] in output
     assert "C++17" in output
@@ -427,4 +451,6 @@ def test_format_build_info_for_supported_platforms(buildInfo, expectedText):
 
     for text in expectedText:
         assert text in output
+    for featureName, enabled in buildInfo["features"].items():
+        assert f"{featureName}={'on' if enabled else 'off'}" in output
     assert "''" not in output

--- a/src/tests/test_scenarioMujoco.py
+++ b/src/tests/test_scenarioMujoco.py
@@ -28,14 +28,14 @@ filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
 import pytest
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import simHelpers
 
-try:
-    from Basilisk.simulation import mujoco
-
-    couldImportMujoco = True
-except:
-    couldImportMujoco = False
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
 
 THIS_FOLDER = os.path.dirname(__file__)
 SCENARIO_FOLDER = os.path.join(
@@ -63,7 +63,6 @@ OPTIONAL_EXAMPLE_DEPENDENCIES = {"scipy"}
 sys.path.append(SCENARIO_FOLDER)
 
 
-@pytest.mark.skipif(not couldImportMujoco, reason="Compiled Basilisk without --mujoco")
 @pytest.mark.parametrize("scenario", SCENARIO_FILES)
 @pytest.mark.scenarioTest
 def test_scenarios(scenario: str):

--- a/src/tests/test_scenarioSpiceReconstruction.py
+++ b/src/tests/test_scenarioSpiceReconstruction.py
@@ -20,16 +20,20 @@ import os
 import sys
 
 import pytest
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 sys.path.append(path + "/../../examples")
 
-# The scenario imports Basilisk.simulation.mujoco at module load, so skip collection entirely on
-# a build compiled without optional MuJoCo support.
-pytest.importorskip("Basilisk.simulation.mujoco")
-import scenarioSpiceReconstruction
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
+    import scenarioSpiceReconstruction
 
 
 @pytest.mark.scenarioTest

--- a/src/tests/test_scenarioVestaOrientation.py
+++ b/src/tests/test_scenarioVestaOrientation.py
@@ -20,16 +20,20 @@ import os
 import sys
 
 import pytest
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import simHelpers
 
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 sys.path.append(path + "/../../examples")
 
-# The scenario imports Basilisk.simulation.mujoco at module load, so skip collection entirely on
-# a build compiled without optional MuJoCo support.
-pytest.importorskip("Basilisk.simulation.mujoco")
-import scenarioVestaOrientation
+mujocoEnabled = hasBuildFeature("mujoco")
+pytestmark = pytest.mark.skipif(
+    not mujocoEnabled,
+    reason="Requires Basilisk built with --mujoco True",
+)
+if mujocoEnabled:
+    import scenarioVestaOrientation
 
 
 @pytest.mark.scenarioTest

--- a/src/tests/test_scenarioVizPoint.py
+++ b/src/tests/test_scenarioVizPoint.py
@@ -32,20 +32,23 @@ import os
 import sys
 
 import pytest
+from Basilisk import hasBuildFeature
 from Basilisk.utilities import simHelpers
 
 # Get current file path
 filename = inspect.getframeinfo(inspect.currentframe()).filename
 path = os.path.dirname(os.path.abspath(filename))
 
-try:
-    from Basilisk.simulation import vizInterface
-except ImportError:
-    pytestmark = pytest.mark.skip(reason="viz interface not built without required libraries")
+vizInterfaceEnabled = hasBuildFeature("vizInterface")
+pytestmark = pytest.mark.skipif(
+    not vizInterfaceEnabled,
+    reason="Requires Basilisk built with --vizInterface True",
+)
 
 
 sys.path.append(path + '/../../examples')
-import scenarioVizPoint
+if vizInterfaceEnabled:
+    import scenarioVizPoint
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)

--- a/src/utilities/quadMapSupport.py
+++ b/src/utilities/quadMapSupport.py
@@ -19,13 +19,14 @@
 
 # Import required resources
 import numpy as np
+from Basilisk import hasBuildFeature
+from Basilisk.architecture import messaging
 from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import vizSupport
-try:
+
+vizInterfaceEnabled = hasBuildFeature("vizInterface")
+if vizInterfaceEnabled:
     from Basilisk.simulation import vizInterface
-except ImportError:
-    pass
-from Basilisk.architecture import messaging
 
 def computeRectMesh(parentBody, latBounds, lonBounds, maxAngWidth):
     """
@@ -127,7 +128,7 @@ def computeCamFOVBox(parentBody, spiceObject, scObject, cam):
     PC = []
     FOV = 0
     # -- Standard camera
-    if isinstance(cam, vizInterface.StdCameraSettings):
+    if vizInterfaceEnabled and isinstance(cam, vizInterface.StdCameraSettings):
         r_CB_B = cam.position_B
         r_CB_N = np.matmul(np.transpose(BN), r_CB_B)
         r_CB_P = np.matmul(PN, r_CB_N)

--- a/src/utilities/simIncludeGravBody.py
+++ b/src/utilities/simIncludeGravBody.py
@@ -52,7 +52,7 @@ from typing import (
     runtime_checkable,
 )
 
-from Basilisk import __path__
+from Basilisk import __path__, hasBuildFeature
 from Basilisk.architecture import astroConstants
 from Basilisk.architecture import messaging
 from Basilisk.simulation import gravityEffector
@@ -290,16 +290,16 @@ class gravBodyFactory:
 
     def _addBodiesToMJScene(self, scene: Any) -> Any:
         """Create and attach an ``NBodyGravity`` model for a MuJoCo scene."""
-        # MuJoCo is an optional Basilisk build feature. Import it only after the
-        # conventional gravity-effector path has been ruled out.
-        try:
-            from Basilisk.simulation import NBodyGravity
-            from Basilisk.simulation import mujoco
-        except ImportError as error:
+        # MuJoCo is optional. Check the recorded build configuration before
+        # importing its modules so an enabled but broken build still fails.
+        if not hasBuildFeature("mujoco"):
             raise TypeError(
                 "The supplied object does not support gravity-body attachment, "
                 "and this Basilisk build does not include MuJoCo."
-            ) from error
+            )
+
+        from Basilisk.simulation import NBodyGravity
+        from Basilisk.simulation import mujoco
 
         if not isinstance(scene, mujoco.MJScene):
             raise TypeError(

--- a/src/utilities/vizSupport.py
+++ b/src/utilities/vizSupport.py
@@ -19,7 +19,7 @@
 import os
 
 import numpy as np
-from Basilisk import __path__
+from Basilisk import __path__, hasBuildFeature
 from Basilisk.architecture import messaging
 from Basilisk.simulation import spacecraft
 from Basilisk.utilities import deprecated
@@ -28,21 +28,14 @@ from Basilisk.utilities import simHelpers
 from matplotlib import colors
 from matplotlib.colors import is_color_like
 from typing import Optional, Sequence
-from Basilisk.utilities import deprecated
 
-try:
+vizFound = hasBuildFeature("vizInterface")
+if vizFound:
     from Basilisk.simulation import vizInterface
 
-    vizFound = True
-except ImportError:
-    vizFound = False
-
-try:
+mujocoFound = hasBuildFeature("mujoco")
+if mujocoFound:
     from Basilisk.simulation import mujoco
-
-    mujocoFound = True
-except ImportError:
-    mujocoFound = False
 
 pauseFlag = False
 endFlag = False


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

This PR exposes Basilisk’s configured optional capabilities through the existing build metadata and uses that metadata to guard feature-dependent scenarios and tests.

The commits are organized in dependency order:

1. Add missing guards around scenarios and tests that depend on optional components.
2. Configure the plain-build CI job with `vizInterface`, `opNav`, and `mujoco` disabled.
3. Extend the generated build metadata with the configured feature set and add `Basilisk.hasBuildFeature()`.
4. Replace ad hoc import probing and legacy availability flags with metadata-based guards.
5. Document the recommended guard patterns for unit tests.

The metadata check distinguishes a deliberately omitted feature from a broken import in a build where the feature was enabled. Test modules use module-level `pytest.skip(..., allow_module_level=True)` before importing optional bindings, while executable scenarios fail early with a clear build-configuration error.

## Verification

- A clean plain build with `--vizInterface False --opNav False --mujoco False` completed the Python test suite with 5,511 tests passing and 215 feature-dependent tests skipped as expected.
- A clean build with all optional features enabled completed the CI-shaped Python test suite with 5,726 tests passing.
- The CTest suite completed with 67 of 67 tests passing.
- The focused `vizInterface` regression test completed with 2 tests passing.
- Pre-commit checks passed for all files changed by this branch.
- `src/tests/test_buildInfo.py` was expanded to cover the metadata schema, feature values, query behavior, defensive copying, error handling, and printed output.
- Existing scenario and unit-test guards were updated rather than re-baselined.

## Documentation

- `docs/source/Build/installBuild.rst` documents the generated feature metadata and `Basilisk.hasBuildFeature()` query API.
- `docs/source/Support/Developer/CodingGuidlines.rst` documents module-level guards for optional unit-test dependencies and early runtime guards for scenarios.
- `docs/source/Support/bskReleaseNotesSnippets/build-feature-metadata.rst` records the user-visible addition.

## Future work

If new build options are introduced (i.e. Rust modules), be sure to use these new guards and update the BSK build information tool.