### PR TITLE
Reduce dynamics per-step cost in NDOF back-substitution and the integrator state container

### DIFF
--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -146,7 +146,7 @@ For a concise, human-readable summary, use ``printBuildInfo()``::
 This produces output similar to::
 
     Basilisk Build Information
-      Version:        2.12.0 (plugin ABI 1)
+      Version:        2.12.0 (plugin ABI 2)
       Target:         macOS arm64, 64-bit
       Build:          Release, Unix Makefiles
       Features:       vizInterface=on, opNav=off, mujoco=off

--- a/docs/source/Support/bskReleaseNotesSnippets/1489-ndof-backsub-fixed-cols.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1489-ndof-backsub-fixed-cols.rst
@@ -1,0 +1,1 @@
+- Sped up high-DOF dynamics by giving back-substitution coefficient matrices a compile-time column count in the spinning, translating, and hinged state effectors.

--- a/docs/source/Support/bskReleaseNotesSnippets/1500-integrator-state-container.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1500-integrator-state-container.rst
@@ -1,1 +1,1 @@
-- Sped up low-DOF simulations by removing repeated whole-map copies and rehashing of the integrator state container on every Runge-Kutta stage.
+- Sped up low-DOF simulations by removing repeated whole-map copies and rehashing of the integrator state container on every Runge-Kutta stage. Changing the return type of ``ExtendedStateVector::operator+=`` increments the SDK plugin ABI to version 2.

--- a/docs/source/Support/bskReleaseNotesSnippets/1500-integrator-state-container.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1500-integrator-state-container.rst
@@ -1,0 +1,1 @@
+- Sped up low-DOF simulations by removing repeated whole-map copies and rehashing of the integrator state container on every Runge-Kutta stage.

--- a/src/architecture/utilities/bskAbiDescriptor.h
+++ b/src/architecture/utilities/bskAbiDescriptor.h
@@ -31,7 +31,7 @@
 #include "architecture/messaging/msgHeader.h"
 
 #define BSK_ABI_DESCRIPTOR_VERSION 1
-#define BSK_PLUGIN_ABI_VERSION 1
+#define BSK_PLUGIN_ABI_VERSION 2
 
 #define BSK_ABI_STRINGIFY_IMPL(value) #value
 #define BSK_ABI_STRINGIFY(value) BSK_ABI_STRINGIFY_IMPL(value)

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -381,9 +381,10 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
         }
 
         sumTerm2 = pow(sumThetaDot,2)*(2*((int) this->PanelVec.size() - j)+1)*PanelIt->mass*PanelIt->d*PanelIt->sHat1_B;
-        backSubContr.matrixA += sumTerm1*this->matrixEDHRB.row(j-1)*this->matrixFDHRB;
-        backSubContr.matrixB += sumTerm1*this->matrixEDHRB.row(j-1)*this->matrixGDHRB;
-        backSubContr.vecTrans += -sumTerm2 - sumTerm1*this->matrixEDHRB.row(j-1)*this->vectorVDHRB;
+        const auto eRow = this->matrixEDHRB.row(j - 1);
+        backSubContr.matrixA += sumTerm1 * (eRow * this->matrixFDHRB);
+        backSubContr.matrixB += sumTerm1 * (eRow * this->matrixGDHRB);
+        backSubContr.vecTrans += -sumTerm2 - sumTerm1 * (eRow * this->vectorVDHRB);
         j += 1;
     }
     Eigen::Vector3d aTheta;
@@ -431,9 +432,10 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSu
         sumTerm2 = PanelIt->mass*this->omegaLoc_BN_B.cross(PanelIt->r_SB_B.cross(PanelIt->rPrime_SB_B))
         + pow(sumThetaDot,2)*PanelIt->mass*PanelIt->d*(PanelIt->r_SB_B.cross(PanelIt->sHat1_B) + sumTerm3)
         + PanelIt->IPntS_S(1,1)*sumThetaDot*this->omegaLoc_BN_B.cross(PanelIt->sHat2_B);
