### PR TITLE
Share protobuf runtime and expose optional-wheel build capabilities

### DIFF
--- a/.github/scripts/build_optional_bsk_wheel.py
+++ b/.github/scripts/build_optional_bsk_wheel.py
@@ -22,7 +22,9 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import base64
+import copy
 import csv
 import hashlib
 import io
@@ -37,6 +39,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_VERSION_FILE = REPO_ROOT / "docs/source/bskVersion.txt"
 BASE_DISTRIBUTION = "bsk"
+BUILD_INFO_DATA_PATH = "Basilisk/_buildInfoData.py"
+BUILD_FEATURE_ENTRY_POINT_GROUP = "basilisk.build_features"
 NATIVE_PAYLOAD_SUFFIXES = (".a", ".dll", ".dylib", ".lib", ".pyd", ".so")
 NATIVE_PAYLOAD_PREFIXES = ("bsk.libs/",)
 PRE_RELEASE_ALIASES = {
@@ -59,6 +63,7 @@ PRE_RELEASE_VERSION_PATTERN = re.compile(
 @dataclass(frozen=True)
 class OptionalComponent:
     distribution: str
+    build_feature: str
     summary: str
     description: str
     cmake_include: str
@@ -68,6 +73,7 @@ class OptionalComponent:
 COMPONENTS = {
     "opnav": OptionalComponent(
         distribution="bsk-opnav",
+        build_feature="opNav",
         summary="Basilisk optical navigation extension modules",
         description="Optional optical navigation extension modules for Basilisk.",
         # Basilisk treats OpenCV-backed modules as optical navigation modules.
@@ -250,12 +256,89 @@ def warn_changed_native_payloads(changed: list[str]) -> None:
     )
 
 
+def parse_build_info_data(data: bytes) -> dict[str, object]:
+    """Parse the generated build-information dictionary without executing it."""
+    tree = ast.parse(data.decode("utf-8"), filename=BUILD_INFO_DATA_PATH)
+    assignments = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "buildInfoData"
+    ]
+    if len(assignments) != 1:
+        raise ValueError(
+            f"Expected one buildInfoData assignment in {BUILD_INFO_DATA_PATH}."
+        )
+
+    build_info = ast.literal_eval(assignments[0].value)
+    if not isinstance(build_info, dict):
+        raise ValueError(f"Expected a dictionary in {BUILD_INFO_DATA_PATH}.")
+    return build_info
+
+
+def validate_build_feature_metadata(
+    base_archive: zipfile.ZipFile,
+    component_archive: zipfile.ZipFile,
+    component: OptionalComponent,
+) -> None:
+    """Validate the intentional feature difference between wheel build inputs."""
+    base_build_info = parse_build_info_data(base_archive.read(BUILD_INFO_DATA_PATH))
+    component_build_info = parse_build_info_data(
+        component_archive.read(BUILD_INFO_DATA_PATH)
+    )
+
+    base_features = base_build_info.get("features")
+    component_features = component_build_info.get("features")
+    if not isinstance(base_features, dict) or not isinstance(component_features, dict):
+        raise ValueError(
+            f"Expected a features dictionary in {BUILD_INFO_DATA_PATH}."
+        )
+
+    try:
+        base_enabled = base_features[component.build_feature]
+        component_enabled = component_features[component.build_feature]
+    except KeyError as err:
+        raise ValueError(
+            f"Missing build feature {component.build_feature!r} in "
+            f"{BUILD_INFO_DATA_PATH}."
+        ) from err
+
+    if base_enabled is not False or component_enabled is not True:
+        raise ValueError(
+            f"Expected {component.build_feature!r} to be disabled in the base build "
+            "and enabled in the component build."
+        )
+
+    normalized_component_info = copy.deepcopy(component_build_info)
+    normalized_component_info["features"] = {
+        **component_features,
+        component.build_feature: base_enabled,
+    }
+    if normalized_component_info != base_build_info:
+        raise ValueError(
+            f"{BUILD_INFO_DATA_PATH} differs between the base and component builds "
+            f"beyond the expected {component.build_feature!r} feature value."
+        )
+
+
 def validate_common_payloads(
     base_archive: zipfile.ZipFile,
     component_archive: zipfile.ZipFile,
     base_payload: set[str],
     component_payload: set[str],
+    component: OptionalComponent,
 ) -> None:
+    if (
+        BUILD_INFO_DATA_PATH not in base_payload
+        or BUILD_INFO_DATA_PATH not in component_payload
+    ):
+        raise ValueError(
+            f"Both wheel build inputs must contain {BUILD_INFO_DATA_PATH}."
+        )
+    validate_build_feature_metadata(base_archive, component_archive, component)
+
     changed = []
     for name in sorted(base_payload & component_payload):
         base_digest = archive_payload_digest(base_archive, name)
@@ -266,6 +349,9 @@ def validate_common_payloads(
     native_changed = [name for name in changed if is_native_payload(name)]
     non_native_changed = [name for name in changed if not is_native_payload(name)]
     warn_changed_native_payloads(native_changed)
+
+    if BUILD_INFO_DATA_PATH in non_native_changed:
+        non_native_changed.remove(BUILD_INFO_DATA_PATH)
 
     if non_native_changed:
         details = "\n  ".join(non_native_changed)
@@ -398,6 +484,10 @@ def build_wheel_file(
             version,
             include_license_file=license_data is not None,
         )
+        entry_points = (
+            f"[{BUILD_FEATURE_ENTRY_POINT_GROUP}]\n"
+            f"{component.build_feature} = Basilisk\n"
+        ).encode("utf-8")
 
         with zipfile.ZipFile(output_wheel, "w", compression=zipfile.ZIP_DEFLATED) as output:
             for name in payload:
@@ -408,6 +498,7 @@ def build_wheel_file(
 
             add_bytes(output, records, f"{dist_info}/METADATA", metadata)
             add_bytes(output, records, f"{dist_info}/WHEEL", wheel_data)
+            add_bytes(output, records, f"{dist_info}/entry_points.txt", entry_points)
             add_bytes(output, records, f"{dist_info}/top_level.txt", b"Basilisk\n")
 
             record_name = f"{dist_info}/RECORD"
@@ -454,6 +545,7 @@ def build_optional_wheel(
             component_archive,
             base_payload,
             component_payload,
+            component,
         )
         payload = validate_delta(base_payload, component_payload, component)
 

--- a/.github/scripts/test_optional_bsk_wheels.py
+++ b/.github/scripts/test_optional_bsk_wheels.py
@@ -35,6 +35,7 @@ CORE_IMPORTS = [
     "Basilisk.architecture.messaging",
     "Basilisk.utilities.SimulationBaseClass",
     "Basilisk.simulation.spacecraft",
+    "Basilisk.simulation.vizInterface",
     "Basilisk.fswAlgorithms.mrpFeedback",
     "Basilisk.simulation.mujoco",
     "Basilisk.simulation.thrOnTimeToForce",
@@ -45,6 +46,10 @@ OPNAV_IMPORTS = [
     "Basilisk.fswAlgorithms.houghCircles",
     "Basilisk.fswAlgorithms.limbFinding",
 ]
+PROTOBUF_CONSUMERS = (
+    ("Basilisk.fswAlgorithms.centerRadiusCNN", "CenterRadiusCNN"),
+    ("Basilisk.simulation.vizInterface", "VizInterface"),
+)
 
 
 def venv_python(venv_path: Path) -> Path:
@@ -105,6 +110,32 @@ def run_import_check(
     run([python, "-c", import_check_script(required, missing)], env=env)
 
 
+def protobuf_consumer_check_script(consumers: tuple[tuple[str, str], ...]) -> str:
+    """Return a worker script that holds both protobuf consumers through shutdown."""
+    return f"""
+import importlib
+
+consumers = {consumers!r}
+instances = []
+for module_name, class_name in consumers:
+    module = importlib.import_module(module_name)
+    instances.append(getattr(module, class_name)())
+"""
+
+
+def run_protobuf_consumer_checks(python: Path, env: dict[str, str]) -> None:
+    """Check both protobuf-consumer import orders in isolated interpreters."""
+    import_orders = (PROTOBUF_CONSUMERS, tuple(reversed(PROTOBUF_CONSUMERS)))
+    for import_order in import_orders:
+        run([
+            python,
+            "-X",
+            "faulthandler",
+            "-c",
+            protobuf_consumer_check_script(import_order),
+        ], env=env)
+
+
 def install_extra(python: Path, wheelhouse: Path, extra: str) -> None:
     run([
         python,
@@ -149,6 +180,7 @@ def test_optional_wheels(wheelhouse: Path) -> None:
             missing=[],
             env=test_env,
         )
+        run_protobuf_consumer_checks(python, test_env)
 
         run([python, "-m", "pip", "uninstall", "-y", "bsk-opnav"])
         run_import_check(
@@ -166,6 +198,7 @@ def test_optional_wheels(wheelhouse: Path) -> None:
             missing=[],
             env=test_env,
         )
+        run_protobuf_consumer_checks(python, test_env)
 
 
 def parse_args() -> argparse.Namespace:

--- a/.github/scripts/test_optional_bsk_wheels.py
+++ b/.github/scripts/test_optional_bsk_wheels.py
@@ -77,7 +77,11 @@ def create_venv(parent: Path, name: str) -> Path:
     return venv_path
 
 
-def import_check_script(required: list[str], missing: list[str]) -> str:
+def import_check_script(
+    required: list[str],
+    missing: list[str],
+    expected_features: dict[str, bool],
+) -> str:
     return f"""
 import importlib
 import importlib.util
@@ -85,9 +89,18 @@ import sys
 
 required = {required!r}
 missing = {missing!r}
+expected_features = {expected_features!r}
 
 import Basilisk
 print("Basilisk:", Basilisk.__file__)
+
+for name, expected in expected_features.items():
+    actual = Basilisk.hasBuildFeature(name)
+    if actual is not expected:
+        raise SystemExit(
+            f"unexpected build feature {{name}}={{actual}}; expected {{expected}}"
+        )
+    print("OK feature", name, "->", actual)
 
 for name in required:
     module = importlib.import_module(name)
@@ -105,9 +118,13 @@ def run_import_check(
     *,
     required: list[str],
     missing: list[str],
+    expected_features: dict[str, bool],
     env: dict[str, str],
 ) -> None:
-    run([python, "-c", import_check_script(required, missing)], env=env)
+    run(
+        [python, "-c", import_check_script(required, missing, expected_features)],
+        env=env,
+    )
 
 
 def protobuf_consumer_check_script(consumers: tuple[tuple[str, str], ...]) -> str:
@@ -169,6 +186,7 @@ def test_optional_wheels(wheelhouse: Path) -> None:
             python,
             required=CORE_IMPORTS,
             missing=OPNAV_IMPORTS,
+            expected_features={"vizInterface": True, "opNav": False, "mujoco": True},
             env=test_env,
         )
 
@@ -178,6 +196,7 @@ def test_optional_wheels(wheelhouse: Path) -> None:
             python,
             required=CORE_IMPORTS + OPNAV_IMPORTS,
             missing=[],
+            expected_features={"vizInterface": True, "opNav": True, "mujoco": True},
             env=test_env,
         )
         run_protobuf_consumer_checks(python, test_env)
@@ -187,6 +206,7 @@ def test_optional_wheels(wheelhouse: Path) -> None:
             python,
             required=CORE_IMPORTS,
             missing=OPNAV_IMPORTS,
+            expected_features={"vizInterface": True, "opNav": False, "mujoco": True},
             env=test_env,
         )
 
@@ -196,6 +216,7 @@ def test_optional_wheels(wheelhouse: Path) -> None:
             python,
             required=CORE_IMPORTS + OPNAV_IMPORTS,
             missing=[],
+            expected_features={"vizInterface": True, "opNav": True, "mujoco": True},
             env=test_env,
         )
         run_protobuf_consumer_checks(python, test_env)

--- a/conanfile.py
+++ b/conanfile.py
@@ -307,6 +307,9 @@ class BasiliskConan(ConanFile):
 
         # Other dependency options
         if self.options.get_safe("vizInterface") or self.options.get_safe("opNav"):
+            if self.settings.get_safe("os") == "Macos":
+                # Avoid loading separate protobuf runtimes through OpenCV and vizInterface.
+                self.options["protobuf"].shared = True
             self.options['zeromq'].encryption = False # Basilisk does not use data streaming encryption.
 
 

--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -184,10 +184,15 @@ incremented when Basilisk intentionally changes the C/C++ object contract expose
 promise compatibility between different Basilisk versions; the SDK's exact-version check remains required unless a
 future compatibility policy explicitly relaxes it.
 
-``features`` reports whether ``vizInterface``, ``opNav``, and ``mujoco`` were enabled when CMake configured the
-installed package.  The same values can be queried with ``hasBuildFeature()``.  Feature names are case-sensitive,
-and an unknown name raises ``KeyError``.  These values describe compiled Basilisk capabilities; they do not report
-the availability of external applications such as Vizard.
+``features`` records whether ``vizInterface``, ``opNav``, and ``mujoco`` were enabled when CMake configured the core
+artifact.  ``hasBuildFeature()`` answers whether the installed Basilisk environment provides a capability: it
+combines those core values with capabilities supplied by installed optional Basilisk distributions such as
+``bsk-opnav``.  Optional distributions declare their capabilities through package entry-point metadata and must
+have the same version as the core artifact.  A mismatched provider raises ``RuntimeError`` instead of exposing an
+incompatible compiled extension.  This distinction lets ``getBuildInfo()`` retain the core artifact's provenance
+while feature guards continue to work when Basilisk is distributed across multiple wheels.  Feature names are
+case-sensitive, and an unknown name raises ``KeyError``.  These values describe compiled Basilisk capabilities;
+they do not report the availability of external applications such as Vizard.
 
 ``abi`` is captured by C and C++ translation units compiled with the selected Basilisk build configuration.  It
 records the actual target architecture, endianness, C and C++ language modes, compiler ABI, standard-library ABI and

--- a/docs/source/Support/Developer/CodingGuidlines.rst
+++ b/docs/source/Support/Developer/CodingGuidlines.rst
@@ -256,6 +256,13 @@ metadata with ``Basilisk.hasBuildFeature()``.  Do not infer build capabilities b
 catching ``ImportError``.  Import probing can hide a broken build where a feature was
 enabled but its module failed to import.
 
+``hasBuildFeature()`` reports capabilities supplied either by the core Basilisk artifact
+or by an installed optional Basilisk distribution.  The same guard therefore works for a
+monolithic source build and for a split-wheel installation.  Optional distributions must
+match the core version; a mismatch raises ``RuntimeError`` rather than silently skipping
+the affected tests.  Once the guard reports that a feature is present, import its module
+normally so a broken installation still fails during test collection.
+
 If every test in a file requires the same optional feature, use a module-level
 ``pytestmark`` and import the optional modules conditionally:
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -13,6 +13,10 @@ Version |release| (July 7, 2026)
 - :ref:`vizInterface` left its protobuf output stream open after the module was destroyed. On Windows, this could
   prevent saved Vizard data files from being removed until the Python process exited. The stream is now owned and
   closed automatically by the module. This is fixed in the current version.
+- Builds with both ``opNav`` and ``vizInterface`` enabled could load separate static protobuf runtimes through
+- macOS builds with both ``opNav`` and ``vizInterface`` enabled could load separate static protobuf runtimes through
+  OpenCV and :ref:`vizInterface`, causing an interpreter-shutdown crash after otherwise successful Python tests.
+  On macOS, both modules now use the same shared protobuf runtime. This is fixed in the current version.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
   for Basilisk and compatible extensions. If source builds fail with SWIG 4.4.0 or emit

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -13,10 +13,12 @@ Version |release| (July 7, 2026)
 - :ref:`vizInterface` left its protobuf output stream open after the module was destroyed. On Windows, this could
   prevent saved Vizard data files from being removed until the Python process exited. The stream is now owned and
   closed automatically by the module. This is fixed in the current version.
-- Builds with both ``opNav`` and ``vizInterface`` enabled could load separate static protobuf runtimes through
 - macOS builds with both ``opNav`` and ``vizInterface`` enabled could load separate static protobuf runtimes through
   OpenCV and :ref:`vizInterface`, causing an interpreter-shutdown crash after otherwise successful Python tests.
   On macOS, both modules now use the same shared protobuf runtime. This is fixed in the current version.
+- ``hasBuildFeature("opNav")`` previously reflected only the core wheel's build metadata, so it reported ``False``
+  after the separately distributed ``bsk-opnav`` wheel was installed. The query now aggregates capabilities from
+  the core artifact and compatible installed optional Basilisk distributions. This is fixed in the current version.
 - SWIG 4.4.0 caused Basilisk build failures in some Python 3.13+ source-build configurations.
   Basilisk now requires SWIG 4.4.1 or a newer supported 4.x release, which provides SWIG ABI 5 support
   for Basilisk and compatible extensions. If source builds fail with SWIG 4.4.0 or emit

--- a/docs/source/Support/bskReleaseNotesSnippets/optional-wheel-build-features.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/optional-wheel-build-features.rst
@@ -1,0 +1,1 @@
+- ``Basilisk.hasBuildFeature()`` now aggregates capabilities from the core artifact and compatible installed optional Basilisk distributions, allowing the same feature guards to work with monolithic and split-wheel installations.

--- a/docs/source/Support/bskReleaseNotesSnippets/shared-protobuf-runtime.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/shared-protobuf-runtime.rst
@@ -1,0 +1,1 @@
+- macOS builds now use a shared protobuf dependency, preventing interpreter-shutdown crashes when OpenCV-backed OpNav modules and :ref:`vizInterface` are loaded in the same process.

--- a/src/cmake/bskBuildInfo.py
+++ b/src/cmake/bskBuildInfo.py
@@ -17,11 +17,33 @@
 #
 
 from copy import deepcopy as _deepcopy
+from functools import lru_cache as _lruCache
+from importlib.metadata import distributions as _distributions
 
 from Basilisk._buildAbiData import buildAbiData as _buildAbiData
 from Basilisk._buildInfoData import buildInfoData as _buildInfoData
 
 _buildInfoData = {**_buildInfoData, "abi": _buildAbiData}
+_buildFeatureEntryPointGroup = "basilisk.build_features"
+
+
+@_lruCache(maxsize=1)
+def _installedBuildFeatureProviders() -> dict[str, tuple[tuple[str, str], ...]]:
+    """Return optional feature providers discovered from distribution metadata."""
+    providers: dict[str, set[tuple[str, str]]] = {}
+    for distribution in _distributions():
+        distributionName = distribution.metadata.get("Name") or "<unknown>"
+        distributionVersion = distribution.version or "<unknown>"
+        for entryPoint in distribution.entry_points:
+            if entryPoint.group == _buildFeatureEntryPointGroup:
+                providers.setdefault(entryPoint.name, set()).add(
+                    (distributionName, distributionVersion)
+                )
+
+    return {
+        featureName: tuple(sorted(featureProviders))
+        for featureName, featureProviders in providers.items()
+    }
 
 
 def getBuildInfo() -> dict[str, object]:
@@ -39,21 +61,44 @@ def getBuildInfo() -> dict[str, object]:
 
 
 def hasBuildFeature(featureName: str) -> bool:
-    """Return whether an optional Basilisk build feature is enabled.
+    """Return whether the installed Basilisk distributions provide a build feature.
 
     :param featureName: Name from the ``features`` section of :func:`getBuildInfo`.
-    :return: ``True`` when the feature was enabled when Basilisk was configured.
+    :return: ``True`` when the core build or an installed optional Basilisk
+        distribution provides the feature.
     :raises KeyError: If ``featureName`` is not a known build feature.
+    :raises RuntimeError: If an optional feature provider is incompatible with
+        the installed Basilisk core version.
     """
     features = _buildInfoData["features"]
     try:
-        return features[featureName]
+        configured = features[featureName]
     except KeyError:
         availableFeatures = ", ".join(sorted(features))
         raise KeyError(
             f"Unknown Basilisk build feature '{featureName}'. "
             f"Available features: {availableFeatures}"
         ) from None
+
+    providers = _installedBuildFeatureProviders().get(featureName, ())
+    coreVersion = _buildInfoData["artifact"]["basiliskVersion"]
+    incompatibleProviders = sorted(
+        (distributionName, version)
+        for distributionName, version in providers
+        if version != coreVersion
+    )
+    if incompatibleProviders:
+        details = ", ".join(
+            f"{distributionName}=={version}"
+            for distributionName, version in incompatibleProviders
+        )
+        raise RuntimeError(
+            f"Basilisk build feature '{featureName}' is provided by an incompatible "
+            f"optional distribution ({details}); install a provider matching "
+            f"bsk=={coreVersion}."
+        )
+
+    return configured or bool(providers)
 
 
 def _appendField(lines: list[str], label: str, value: str) -> None:

--- a/src/cmake/bskBuildInfo.py
+++ b/src/cmake/bskBuildInfo.py
@@ -17,7 +17,6 @@
 #
 
 from copy import deepcopy as _deepcopy
-from functools import lru_cache as _lruCache
 from importlib.metadata import distributions as _distributions
 
 from Basilisk._buildAbiData import buildAbiData as _buildAbiData
@@ -27,7 +26,6 @@ _buildInfoData = {**_buildInfoData, "abi": _buildAbiData}
 _buildFeatureEntryPointGroup = "basilisk.build_features"
 
 
-@_lruCache(maxsize=1)
 def _installedBuildFeatureProviders() -> dict[str, tuple[tuple[str, str], ...]]:
     """Return optional feature providers discovered from distribution metadata."""
     providers: dict[str, set[tuple[str, str]]] = {}

--- a/src/tests/test_buildInfo.py
+++ b/src/tests/test_buildInfo.py
@@ -20,6 +20,7 @@ import ctypes
 import platform
 import re
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -30,6 +31,14 @@ import Basilisk._buildInfo as buildInfoFormatter
 ABI_CONTRACT_HEADER = (
     Path(__file__).parents[1] / "architecture" / "utilities" / "bskAbiDescriptor.h"
 )
+
+
+@pytest.fixture(autouse=True)
+def clearBuildFeatureProviderCache():
+    """Clear cached distribution metadata around each build-information test."""
+    buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
+    yield
+    buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
 
 
 def _integerDefine(name):
@@ -287,15 +296,75 @@ def test_build_info():
 
 
 def test_build_feature_query(monkeypatch):
-    """Verify configured features can be queried and unknown names are rejected."""
+    """Verify configured and installed optional features can be queried."""
     features = {"vizInterface": True, "opNav": False, "mujoco": True}
     monkeypatch.setitem(buildInfoFormatter._buildInfoData, "features", features)
 
-    for featureName, enabled in features.items():
-        assert Basilisk.hasBuildFeature(featureName) is enabled
+    coreVersion = buildInfoFormatter._buildInfoData["artifact"]["basiliskVersion"]
+    entryPoint = SimpleNamespace(
+        group=buildInfoFormatter._buildFeatureEntryPointGroup,
+        name="opNav",
+    )
+    optionalDistribution = SimpleNamespace(
+        entry_points=[entryPoint],
+        metadata={"Name": "bsk-opnav"},
+        version=coreVersion,
+    )
+    distributionQueries = []
+
+    def installedDistributions():
+        distributionQueries.append(True)
+        return [optionalDistribution]
+
+    monkeypatch.setattr(
+        buildInfoFormatter,
+        "_distributions",
+        installedDistributions,
+    )
+
+    assert Basilisk.hasBuildFeature("vizInterface") is True
+    assert Basilisk.hasBuildFeature("opNav") is True
+    assert Basilisk.hasBuildFeature("mujoco") is True
+    assert Basilisk.getBuildInfo()["features"] == features
+    assert distributionQueries == [True]
 
     with pytest.raises(KeyError, match="unknownFeature"):
         Basilisk.hasBuildFeature("unknownFeature")
+
+
+def test_missing_optional_build_feature(monkeypatch):
+    """Verify a feature is unavailable when neither core nor an extension provides it."""
+    features = {"vizInterface": True, "opNav": False, "mujoco": True}
+    monkeypatch.setitem(buildInfoFormatter._buildInfoData, "features", features)
+
+    monkeypatch.setattr(buildInfoFormatter, "_distributions", lambda: [])
+
+    assert Basilisk.hasBuildFeature("opNav") is False
+
+
+def test_incompatible_optional_build_feature(monkeypatch):
+    """Verify an incompatible optional feature provider is rejected."""
+    features = {"vizInterface": True, "opNav": True, "mujoco": True}
+    monkeypatch.setitem(buildInfoFormatter._buildInfoData, "features", features)
+    coreVersion = buildInfoFormatter._buildInfoData["artifact"]["basiliskVersion"]
+    incompatibleVersion = "0" if coreVersion != "0" else "1"
+    entryPoint = SimpleNamespace(
+        group=buildInfoFormatter._buildFeatureEntryPointGroup,
+        name="opNav",
+    )
+    optionalDistribution = SimpleNamespace(
+        entry_points=[entryPoint],
+        metadata={"Name": "bsk-opnav"},
+        version=incompatibleVersion,
+    )
+    monkeypatch.setattr(
+        buildInfoFormatter,
+        "_distributions",
+        lambda: [optionalDistribution],
+    )
+
+    with pytest.raises(RuntimeError, match=r"bsk-opnav.*install a provider matching"):
+        Basilisk.hasBuildFeature("opNav")
 
 
 def test_shared_abi_contract_header():

--- a/src/tests/test_buildInfo.py
+++ b/src/tests/test_buildInfo.py
@@ -19,6 +19,7 @@
 import ctypes
 import platform
 import re
+from importlib.metadata import distributions
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -31,14 +32,6 @@ import Basilisk._buildInfo as buildInfoFormatter
 ABI_CONTRACT_HEADER = (
     Path(__file__).parents[1] / "architecture" / "utilities" / "bskAbiDescriptor.h"
 )
-
-
-@pytest.fixture(autouse=True)
-def clearBuildFeatureProviderCache():
-    """Clear cached distribution metadata around each build-information test."""
-    buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
-    yield
-    buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
 
 
 def _integerDefine(name):
@@ -326,45 +319,51 @@ def test_build_feature_query(monkeypatch):
     assert Basilisk.hasBuildFeature("opNav") is True
     assert Basilisk.hasBuildFeature("mujoco") is True
     assert Basilisk.getBuildInfo()["features"] == features
-    assert distributionQueries == [True]
+    assert distributionQueries == [True, True, True]
 
     with pytest.raises(KeyError, match="unknownFeature"):
         Basilisk.hasBuildFeature("unknownFeature")
 
 
-def test_missing_optional_build_feature(monkeypatch):
-    """Verify a feature is unavailable when neither core nor an extension provides it."""
+def test_optional_build_feature_environment_changes(monkeypatch, tmp_path):
+    """Verify provider changes are detected within a running process."""
     features = {"vizInterface": True, "opNav": False, "mujoco": True}
     monkeypatch.setitem(buildInfoFormatter._buildInfoData, "features", features)
-
-    monkeypatch.setattr(buildInfoFormatter, "_distributions", lambda: [])
-
-    assert Basilisk.hasBuildFeature("opNav") is False
-
-
-def test_incompatible_optional_build_feature(monkeypatch):
-    """Verify an incompatible optional feature provider is rejected."""
-    features = {"vizInterface": True, "opNav": True, "mujoco": True}
-    monkeypatch.setitem(buildInfoFormatter._buildInfoData, "features", features)
     coreVersion = buildInfoFormatter._buildInfoData["artifact"]["basiliskVersion"]
-    incompatibleVersion = "0" if coreVersion != "0" else "1"
-    entryPoint = SimpleNamespace(
-        group=buildInfoFormatter._buildFeatureEntryPointGroup,
-        name="opNav",
-    )
-    optionalDistribution = SimpleNamespace(
-        entry_points=[entryPoint],
-        metadata={"Name": "bsk-opnav"},
-        version=incompatibleVersion,
-    )
     monkeypatch.setattr(
         buildInfoFormatter,
         "_distributions",
-        lambda: [optionalDistribution],
+        lambda: distributions(path=[tmp_path]),
     )
 
+    assert Basilisk.hasBuildFeature("opNav") is False
+
+    providerPath = tmp_path / f"bsk_opnav-{coreVersion}.dist-info"
+    providerPath.mkdir()
+    metadataPath = providerPath / "METADATA"
+    metadataPath.write_text(
+        f"Metadata-Version: 2.4\nName: bsk-opnav\nVersion: {coreVersion}\n",
+        encoding="utf-8",
+    )
+    entryPointPath = providerPath / "entry_points.txt"
+    entryPointPath.write_text(
+        f"[{buildInfoFormatter._buildFeatureEntryPointGroup}]\nopNav = Basilisk\n",
+        encoding="utf-8",
+    )
+    assert Basilisk.hasBuildFeature("opNav") is True
+
+    incompatibleVersion = "0" if coreVersion != "0" else "1"
+    metadataPath.write_text(
+        f"Metadata-Version: 2.4\nName: bsk-opnav\nVersion: {incompatibleVersion}\n",
+        encoding="utf-8",
+    )
     with pytest.raises(RuntimeError, match=r"bsk-opnav.*install a provider matching"):
         Basilisk.hasBuildFeature("opNav")
+
+    metadataPath.unlink()
+    entryPointPath.unlink()
+    providerPath.rmdir()
+    assert Basilisk.hasBuildFeature("opNav") is False
 
 
 def test_shared_abi_contract_header():

--- a/src/tests/test_optionalWheelBuilder.py
+++ b/src/tests/test_optionalWheelBuilder.py
@@ -199,8 +199,4 @@ def test_optional_wheel_declares_build_feature(tmp_path, monkeypatch):
         "_distributions",
         lambda: installedDistributions,
     )
-    buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
-    try:
-        assert buildInfoFormatter.hasBuildFeature("opNav") is True
-    finally:
-        buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
+    assert buildInfoFormatter.hasBuildFeature("opNav") is True

--- a/src/tests/test_optionalWheelBuilder.py
+++ b/src/tests/test_optionalWheelBuilder.py
@@ -1,0 +1,206 @@
+#
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import importlib.util
+import io
+import sys
+import zipfile
+from contextlib import contextmanager
+from importlib.metadata import distributions
+from pathlib import Path
+
+import pytest
+
+import Basilisk._buildInfo as buildInfoFormatter
+
+
+REPO_ROOT = Path(__file__).parents[2]
+WHEEL_BUILDER_PATH = REPO_ROOT / ".github/scripts/build_optional_bsk_wheel.py"
+
+
+def _loadWheelBuilder():
+    moduleName = "bskOptionalWheelBuilderUnderTest"
+    spec = importlib.util.spec_from_file_location(moduleName, WHEEL_BUILDER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[moduleName] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+WHEEL_BUILDER = _loadWheelBuilder()
+
+
+def _buildInfoData(opNavEnabled, *, schemaVersion=3):
+    buildInfo = {
+        "schemaVersion": schemaVersion,
+        "artifact": {"basiliskVersion": "test-version"},
+        "features": {
+            "vizInterface": True,
+            "opNav": opNavEnabled,
+            "mujoco": True,
+        },
+    }
+    return f"buildInfoData = {buildInfo!r}\n".encode("utf-8")
+
+
+@contextmanager
+def _buildInfoArchive(data):
+    with io.BytesIO() as buffer:
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr(WHEEL_BUILDER.BUILD_INFO_DATA_PATH, data)
+        buffer.seek(0)
+        with zipfile.ZipFile(buffer) as archive:
+            yield archive
+
+
+def test_expected_build_feature_metadata_difference():
+    """Verify the optional-wheel builder accepts only the expected feature change."""
+    payload = {WHEEL_BUILDER.BUILD_INFO_DATA_PATH}
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+
+    with _buildInfoArchive(_buildInfoData(False)) as baseArchive:
+        with _buildInfoArchive(_buildInfoData(True)) as componentArchive:
+            WHEEL_BUILDER.validate_common_payloads(
+                baseArchive,
+                componentArchive,
+                payload,
+                payload,
+                component,
+            )
+
+
+@pytest.mark.parametrize(
+    "componentData, errorText",
+    [
+        pytest.param(
+            _buildInfoData(False),
+            "disabled in the base build and enabled in the component build",
+            id="feature-not-enabled",
+        ),
+        pytest.param(
+            _buildInfoData(True, schemaVersion=4),
+            "beyond the expected 'opNav' feature value",
+            id="unrelated-metadata-drift",
+        ),
+        pytest.param(
+            (
+                b'buildInfoData = {"schemaVersion": 3, "artifact": '
+                b'{"basiliskVersion": "test-version"}, "features": '
+                b'{"vizInterface": True, "mujoco": True}}\n'
+            ),
+            "Missing build feature 'opNav'",
+            id="feature-missing",
+        ),
+    ],
+)
+def test_invalid_build_feature_metadata_difference(componentData, errorText):
+    """Verify invalid component build metadata is rejected.
+
+    :param componentData: Generated component build-information source.
+    :param errorText: Expected validation-error text.
+    """
+    payload = {WHEEL_BUILDER.BUILD_INFO_DATA_PATH}
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+
+    with _buildInfoArchive(_buildInfoData(False)) as baseArchive:
+        with _buildInfoArchive(componentData) as componentArchive:
+            with pytest.raises(ValueError, match=errorText):
+                WHEEL_BUILDER.validate_common_payloads(
+                    baseArchive,
+                    componentArchive,
+                    payload,
+                    payload,
+                    component,
+                )
+
+
+def test_missing_or_malformed_build_feature_metadata():
+    """Verify missing and non-literal build metadata is rejected."""
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    buildInfoPath = WHEEL_BUILDER.BUILD_INFO_DATA_PATH
+
+    with _buildInfoArchive(_buildInfoData(False)) as baseArchive:
+        with _buildInfoArchive(_buildInfoData(True)) as componentArchive:
+            with pytest.raises(ValueError, match="Both wheel build inputs must contain"):
+                WHEEL_BUILDER.validate_common_payloads(
+                    baseArchive,
+                    componentArchive,
+                    set(),
+                    {buildInfoPath},
+                    component,
+                )
+
+    malformedData = b"buildInfoData = dict(features={})\n"
+    with pytest.raises(ValueError):
+        WHEEL_BUILDER.parse_build_info_data(malformedData)
+
+
+def test_optional_wheel_declares_build_feature(tmp_path, monkeypatch):
+    """Verify an optional wheel declares a discoverable build feature."""
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    assert (
+        WHEEL_BUILDER.BUILD_FEATURE_ENTRY_POINT_GROUP
+        == buildInfoFormatter._buildFeatureEntryPointGroup
+    )
+    sourceWheel = tmp_path / "bsk-full.whl"
+    outputWheel = tmp_path / "bsk-opnav.whl"
+    payloadName = "Basilisk/fswAlgorithms/example.py"
+    coreVersion = buildInfoFormatter._buildInfoData["artifact"]["basiliskVersion"]
+    sourceDistInfo = f"bsk-{coreVersion}.dist-info"
+
+    with zipfile.ZipFile(sourceWheel, "w") as archive:
+        archive.writestr(payloadName, b"# optional payload\n")
+        archive.writestr(
+            f"{sourceDistInfo}/WHEEL",
+            "Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: false\n",
+        )
+
+    WHEEL_BUILDER.build_wheel_file(
+        sourceWheel,
+        outputWheel,
+        component,
+        {},
+        [payloadName],
+        coreVersion,
+    )
+
+    optionalDistInfo = f"bsk_opnav-{coreVersion}.dist-info"
+    entryPointPath = f"{optionalDistInfo}/entry_points.txt"
+    with zipfile.ZipFile(outputWheel) as archive:
+        entryPointData = archive.read(entryPointPath).decode("utf-8")
+        recordData = archive.read(f"{optionalDistInfo}/RECORD").decode("utf-8")
+        installPath = tmp_path / "installed"
+        archive.extractall(installPath)
+
+    assert entryPointData == "[basilisk.build_features]\nopNav = Basilisk\n"
+    assert entryPointPath in recordData
+
+    installedDistributions = list(distributions(path=[installPath]))
+    monkeypatch.setitem(buildInfoFormatter._buildInfoData["features"], "opNav", False)
+    monkeypatch.setattr(
+        buildInfoFormatter,
+        "_distributions",
+        lambda: installedDistributions,
+    )
+    buildInfoFormatter._installedBuildFeatureProviders.cache_clear()
+    try:
+        assert buildInfoFormatter.hasBuildFeature("opNav") is True
+    finally:
+        buildInfoFormatter._installedBuildFeatureProviders.cache_clear()

--- a/src/tests/test_protobufRuntime.py
+++ b/src/tests/test_protobufRuntime.py
@@ -1,0 +1,79 @@
+#
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+
+_PROTOBUF_CONSUMERS = (
+    ("Basilisk.fswAlgorithms.centerRadiusCNN", "CenterRadiusCNN"),
+    ("Basilisk.simulation.vizInterface", "VizInterface"),
+)
+_CONSUMERS_AVAILABLE = all(
+    importlib.util.find_spec(module_name) is not None
+    for module_name, _ in _PROTOBUF_CONSUMERS
+)
+pytestmark = pytest.mark.skipif(
+    not _CONSUMERS_AVAILABLE,
+    reason="Requires Basilisk built with --opNav True and --vizInterface True",
+)
+
+_WORKER = """
+import importlib
+import sys
+
+instances = []
+for moduleName, className in zip(sys.argv[1::2], sys.argv[2::2]):
+    module = importlib.import_module(moduleName)
+    instances.append(getattr(module, className)())
+"""
+
+
+@pytest.mark.parametrize(
+    "import_order",
+    [
+        pytest.param(_PROTOBUF_CONSUMERS, id="centerRadiusCNN-first"),
+        pytest.param(tuple(reversed(_PROTOBUF_CONSUMERS)), id="vizInterface-first"),
+    ],
+)
+def test_protobuf_consumers_exit_cleanly(import_order):
+    """Verify that both protobuf consumers can share and cleanly exit a process.
+
+    Each import order runs in a fresh interpreter because the regression occurs
+    during interpreter shutdown, after ordinary in-process assertions pass.
+
+    :param import_order: Module and class pairs in the order to load them.
+    """
+    arguments = [value for module_info in import_order for value in module_info]
+    timeout = 60  # [s]
+    result = subprocess.run(
+        [sys.executable, "-X", "faulthandler", "-c", _WORKER, *arguments],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"Protobuf consumer process exited abnormally with return code "
+        f"{result.returncode}:\n{output}"
+    )

--- a/src/tests/test_protobufRuntime.py
+++ b/src/tests/test_protobufRuntime.py
@@ -16,23 +16,23 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-import importlib.util
 import subprocess
 import sys
 
 import pytest
+
+from Basilisk import hasBuildFeature
 
 
 _PROTOBUF_CONSUMERS = (
     ("Basilisk.fswAlgorithms.centerRadiusCNN", "CenterRadiusCNN"),
     ("Basilisk.simulation.vizInterface", "VizInterface"),
 )
-_CONSUMERS_AVAILABLE = all(
-    importlib.util.find_spec(module_name) is not None
-    for module_name, _ in _PROTOBUF_CONSUMERS
+_PROTOBUF_CONSUMERS_ENABLED = (
+    hasBuildFeature("opNav") and hasBuildFeature("vizInterface")
 )
 pytestmark = pytest.mark.skipif(
-    not _CONSUMERS_AVAILABLE,
+    not _PROTOBUF_CONSUMERS_ENABLED,
     reason="Requires Basilisk built with --opNav True and --vizInterface True",
 )
 


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

This PR prevents interpreter-shutdown crashes on macOS when OpenCV-backed OpNav modules and `vizInterface` are loaded in the same process. Protobuf is built as a shared Conan dependency on macOS so both consumers use one runtime.

It also extends `Basilisk.hasBuildFeature()` to aggregate capabilities provided by the core artifact and separately installed optional wheels. Optional wheels advertise their features through package entry-point metadata and must match the core Basilisk version.

The commits are organized as follows:

1. Configure the shared protobuf runtime and add regression coverage for loading OpNav and `vizInterface` in either order.
2. Add optional-wheel feature metadata, capability aggregation, compatibility validation, tests, and documentation.

## Verification

- Completed a clean macOS build with all build options enabled and ran the full test suite successfully.
- The GitHub “Test Optional Wheels” workflow passed on Windows, macOS, Ubuntu x64, and Ubuntu ARM for the identical source tree.
- A repeat workflow run against the rewritten branch tip is in progress: https://github.com/AVSLab/basilisk/actions/runs/30227387528
- Added subprocess regression tests that instantiate both protobuf consumers in both import orders and verify clean interpreter shutdown.
- Added tests for optional-wheel metadata generation, feature discovery, missing providers, incompatible provider versions, malformed build metadata, and unexpected metadata drift.
- Verified installation, removal, and reinstallation of the `bsk-opnav` wheel updates the reported `opNav` capability as expected.
- The focused build-information, wheel-builder, and protobuf-runtime suite passes with 19 tests.
- Pre-commit, Python compilation, release-note compilation, and `git diff --check` pass.

No test baselines were changed.

## Documentation

Updated the following documentation:

- Build metadata documentation describing the distinction between core build provenance and aggregate installed capabilities.
- Coding guidelines for guarding tests in monolithic and split-wheel installations.
- Known issues documenting the macOS protobuf shutdown crash and optional-wheel capability reporting.
- Release-note snippets for the shared protobuf runtime and optional-wheel feature aggregation.

Reviewers should verify the documented behavior of `getBuildInfo()` versus `hasBuildFeature()`, particularly that the former preserves core build provenance while the latter reports aggregate installed capabilities.

## Future work

Future optional Basilisk wheels can use the same entry-point metadata mechanism to advertise their build capabilities. No additional wheel splits are included in this PR.