### PR TITLE
Parallelize and cache distribution wheel builds

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -22,6 +22,17 @@ runs:
     - name: Setup system dependencies
       uses: ./.github/actions/setup
 
+    - name: Setup Python for Conan cache context
+      if: ${{ runner.os != 'Linux' }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.14"
+
+    - name: Install Conan cache tooling
+      if: ${{ runner.os != 'Linux' }}
+      shell: bash
+      run: python -m pip install "conan>=2.0.5,<=2.28.1"
+
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@v0.0.10
       continue-on-error: true
@@ -65,15 +76,35 @@ runs:
           sccache --zero-stats
         fi
 
+    - name: Prepare Conan cache context
+      id: conan-context
+      shell: bash
+      env:
+        RUNNER_ARCH: ${{ runner.arch }}
+      run: |
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          # The short image name resolves to an image pinned by cibuildwheel.
+          # Hashing this action and pyproject.toml below invalidates the cache
+          # when either the cibuildwheel version or image selection changes.
+          echo "fingerprint=manylinux-2-28-${RUNNER_ARCH}" >> "${GITHUB_OUTPUT}"
+        else
+          python .github/scripts/configure_conan_profile.py --emit-cache-fingerprint
+        fi
+
     - name: Restore Conan cache
       id: conan-cache
       continue-on-error: true
       uses: actions/cache/restore@v5
       with:
         path: ~/.conan2
-        key: conan-wheel-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('conan.lock', 'conanfile.py', 'libs/**', 'pyproject.toml') }}
+        key: conan-wheel-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.conan-context.outputs.fingerprint }}-${{ hashFiles('conan.lock', 'conanfile.py', 'libs/**', 'pyproject.toml', '.github/actions/build-wheel/action.yml', '.github/scripts/configure_conan_profile.py') }}
         restore-keys: |
-          conan-wheel-v1-${{ runner.os }}-${{ runner.arch }}-
+          conan-wheel-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.conan-context.outputs.fingerprint }}-
+
+    - name: Refresh Conan profile
+      if: ${{ runner.os != 'Linux' }}
+      shell: bash
+      run: python .github/scripts/configure_conan_profile.py
 
     - name: Build wheel
       if: ${{ inputs.cibw-build == '' }}