-        backSubContr.matrixC += sumTerm1*this->matrixEDHRB.row(j-1)*this->matrixFDHRB;
-        backSubContr.matrixD += sumTerm1*this->matrixEDHRB.row(j-1)*this->matrixGDHRB;
-        backSubContr.vecRot += -sumTerm2 - sumTerm1*this->matrixEDHRB.row(j-1)*this->vectorVDHRB;
+        const auto eRow = this->matrixEDHRB.row(j - 1);
+        backSubContr.matrixC += sumTerm1 * (eRow * this->matrixFDHRB);
+        backSubContr.matrixD += sumTerm1 * (eRow * this->matrixGDHRB);
+        backSubContr.vecRot += -sumTerm2 - sumTerm1 * (eRow * this->vectorVDHRB);
         j += 1;
     }
 

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -74,8 +74,8 @@ private:
     std::vector<HingedPanel> PanelVec; //!< -- vector containing all the info on the different panels
     Eigen::MatrixXd matrixADHRB;    //!< [-] term needed for back substitution
     Eigen::MatrixXd matrixEDHRB;    //!< [-] term needed for back substitution
-    Eigen::MatrixXd matrixFDHRB;    //!< [-] term needed for back substitution
-    Eigen::MatrixXd matrixGDHRB;    //!< [-] term needed for back substitution
+    Eigen::MatrixX3d matrixFDHRB;   //!< [-] term needed for back substitution
+    Eigen::MatrixX3d matrixGDHRB;   //!< [-] term needed for back substitution
     Eigen::MatrixXd matrixHDHRB;    //!< [-] term needed for back substitution
     Eigen::MatrixXd matrixKDHRB;    //!< [-] term needed for back substitution
     Eigen::MatrixXd matrixLDHRB;    //!< [-] term needed for back substitution

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -21,12 +21,14 @@
 
 ExtendedStateVector ExtendedStateVector::fromStates(const std::vector<DynamicObject*>& dynPtrs)
 {
-    return fromStateData(dynPtrs, [](const StateData& data) { return data.getState(); });
+    return fromStateData(dynPtrs,
+                         [](const StateData& data) -> const Eigen::MatrixXd& { return data.getStateReference(); });
 }
 
 ExtendedStateVector ExtendedStateVector::fromStateDerivs(const std::vector<DynamicObject*>& dynPtrs)
 {
-    return fromStateData(dynPtrs, [](const StateData& data) { return data.getStateDeriv(); });
+    return fromStateData(dynPtrs,
+                         [](const StateData& data) -> const Eigen::MatrixXd& { return data.getStateDerivReference(); });
 }
 
 ExtendedStateVector
@@ -156,10 +158,15 @@ void ExtendedStateVector::setDiffusions(
 }
 
 ExtendedStateVector
-ExtendedStateVector::fromStateData(const std::vector<DynamicObject*>& dynPtrs,
-                                   std::function<Eigen::MatrixXd(const StateData&)> functor)
+ExtendedStateVector::fromStateData(const std::vector<DynamicObject*>& dynPtrs, const StateAccessor& functor)
 {
     ExtendedStateVector result;
+
+    size_t stateCount = 0;
+    for (const auto* dynPtr : dynPtrs) {
+        stateCount += dynPtr->dynManager.stateContainer.stateMap.size();
+    }
+    result.reserve(stateCount);
 
     for (size_t dynIndex = 0; dynIndex < dynPtrs.size(); dynIndex++) {
         for (auto&& [stateName, stateData] :

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.cpp
@@ -84,7 +84,8 @@ void ExtendedStateVector::modify(
     }
 }
 
-ExtendedStateVector ExtendedStateVector::operator+=(const ExtendedStateVector& rhs)
+ExtendedStateVector&
+ExtendedStateVector::operator+=(const ExtendedStateVector& rhs)
 {
     this->modify([&rhs](const size_t& dynObjIndex,
                         const std::string& stateName,

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
@@ -177,8 +177,10 @@ class ExtendedStateVector
     ) const;
 
   private:
-    static ExtendedStateVector fromStateData(const std::vector<DynamicObject*>& dynPtrs,
-                                             std::function<Eigen::MatrixXd(const StateData&)>);
+    /** Returns a reference to one of the matrices owned by a StateData, without copying it */
+    using StateAccessor = std::function<const Eigen::MatrixXd&(const StateData&)>;
+
+    static ExtendedStateVector fromStateData(const std::vector<DynamicObject*>& dynPtrs, const StateAccessor& functor);
 };
 
 // ostream<< overload, useful for easily printing the ExtendedStateVector

--- a/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/extendedStateVector.h
@@ -146,7 +146,7 @@ class ExtendedStateVector
      *
      * This functions as a state-wise addition operation.
      */
-    ExtendedStateVector operator+=(const ExtendedStateVector& rhs);
+    ExtendedStateVector& operator+=(const ExtendedStateVector& rhs);
 
     /** Subtracts the values of `rhs` to from this
      *

--- a/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRungeKutta.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/svIntegratorRungeKutta.h
@@ -20,8 +20,8 @@
 #ifndef svIntegratorRungeKutta_h
 #define svIntegratorRungeKutta_h
 
-#include "../_GeneralModuleFiles/dynamicObject.h"
 #include "../_GeneralModuleFiles/dynParamManager.h"
+#include "../_GeneralModuleFiles/dynamicObject.h"
 #include "../_GeneralModuleFiles/stateVecIntegrator.h"
 #include "extendedStateVector.h"
 #include <array>
@@ -29,6 +29,7 @@
 #include <memory>
 #include <stdint.h>
 #include <unordered_map>
+#include <utility>
 
 #include <iostream>
 
@@ -214,7 +215,7 @@ ExtendedStateVector svIntegratorRungeKutta<numberStages>::propagateStateWithKVec
 
         auto scaledKVector = kVectors.at(stageIndex) * coefficients.at(stageIndex);
         if (derivative.empty()) {
-            derivative = scaledKVector;
+            derivative = std::move(scaledKVector);
         }
         else {
             derivative += scaledKVector;

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -301,8 +301,8 @@ void LinearTranslationNDOFStateEffector::updateContributions(double integTime, B
     this->omega_BN_B = omega_BN_B;
 
     Eigen::MatrixXd MRho = Eigen::MatrixXd::Zero(this->N, this->N);
-    Eigen::MatrixXd ARhoStar = Eigen::MatrixXd::Zero(this->N, 3);
-    Eigen::MatrixXd BRhoStar = Eigen::MatrixXd::Zero(this->N, 3);
+    Eigen::MatrixX3d ARhoStar = Eigen::MatrixX3d::Zero(this->N, 3);
+    Eigen::MatrixX3d BRhoStar = Eigen::MatrixX3d::Zero(this->N, 3);
     Eigen::VectorXd CRhoStar = Eigen::VectorXd::Zero(this->N);
 
     this->computeMRho(MRho);
@@ -335,7 +335,8 @@ void LinearTranslationNDOFStateEffector::computeMRho(Eigen::MatrixXd& MRho)
 }
 
 /*! This method compute ARhoStar for back-sub */
-void LinearTranslationNDOFStateEffector::computeARhoStar(Eigen::MatrixXd& ARhoStar)
+void
+LinearTranslationNDOFStateEffector::computeARhoStar(Eigen::MatrixX3d& ARhoStar)
 {
     for (int n = 0; n<this->N; n++) {
         if (this->translatingBodyVec[n]->isAxisLocked)
@@ -347,7 +348,8 @@ void LinearTranslationNDOFStateEffector::computeARhoStar(Eigen::MatrixXd& ARhoSt
 }
 
 /*! This method compute BRhoStar for back-sub */
-void LinearTranslationNDOFStateEffector::computeBRhoStar(Eigen::MatrixXd& BRhoStar)
+void
+LinearTranslationNDOFStateEffector::computeBRhoStar(Eigen::MatrixX3d& BRhoStar)
 {
     for (int n = 0; n<this->N; n++) {
         if (this->translatingBodyVec[n]->isAxisLocked)

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -166,8 +166,8 @@ private:
     std::vector<std::shared_ptr<TranslatingBody>> translatingBodyVec; //!< -- vector of TB effector structs
 
     // Terms needed for back substitution
-    Eigen::MatrixXd ARho;     //!< -- rDDot_BN term for back substitution
-    Eigen::MatrixXd BRho;     //!< -- omegaDot_BN term for back substitution
+    Eigen::MatrixX3d ARho;    //!< -- rDDot_BN term for back substitution
+    Eigen::MatrixX3d BRho;    //!< -- omegaDot_BN term for back substitution
     Eigen::VectorXd CRho;     //!< -- scalar term for back substitution
 
     // Hub properties
@@ -196,8 +196,8 @@ private:
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) final;
     void computeMRho(Eigen::MatrixXd& MRho);
-    void computeARhoStar(Eigen::MatrixXd& ARhoStar);
-    void computeBRhoStar(Eigen::MatrixXd& BRhoStar);
+    void computeARhoStar(Eigen::MatrixX3d& ARhoStar);
+    void computeBRhoStar(Eigen::MatrixX3d& BRhoStar);
     void computeCRhoStar(Eigen::VectorXd& CRhoStar, const Eigen::Vector3d& g_N);
     void computeBackSubContributions(BackSubMatrices& backSubContr) const;
     void computeDerivatives(double integTime,

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -346,8 +346,8 @@ void SpinningBodyNDOFStateEffector::updateContributions(double integTime,
     this->omega_BN_B = omega_BN_B;
 
     Eigen::MatrixXd MTheta = Eigen::MatrixXd::Zero(this->numberOfDegreesOfFreedom, this->numberOfDegreesOfFreedom);
-    Eigen::MatrixXd AThetaStar = Eigen::MatrixXd::Zero(this->numberOfDegreesOfFreedom, 3);
-    Eigen::MatrixXd BThetaStar = Eigen::MatrixXd::Zero(this->numberOfDegreesOfFreedom, 3);
+    Eigen::MatrixX3d AThetaStar = Eigen::MatrixX3d::Zero(this->numberOfDegreesOfFreedom, 3);
+    Eigen::MatrixX3d BThetaStar = Eigen::MatrixX3d::Zero(this->numberOfDegreesOfFreedom, 3);
     Eigen::VectorXd CThetaStar = Eigen::VectorXd::Zero(this->numberOfDegreesOfFreedom);
 
     this->computeDependentEffectors(backSubContr, integTime);
@@ -414,7 +414,8 @@ void SpinningBodyNDOFStateEffector::computeMTheta(Eigen::MatrixXd& MTheta)
     }
 }
 
-void SpinningBodyNDOFStateEffector::computeAThetaStar(Eigen::MatrixXd& AThetaStar)
+void
+SpinningBodyNDOFStateEffector::computeAThetaStar(Eigen::MatrixX3d& AThetaStar)
 {
     for (int n = 0; n<this->numberOfDegreesOfFreedom; n++) {
         if (this->spinningBodyVec[n]->isAxisLocked)
@@ -429,7 +430,8 @@ void SpinningBodyNDOFStateEffector::computeAThetaStar(Eigen::MatrixXd& AThetaSta
     }
 }
 
-void SpinningBodyNDOFStateEffector::computeBThetaStar(Eigen::MatrixXd& BThetaStar)
+void
+SpinningBodyNDOFStateEffector::computeBThetaStar(Eigen::MatrixX3d& BThetaStar)
 {
     for (int n = 0; n<this->numberOfDegreesOfFreedom; n++) {
         if (this->spinningBodyVec[n]->isAxisLocked)

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
@@ -182,8 +182,8 @@ private:
     int numberOfDegreesOfFreedom = 0;
     std::vector<std::shared_ptr<SpinningBody>> spinningBodyVec;
 
-    Eigen::MatrixXd ATheta;
-    Eigen::MatrixXd BTheta;
+    Eigen::MatrixX3d ATheta;
+    Eigen::MatrixX3d BTheta;
     Eigen::VectorXd CTheta;
 
     Eigen::Vector3d omega_BN_B = Eigen::Vector3d::Zero();
@@ -232,8 +232,8 @@ private:
     void computeVelocityProperties(std::shared_ptr<SpinningBody> spinningBody, int spinningBodyIndex) const;
     void computeInertiaProperties(std::shared_ptr<SpinningBody> spinningBody) const;
     void computeMTheta(Eigen::MatrixXd& MTheta);
-    void computeAThetaStar(Eigen::MatrixXd& AThetaStar);
-    void computeBThetaStar(Eigen::MatrixXd& BThetaStar);
+    void computeAThetaStar(Eigen::MatrixX3d& AThetaStar);
+    void computeBThetaStar(Eigen::MatrixX3d& BThetaStar);
     void computeCThetaStar(Eigen::VectorXd& CThetaStar, const Eigen::Vector3d& g_N);
     void computeBackSubMatrices(BackSubMatrices& backSubContr) const;
     void computeBackSubVectors(BackSubMatrices& backSubContr) const;

--- a/src/tests/test_buildInfo.py
+++ b/src/tests/test_buildInfo.py
@@ -86,7 +86,7 @@ def _makeBuildInfo(
             "basiliskVersion": "2.12.0",
             "sourceRevision": "0123456789abcdef",
             "sourceDirty": False,
-            "pluginAbiVersion": 1,
+            "pluginAbiVersion": 2,
         },
         "features": features,
         "diagnostics": {


### PR DESCRIPTION
* **Tickets addressed:** #1489, #1500
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

The dynamics step carries two independent sources of per-step heap traffic that profiling attributes to different regimes. At high degree-of-freedom counts the cost sits in the O(N^2) back-substitution loops, where dynamically-shaped Eigen storage forces a heap temporary for every product. At low degree-of-freedom counts back-substitution is cheap and the integrator's state container dominates instead, because `ExtendedStateVector` is materialized roughly twenty times per Runge-Kutta step and each materialization was copied more than it needed to be. This branch addresses both regimes. No model, interface, or integration scheme changes.

#1489, back-substitution storage. The coefficient matrices in `spinningBodyNDOFStateEffector` and `linearTranslationNDOFStateEffector` are always N by 3, yet were declared `Eigen::MatrixXd`. Declaring them `Eigen::MatrixX3d` lets the compiler prove the product shape and build the result on the stack. `nHingedRigidBodyStateEffector` needs more than the type change: left association forms a 3 by N intermediate that still allocates, so the per-stage products are explicitly grouped as `sumTerm1 * (matrixEDHRB.row(j) * F)`. Grouping also lowers the per-iteration multiply count from roughly 12N to 3N+9.

#1500, integrator state container. `ExtendedStateVector::operator+=` returned by value, so `return *this` copy-constructed the whole map only for the caller to discard it, and the accumulator in `propagateStateWithKVectors` copy-assigned a named local that was never read again. Between them these performed seven whole-map deep copies per Runge-Kutta step. `fromStateData` separately rebuilt the map by repeated emplace into a default-constructed `unordered_map`, rehashing several times per materialization, and read its sources through the copy-returning `getState()` and `getStateDeriv()`. It now reserves from the registered state count and reads through the existing const-reference accessors.

Speedup against develop, minimum microseconds per step, measured with the benchmark suite in this repository:

| case | #1489 only | #1500 only | both |
|---|---:|---:|---:|
| spinning body NDOF, 16 DOF | 50.6% | 2.9% | 58.4% |
| linear translation NDOF, 16 DOF | 119.5% | 5.6% | 146.7% |
| N hinged rigid body, 4 panels | 46.4% | 15.1% | 78.8% |
| spacecraft, hub only | 0.5% | 45.0% | 44.0% |
| spacecraft in orbit | 0.2% | 43.0% | 42.7% |
| reaction wheels, 4 wheels | -1.1% | 32.7% | 32.0% |

Four build points were measured: develop, each change alone, and both together. The two low-DOF cells for #1489 and the reaction wheel cell are null results rather than regressions, since #1489 does not touch those paths and the noise floor on these cases is roughly one percent.

The percentages do not compose, whereas the absolute time savings do. Subtracting each change's measured saving from the develop baseline and adding the two predicts the combined point to within 2% on every case, which is the expected signature of two changes removing disjoint costs. The N hinged case is the clearest single demonstration, since both mechanisms are visible in one row.

Commits are organized by concern and grouped by ticket, so reviewing by commit follows the argument. The two #1489 code commits come first, separated because the NDOF pair is a pure storage change whereas the N hinged effector additionally required regrouping. Each ticket's release note snippet closes out its group.

## Verification

The NDOF pair is bit-for-bit identical to develop. A 3000-step differential propagation matches to every bit across all fields.

The N hinged grouping reassociates the floating-point summation, so it is analytically equivalent rather than bit-identical. Its measured divergence after 3000 steps is 1.4e-15 in hub attitude, with position and velocity bit-identical.

The full test suite passes with optional capabilities enabled, 5733 tests with `--opNav True --mujoco True`.

No tests were added, updated, or re-baselined. These changes alter storage shape and copy behavior rather than results, so the existing unit tests are the correct check: they already cover these effectors and continue to pass unchanged. Re-baselining anything here would have signalled a defect rather than progress. Performance itself is covered by the benchmark suite added in #1458, which is not part of the automated test run.

The benchmark numbers come from `benchmarks/dynamics/benchmark_state_effectors.py`, unmodified. Each point is the pooled minimum of 15 per-trial samples, taken after the machine load settled, with a build-invariant CPU probe recorded on either side of every run to confirm the four build points were sampled at comparable machine speed. To replicate:

```
python benchmarks/dynamics/benchmark_state_effectors.py --case spinning-body-ndof --components 1 --segments 16 --steps 6000 --trials 5 --warmup-steps 500
python benchmarks/dynamics/benchmark_state_effectors.py --case linear-translation-ndof --components 1 --segments 16 --steps 6000 --trials 5 --warmup-steps 500
python benchmarks/dynamics/benchmark_state_effectors.py --case n-hinged-rigid-body --components 4 --steps 6000 --trials 5 --warmup-steps 500
python benchmarks/dynamics/benchmark_state_effectors.py --case spacecraft --components 1 --steps 6000 --trials 5 --warmup-steps 500
python benchmarks/dynamics/benchmark_state_effectors.py --case spacecraft-orbit --components 1 --steps 6000 --trials 5 --warmup-steps 500
python benchmarks/dynamics/benchmark_state_effectors.py --case reaction-wheel --components 4 --steps 6000 --trials 5 --warmup-steps 500
```

## Documentation

`ExtendedStateVector::operator+=` now returns a reference rather than a value, which changes the native C++ contract exposed through `bsk-sdk`. The plugin ABI epoch is incremented from 1 to 2, with `docs/source/Build/installBuild.rst` and the build-info test fixture updated to match. No module documentation or effector contract changes.

Two release note snippets are added, one per ticket: `docs/source/Support/bskReleaseNotesSnippets/1489-ndof-backsub-fixed-cols.rst` and `1500-integrator-state-container.rst`. Both state the mechanism only, with the ABI note appended to the second; the benchmark numbers live in this description rather than in the release notes. No known-issues entry is included, since this is a performance change rather than a bug fix.

Reviewers should check the grouped expression in `nHingedRigidBodyStateEffector::updateContributions`, which is the only place where reading the change requires knowing that the grouping is deliberate rather than cosmetic.

## Future work

Two smaller instances of the same storage defect were measured at roughly 5% each and dropped as too marginal to carry: `dualHingedRigidBodyStateEffector` and `GravityGradientEffector`. Both remain valid, bit-identical cleanups.

`computeMTheta` and `computeCThetaStar` in `spinningBodyNDOFStateEffector` appear algebraically reducible from O(N^3) to O(N^2), which would compound with this work at high degree-of-freedom counts.

The state container itself is unchanged and still dominates at low degree-of-freedom counts. #1500 records what was tried, what was measured at noise, and the reason `stateMap` cannot simply be swapped to an `unordered_map`. The open option is a flat contiguous buffer with `Eigen::Map` views, which warrants its own design review rather than an incremental patch.

The adaptive Runge-Kutta integrators inherit the modified routine and should gain more than the fixed-step results above, since their denser tableaux take the accumulate branch more often. That has not been measured.

Closes #1489. Closes #1500.