--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -1,0 +1,119 @@
+name: build wheel
+description: Build a Basilisk wheel with compiler and Conan caching.
+inputs:
+  output-dir:
+    description: Directory that receives the built wheel.
+    required: true
+  conan-args:
+    description: Conan arguments passed to the Basilisk wheel build.
+    required: true
+  cibw-build:
+    description: Optional cibuildwheel build selector.
+    required: false
+    default: ""
+  save-conan-cache:
+    description: Save the platform cache; enable only for the full dependency producer.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup system dependencies
+      uses: ./.github/actions/setup
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+      continue-on-error: true
+      with:
+        disable_annotations: true
+
+    - name: Configure wheel build caches
+      shell: bash
+      run: |
+        mkdir -p "${HOME}/.conan2"
+
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          echo "CONAN_HOME=/host${HOME}/.conan2" >> "${GITHUB_ENV}"
+          linux_environment_pass="CONAN_ARGS CONAN_HOME"
+        fi
+
+        if command -v sccache >/dev/null 2>&1; then
+          compiler_launcher="sccache"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            compiler_launcher="/host$(command -v sccache)"
+            linux_environment_pass+=" CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER SCCACHE_GHA_ENABLED ACTIONS_CACHE_SERVICE_V2 ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN"
+          fi
+          {
+            echo "SCCACHE_GHA_ENABLED=true"
+            echo "CMAKE_C_COMPILER_LAUNCHER=${compiler_launcher}"
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=${compiler_launcher}"
+          } >> "${GITHUB_ENV}"
+        else
+          echo "sccache is unavailable; continuing without compiler caching"
+        fi
+
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          echo "CIBW_ENVIRONMENT_PASS_LINUX=${linux_environment_pass}" >> "${GITHUB_ENV}"
+        fi
+
+    - name: Reset sccache statistics
+      continue-on-error: true
+      shell: bash
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --zero-stats
+        fi
+
+    - name: Restore Conan cache
+      id: conan-cache
+      continue-on-error: true
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.conan2
+        key: conan-wheel-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('conan.lock', 'conanfile.py', 'libs/**', 'pyproject.toml') }}
+        restore-keys: |
+          conan-wheel-v1-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Build wheel
+      if: ${{ inputs.cibw-build == '' }}
+      uses: pypa/cibuildwheel@v3.4.1
+      with:
+        output-dir: ${{ inputs.output-dir }}
+      env:
+        CIBW_TEST_SKIP: "*"
+        CONAN_ARGS: ${{ inputs.conan-args }}
+
+    - name: Build selected wheel
+      if: ${{ inputs.cibw-build != '' }}
+      uses: pypa/cibuildwheel@v3.4.1
+      with:
+        output-dir: ${{ inputs.output-dir }}
+      env:
+        CIBW_BUILD: ${{ inputs.cibw-build }}
+        CIBW_TEST_SKIP: "*"
+        CONAN_ARGS: ${{ inputs.conan-args }}
+
+    - name: Normalize Linux Conan cache ownership
+      id: conan-cache-ownership
+      if: ${{ runner.os == 'Linux' && success() && inputs.save-conan-cache == 'true' && steps.conan-cache.outcome == 'success' && steps.conan-cache.outputs.cache-hit != 'true' }}
+      continue-on-error: true
+      shell: bash
+      run: sudo chown -R "$(id -u):$(id -g)" "${HOME}/.conan2"
+
+    - name: Save Conan cache
+      if: ${{ success() && inputs.save-conan-cache == 'true' && steps.conan-cache.outcome == 'success' && steps.conan-cache.outputs.cache-hit != 'true' && (runner.os != 'Linux' || steps.conan-cache-ownership.outcome == 'success') }}
+      continue-on-error: true
+      uses: actions/cache/save@v5
+      with:
+        path: ~/.conan2
+        key: ${{ steps.conan-cache.outputs.cache-primary-key }}
+
+    - name: Show sccache statistics
+      if: ${{ always() }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        if command -v sccache >/dev/null 2>&1; then
+          sccache --show-stats
+        fi

--- a/.github/workflows/nightly-wheels.yml
+++ b/.github/workflows/nightly-wheels.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-wheels:
-    name: Build Wheels (${{ matrix.os }})
+    name: Build Wheel Input (${{ matrix.wheel-kind }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -17,7 +17,18 @@ jobs:
           - ubuntu-24.04
           - ubuntu-24.04-arm
           - windows-2025-vs2026
+        wheel-kind:
+          - core
+          - opnav-full
         include:
+          - wheel-kind: core
+            output-dir: wheelhouse-core
+            conan-args: --opNav False --mujoco True --clean
+            save-conan-cache: "false"
+          - wheel-kind: opnav-full
+            output-dir: wheelhouse-opnav-full
+            conan-args: --opNav True --mujoco True --clean
+            save-conan-cache: "true"
           - os: windows-2025-vs2026
             extra-conan-args: --generator Ninja
 
@@ -27,19 +38,8 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Setup system dependencies
-        uses: ./.github/actions/setup
-
-      - name: Build core bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
-        with:
-          output-dir: wheelhouse-core
-        env:
-          CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
-          CIBW_TEST_SKIP: "*"
-
-      - name: Free runner disk before opNav Linux wheel
-        if: ${{ matrix.os == 'ubuntu-24.04' }}
+      - name: Free runner disk for heavy optional Linux wheel
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.wheel-kind == 'opnav-full' }}
         shell: bash
         run: |
           echo "Disk space before cleanup:"
@@ -52,17 +52,60 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
 
-      - name: Build opNav-enabled bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
+      - name: Build ${{ matrix.wheel-kind }} bsk wheel
+        uses: ./.github/actions/build-wheel
         with:
-          output-dir: wheelhouse-opnav-full
-        env:
-          CONAN_ARGS: "--opNav True --mujoco True --clean ${{ matrix.extra-conan-args }}"
-          CIBW_TEST_SKIP: "*"
+          output-dir: ${{ matrix.output-dir }}
+          conan-args: ${{ matrix.conan-args }} ${{ matrix.extra-conan-args }}
+          save-conan-cache: ${{ matrix.save-conan-cache }}
+
+      - name: Upload wheel input
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-wheel-input-${{ matrix.os }}-${{ matrix.wheel-kind }}
+          path: ${{ matrix.output-dir }}/*.whl
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  package-wheels:
+    name: Test and Package Wheels (${{ matrix.os }})
+    needs: build-wheels
+    if: ${{ !cancelled() }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: # keep these platforms in sync with the pull-request.yml file
+          - macos-26
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - windows-2025-vs2026
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
 
       - uses: actions/setup-python@v6
         with:
           python-version: 3.14
+
+      - name: Download core wheel input
+        uses: actions/download-artifact@v6
+        with:
+          name: nightly-wheel-input-${{ matrix.os }}-core
+          path: wheelhouse-core
+
+      - name: Download opNav-enabled wheel input
+        uses: actions/download-artifact@v6
+        with:
+          name: nightly-wheel-input-${{ matrix.os }}-opnav-full
+          path: wheelhouse-opnav-full
 
       - name: Generate and test optional wheel installs
         shell: bash
@@ -89,8 +132,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [build-wheels, publish-index]
-    if: ${{ always() && (needs.build-wheels.result == 'failure' || needs.publish-index.result == 'failure') }}
+    needs: [build-wheels, package-wheels, publish-index]
+    if: ${{ always() && (needs.build-wheels.result == 'failure' || needs.package-wheels.result == 'failure' || needs.publish-index.result == 'failure') }}
     runs-on: ubuntu-24.04
     permissions: {}
 
@@ -137,8 +180,8 @@ jobs:
 
   publish-index:
     name: Publish Nightly Index
-    needs: [build-wheels]
-    if: ${{ (github.ref_name == 'develop' || github.event_name == 'workflow_dispatch') && needs.build-wheels.result == 'success' }}
+    needs: [package-wheels]
+    if: ${{ (github.ref_name == 'develop' || github.event_name == 'workflow_dispatch') && needs.package-wheels.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build-wheels:
-    name: Build Basilisk Wheels (${{ matrix.os }})
+    name: Build Wheel Input (${{ matrix.wheel-kind }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -28,7 +28,18 @@ jobs:
           - ubuntu-24.04 # x86_64
           - ubuntu-24.04-arm # ARM64
           - windows-2025-vs2026 # x86_64
+        wheel-kind:
+          - core
+          - opnav-full
         include:
+          - wheel-kind: core
+            output-dir: wheelhouse-core
+            conan-args: --opNav False --mujoco True --clean
+            save-conan-cache: "false"
+          - wheel-kind: opnav-full
+            output-dir: wheelhouse-opnav-full
+            conan-args: --opNav True --mujoco True --clean
+            save-conan-cache: "true"
           - os: windows-2025-vs2026
             extra-conan-args: --generator Ninja
 
@@ -54,19 +65,8 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "Using CA: $CA"
 
-      - name: Setup system dependencies
-        uses: ./.github/actions/setup
-
-      - name: Build core bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
-        with:
-          output-dir: wheelhouse-core
-        env:
-          CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
-          CIBW_TEST_SKIP: "*"
-
-      - name: Free runner disk before opNav Linux wheel
-        if: ${{ matrix.os == 'ubuntu-24.04' }}
+      - name: Free runner disk for heavy optional Linux wheel
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.wheel-kind == 'opnav-full' }}
         shell: bash
         run: |
           echo "Disk space before cleanup:"
@@ -79,17 +79,60 @@ jobs:
           echo "Disk space after cleanup:"
           df -h
 
-      - name: Build opNav-enabled bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
+      - name: Build ${{ matrix.wheel-kind }} bsk wheel
+        uses: ./.github/actions/build-wheel
         with:
-          output-dir: wheelhouse-opnav-full
-        env:
-          CONAN_ARGS: "--opNav True --mujoco True --clean ${{ matrix.extra-conan-args }}"
-          CIBW_TEST_SKIP: "*"
+          output-dir: ${{ matrix.output-dir }}
+          conan-args: ${{ matrix.conan-args }} ${{ matrix.extra-conan-args }}
+          save-conan-cache: ${{ matrix.save-conan-cache }}
+
+      - name: Upload wheel input
+        uses: actions/upload-artifact@v6
+        with:
+          name: cibw-wheel-input-${{ matrix.os }}-${{ matrix.wheel-kind }}
+          path: ${{ matrix.output-dir }}/*.whl
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+  package-wheels:
+    name: Test and Package Wheels (${{ matrix.os }})
+    needs: build-wheels
+    if: ${{ !cancelled() }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-26 # ARM64
+          - ubuntu-24.04 # x86_64
+          - ubuntu-24.04-arm # ARM64
+          - windows-2025-vs2026 # x86_64
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup system dependencies
+        uses: ./.github/actions/setup
 
       - uses: actions/setup-python@v6
         with:
           python-version: 3.14
+
+      - name: Download core wheel input
+        uses: actions/download-artifact@v6
+        with:
+          name: cibw-wheel-input-${{ matrix.os }}-core
+          path: wheelhouse-core
+
+      - name: Download opNav-enabled wheel input
+        uses: actions/download-artifact@v6
+        with:
+          name: cibw-wheel-input-${{ matrix.os }}-opnav-full
+          path: wheelhouse-opnav-full
 
       - name: Generate and test optional wheel installs
         shell: bash
@@ -111,7 +154,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v6
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.os }}
           path: ./wheelhouse-publish/*.whl
 
   make_sdist:
@@ -158,7 +201,7 @@ jobs:
 
   publish:
     name: Publish
-    needs: [build-wheels, test-sdist]
+    needs: [package-wheels, test-sdist]
     runs-on: ubuntu-24.04
     permissions:
       id-token: write

--- a/.github/workflows/test-optional-wheels.yml
+++ b/.github/workflows/test-optional-wheels.yml
@@ -4,17 +4,29 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-opnav-wheels:
-    name: Test opNav Wheels (${{ matrix.os }})
+  build-opnav-wheels:
+    name: Build opNav Wheel Input (${{ matrix.wheel-kind }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
           - macos-26
+          - ubuntu-24.04
           - ubuntu-24.04-arm
           - windows-2025-vs2026
+        wheel-kind:
+          - core
+          - opnav-full
         include:
+          - wheel-kind: core
+            output-dir: wheelhouse-core
+            conan-args: --opNav False --mujoco True --clean
+            save-conan-cache: "false"
+          - wheel-kind: opnav-full
+            output-dir: wheelhouse-opnav-full
+            conan-args: --opNav True --mujoco True --clean
+            save-conan-cache: "true"
           - os: windows-2025-vs2026
             extra-conan-args: --generator Ninja
 
@@ -31,85 +43,8 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.sources
 
-      - name: Setup system dependencies
-        uses: ./.github/actions/setup
-
-      - name: Build core bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
-        with:
-          output-dir: wheelhouse-core
-        env:
-          CIBW_BUILD: "cp314-*"
-          CIBW_TEST_SKIP: "*"
-          CONAN_ARGS: "--opNav False --mujoco True --clean ${{ matrix.extra-conan-args }}"
-
-      - name: Build opNav-enabled bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
-        with:
-          output-dir: wheelhouse-opnav-full
-        env:
-          CIBW_BUILD: "cp314-*"
-          CIBW_TEST_SKIP: "*"
-          CONAN_ARGS: "--opNav True --mujoco True --clean ${{ matrix.extra-conan-args }}"
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Generate and test optional wheel installs
-        shell: bash
-        run: >
-          python .github/scripts/run_optional_bsk_wheel_test.py
-          --component opnav
-          --base-wheel-dir wheelhouse-core
-          --component-wheel-dir wheelhouse-opnav-full
-          --optional-wheel-dir wheelhouse-optional
-          --test-wheelhouse wheelhouse-test
-
-      - name: Upload wheel artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: optional-wheel-test-${{ matrix.os }}
-          path: |
-            wheelhouse-core/*.whl
-            wheelhouse-opnav-full/*.whl
-            wheelhouse-optional/*.whl
-
-  build-opnav-linux-x64-wheels:
-    name: Build opNav Wheel Input (${{ matrix.wheel-kind }}, ubuntu-24.04)
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - wheel-kind: core
-            output-dir: wheelhouse-core
-            conan-args: --opNav False --mujoco True --clean
-            needs_disk_cleanup: false
-          - wheel-kind: opnav-full
-            output-dir: wheelhouse-opnav-full
-            conan-args: --opNav True --mujoco True --clean
-            needs_disk_cleanup: true
-
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-
-      - name: Remove runner-provided Microsoft apt sources
-        shell: bash
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.sources
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.sources
-
-      - name: Setup system dependencies
-        uses: ./.github/actions/setup
-
       - name: Free runner disk for heavy optional Linux wheel
-        if: ${{ runner.os == 'Linux' && matrix.needs_disk_cleanup }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.wheel-kind == 'opnav-full' }}
         shell: bash
         run: |
           echo "Disk space before cleanup:"
@@ -123,30 +58,42 @@ jobs:
           df -h
 
       - name: Build ${{ matrix.wheel-kind }} bsk wheel
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: ./.github/actions/build-wheel
         with:
           output-dir: ${{ matrix.output-dir }}
-        env:
-          CIBW_BUILD: "cp314-*"
-          CIBW_TEST_SKIP: "*"
-          CONAN_ARGS: "${{ matrix.conan-args }}"
+          conan-args: ${{ matrix.conan-args }} ${{ matrix.extra-conan-args }}
+          cibw-build: cp314-*
+          save-conan-cache: ${{ matrix.save-conan-cache }}
 
       - name: Upload wheel input
         uses: actions/upload-artifact@v6
         with:
-          name: optional-wheel-test-ubuntu-24.04-${{ matrix.wheel-kind }}
+          name: optional-wheel-input-${{ matrix.os }}-${{ matrix.wheel-kind }}
           path: ${{ matrix.output-dir }}/*.whl
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
 
-  test-opnav-wheels-linux-x64:
-    name: Test opNav Wheels (ubuntu-24.04)
-    runs-on: ubuntu-24.04
-    needs: build-opnav-linux-x64-wheels
+  test-opnav-wheels:
+    name: Test opNav Wheels (${{ matrix.os }})
+    needs: build-opnav-wheels
+    if: ${{ !cancelled() }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-26
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - windows-2025-vs2026
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
 
       - name: Remove runner-provided Microsoft apt sources
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           sudo rm -f /etc/apt/sources.list.d/azure-cli.list
@@ -165,13 +112,13 @@ jobs:
       - name: Download core wheel input
         uses: actions/download-artifact@v6
         with:
-          name: optional-wheel-test-ubuntu-24.04-core
+          name: optional-wheel-input-${{ matrix.os }}-core
           path: wheelhouse-core
 
       - name: Download opNav-enabled wheel input
         uses: actions/download-artifact@v6
         with:
-          name: optional-wheel-test-ubuntu-24.04-opnav-full
+          name: optional-wheel-input-${{ matrix.os }}-opnav-full
           path: wheelhouse-opnav-full
 
       - name: Generate and test optional wheel installs
@@ -188,7 +135,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v6
         with:
-          name: optional-wheel-test-ubuntu-24.04
+          name: optional-wheel-test-${{ matrix.os }}
           path: |
             wheelhouse-core/*.whl
             wheelhouse-opnav-full/*.whl

--- a/docs/source/Support/bskReleaseNotesSnippets/ci-wheel-caching.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/ci-wheel-caching.rst
@@ -1,0 +1,1 @@
+- Parallelized distribution wheel builds and added compiler and Conan caching to wheel CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ repair-wheel-command = "python -m delvewheel repair -v --ignore-existing --analy
 
 [tool.cibuildwheel.linux]
 archs = ["native"]
-before-all = "mkdir -p ~/.conan2 && printf '%s\\n' 'tools.system.package_manager:mode=install' 'tools.system.package_manager:sudo=False' >> ~/.conan2/global.conf"
+before-all = "conan_home=\"${CONAN_HOME:-$HOME/.conan2}\" && mkdir -p \"$conan_home\" && touch \"$conan_home/global.conf\" && for setting in 'tools.system.package_manager:mode=install' 'tools.system.package_manager:sudo=False'; do grep -qxF \"$setting\" \"$conan_home/global.conf\" || printf '%s\\n' \"$setting\" >> \"$conan_home/global.conf\"; done"
 repair-wheel-command = [
   "auditwheel repair --strip -w {dest_dir} {wheel}"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ repair-wheel-command = "python -m delvewheel repair -v --ignore-existing --analy
 
 [tool.cibuildwheel.linux]
 archs = ["native"]
-before-all = "conan_home=\"${CONAN_HOME:-$HOME/.conan2}\" && mkdir -p \"$conan_home\" && touch \"$conan_home/global.conf\" && for setting in 'tools.system.package_manager:mode=install' 'tools.system.package_manager:sudo=False'; do grep -qxF \"$setting\" \"$conan_home/global.conf\" || printf '%s\\n' \"$setting\" >> \"$conan_home/global.conf\"; done"
+before-all = "python -m pip install 'conan>=2.0.5,<=2.28.1' && python -m conans.conan profile detect --force && conan_home=\"${CONAN_HOME:-$HOME/.conan2}\" && mkdir -p \"$conan_home\" && touch \"$conan_home/global.conf\" && for setting in 'tools.system.package_manager:mode=install' 'tools.system.package_manager:sudo=False'; do grep -qxF \"$setting\" \"$conan_home/global.conf\" || printf '%s\\n' \"$setting\" >> \"$conan_home/global.conf\"; done"
 repair-wheel-command = [
   "auditwheel repair --strip -w {dest_dir} {wheel}"
 ]


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

Refactors the nightly, release, and optional-wheel workflows to build core and opNav-enabled wheels concurrently across macOS, Linux x86_64, Linux ARM64, and Windows.

A reusable wheel-building action now configures `sccache`, restores an isolated Conan cache, and handles the path and ownership differences between native runners and Linux `cibuildwheel` containers. Built wheels are transferred as short-lived artifacts to downstream jobs, where the optional distributions are assembled and tested before publishing can proceed.

The commits are organized as follows:

1. Parallelize and cache the wheel builds.
2. Add the corresponding release-note snippet.

## Verification

- Successfully ran the complete [Test Optional Wheels workflow](https://github.com/AVSLab/basilisk/actions/runs/30221063362).
- All core and opNav wheel builds completed on macOS, Linux x86_64, Linux ARM64, and Windows.
- All four downstream optional-wheel installation tests passed.
- The warm-cache workflow completed in approximately 16.5 minutes, compared with approximately 99 minutes for the previous sequential workflow.
- Repository pre-commit hooks and `git diff --check` passed.

No product test files were added or modified because this change only restructures CI execution. The existing optional-wheel installation test provides end-to-end validation of the generated distributions.

The nightly and publishing workflows were not dispatched because they can publish external artifacts. They use the same reusable build action and build/package topology exercised by the test workflow.

## Documentation

Added a release-note snippet describing the parallel wheel builds and compiler/Conan caching.

No user-facing installation documentation was invalidated because the generated wheel contents and supported platforms remain unchanged.

## Future work

Monitor GitHub Actions cache usage and eviction rates. A dedicated remote `sccache` backend or additional cache capacity may be considered separately if repository cache pressure affects hit rates.