### PR TITLE
Reduce Eigen allocations with fixed-size matrix and vector types

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/eigen-fixed-size-operations.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/eigen-fixed-size-operations.rst
@@ -1,0 +1,1 @@
+- Reduced heap allocation in fixed-dimension Eigen operations used by Lambert propagation, navigation models and filters, VSCMG steering, magnetic torque bars, hinged-joint controllers, coordinate conversions, and common numerical support utilities.

--- a/src/architecture/utilities/BSpline.cpp
+++ b/src/architecture/utilities/BSpline.cpp
@@ -29,7 +29,7 @@ InputDataSet::InputDataSet()
 }
 
 /*! The constructor requires 3 N-dimensional vectors containing the coordinates of the waypoints */
-InputDataSet::InputDataSet(Eigen::VectorXd X1, Eigen::VectorXd X2, Eigen::VectorXd X3)
+InputDataSet::InputDataSet(const Eigen::VectorXd& X1, const Eigen::VectorXd& X2, const Eigen::VectorXd& X3)
 {
     this->X1 = X1;
     this->X2 = X2;
@@ -72,13 +72,13 @@ void InputDataSet::setXDDot_0(Eigen::Vector3d XDDot_0) {this->XDDot_0 = XDDot_0;
 void InputDataSet::setXDDot_N(Eigen::Vector3d XDDot_N) {this->XDDot_N = XDDot_N; this->XDDot_N_flag = true; return;}
 
 /*! Set the time tags for each waypoint (optional). Cannot be imposed together with avg velocity norm below */
-void InputDataSet::setT(Eigen::VectorXd T) {this->T = T; this->T_flag = true; this->AvgXDot_flag = false; return;}
+void InputDataSet::setT(const Eigen::VectorXd& T) {this->T = T; this->T_flag = true; this->AvgXDot_flag = false; return;}
 
 /*! Set the average velocity norm (optional). Cannot be imposed together with time tag vector above */
 void InputDataSet::setAvgXDot(double AvgXDot) {this->AvgXDot = AvgXDot; this->AvgXDot_flag = true; this->T_flag = false; return;}
 
 /*! Set the weights for each waypoint. Weights are used in the LS approximation */
-void InputDataSet::setW(Eigen::VectorXd W) {this->W = W; this->W_flag = true; return;}
+void InputDataSet::setW(const Eigen::VectorXd& W) {this->W = W; this->W_flag = true; return;}
 
 /*! This constructor initializes an Output structure for BSpline interpolation */
 OutputDataSet::OutputDataSet()
@@ -231,7 +231,7 @@ double OutputDataSet::getStates(double T, int derivative, int index)
 }
 
 /*! This function takes the Input structure, performs the BSpline interpolation and outputs the result into Output structure */
-void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output)
+void interpolate(const InputDataSet& Input, int Num, int P, OutputDataSet *Output)
 {
     Output->P = P;
 
@@ -410,7 +410,7 @@ void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output)
 }
 
 /*! This function takes the Input structure, performs the BSpline LS approximation and outputs the result into Output structure */
-void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Output)
+void approximate(const InputDataSet& Input, int Num, int Q, int P, OutputDataSet *Output)
 {
     Output->P = P;
 
@@ -677,7 +677,7 @@ void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Outpu
 }
 
 /*! This function calculates the basis functions NN of order P, and derivatives NN1, NN2, for a given time t and knot vector U */
-void basisFunction(double t, Eigen::VectorXd U, int I, int P, double *NN, double *NN1, double *NN2)
+void basisFunction(double t, const Eigen::VectorXd& U, int I, int P, double *NN, double *NN1, double *NN2)
 {
     Eigen::MatrixXd N(I, P+1);
     Eigen::MatrixXd N1(I, P+1);

--- a/src/architecture/utilities/BSpline.h
+++ b/src/architecture/utilities/BSpline.h
@@ -23,23 +23,23 @@
 #include "architecture/utilities/macroDefinitions.h"
 
 
-//! @brief The InputDataSet class contains the information about the points that must be interpolated.
-//! It is used as a data structure to intialize the inputs that are passed to the interpolating function.
+//! The InputDataSet class contains the information about the points that must be interpolated.
+//! It is used as a data structure to initialize the inputs that are passed to the interpolating function.
 
 class InputDataSet {
 public:
     InputDataSet();
-    InputDataSet(Eigen::VectorXd X1, Eigen::VectorXd X2, Eigen::VectorXd X3);
+    InputDataSet(const Eigen::VectorXd& X1, const Eigen::VectorXd& X2, const Eigen::VectorXd& X3);
     ~InputDataSet();
 
     void setXDot_0(Eigen::Vector3d XDot_0);
     void setXDot_N(Eigen::Vector3d XDot_N);
     void setXDDot_0(Eigen::Vector3d XDDot_0);
     void setXDDot_N(Eigen::Vector3d XDDot_N);
-    void setT(Eigen::VectorXd T);
-    void setW(Eigen::VectorXd W);
+    void setT(const Eigen::VectorXd& T);
+    void setW(const Eigen::VectorXd& W);
     void setAvgXDot(double AvgXDot);
-    
+
     double AvgXDot;                  //!< desired average velocity norm
     Eigen::VectorXd T;               //!< time tags: specifies at what time each waypoint is hit
     Eigen::VectorXd W;               //!< weight vector for the LS approximation
@@ -59,7 +59,7 @@ public:
     bool XDDot_N_flag;               //!< indicates that second derivative at final point has been specified
 };
 
-//! @brief The OutputDataSet class is used as a data structure to contain the interpolated function and its first- and 
+//! @brief The OutputDataSet class is used as a data structure to contain the interpolated function and its first- and
 //! second-order derivatives, together with the time-tag vector T.
 class OutputDataSet {
 public:
@@ -67,7 +67,7 @@ public:
     ~OutputDataSet();
     void getData(double t, double x[3], double xDot[3], double xDDot[3]);
     double getStates(double t, int derivative,  int index);
-    
+
     Eigen::VectorXd T;               //!< time tags for each point of the interpolated trajectory
     Eigen::VectorXd X1;              //!< coordinate #1 of the interpolated trajectory
     Eigen::VectorXd X2;              //!< coordinate #2 of the interpolated trajectory
@@ -86,8 +86,8 @@ public:
     Eigen::VectorXd C3;              //!< coordinate #3 of the control points
 };
 
-void interpolate(InputDataSet Input, int Num, int P, OutputDataSet *Output);
+void interpolate(const InputDataSet& Input, int Num, int P, OutputDataSet *Output);
 
-void approximate(InputDataSet Input, int Num, int Q, int P, OutputDataSet *Output);
+void approximate(const InputDataSet& Input, int Num, int Q, int P, OutputDataSet *Output);
 
-void basisFunction(double t, Eigen::VectorXd U, int I, int P, double *NN, double *NN1, double *NN2);
+void basisFunction(double t, const Eigen::VectorXd& U, int I, int P, double *NN, double *NN1, double *NN2);

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -30,141 +30,119 @@
 
  */
 
-/*! This function provides a general conversion between an Eigen matrix and
-an output C array. Note that this routine would convert an inbound type
-to a MatrixXd and then transpose the matrix which would be inefficient
-in a lot of cases.
-@return void
-@param inMat The source Eigen matrix that we are converting
-@param outArray The destination array (sized by the user!) we copy into
+/*! Copy a dynamic Eigen matrix into a row-major C array without an intermediate
+    transpose.
+
+    @param inMat Source Eigen matrix.
+    @param outArray Destination array sized by the caller.
 */
-void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray)
+void eigenMatrixXd2CArray(const Eigen::MatrixXd& inMat, double *outArray)
 {
-	Eigen::MatrixXd tempMat = inMat.transpose();
-	memcpy(outArray, tempMat.data(), inMat.rows()*inMat.cols()*sizeof(double));
+    using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    Eigen::Map<RowMajorMatrixXd> outMat(outArray, inMat.rows(), inMat.cols());
+    outMat = inMat;
 }
 
-/*! This function provides a general conversion between an Eigen matrix and
-an output C array. Note that this routine would convert an inbound type
-to a MatrixXd and then transpose the matrix which would be inefficient
-in a lot of cases.
+/*! Copy a dynamic integer Eigen matrix into a row-major C array without an
+    intermediate transpose.
 
-@param inMat The source Eigen matrix that we are converting
-@param outArray The destination array (sized by the user!) we copy into
+    @param inMat Source Eigen matrix.
+    @param outArray Destination array sized by the caller.
 */
-void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray)
+void eigenMatrixXi2CArray(const Eigen::MatrixXi& inMat, int *outArray)
 {
-    Eigen::MatrixXi tempMat = inMat.transpose();
-    memcpy(outArray, tempMat.data(), inMat.rows()*inMat.cols()*sizeof(int));
+    using RowMajorMatrixXi = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    Eigen::Map<RowMajorMatrixXi> outMat(outArray, inMat.rows(), inMat.cols());
+    outMat = inMat;
 }
 
 
-/*! This function provides a direct conversion between a 3-vector and an
-output C array. We are providing this function to save on the  inline conversion
-and the transpose that would have been performed by the general case.
-@return void
-@param inMat The source Eigen matrix that we are converting
-@param outArray The destination array we copy into
+/*! Copy an Eigen 3-vector into a C array.
+
+    @param inMat Source Eigen vector.
+    @param outArray Destination three-element array.
 */
-void eigenVector3d2CArray(Eigen::Vector3d & inMat, double *outArray)
+void eigenVector3d2CArray(const Eigen::Vector3d& inMat, double *outArray)
 {
-	memcpy(outArray, inMat.data(), 3 * sizeof(double));
+    Eigen::Map<Eigen::Vector3d> outVector(outArray);
+    outVector = inMat;
 }
 
-/*! This function provides a direct conversion between an MRP and an
-output C array. We are providing this function to save on the inline conversion
-and the transpose that would have been performed by the general case.
-@return void
-@param inMat The source Eigen MRP that we are converting
-@param outArray The destination array we copy into
+/*! Copy an Eigen MRP vector into a C array.
+
+    @param inMat Source Eigen MRP vector.
+    @param outArray Destination three-element array.
 */
-void eigenMRPd2CArray(Eigen::Vector3d& inMat, double* outArray)
+void eigenMRPd2CArray(const Eigen::Vector3d& inMat, double* outArray)
 {
-    memcpy(outArray, inMat.data(), 3 * sizeof(double));
+    Eigen::Map<Eigen::Vector3d> outVector(outArray);
+    outVector = inMat;
 }
 
-/*! This function provides a direct conversion between a 3x3 matrix and an
-output C array. We are providing this function to save on the inline conversion
-that would have been performed by the general case.
-@return void
-@param inMat The source Eigen matrix that we are converting
-@param outArray The destination array we copy into
+/*! Copy an Eigen 3x3 matrix into a row-major C array.
+
+    @param inMat Source Eigen matrix.
+    @param outArray Destination nine-element array.
 */
-void eigenMatrix3d2CArray(Eigen::Matrix3d & inMat, double *outArray)
+void eigenMatrix3d2CArray(const Eigen::Matrix3d& inMat, double *outArray)
 {
-	Eigen::MatrixXd tempMat = inMat.transpose();
-	memcpy(outArray, tempMat.data(), 9 * sizeof(double));
+    using RowMajorMatrix3d = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+    Eigen::Map<RowMajorMatrix3d> outMat(outArray);
+    outMat = inMat;
 }
 
-/*! This function performs the general conversion between an input C array
-and an Eigen matrix. Note that to use this function the user MUST size
-the Eigen matrix ahead of time so that the internal map call has enough
-information to ingest the C array.
-@return Eigen::MatrixXd
-@param inArray The input array (row-major)
-@param nRows
-@param nCols
+/*! Convert a column-major C array into a dynamic Eigen matrix.
+
+    @param inArray Source array.
+    @param nRows Number of matrix rows.
+    @param nCols Number of matrix columns.
+    @return Dynamic Eigen matrix containing the source values.
 */
 Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols)
 {
-    Eigen::MatrixXd outMat;
-    outMat.resize(nRows, nCols);
-	outMat = Eigen::Map<Eigen::MatrixXd>(inArray, outMat.rows(), outMat.cols());
-    return outMat;
+    return Eigen::Map<Eigen::MatrixXd>(inArray, nRows, nCols);
 }
 
-/*! This function performs the conversion between an input C array
-3-vector and an output Eigen vector3d. This function is provided
-in order to save an unnecessary conversion between types.
-@return Eigen::Vector3d
-@param inArray The input array (row-major)
+/*! Convert a C array into an Eigen 3-vector.
+
+    @param inArray Source three-element array.
+    @return Eigen vector containing the source values.
 */
 Eigen::Vector3d cArray2EigenVector3d(double *inArray)
 {
     return Eigen::Map<Eigen::Vector3d>(inArray, 3, 1);
 }
 
-/*! This function performs the conversion between an input C array
-3-vector and an output Eigen MRPd. This function is provided
-in order to save an unnecessary conversion between types.
-@return Eigen::MRPd
-@param inArray The input array (row-major)
+/*! Convert a C array into an Eigen MRP.
+
+    @param inArray Source three-element array.
+    @return Eigen MRP containing the source values.
 */
 Eigen::MRPd cArray2EigenMRPd(double* inArray)
 {
-    Eigen::MRPd sigma_Eigen;
-    sigma_Eigen = cArray2EigenVector3d(inArray);
-
-    return sigma_Eigen;
+    return Eigen::MRPd(cArray2EigenVector3d(inArray));
 }
 
-/*! This function performs the conversion between an input C array
-3x3-matrix and an output Eigen vector3d. This function is provided
-in order to save an unnecessary conversion between types.
-@return Eigen::Matrix3d
-@param inArray The input array (row-major)
+/*! Convert a row-major C array into an Eigen 3x3 matrix.
+
+    @param inArray Source nine-element array.
+    @return Eigen matrix containing the source values.
 */
 Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray)
 {
-	return Eigen::Map<Eigen::Matrix3d>(inArray, 3, 3).transpose();
+    using RowMajorMatrix3d = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+    return Eigen::Map<RowMajorMatrix3d>(inArray);
 }
 
-/*! This function performs the conversion between an input C 3x3
-2D-array and an output Eigen vector3d. This function is provided
-in order to save an unnecessary conversion between types
-@return Eigen::Matrix3d
-@param in2DArray The input 2D-array
+/*! Convert a C 3x3 array into an Eigen 3x3 matrix.
+
+    @param in2DArray Source 3x3 array.
+    @return Eigen matrix containing the source values.
 */
 Eigen::Matrix3d c2DArray2EigenMatrix3d(double in2DArray[3][3])
 {
-    Eigen::Matrix3d outMat;
-    for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 3; j++) {
-            outMat(i, j) = in2DArray[i][j];
-        }
-    }
-
-    return outMat;
+    using RowMajorMatrix3d = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+    return Eigen::Map<RowMajorMatrix3d>(&in2DArray[0][0]);
 }
 
 /*! This function returns the Eigen DCM that corresponds to a 1-axis rotation
@@ -412,9 +390,9 @@ bool eigenIsValidInertiaMatrix(const Eigen::Matrix3d& inertia, double tolerance)
     The tolerance bounds both the deviation from symmetry and small negative
     eigenvalues caused by roundoff.
 
-    :param matrix: matrix to test
-    :param tolerance: allowed deviation from symmetry and positive semidefiniteness
-    :return: ``true`` when the matrix is symmetric positive semidefinite
+    @param matrix matrix to test
+    @param tolerance allowed deviation from symmetry and positive semidefiniteness
+    @return ``true`` when the matrix is symmetric positive semidefinite
  */
 bool eigenIsPositiveSemidefiniteMatrix(const Eigen::Matrix3d& matrix, double tolerance)
 {

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -24,25 +24,54 @@
 #include "avsEigenMRP.h"
 
 
-//!@brief General conversion between any Eigen matrix and output array
-void eigenMatrixXd2CArray(Eigen::MatrixXd inMat, double *outArray);
-//!@brief General conversion between any Eigen matrix and output array
-void eigenMatrixXi2CArray(Eigen::MatrixXi inMat, int *outArray);
-//!@brief Rapid conversion between 3-vector and output array
-void eigenVector3d2CArray(Eigen::Vector3d & inMat, double *outArray);
-//!@brief Rapid conversion between MRP and output array
-void eigenMRPd2CArray(Eigen::Vector3d& inMat, double* outArray);
-//!@brief Rapid conversion between 3x3 matrix and output array
-void eigenMatrix3d2CArray(Eigen::Matrix3d & inMat, double *outArray);
-//!@brief General conversion between a C array and an Eigen matrix
+//! General conversion between any Eigen matrix and output array.
+void eigenMatrixXd2CArray(const Eigen::MatrixXd& inMat, double *outArray);
+//! General conversion between any integer Eigen matrix and output array.
+void eigenMatrixXi2CArray(const Eigen::MatrixXi& inMat, int *outArray);
+#ifndef SWIG
+/*! Copy any double-precision Eigen expression into a row-major C array
+    without first converting it to a dynamic matrix.
+
+    @param inMat Source Eigen expression.
+    @param outArray Destination array sized by the caller.
+*/
+template<typename Derived>
+void eigenMatrixXd2CArray(const Eigen::MatrixBase<Derived>& inMat, double *outArray)
+{
+    using RowMajorMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    Eigen::Map<RowMajorMatrixXd> outMat(outArray, inMat.rows(), inMat.cols());
+    outMat = inMat;
+}
+
+/*! Copy any integer Eigen expression into a row-major C array without first
+    converting it to a dynamic matrix.
+
+    @param inMat Source Eigen expression.
+    @param outArray Destination array sized by the caller.
+*/
+template<typename Derived>
+void eigenMatrixXi2CArray(const Eigen::MatrixBase<Derived>& inMat, int *outArray)
+{
+    using RowMajorMatrixXi = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    Eigen::Map<RowMajorMatrixXi> outMat(outArray, inMat.rows(), inMat.cols());
+    outMat = inMat;
+}
+#endif
+//! Rapid conversion between 3-vector and output array.
+void eigenVector3d2CArray(const Eigen::Vector3d& inMat, double *outArray);
+//! Rapid conversion between MRP and output array.
+void eigenMRPd2CArray(const Eigen::Vector3d& inMat, double* outArray);
+//! Rapid conversion between 3x3 matrix and output array.
+void eigenMatrix3d2CArray(const Eigen::Matrix3d& inMat, double *outArray);
+//! General conversion between a C array and an Eigen matrix.
 Eigen::MatrixXd cArray2EigenMatrixXd(double *inArray, int nRows, int nCols);
-//!@brief Specific conversion between a C array and an Eigen 3-vector
+//! Specific conversion between a C array and an Eigen 3-vector.
 Eigen::Vector3d cArray2EigenVector3d(double *inArray);
-//!@brief Specific conversion between a C array and an Eigen MRPs
+//! Specific conversion between a C array and an Eigen MRP.
 Eigen::MRPd cArray2EigenMRPd(double* inArray);
-//!@brief Specfici conversion between a C array and an Eigen 3x3 matrix
+//! Specific conversion between a C array and an Eigen 3x3 matrix.
 Eigen::Matrix3d cArray2EigenMatrix3d(double *inArray);
-//!@brief Specfici conversion between a C 2D array and an Eigen 3x3 matrix
+//! Specific conversion between a C 2D array and an Eigen 3x3 matrix.
 Eigen::Matrix3d c2DArray2EigenMatrix3d(double in2DArray[3][3]);
 //!@brief returns the first axis DCM with the input angle
 Eigen::Matrix3d eigenM1(double angle);

--- a/src/architecture/utilities/discretize.cpp
+++ b/src/architecture/utilities/discretize.cpp
@@ -58,17 +58,23 @@ void Discretize::setRoundDirection(roundDirection_t direction){
 }
 
 
-/*!@brief Discretizes the given truth vector according to a least significant bit (binSize)
- @param undiscretizedVector
- @return vector of discretized values*/
-Eigen::VectorXd Discretize::discretize(Eigen::VectorXd undiscretizedVector){
+/*! Discretize a truth vector according to the least-significant-bit resolution.
+
+    @param undiscretizedVector Truth values to discretize.
+    @return Vector of discretized values.
+*/
+Eigen::VectorXd Discretize::discretize(const Eigen::Ref<const Eigen::VectorXd>& undiscretizedVector){
+
+    Eigen::VectorXd workingVector = undiscretizedVector;
 
     if (this->carryError){
-        undiscretizedVector += this->discErrors;
+        workingVector += this->discErrors;
     }
 
+    this->discErrors = workingVector;
+
     //discretize the data
-    Eigen::VectorXd workingVector = undiscretizedVector.cwiseQuotient(this->LSB);
+    workingVector = workingVector.cwiseQuotient(this->LSB);
     workingVector = workingVector.cwiseAbs();
 
     if (this->roundDirection == TO_ZERO){
@@ -87,9 +93,9 @@ Eigen::VectorXd Discretize::discretize(Eigen::VectorXd undiscretizedVector){
 
     workingVector = workingVector.cwiseProduct(this->LSB);
     for (uint8_t i = 0; i < this->numStates; i++){
-        workingVector[i] = copysign(workingVector[i], undiscretizedVector[i]);
+        workingVector[i] = copysign(workingVector[i], this->discErrors[i]);
     }
-    this->discErrors = undiscretizedVector - workingVector;
+    this->discErrors -= workingVector;
 
     return workingVector;
 }

--- a/src/architecture/utilities/discretize.h
+++ b/src/architecture/utilities/discretize.h
@@ -44,10 +44,11 @@ public:
 //    /*!@brief Method determines the size of an output data bin (bit-value) making sure that zero is
 //     a possible output and giving proportionate numbers of bits to the size of max and min void*/
 
-    /*!@brief Avoid calculating bit value (bin size) and just set it because a resolution is known
-       @param givenLSB
-     */
-    void setLSB(Eigen::VectorXd givenLSB) {this->LSB = givenLSB;}
+    /*! Set a known least-significant-bit resolution directly.
+
+        @param givenLSB Resolution for each state.
+    */
+    void setLSB(const Eigen::Ref<const Eigen::VectorXd>& givenLSB) {this->LSB = givenLSB;}
 
     void setRoundDirection(roundDirection_t direction);
 
@@ -56,14 +57,14 @@ public:
      */
     void setCarryError(bool carryErrorIn){this->carryError = carryErrorIn;}
 
-    /*!@brief Discretizes the given truth vector according to a least significant bit (binSize)
-       @param undiscretizedVector
-       @return vector of discretized values*/
-    Eigen::VectorXd discretize(Eigen::VectorXd undiscretizedVector);
+    //! Discretize a truth vector according to the least-significant-bit resolution.
+    Eigen::VectorXd discretize(const Eigen::Ref<const Eigen::VectorXd>& undiscretizedVector);
 
-    /*!@brief Get the discretization errors
-     @return the errors due to discretization in a corresponding vector*/
-    Eigen::VectorXd getDiscretizationErrors(){return(this->discErrors);}
+    /*! Get the current discretization errors.
+
+        @return Reference to the error vector.
+    */
+    const Eigen::VectorXd& getDiscretizationErrors() const {return this->discErrors;}
 
     Eigen::VectorXd LSB;                //!< -- size of bin, bit value, least significant bit
 

--- a/src/architecture/utilities/gauss_markov.cpp
+++ b/src/architecture/utilities/gauss_markov.cpp
@@ -42,6 +42,9 @@ GaussMarkov::GaussMarkov(uint64_t size, uint64_t newSeed)
     this->noiseMatrix.fill(0.0);
     this->stateBounds.resize((int64_t) size);
     this->stateBounds.fill(DEFAULT_BOUND);
+    this->randomValues.resize((int64_t) size);
+    this->stateNoise.resize((int64_t) size);
+    this->propagatedState.resize((int64_t) size);
 }
 
 void GaussMarkov::initializeRNG() {
@@ -63,9 +66,6 @@ GaussMarkov::~GaussMarkov()
 */
 void GaussMarkov::computeNextState()
 {
-    Eigen::VectorXd errorVector;
-    Eigen::VectorXd ranNums;
-
     //! - Check for consistent sizes
     if((this->propMatrix.size() != this->noiseMatrix.size()) ||
        ((uint64_t) this->propMatrix.size() != this->numStates*this->numStates))
@@ -78,19 +78,18 @@ void GaussMarkov::computeNextState()
     }
 
     //! - Generate base random numbers
-    ranNums.resize((int64_t) this->numStates);
     for(size_t i = 0; i < this->numStates; i++) {
-        ranNums[i] = this->rNum(rGen);
+        this->randomValues[i] = this->rNum(rGen);
     }
 
     //! - Apply noise first
-    errorVector = this->noiseMatrix * ranNums;
+    this->stateNoise.noalias() = this->noiseMatrix * this->randomValues;
 
     //! - Then propagate previous state
-    this->currentState = this->propMatrix * this->currentState;
+    this->propagatedState.noalias() = this->propMatrix * this->currentState;
 
     //! - Add noise to propagated state
-    this->currentState += errorVector;
+    this->currentState = this->propagatedState + this->stateNoise;
 
     //! - Apply bounds if needed
     for(size_t i = 0; i < this->numStates; i++) {

--- a/src/architecture/utilities/gauss_markov.h
+++ b/src/architecture/utilities/gauss_markov.h
@@ -47,14 +47,17 @@ public:
      */
     void setRNGSeed(uint64_t newSeed) {rGen.seed((unsigned int)newSeed); RNGSeed = newSeed;}
 
-    /*!@brief Method returns the current random walk state from model
-       @return The private currentState which is the vector of random walk values*/
-    Eigen::VectorXd getCurrentState() {return(currentState);}
+    /*! Method returns the current random walk state from the model.
 
-    /*!@brief Set the upper bounds on the random walk to newBounds
-       @param newBounds the bounds to put on the random walk states
-     */
-    void setUpperBounds(Eigen::VectorXd newBounds) {
+        @return Reference to the vector of random walk values.
+    */
+    const Eigen::VectorXd& getCurrentState() const {return currentState;}
+
+    /*! Set the upper bounds on the random walk.
+
+        @param newBounds Bounds to put on the random walk states.
+    */
+    void setUpperBounds(const Eigen::Ref<const Eigen::VectorXd>& newBounds) {
         // For normal distribution, ~99.7% of values fall within ±3σ
         // So bounds should be at least 3x the standard deviation
         for(int i = 0; i < noiseMatrix.rows(); i++) {
@@ -67,15 +70,17 @@ public:
         stateBounds = newBounds;
     }
 
-    /*!@brief Set the noiseMatrix that is used to define error sigmas
-       @param noise The new value to use for the noiseMatrix variable (error sigmas)
-     */
-    void setNoiseMatrix(Eigen::MatrixXd noise){noiseMatrix = noise;}
+    /*! Set the matrix used to define error sigmas.
 
-    /*!@brief Set the propagation matrix that is used to propagate the state.
-       @param prop The new value for the state propagation matrix
-     */
-    void setPropMatrix(Eigen::MatrixXd prop){propMatrix = prop;}
+        @param noise New value for the noise matrix.
+    */
+    void setNoiseMatrix(const Eigen::Ref<const Eigen::MatrixXd>& noise) {noiseMatrix = noise;}
+
+    /*! Set the matrix used to propagate the state.
+
+        @param prop New value for the state propagation matrix.
+    */
+    void setPropMatrix(const Eigen::Ref<const Eigen::MatrixXd>& prop) {propMatrix = prop;}
 
     Eigen::VectorXd stateBounds;  //!< -- Upper bounds to use for markov
     Eigen::VectorXd currentState;  //!< -- State of the markov model
@@ -85,6 +90,9 @@ public:
 
 private:
     void initializeRNG();
+    Eigen::VectorXd randomValues;        //!< -- Reusable standard-normal samples
+    Eigen::VectorXd stateNoise;          //!< -- Reusable process-noise workspace
+    Eigen::VectorXd propagatedState;     //!< -- Reusable propagation workspace
     uint64_t RNGSeed;                 //!< -- Seed for random number generator
     std::minstd_rand rGen; //!< -- Random number generator for model
     std::normal_distribution<double> rNum;  //!< -- Random number distribution for model

--- a/src/architecture/utilities/geodeticConversion.cpp
+++ b/src/architecture/utilities/geodeticConversion.cpp
@@ -27,8 +27,8 @@
 @return pcpfPosition: [m] Position vector in PCPF coordinates
 */
 Eigen::Vector3d PCI2PCPF(Eigen::Vector3d pciPosition, double J20002Pfix[3][3]){
-    // cArray2EigenMatrixd expects a column major input, thus the result is transposed
-    Eigen::MatrixXd dcm_PN = cArray2EigenMatrixXd(*J20002Pfix,3,3).transpose();
+    // The source DCM is stored in row-major order.
+    Eigen::Matrix3d dcm_PN = cArray2EigenMatrix3d(*J20002Pfix);
     Eigen::Vector3d pcpfPosition = dcm_PN * pciPosition;
 
     return pcpfPosition;
@@ -131,8 +131,8 @@ Eigen::Vector3d LLA2PCPF(Eigen::Vector3d llaPosition, double planetEqRad, double
 */
 Eigen::Vector3d PCPF2PCI(Eigen::Vector3d pcpfPosition, double J20002Pfix[3][3])
 {
-    // cArray2EigenMatrixd expects a column major input, thus the result is transposed
-    Eigen::MatrixXd dcm_NP = cArray2EigenMatrixXd(*J20002Pfix,3,3);
+    // Transpose the row-major source DCM for the inverse transformation.
+    Eigen::Matrix3d dcm_NP = cArray2EigenMatrix3d(*J20002Pfix).transpose();
     Eigen::Vector3d pciPosition = dcm_NP * pcpfPosition;
 
     return pciPosition;
@@ -162,7 +162,7 @@ Eigen::Matrix3d C_PCPF2SEZ(double lat, double longitude)
      Euler2(M_PI_2-lat, m1);
      Euler3(longitude, m2);
 
-     Eigen::MatrixXd rot2 = cArray2EigenMatrix3d(*m1);
-     Eigen::MatrixXd rot3 = cArray2EigenMatrix3d(*m2);
+     Eigen::Matrix3d rot2 = cArray2EigenMatrix3d(*m1);
+     Eigen::Matrix3d rot3 = cArray2EigenMatrix3d(*m2);
      return rot2*rot3;
 }

--- a/src/architecture/utilities/saturate.cpp
+++ b/src/architecture/utilities/saturate.cpp
@@ -24,6 +24,7 @@
 /*! The constructor initialies the random number generator used for the walks*/
 Saturate::Saturate()
 {
+    this->numStates = 0;
 }
 
 Saturate::Saturate(int64_t size) : Saturate() {
@@ -35,13 +36,12 @@ Saturate::~Saturate()
 {
 }
 
-/*!
-    @brief This method should be used as the standard way to saturate an output. It will also be utilized by
-other utilities
-    @param unsaturatedStates a vector of the unsaturated states
-    @return saturatedStates
- */
-Eigen::VectorXd Saturate::saturate(Eigen::VectorXd unsaturatedStates)
+/*! Saturate an output vector using the configured bounds.
+
+    @param unsaturatedStates Vector of unsaturated states.
+    @return Vector of saturated states.
+*/
+Eigen::VectorXd Saturate::saturate(const Eigen::Ref<const Eigen::VectorXd>& unsaturatedStates)
 {
     Eigen::VectorXd workingStates;
     workingStates.resize(this->numStates);
@@ -53,10 +53,10 @@ Eigen::VectorXd Saturate::saturate(Eigen::VectorXd unsaturatedStates)
 
 }
 
-/*!
-    @brief sets upper and lower bounds for each state
-    @param bounds one row for each state. lower bounds in left column, upper in right column
- */
-void Saturate::setBounds(Eigen::MatrixXd bounds) {
+/*! Set the lower and upper bounds for each state.
+
+    @param bounds One row per state, with lower and upper bounds in the two columns.
+*/
+void Saturate::setBounds(const Eigen::Ref<const Eigen::MatrixX2d>& bounds) {
     this->stateBounds = bounds;
 }

--- a/src/architecture/utilities/saturate.h
+++ b/src/architecture/utilities/saturate.h
@@ -28,20 +28,19 @@
 */
 class Saturate
 {
-    
+
 public:
     Saturate();
-    Saturate(int64_t size);     //!< class constructor 
+    Saturate(int64_t size);     //!< class constructor
     ~Saturate();
-    void setBounds(Eigen::MatrixXd bounds);
-    Eigen::VectorXd saturate(Eigen::VectorXd unsaturatedStates);
-    /*!@brief Saturates the given unsaturated states
-       @param unsaturated States, a vector of the unsaturated states
-       @return saturatedStates*/
-    
+    //! Set lower and upper bounds for each state.
+    void setBounds(const Eigen::Ref<const Eigen::MatrixX2d>& bounds);
+    //! Saturate the given states.
+    Eigen::VectorXd saturate(const Eigen::Ref<const Eigen::VectorXd>& unsaturatedStates);
+
 private:
     int64_t numStates;              //!< -- Number of states to generate noise for
-    Eigen::MatrixXd stateBounds;    //!< -- one row for each state. lower bounds in left column, upper in right column
+    Eigen::MatrixX2d stateBounds;   //!< -- one row for each state. lower bounds in left column, upper in right column
 };
 
 

--- a/src/architecture/utilities/tests/test_saturate.cpp
+++ b/src/architecture/utilities/tests/test_saturate.cpp
@@ -26,8 +26,7 @@ TEST(Saturate, testSaturate) {
     Eigen::Vector3d states;
     states << -555, 1.27, 5000000.;
     auto saturator = Saturate(3);
-    Eigen::MatrixXd bounds;
-    bounds.resize(3,2);
+    Eigen::Matrix<double, 3, 2> bounds;
     bounds << -400., 0, 5, 10, -1, 5000001;
     saturator.setBounds(bounds);
     states = saturator.saturate(states);

--- a/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/hingedJointArrayMotor/hingedJointArrayMotor.cpp
@@ -179,8 +179,8 @@ void HingedJointArrayMotor::UpdateState(uint64_t CurrentSimNanos)
 
         // Extract the submatrices
         Eigen::Matrix3d Mtt = Mfull.block<3, 3>(0, 0);
-        Eigen::MatrixXd Mtth = Mfull.block(0, nTransDOF, 3, nHingeJoints);
-        Eigen::MatrixXd Mtht = Mfull.block(nTransDOF, 0, nHingeJoints, 3);
+        Eigen::Matrix3Xd Mtth = Mfull.block(0, nTransDOF, 3, nHingeJoints);
+        Eigen::MatrixX3d Mtht = Mfull.block(nTransDOF, 0, nHingeJoints, 3);
         Eigen::MatrixXd Mthth = Mfull.block(nTransDOF, nTransDOF, nHingeJoints, nHingeJoints);
 
         // Build the non-actuator force vectors

--- a/src/fswAlgorithms/effectorInterfaces/jointMotionCompensator/jointMotionCompensator.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/jointMotionCompensator/jointMotionCompensator.cpp
@@ -145,9 +145,9 @@ void JointMotionCompensator::UpdateState(uint64_t CurrentSimNanos)
 
         Eigen::Matrix3d Mtt  = Mfull.block<3,3>(0, 0);
         Eigen::Matrix3d Mrt  = Mfull.block<3,3>(3, 0);
-        Eigen::MatrixXd Mtth = Mfull.block(0, 6, 3, nHingeJoints);
-        Eigen::MatrixXd Mrth = Mfull.block(3, 6, 3, nHingeJoints);
-        Eigen::MatrixXd Mtht = Mfull.block(6, 0, nHingeJoints, 3);
+        Eigen::Matrix3Xd Mtth = Mfull.block(0, 6, 3, nHingeJoints);
+        Eigen::Matrix3Xd Mrth = Mfull.block(3, 6, 3, nHingeJoints);
+        Eigen::MatrixX3d Mtht = Mfull.block(6, 0, nHingeJoints, 3);
         Eigen::MatrixXd Mthth= Mfull.block(6, 6, nHingeJoints, nHingeJoints);
 
         // Build the non-actuator force vectors
@@ -172,7 +172,7 @@ void JointMotionCompensator::UpdateState(uint64_t CurrentSimNanos)
         // compute the hub torque
         Eigen::LDLT<Eigen::Matrix3d> ldltMtt(Mtt);
         Eigen::Vector3d temp1 = ldltMtt.solve(baseTransBias);
-        Eigen::MatrixXd temp2 = ldltMtt.solve(Mtth);
+        Eigen::Matrix3Xd temp2 = ldltMtt.solve(Mtth);
         Eigen::MatrixXd temp3 = Mthth - Mtht*temp2;
         Eigen::VectorXd thetaDDot = temp3.ldlt().solve(jointBias + treeMotorTorque - Mtht*temp1);
         Eigen::Vector3d rDDot = temp1 - temp2*thetaDDot;

--- a/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.cpp
+++ b/src/fswAlgorithms/effectorInterfaces/vscmgVelocitySteering/vscmgVelocitySteering.cpp
@@ -66,7 +66,7 @@ VscmgVelocitySteering::Reset(uint64_t CurrentSimNanos)
     for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
         this->h_bar[i] = vscmgConfigParams.JsList[i] * vscmgConfigParams.Omega0List[i];
     }
-    Eigen::VectorXd h_bar_vec = Eigen::Map<Eigen::VectorXd>(this->h_bar.data(), this->h_bar.size());
+    const Eigen::Map<const Eigen::VectorXd> h_bar_vec(this->h_bar.data(), vscmgConfigParams.numVSCMG);
     double mean_h_bar = 0.0;
     for (int i = 0; i < vscmgConfigParams.numVSCMG; i++) {
         mean_h_bar += h_bar_vec[i];
@@ -94,13 +94,13 @@ VscmgVelocitySteering::UpdateState(uint64_t CurrentSimNanos)
     Eigen::Matrix3d GG0;                                    /*![-] DCM between gimbal frame and gimbal frame when rotation angle is zero */
     Eigen::Matrix3d BG;                                     /*![-] DCM between body frame and gimbal frame */
     Eigen::Matrix3d QWQT;
-    Eigen::MatrixXd D0(3, vscmgConfigParams.numVSCMG);
-    Eigen::MatrixXd D1(3, vscmgConfigParams.numVSCMG);
-    Eigen::MatrixXd D2(3, vscmgConfigParams.numVSCMG);
-    Eigen::MatrixXd D3(3, vscmgConfigParams.numVSCMG);
-    Eigen::MatrixXd D4(3, vscmgConfigParams.numVSCMG);
-    Eigen::MatrixXd D(3, vscmgConfigParams.numVSCMG);
-    Eigen::MatrixXd Q(3, 2 * vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd D0(3, vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd D1(3, vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd D2(3, vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd D3(3, vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd D4(3, vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd D(3, vscmgConfigParams.numVSCMG);
+    Eigen::Matrix3Xd Q(3, 2 * vscmgConfigParams.numVSCMG);
     Eigen::MatrixXd W(2 * vscmgConfigParams.numVSCMG, 2 * vscmgConfigParams.numVSCMG);
     CmdTorqueBodyMsgPayload Lr;
     NavAttMsgPayload hubAttState;

--- a/src/fswAlgorithms/orbitControl/lambertPlanner/lambertPlanner.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertPlanner/lambertPlanner.cpp
@@ -59,30 +59,28 @@ void LambertPlanner::UpdateState(uint64_t currentSimNanos)
     this->readMessages();
 
     // initial state vector
-    Eigen::VectorXd X0(this->r_N.rows()+this->v_N.rows(), this->r_N.cols());
+    StateVector X0;
     X0 << this->r_N,
             this->v_N;
 
     // equations of motion (assuming two body point mass gravity)
-    std::function<Eigen::VectorXd(double, Eigen::VectorXd)> EOM = [this](double t, Eigen::VectorXd state)
+    EquationsOfMotion EOM = [this](double, const StateVector& state)
     {
-        Eigen::VectorXd stateDerivative(state.size());
+        StateVector stateDerivative;
 
-        stateDerivative.segment(0,3) = state.segment(3, 3);
-        stateDerivative.segment(3, 3) = -this->mu/(pow(state.head(3).norm(),3)) * state.head(3);
+        stateDerivative.head<3>() = state.tail<3>();
+        stateDerivative.tail<3>() = -this->mu/(pow(state.head<3>().norm(),3)) * state.head<3>();
 
         return stateDerivative;
     };
 
     // propagate to obtain expected position at maneuver time tm
-    std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> states = this->propagate(
+    PropagationResult states = this->propagate(
             EOM,
             {this->time, this->maneuverTime},
             X0,
             10);
-    std::vector<Eigen::VectorXd> X = states.second;
-    Eigen::VectorXd Xm = X.back();
-    this->rm_N = Xm.head(3);
+    this->rm_N = states.second.back().head<3>();
 
     // write messages
     this->writeMessages(currentSimNanos);
@@ -144,23 +142,24 @@ void LambertPlanner::writeMessages(uint64_t currentSimNanos)
 
 /*! This method integrates the provided equations of motion using Runge-Kutta 4 (RK4) and returns the time steps and
     state vectors at each time step.
-    @param EOM equations of motion function to be propagated
-    @param interval integration interval
-    @param X0 initial state
-    @param dt time step
-    @return std::pair<std::vector<double>, std::vector<Eigen::VectorXd>>
+
+    @param EOM Equations of motion function to propagate.
+    @param interval Integration interval.
+    @param X0 Initial state.
+    @param dt Time step.
+    @return Time values and corresponding six-element state vectors.
 */
-std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> LambertPlanner::propagate(
-        const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& EOM,
+LambertPlanner::PropagationResult LambertPlanner::propagate(
+        const EquationsOfMotion& EOM,
         std::array<double, 2> interval,
-        const Eigen::VectorXd& X0,
+        const StateVector& X0,
         double dt)
 {
     double t0 = interval[0];
     double tf = interval[1];
 
     std::vector<double> t = {t0};
-    std::vector<Eigen::VectorXd> X = {X0};
+    std::vector<StateVector> X = {X0};
 
     // propagate forward to tf
     double N = ceil(abs(tf-t0)/dt);
@@ -171,37 +170,36 @@ std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> LambertPlanner::pro
             step = -step;
         }
 
-        Eigen::VectorXd Xnew = this->RK4(EOM, X.at(c), t.at(c), step);
+        StateVector Xnew = this->RK4(EOM, X.at(c), t.at(c), step);
         double tnew = t.at(c) + step;
 
         t.push_back(tnew);
         X.push_back(Xnew);
     }
-    std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> statesOut = {t,X};
-
-    return statesOut;
+    return {std::move(t), std::move(X)};
 }
 
 /*! This method provides the 4th order Runge-Kutta (RK4)
-    @param ODEfunction function handle that includes the equations of motion
-    @param X0 initial state
-    @param t0 initial time
-    @param dt time step
-    @return Eigen::VectorXd
+
+    @param ODEfunction Function handle that includes the equations of motion.
+    @param X0 Initial state.
+    @param t0 Initial time.
+    @param dt Time step.
+    @return Integrated six-element state vector.
 */
-Eigen::VectorXd LambertPlanner::RK4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                                    const Eigen::VectorXd& X0,
-                                    double t0,
-                                    double dt)
+LambertPlanner::StateVector LambertPlanner::RK4(const EquationsOfMotion& ODEfunction,
+                                                const StateVector& X0,
+                                                double t0,
+                                                double dt)
 {
     double h = dt;
 
-    Eigen::VectorXd k1 = ODEfunction(t0, X0);
-    Eigen::VectorXd k2 = ODEfunction(t0 + h/2., X0 + h*k1/2.);
-    Eigen::VectorXd k3 = ODEfunction(t0 + h/2., X0 + h*k2/2.);
-    Eigen::VectorXd k4 = ODEfunction(t0 + h, X0 + h*k3);
+    StateVector k1 = ODEfunction(t0, X0);
+    StateVector k2 = ODEfunction(t0 + h/2., X0 + h*k1/2.);
+    StateVector k3 = ODEfunction(t0 + h/2., X0 + h*k2/2.);
+    StateVector k4 = ODEfunction(t0 + h, X0 + h*k3);
 
-    Eigen::VectorXd X = X0 + 1./6.*h*(k1 + 2.*k2 + 2.*k3 + k4);
+    StateVector X = X0 + 1./6.*h*(k1 + 2.*k2 + 2.*k3 + k4);
 
     return X;
 }

--- a/src/fswAlgorithms/orbitControl/lambertPlanner/lambertPlanner.h
+++ b/src/fswAlgorithms/orbitControl/lambertPlanner/lambertPlanner.h
@@ -28,6 +28,9 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/astroConstants.h"
+#include <array>
+#include <functional>
+#include <utility>
 #include <vector>
 
 /*! @brief This module creates the LambertProblemMsg to be used for the LambertSolver module
@@ -70,17 +73,21 @@ public:
     int getNumRevolutions() const {return this->numRevolutions;}
 
 private:
+    static constexpr int stateSize = 6;
+    using StateVector = Eigen::Matrix<double, stateSize, 1>;
+    using EquationsOfMotion = std::function<StateVector(double, const StateVector&)>;
+    using PropagationResult = std::pair<std::vector<double>, std::vector<StateVector>>;
+
     void readMessages();
     void writeMessages(uint64_t currentSimNanos);
-    std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> propagate(
-            const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& EOM,
-            std::array<double, 2> interval,
-            const Eigen::VectorXd& X0,
-            double dt);
-    Eigen::VectorXd RK4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                        const Eigen::VectorXd& X0,
-                        double t0,
-                        double dt);
+    PropagationResult propagate(const EquationsOfMotion& EOM,
+                                std::array<double, 2> interval,
+                                const StateVector& X0,
+                                double dt);
+    StateVector RK4(const EquationsOfMotion& ODEfunction,
+                    const StateVector& X0,
+                    double t0,
+                    double dt);
 
     Eigen::Vector3d r_TN_N; //!< [m] targeted position vector with respect to celestial body at finalTime, in N frame
     double finalTime{}; //!< [s] time at which target position should be reached

--- a/src/fswAlgorithms/orbitControl/lambertValidator/lambertValidator.cpp
+++ b/src/fswAlgorithms/orbitControl/lambertValidator/lambertValidator.cpp
@@ -72,31 +72,30 @@ void LambertValidator::UpdateState(uint64_t currentSimNanos)
     this->readMessages();
 
     // initial state vector
-    Eigen::VectorXd X0(this->r_N.rows()+this->v_N.rows(), this->r_N.cols());
+    StateVector X0;
     X0 << this->r_N,
             this->v_N;
 
     // equations of motion (assuming two body point mass gravity)
-    this->EOM_2BP = [this](double t, Eigen::VectorXd state)
+    this->EOM_2BP = [this](double, const StateVector& state)
     {
-        Eigen::VectorXd stateDerivative(state.size());
+        StateVector stateDerivative;
 
-        stateDerivative.segment(0,3) = state.segment(3, 3);
-        stateDerivative.segment(3, 3) = -this->mu/(pow(state.head(3).norm(),3)) * state.head(3);
+        stateDerivative.head<3>() = state.tail<3>();
+        stateDerivative.tail<3>() = -this->mu/(pow(state.head<3>().norm(),3)) * state.head<3>();
 
         return stateDerivative;
     };
 
     // propagate to obtain expected position at maneuver time
-    std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> states = this->propagate(
+    PropagationResult states = this->propagate(
             this->EOM_2BP,
             {this->time, this->maneuverTime},
             X0,
             10);
-    std::vector<Eigen::VectorXd> X = states.second;
-    Eigen::VectorXd Xm = X.back();
-    this->rm_N = Xm.head(3);
-    this->vm_N = Xm.tail(3);
+    const StateVector& finalState = states.second.back();
+    this->rm_N = finalState.head<3>();
+    this->vm_N = finalState.tail<3>();
 
     // compute required Delta-V vector
     this->dv_N = this->vLambert_N - this->vm_N;
@@ -104,7 +103,7 @@ void LambertValidator::UpdateState(uint64_t currentSimNanos)
     // only propagate the perturbed initial states if Lambert solution is valid in order to safe computation effort
     // also skip propagation of perturbed initial states if the constraint violations should be ignored anyway
     if (this->validLambert == 1 && !this->ignoreConstraintViolations) {
-        std::array<Eigen::VectorXd, NUM_INITIALSTATES> initialStates = this->getInitialStates();
+        InitialStates initialStates = this->getInitialStates();
         // check if any of the perturbed initial states violates the given constraints
         this->countViolations(initialStates);
     }
@@ -238,13 +237,11 @@ void LambertValidator::writeMessages(uint64_t currentSimNanos)
 }
 
 /*! This method creates the initial state vectors that will be propagated by the module
-    @return std::array<Eigen::VectorXd, NUM_INITIALSTATES>
-*/
-std::array<Eigen::VectorXd, NUM_INITIALSTATES> LambertValidator::getInitialStates()
-{
-    // size of state vector
-    int N = 6;
 
+    @return Fixed-size initial state vectors to propagate.
+*/
+LambertValidator::InitialStates LambertValidator::getInitialStates()
+{
     // get direction cosine matrix (DCM) from inertial frame N to Hill frame H
     double rc_N[3];
     double vc_N[3];
@@ -261,27 +258,26 @@ std::array<Eigen::VectorXd, NUM_INITIALSTATES> LambertValidator::getInitialState
     Eigen::Vector3d dvHat_H = dv_H.normalized();
 
     // DCM block matrix that can be used on entire 6x1 state vector
-    Eigen::MatrixXd dcm_HN_state(N, N);
+    StateMatrix dcm_HN_state;
     dcm_HN_state << this->dcm_HN, Eigen::Matrix3d::Zero(),
                     Eigen::Matrix3d::Zero(), this->dcm_HN;
 
     // nominal state vector (not perturbed) in Hill frame
-    Eigen::VectorXd X0nom_H(N, 1);
+    StateVector X0nom_H;
     X0nom_H << rm_H,
             vm_H;
 
     // square root of uncertainty covariance matrix
-    Eigen::MatrixXd Psqrt(N,N);
-    Psqrt = this->uncertaintyStates;
+    StateMatrix Psqrt = this->uncertaintyStates;
 
     // Create initial state vectors.
     // Perturb all states in + and - direction, and for each case use min and max expected DV magnitude
-    std::array<Eigen::VectorXd, NUM_INITIALSTATES> initialStates;
-    for (int c1=0; c1 < N; c1++) {
+    InitialStates initialStates;
+    for (int c1=0; c1 < stateSize; c1++) {
         for (int c2=0; c2 < 2; c2++) {
-            Eigen::VectorXd X0_H(N, 1);
-            Eigen::VectorXd X0minDV_H(N, 1);
-            Eigen::VectorXd X0maxDV_H(N, 1);
+            StateVector X0_H;
+            StateVector X0minDV_H;
+            StateVector X0maxDV_H;
 
             double multiplier;
             if (c2 == 0) {
@@ -299,15 +295,15 @@ std::array<Eigen::VectorXd, NUM_INITIALSTATES> LambertValidator::getInitialState
             X0minDV_H.segment(3, 3) += dv_H - this->uncertaintyDV * dvHat_H;
             X0maxDV_H.segment(3, 3) += dv_H + this->uncertaintyDV * dvHat_H;
 
-            initialStates.at(c2*N + c1) = dcm_HN_state.transpose() * X0minDV_H;
-            initialStates.at(2*N + c2*N + c1) = dcm_HN_state.transpose() * X0maxDV_H;
+            initialStates.at(c2*stateSize + c1) = dcm_HN_state.transpose() * X0minDV_H;
+            initialStates.at(2*stateSize + c2*stateSize + c1) = dcm_HN_state.transpose() * X0maxDV_H;
         }
     }
 
     // 3 more initial states for unperturbed state, only DV perturbation
-    Eigen::VectorXd X0_H(N, 1);
-    Eigen::VectorXd X0minDV_H(N, 1);
-    Eigen::VectorXd X0maxDV_H(N, 1);
+    StateVector X0_H;
+    StateVector X0minDV_H;
+    StateVector X0maxDV_H;
 
     X0_H = X0nom_H;
     X0minDV_H = X0_H;
@@ -317,9 +313,9 @@ std::array<Eigen::VectorXd, NUM_INITIALSTATES> LambertValidator::getInitialState
     X0minDV_H.segment(3, 3) += dv_H - this->uncertaintyDV * dvHat_H;
     X0maxDV_H.segment(3, 3) += dv_H + this->uncertaintyDV * dvHat_H;
 
-    initialStates.at(4*N) = dcm_HN_state.transpose() * X0_H;
-    initialStates.at(4*N + 1) = dcm_HN_state.transpose() * X0minDV_H;
-    initialStates.at(4*N + 2) = dcm_HN_state.transpose() * X0maxDV_H;
+    initialStates.at(4*stateSize) = dcm_HN_state.transpose() * X0_H;
+    initialStates.at(4*stateSize + 1) = dcm_HN_state.transpose() * X0minDV_H;
+    initialStates.at(4*stateSize + 2) = dcm_HN_state.transpose() * X0maxDV_H;
 
     return initialStates;
 }
@@ -328,24 +324,21 @@ std::array<Eigen::VectorXd, NUM_INITIALSTATES> LambertValidator::getInitialState
     @param initialStates array of initial state vectors to be propagated
 
 */
-void LambertValidator::countViolations(std::array<Eigen::VectorXd, NUM_INITIALSTATES> initialStates)
+void LambertValidator::countViolations(const InitialStates& initialStates)
 {
     this->violationsDistanceTarget = 0;
     this->violationsOrbitRadius = 0;
 
     // propagate each initial condition from maneuver time to final time and check if constraints are violated
     for (int c=0; c < NUM_INITIALSTATES; c++) {
-        Eigen::VectorXd X0 = initialStates.at(c);
+        const StateVector& X0 = initialStates.at(c);
 
-        std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> states = this->propagate(
+        PropagationResult states = this->propagate(
                 this->EOM_2BP,
                 {this->maneuverTime, this->finalTime},
                 X0,
                 this->timestep);
-        std::vector<double> t = states.first;
-        std::vector<Eigen::VectorXd> X = states.second;
-
-        this->checkConstraintViolations(t, X);
+        this->checkConstraintViolations(states.first, states.second);
     }
 }
 
@@ -354,17 +347,18 @@ void LambertValidator::countViolations(std::array<Eigen::VectorXd, NUM_INITIALST
     @param X state for each time step
 
 */
-void LambertValidator::checkConstraintViolations(std::vector<double> t, std::vector<Eigen::VectorXd> X)
+void LambertValidator::checkConstraintViolations(const std::vector<double>& t,
+                                                 const std::vector<StateVector>& X)
 {
     // check maximum distance from target at final time constraint
-    Eigen::Vector3d rf_BN_N = X.back().head(3);
+    Eigen::Vector3d rf_BN_N = X.back().head<3>();
     Eigen::Vector3d rf_BT_N = rf_BN_N - this->r_TN_N;
     if (rf_BT_N.norm() > this->maxDistanceTarget) {
         this->violationsDistanceTarget++;
     }
     // check minimum orbit radius constraint
     for (size_t c = 0; c < t.size(); ++c) {
-        Eigen::Vector3d r_BN_N = X.at(c).head(3);
+        Eigen::Vector3d r_BN_N = X.at(c).head<3>();
         if (r_BN_N.norm() < this->minOrbitRadius) {
             this->violationsOrbitRadius++;
             break;
@@ -406,23 +400,24 @@ bool LambertValidator::checkPerformance() const
 
 /*! This method integrates the provided equations of motion using Runge-Kutta 4 (RK4) and returns the time steps
     and state vectors at each time step.
-    @param EOM equations of motion function to be propagated
-    @param interval integration interval
-    @param X0 initial state
-    @param dt time step
-    @return std::pair<std::vector<double>, std::vector<Eigen::VectorXd>>
+
+    @param EOM Equations of motion function to propagate.
+    @param interval Integration interval.
+    @param X0 Initial state.
+    @param dt Time step.
+    @return Time values and corresponding six-element state vectors.
 */
-std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> LambertValidator::propagate(
-        const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& EOM,
+LambertValidator::PropagationResult LambertValidator::propagate(
+        const EquationsOfMotion& EOM,
         std::array<double, 2> interval,
-        const Eigen::VectorXd& X0,
+        const StateVector& X0,
         double dt)
 {
     double t0 = interval[0];
     double tf = interval[1];
 
     std::vector<double> t = {t0};
-    std::vector<Eigen::VectorXd> X = {X0};
+    std::vector<StateVector> X = {X0};
 
     // propagate forward to tf
     double N = ceil(abs(tf-t0)/dt);
@@ -433,37 +428,36 @@ std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> LambertValidator::p
             step = -step;
         }
 
-        Eigen::VectorXd Xnew = this->RK4(EOM, X.at(c), t.at(c), step);
+        StateVector Xnew = this->RK4(EOM, X.at(c), t.at(c), step);
         double tnew = t.at(c) + step;
 
         t.push_back(tnew);
         X.push_back(Xnew);
     }
-    std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> statesOut = {t,X};
-
-    return statesOut;
+    return {std::move(t), std::move(X)};
 }
 
 /*! This method provides the 4th order Runge-Kutta (RK4)
-    @param ODEfunction function handle that includes the equations of motion
-    @param X0 initial state
-    @param t0 initial time
-    @param dt time step
-    @return Eigen::VectorXd
+
+    @param ODEfunction Function handle that includes the equations of motion.
+    @param X0 Initial state.
+    @param t0 Initial time.
+    @param dt Time step.
+    @return Integrated six-element state vector.
 */
-Eigen::VectorXd LambertValidator::RK4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                                      const Eigen::VectorXd& X0,
-                                      double t0,
-                                      double dt)
+LambertValidator::StateVector LambertValidator::RK4(const EquationsOfMotion& ODEfunction,
+                                                    const StateVector& X0,
+                                                    double t0,
+                                                    double dt)
 {
     double h = dt;
 
-    Eigen::VectorXd k1 = ODEfunction(t0, X0);
-    Eigen::VectorXd k2 = ODEfunction(t0 + h/2., X0 + h*k1/2.);
-    Eigen::VectorXd k3 = ODEfunction(t0 + h/2., X0 + h*k2/2.);
-    Eigen::VectorXd k4 = ODEfunction(t0 + h, X0 + h*k3);
+    StateVector k1 = ODEfunction(t0, X0);
+    StateVector k2 = ODEfunction(t0 + h/2., X0 + h*k1/2.);
+    StateVector k3 = ODEfunction(t0 + h/2., X0 + h*k2/2.);
+    StateVector k4 = ODEfunction(t0 + h, X0 + h*k3);
 
-    Eigen::VectorXd X = X0 + 1./6.*h*(k1 + 2.*k2 + 2.*k3 + k4);
+    StateVector X = X0 + 1./6.*h*(k1 + 2.*k2 + 2.*k3 + k4);
 
     return X;
 }

--- a/src/fswAlgorithms/orbitControl/lambertValidator/lambertValidator.h
+++ b/src/fswAlgorithms/orbitControl/lambertValidator/lambertValidator.h
@@ -32,6 +32,10 @@
 #include "architecture/messaging/messaging.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include "architecture/utilities/astroConstants.h"
+#include <array>
+#include <functional>
+#include <utility>
+#include <vector>
 
 #define NUM_INITIALSTATES 27 // number of initial states
 
@@ -93,21 +97,27 @@ public:
     bool getIgnoreConstraintViolations() const {return this->ignoreConstraintViolations;}
 
 private:
+    static constexpr int stateSize = 6;
+    using StateVector = Eigen::Matrix<double, stateSize, 1>;
+    using StateMatrix = Eigen::Matrix<double, stateSize, stateSize>;
+    using EquationsOfMotion = std::function<StateVector(double, const StateVector&)>;
+    using PropagationResult = std::pair<std::vector<double>, std::vector<StateVector>>;
+    using InitialStates = std::array<StateVector, NUM_INITIALSTATES>;
+
     void readMessages();
     void writeMessages(uint64_t currentSimNanos);
-    std::array<Eigen::VectorXd, NUM_INITIALSTATES> getInitialStates();
-    void countViolations(std::array<Eigen::VectorXd, NUM_INITIALSTATES> initialStates);
-    void checkConstraintViolations(std::vector<double> t, std::vector<Eigen::VectorXd> X);
+    InitialStates getInitialStates();
+    void countViolations(const InitialStates& initialStates);
+    void checkConstraintViolations(const std::vector<double>& t, const std::vector<StateVector>& X);
     bool checkPerformance() const;
-    std::pair<std::vector<double>, std::vector<Eigen::VectorXd>> propagate(
-            const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& EOM,
-            std::array<double, 2> interval,
-            const Eigen::VectorXd& X0,
-            double dt);
-    Eigen::VectorXd RK4(const std::function<Eigen::VectorXd(double, Eigen::VectorXd)>& ODEfunction,
-                        const Eigen::VectorXd& X0,
-                        double t0,
-                        double dt);
+    PropagationResult propagate(const EquationsOfMotion& EOM,
+                                std::array<double, 2> interval,
+                                const StateVector& X0,
+                                double dt);
+    StateVector RK4(const EquationsOfMotion& ODEfunction,
+                    const StateVector& X0,
+                    double t0,
+                    double dt);
 
     double lambertSolutionSpecifier = 1; //!< [-] which Lambert solution (1 or 2), if applicable, should be used
     double finalTime{}; //!< [s] time at which target position should be reached
@@ -137,7 +147,7 @@ private:
     int violationsDistanceTarget = 0; //!< [-] number of violations of the maxDistanceTarget constraint
     int violationsOrbitRadius = 0; //!< [-] number of violations of the minOrbitRadius constraint
     double timestep = 10.; //!< [s] time step used for RK4 propagation
-    std::function<Eigen::VectorXd(double, Eigen::VectorXd)> EOM_2BP; //!< equations of motion to be used for RK4
+    EquationsOfMotion EOM_2BP; //!< equations of motion to be used for RK4
     int maxNumIterLambert = 6; //!< [-] maximum number of iterations for Lambert solver root finder to find x
     double xToleranceLambert = 1e-8; //!< [-] tolerance for Lambert solver root finder to find x
     double xConvergenceTolerance = 1e-2; //!< [-] tolerance on difference between x solutions between time steps

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.cpp
@@ -31,7 +31,7 @@ SmallBodyWaypointFeedback::SmallBodyWaypointFeedback()
     this->o_hat_3_tilde(0, 1) = -1;
     this->o_hat_3_tilde(1, 0) = 1;
     this->o_hat_1 << 1, 0, 0;
-    this->I.setIdentity(3,3);
+    this->I.setIdentity();
     this->C_SRP = 1.0;
     this->P_0 = 4.56e-6;
     this->rho = 0.4;
@@ -97,7 +97,7 @@ void SmallBodyWaypointFeedback::computeControl(uint64_t CurrentSimNanos){
     /* Compute the hill frame DCM of the small body */
     double dcm_ON_array[3][3];
     hillFrame(asteroidEphemerisInMsgBuffer.r_BdyZero_N, asteroidEphemerisInMsgBuffer.v_BdyZero_N, dcm_ON_array);
-    dcm_ON = cArray2EigenMatrixXd(*dcm_ON_array, 3, 3).transpose();
+    dcm_ON = cArray2EigenMatrix3d(*dcm_ON_array);
 
     /* Compute the direction of the sun from the asteroid in the small body's hill frame, assumes heliocentric frame
      * centered at the origin of the sun, not the solar system's barycenter */
@@ -109,7 +109,7 @@ void SmallBodyWaypointFeedback::computeControl(uint64_t CurrentSimNanos){
     double dcm_BN[3][3];
     MRP2C(navAttInMsgBuffer.sigma_BN, dcm_BN);
     Eigen::Matrix3d dcm_OB;
-    dcm_OB = dcm_ON * (cArray2EigenMatrixXd(*dcm_BN, 3, 3));
+    dcm_OB = dcm_ON * cArray2EigenMatrix3d(*dcm_BN).transpose();
 
     /* Compute x1, x2 from the input messages */
     double r_BO_O[3];

--- a/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h
+++ b/src/fswAlgorithms/orbitControl/smallBodyWaypointFeedback/smallBodyWaypointFeedback.h
@@ -82,7 +82,7 @@ private:
     double mu_sun;  //!< Gravitational parameter of the sun
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector
     Eigen::Vector3d o_hat_1;  //!< First asteroid orbit frame base vector
-    Eigen::MatrixXd I;  //!< 3 x 3 identity matrix
+    Eigen::Matrix3d I;  //!< 3 x 3 identity matrix
     ClassicElements oe_ast;  //!< Orbital elements of the asteroid
     double F_dot;  //!< Time rate of change of true anomaly
     double F_ddot;  //!< Second time derivative of true anomaly

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.cpp
@@ -28,38 +28,37 @@
     values and initializes the various parts of the model */
 SmallBodyNavEKF::SmallBodyNavEKF()
 {
-    this->numStates = 12;
     this->mu_sun = 1.327124e20;
     this->o_hat_3_tilde.setZero();
     this->o_hat_3_tilde(0, 1) = -1;
     this->o_hat_3_tilde(1, 0) = 1;
     this->o_hat_1 << 1, 0, 0;
-    this->I.setIdentity(3,3);
-    this->I_full.setIdentity(this->numStates, this->numStates);
+    this->I.setIdentity();
+    this->I_full.setIdentity();
     this->C_SRP = 1.0;
     this->P_0 = 4.56e-6;
     this->rho = 0.4;
-    this->x_hat_dot_k.setZero(this->numStates);
-    this->x_hat_k1_.setZero(this->numStates);
-    this->x_hat_k1.setZero(this->numStates);
-    this->x_hat_k.setZero(this->numStates);
-    this->P_dot_k.setZero(this->numStates, this->numStates);
-    this->P_k1_.setZero(this->numStates, this->numStates);
-    this->P_k1.setZero(this->numStates, this->numStates);
-    this->A_k.setIdentity(this->numStates, this->numStates);
-    this->Phi_k.setIdentity(this->numStates, this->numStates);
-    this->Phi_dot_k.setZero(this->numStates, this->numStates);
-    this->L.setIdentity(this->numStates, this->numStates);
-    this->M.setIdentity(this->numStates, this->numStates);
-    this->H_k1.setIdentity(this->numStates, this->numStates);
-    this->k1.setZero(this->numStates);
-    this->k2.setZero(this->numStates);
-    this->k3.setZero(this->numStates);
-    this->k4.setZero(this->numStates);
-    this->k1_phi.setZero(this->numStates, this->numStates);
-    this->k2_phi.setZero(this->numStates, this->numStates);
-    this->k3_phi.setZero(this->numStates, this->numStates);
-    this->k4_phi.setZero(this->numStates, this->numStates);
+    this->x_hat_dot_k.setZero();
+    this->x_hat_k1_.setZero();
+    this->x_hat_k1.setZero();
+    this->x_hat_k.setZero(stateSize);
+    this->P_dot_k.setZero();
+    this->P_k1_.setZero();
+    this->P_k1.setZero();
+    this->A_k.setIdentity();
+    this->Phi_k.setIdentity();
+    this->Phi_dot_k.setZero();
+    this->L.setIdentity();
+    this->M.setIdentity();
+    this->H_k1.setIdentity();
+    this->k1.setZero();
+    this->k2.setZero();
+    this->k3.setZero();
+    this->k4.setZero();
+    this->k1_phi.setZero();
+    this->k2_phi.setZero();
+    this->k3_phi.setZero();
+    this->k4_phi.setZero();
     this->prevTime = 0;
     return;
 }
@@ -158,7 +157,7 @@ void SmallBodyNavEKF::predict(uint64_t CurrentSimNanos){
     /* Compute the hill frame DCM of the small body */
     double dcm_ON_array[3][3];
     hillFrame(asteroidEphemerisInMsgBuffer.r_BdyZero_N, asteroidEphemerisInMsgBuffer.v_BdyZero_N, dcm_ON_array);
-    dcm_ON = cArray2EigenMatrixXd(*dcm_ON_array, 3, 3).transpose();
+    dcm_ON = cArray2EigenMatrix3d(*dcm_ON_array);
 
     /* Compute the direction of the sun from the asteroid in the small body's hill frame, assumes heliocentric frame
      * centered at the origin of the sun, not the solar system's barycenter*/
@@ -191,28 +190,30 @@ void SmallBodyNavEKF::predict(uint64_t CurrentSimNanos){
 
 */
 void SmallBodyNavEKF::aprioriState(uint64_t CurrentSimNanos){
+    const StateVector currentState = x_hat_k;
+
     /* First RK4 step */
-    computeEquationsOfMotion(x_hat_k, Phi_k);
+    computeEquationsOfMotion(currentState, Phi_k);
     k1 = (CurrentSimNanos-prevTime)*NANO2SEC*x_hat_dot_k;
     k1_phi = (CurrentSimNanos-prevTime)*NANO2SEC*Phi_dot_k;
 
     /* Second RK4 step */
-    computeEquationsOfMotion(x_hat_k + k1/2, Phi_k + k1_phi/2);
+    computeEquationsOfMotion(currentState + k1/2, Phi_k + k1_phi/2);
     k2 = (CurrentSimNanos-prevTime)*NANO2SEC*x_hat_dot_k;
     k2_phi = (CurrentSimNanos-prevTime)*NANO2SEC*Phi_dot_k;
 
     /* Third RK4 step */
-    computeEquationsOfMotion(x_hat_k + k2/2, Phi_k + k2_phi/2);
+    computeEquationsOfMotion(currentState + k2/2, Phi_k + k2_phi/2);
     k3 = (CurrentSimNanos-prevTime)*NANO2SEC*x_hat_dot_k;
     k3_phi = (CurrentSimNanos-prevTime)*NANO2SEC*Phi_dot_k;
 
     /* Fourth RK4 step */
-    computeEquationsOfMotion(x_hat_k + k3, Phi_k + k3_phi);
+    computeEquationsOfMotion(currentState + k3, Phi_k + k3_phi);
     k4 = (CurrentSimNanos-prevTime)*NANO2SEC*x_hat_dot_k;
     k4_phi = (CurrentSimNanos-prevTime)*NANO2SEC*Phi_dot_k;
 
     /* Perform the RK4 integration on the dynamics and STM */
-    x_hat_k1_ = x_hat_k + (k1 + 2*k2 + 2*k3 + k4)/6;
+    x_hat_k1_ = currentState + (k1 + 2*k2 + 2*k3 + k4)/6;
     Phi_k = Phi_k + (k1_phi + 2*k2_phi + 2*k3_phi + k4_phi)/6;
 }
 
@@ -221,7 +222,7 @@ void SmallBodyNavEKF::aprioriState(uint64_t CurrentSimNanos){
     @param Phi
 
 */
-void SmallBodyNavEKF::computeEquationsOfMotion(Eigen::VectorXd x_hat, Eigen::MatrixXd Phi){
+void SmallBodyNavEKF::computeEquationsOfMotion(const StateVector& x_hat, const StateMatrix& Phi){
     /* Create temporary state vectors for readability */
     Eigen::Vector3d x_1;
     Eigen::Vector3d x_2;
@@ -241,7 +242,7 @@ void SmallBodyNavEKF::computeEquationsOfMotion(Eigen::VectorXd x_hat, Eigen::Mat
     double dcm_BN_meas[3][3];
     MRP2C(this->navAttInMsgBuffer.sigma_BN, dcm_BN_meas);
     Eigen::Matrix3d dcm_OB;
-    dcm_OB = dcm_ON*(cArray2EigenMatrixXd(*dcm_BN_meas, 3, 3));
+    dcm_OB = dcm_ON*cArray2EigenMatrix3d(*dcm_BN_meas).transpose();
     /* Now compute x2_dot */
     x_hat_dot_k.segment(3,3) =
             -F_ddot*o_hat_3_tilde*x_1 - 2*F_dot*o_hat_3_tilde*x_2 -pow(F_dot,2)*o_hat_3_tilde*o_hat_3_tilde*x_1
@@ -267,8 +268,11 @@ void SmallBodyNavEKF::computeEquationsOfMotion(Eigen::VectorXd x_hat, Eigen::Mat
 
 */
 void SmallBodyNavEKF::aprioriCovar(uint64_t CurrentSimNanos){
+    const StateMatrix currentCovariance = P_k;
+    const StateMatrix processNoise = Q;
+
     /* Compute the apriori covariance */
-    P_k1_ = Phi_k*P_k*Phi_k.transpose() + L*Q*L.transpose();
+    P_k1_ = Phi_k*currentCovariance*Phi_k.transpose() + L*processNoise*L.transpose();
 }
 
 /*! This method checks the propagated MRP states to see if they exceed a norm of 1. If they do, the appropriate
@@ -281,12 +285,10 @@ void SmallBodyNavEKF::checkMRPSwitching(){
     sigma_AN << x_hat_k1_.segment(6,3);
 
     /* Create a shadow covariance matrix */
-    Eigen::MatrixXd P_k1_s;
-    P_k1_s.setZero(this->numStates, this->numStates);
+    StateMatrix P_k1_s = StateMatrix::Zero();
 
     /* Initialize Lambda, set it to zero, set diagonal 3x3 state blocks to identity */
-    Eigen::MatrixXd Lambda;
-    Lambda.setZero(this->numStates, this->numStates);
+    StateMatrix Lambda = StateMatrix::Zero();
     Lambda.block(0, 0, 3, 3).setIdentity();
     Lambda.block(3, 3, 3, 3).setIdentity();
     Lambda.block(6, 6, 3, 3).setIdentity();
@@ -311,14 +313,13 @@ void SmallBodyNavEKF::checkMRPSwitching(){
 */
 void SmallBodyNavEKF::measurementUpdate(){
     /* Compute Kalman gain */
-    Eigen::MatrixXd K_k1;
-    K_k1.setZero(this->numStates, this->numStates);
-    K_k1 = P_k1_*H_k1.transpose() * (H_k1*P_k1_*H_k1.transpose() + M*R*M.transpose()).inverse();
+    const StateMatrix measurementNoise = R;
+    StateMatrix K_k1 = P_k1_*H_k1.transpose()
+        * (H_k1*P_k1_*H_k1.transpose() + M*measurementNoise*M.transpose()).inverse();
 
     /* Grab the measurements from the input messages */
     /* Subtract the asteroid position from the spacecraft position and rotate it into the small body's hill frame*/
-    Eigen::VectorXd y_k1;
-    y_k1.setZero(this->numStates);
+    StateVector y_k1 = StateVector::Zero();
     y_k1.segment(0, 3) = dcm_ON*(cArray2EigenVector3d(navTransInMsgBuffer.r_BN_N)
             - cArray2EigenVector3d(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
 
@@ -346,7 +347,8 @@ void SmallBodyNavEKF::measurementUpdate(){
     x_hat_k1 = x_hat_k1_ + K_k1*(y_k1 - x_hat_k1_);
 
     /* Update the covariance */
-    P_k1 = (I_full - K_k1*H_k1)*P_k1_*(I_full - K_k1*H_k1).transpose() + K_k1*M*R*M.transpose()*K_k1.transpose();
+    P_k1 = (I_full - K_k1*H_k1)*P_k1_*(I_full - K_k1*H_k1).transpose()
+        + K_k1*M*measurementNoise*M.transpose()*K_k1.transpose();
 
     /* Assign the state estimate and covariance to k for the next iteration */
     x_hat_k = x_hat_k1;
@@ -356,7 +358,7 @@ void SmallBodyNavEKF::measurementUpdate(){
 /*! This method computes the state dynamics matrix, A, for the next iteration
 
 */
-void SmallBodyNavEKF::computeDynamicsMatrix(Eigen::VectorXd x_hat){
+void SmallBodyNavEKF::computeDynamicsMatrix(const StateVector& x_hat){
     /* Create temporary state vectors for readability */
     Eigen::Vector3d x_1;
     Eigen::Vector3d x_2;
@@ -369,7 +371,7 @@ void SmallBodyNavEKF::computeDynamicsMatrix(Eigen::VectorXd x_hat){
     x_4 << x_hat.segment(9,3);
 
     /* First set the matrix to zero (many indices are zero) */
-    A_k.setZero(this->numStates, this->numStates);
+    A_k.setZero();
 
     /* x_1 partial */
     A_k.block(0, 3, 3, 3).setIdentity();

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavEKF/smallBodyNavEKF.h
@@ -46,15 +46,19 @@ public:
     void addThrusterToFilter(Message<THROutputMsgPayload> *tmpThrusterMsg);  //!< Adds thruster message
 
 private:
+    static constexpr int stateSize = 12;
+    using StateVector = Eigen::Matrix<double, stateSize, 1>;
+    using StateMatrix = Eigen::Matrix<double, stateSize, stateSize>;
+
     void readMessages(uint64_t CurrentSimNanos);  //!< Reads input messages
     void writeMessages(uint64_t CurrentSimNanos);  //!< Writes output messages
     void predict(uint64_t CurrentSimNanos);  //!< Prediction step of Kalman filter
     void aprioriState(uint64_t CurrentSimNanos);  //!< Computes the apriori state
     void aprioriCovar(uint64_t CurrentSimNanos);  //!< Computes the apriori covariance
     void checkMRPSwitching();  //!< Checks the MRPs for switching
-    void computeDynamicsMatrix(Eigen::VectorXd x_hat);  //!< Computes the new dynamics matrix, A_k
+    void computeDynamicsMatrix(const StateVector& x_hat);  //!< Computes the new dynamics matrix, A_k
     void measurementUpdate();  //!< Computes the measurement update for the EKF
-    void computeEquationsOfMotion(Eigen::VectorXd x_hat, Eigen::MatrixXd Phi); //!< Computes the EOMs of the state and state transition matrix
+    void computeEquationsOfMotion(const StateVector& x_hat, const StateMatrix& Phi); //!< Computes the EOMs of the state and state transition matrix
 
 public:
     ReadFunctor<NavTransMsgPayload> navTransInMsg;  //!< Translational nav input message
@@ -95,36 +99,35 @@ private:
     CmdForceBodyMsgPayload cmdForceBodyInMsgBuffer; //!< Buffer for the commanded force input
 
     uint64_t prevTime;  //!< Previous time, ns
-    uint64_t numStates;  //!< Number of states
     Eigen::Vector3d thrust_B;  //!< Thrust expressed in body-frame components
     Eigen::Vector3d cmdForce_B;  //!< External force expressed in body-frame components
-    Eigen::VectorXd x_hat_dot_k;  //!< Rate of change of state estimate
-    Eigen::VectorXd x_hat_k1_;  //!< Apriori state estimate for time k+1
-    Eigen::VectorXd x_hat_k1;  //!< Update state estimate for time k+1
-    Eigen::MatrixXd P_dot_k;  //!< Rate of change of estimation error covariance
-    Eigen::MatrixXd P_k1_;  //!< Apriori estimation error covariance
-    Eigen::MatrixXd P_k1;  //!< Updated estimation error covariance
-    Eigen::MatrixXd A_k;  //!< State dynamics matrix
-    Eigen::MatrixXd Phi_k;  //!< State transition matrix
-    Eigen::MatrixXd Phi_dot_k;  //!< Rate of change of STM
-    Eigen::MatrixXd L;  //!<
-    Eigen::MatrixXd M;  //!<
-    Eigen::MatrixXd H_k1;  //!< Jacobian of measurement model
-    Eigen::MatrixXd I_full;  //!< numStates x numStates identity matrix
-    Eigen::VectorXd k1;  //!< k1 constant for RK4 integration
-    Eigen::VectorXd k2;  //!< k2 constant for RK4 integration
-    Eigen::VectorXd k3;  //!< k3 constant for RK4 integration
-    Eigen::VectorXd k4;  //!< k4 constant for RK4 integration
-    Eigen::MatrixXd k1_phi;  //!< k1 STM constant for RK4 integration
-    Eigen::MatrixXd k2_phi;  //!< k2 STM constant for RK4 integration
-    Eigen::MatrixXd k3_phi;  //!< k3 STM constant for RK4 integration
-    Eigen::MatrixXd k4_phi;  //!< k4 STM constant for RK4 integration
+    StateVector x_hat_dot_k;  //!< Rate of change of state estimate
+    StateVector x_hat_k1_;  //!< Apriori state estimate for time k+1
+    StateVector x_hat_k1;  //!< Update state estimate for time k+1
+    StateMatrix P_dot_k;  //!< Rate of change of estimation error covariance
+    StateMatrix P_k1_;  //!< Apriori estimation error covariance
+    StateMatrix P_k1;  //!< Updated estimation error covariance
+    StateMatrix A_k;  //!< State dynamics matrix
+    StateMatrix Phi_k;  //!< State transition matrix
+    StateMatrix Phi_dot_k;  //!< Rate of change of STM
+    StateMatrix L;  //!< Process noise transformation matrix
+    StateMatrix M;  //!< Measurement noise transformation matrix
+    StateMatrix H_k1;  //!< Jacobian of measurement model
+    StateMatrix I_full;  //!< State-space identity matrix
+    StateVector k1;  //!< k1 constant for RK4 integration
+    StateVector k2;  //!< k2 constant for RK4 integration
+    StateVector k3;  //!< k3 constant for RK4 integration
+    StateVector k4;  //!< k4 constant for RK4 integration
+    StateMatrix k1_phi;  //!< k1 STM constant for RK4 integration
+    StateMatrix k2_phi;  //!< k2 STM constant for RK4 integration
+    StateMatrix k3_phi;  //!< k3 STM constant for RK4 integration
+    StateMatrix k4_phi;  //!< k4 STM constant for RK4 integration
     bool newMeasurements;  //! Keeps track of whether or not new measurements have been written
 
     double mu_sun;  //!< Gravitational parameter of the sun
     Eigen::Matrix3d o_hat_3_tilde;  //!< Tilde matrix of the third asteroid orbit frame base vector
     Eigen::Vector3d o_hat_1;  //!< First asteroid orbit frame base vector
-    Eigen::MatrixXd I;  //!< 3 x 3 identity matrix
+    Eigen::Matrix3d I;  //!< 3 x 3 identity matrix
     ClassicElements oe_ast;  //!< Orbital elements of the asteroid
     double F_dot;  //!< Time rate of change of true anomaly
     double F_ddot;  //!< Second time derivative of true anomaly

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.cpp
@@ -27,23 +27,20 @@
     values and initializes the various parts of the model */
 SmallBodyNavUKF::SmallBodyNavUKF()
 {
-    this->numStates = 9;
-    this->numMeas = 3;
-    this->numSigmas = 2*this->numStates + 1;
-    this->x_hat_k1_.setZero(this->numStates);
-    this->P_k1_.setZero(this->numStates, this->numStates);
-    this->x_hat_k1.setZero(this->numStates);
-    this->P_k1.setZero(this->numStates, this->numStates);
-    this->X_sigma_k1_.setZero(this->numStates, this->numSigmas);
-    this->wm_sigma.setZero(this->numSigmas);
-    this->wc_sigma.setZero(this->numSigmas);
-    this->y_hat_k1_.setZero(this->numMeas);
-    this->R_k1_.setZero(this->numMeas, this->numMeas);
-    this->Y_sigma_k1_.setZero(this->numMeas, this->numSigmas);
-    this->H.setZero(this->numStates, this->numMeas);
-    this->K.setZero(this->numStates, this->numMeas);
-    this->dcm_AN.setIdentity(3,3);
-    this->omega_AN_A.setZero(3);
+    this->x_hat_k1_.setZero();
+    this->P_k1_.setZero();
+    this->x_hat_k1.setZero();
+    this->P_k1.setZero();
+    this->X_sigma_k1_.setZero();
+    this->wm_sigma.setZero();
+    this->wc_sigma.setZero();
+    this->y_hat_k1_.setZero();
+    this->R_k1_.setZero();
+    this->Y_sigma_k1_.setZero();
+    this->H.setZero();
+    this->K.setZero();
+    this->dcm_AN.setIdentity();
+    this->omega_AN_A.setZero();
     this->alpha = 0;
     this->beta = 2;
     this->kappa = 1e-3;
@@ -75,14 +72,14 @@ void SmallBodyNavUKF::Reset(uint64_t CurrentSimNanos)
     }
 
     /* compute UT weights to be used in the UT */
-    this->wm_sigma(0) = this->kappa / (this->kappa + this->numStates);
+    this->wm_sigma(0) = this->kappa / (this->kappa + stateSize);
     this->wc_sigma(0) = this->wm_sigma(0) + 1 - pow(this->alpha,2) + this->beta;
-    for (uint64_t i = 0; i < this->numStates; i++) {
+    for (int i = 0; i < stateSize; i++) {
         /* Assign weigths */
-        this->wm_sigma(i+1) = 1 / (2*(this->numStates + this->kappa));
-        this->wm_sigma(numStates+i+1) = this->wm_sigma(i+1);
+        this->wm_sigma(i+1) = 1 / (2*(stateSize + this->kappa));
+        this->wm_sigma(stateSize+i+1) = this->wm_sigma(i+1);
         this->wc_sigma(i+1) = this->wm_sigma(i+1);
-        this->wc_sigma(numStates+i+1) = this->wm_sigma(i+1);
+        this->wc_sigma(stateSize+i+1) = this->wm_sigma(i+1);
     }
 }
 
@@ -103,49 +100,43 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
     /* Read angular velocity of the small body fixed frame */
     this->omega_AN_A = cArray2EigenVector3d(this->asteroidEphemerisInMsgBuffer.omega_BN_B);
 
-    /* Declare matrix to store sigma points spread */
-    Eigen::MatrixXd X_sigma_k;
-    Eigen::MatrixXd X_sigma_dot_k;
-
     /* Set sigma points related matrices and vectors to zero */
-    X_sigma_k.setZero(this->numStates, this->numSigmas);
-    X_sigma_dot_k.setZero(this->numStates, this->numSigmas);
+    StateSigmaMatrix X_sigma_k = StateSigmaMatrix::Zero();
 
     /* Compute square root matrix of covariance */
-    Eigen::MatrixXd Psqrt_k;
-    Psqrt_k = this->P_k.llt().matrixL();
+    const StateVector currentState = this->x_hat_k;
+    const StateMatrix currentCovariance = this->P_k;
+    StateMatrix Psqrt_k = currentCovariance.llt().matrixL();
 
     /* Assign mean to central sigma point */
-    X_sigma_k.col(0) = this->x_hat_k;
+    X_sigma_k.col(0) = currentState;
 
     /* Loop to generate remaining sigma points */
-    for (uint64_t i = 0; i < this->numStates; i++) {
+    for (int i = 0; i < stateSize; i++) {
         /* Generate sigma points */
-        X_sigma_k.col(i+1) = this->x_hat_k
-            - sqrt(this->numStates + this->kappa) * Psqrt_k.col(i);
-        X_sigma_k.col(numStates+i+1) = x_hat_k
-            + sqrt(this->numStates + this->kappa) * Psqrt_k.col(i);
+        X_sigma_k.col(i+1) = currentState
+            - sqrt(stateSize + this->kappa) * Psqrt_k.col(i);
+        X_sigma_k.col(stateSize+i+1) = currentState
+            + sqrt(stateSize + this->kappa) * Psqrt_k.col(i);
     }
 
     /* Loop to propagate sigma points and compute mean */
-    Eigen::VectorXd x_sigma_k;
-    Eigen::VectorXd x_sigma_dot_k;
+    StateVector x_sigma_k = StateVector::Zero();
+    StateVector x_sigma_dot_k = StateVector::Zero();
     Eigen::Vector3d r_sigma_k;
     Eigen::Vector3d v_sigma_k;
     Eigen::Vector3d a_sigma_k;
-    x_sigma_k.setZero(this->numStates);
-    x_sigma_dot_k.setZero(this->numStates);
-    this->x_hat_k1_.setZero(this->numStates);
-    for (uint64_t i = 0; i < this->numSigmas; i++) {
+    this->x_hat_k1_.setZero();
+    for (int i = 0; i < sigmaCount; i++) {
         /* Extract sigma point */
         x_sigma_k = X_sigma_k.col(i);
 
         /* Compute dynamics derivative */
-        r_sigma_k << x_sigma_k.segment(0,3);
-        v_sigma_k << x_sigma_k.segment(3,3);
-        a_sigma_k << x_sigma_k.segment(6,3);
-        x_sigma_dot_k.segment(0,3) = v_sigma_k;
-        x_sigma_dot_k.segment(3,3) = - 2*this->omega_AN_A.cross(v_sigma_k)
+        r_sigma_k = x_sigma_k.segment<3>(0);
+        v_sigma_k = x_sigma_k.segment<3>(3);
+        a_sigma_k = x_sigma_k.segment<3>(6);
+        x_sigma_dot_k.segment<3>(0) = v_sigma_k;
+        x_sigma_dot_k.segment<3>(3) = - 2*this->omega_AN_A.cross(v_sigma_k)
                                      - this->omega_AN_A.cross(this->omega_AN_A.cross(r_sigma_k))
                                      - this->mu_ast*r_sigma_k/pow(r_sigma_k.norm(), 3)
                                      + a_sigma_k;
@@ -158,10 +149,9 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
     }
 
     /* Loop to compute covariance */
-    Eigen::VectorXd x_sigma_dev_k1_;
-    x_sigma_dev_k1_.setZero(this->numStates);
-    this->P_k1_.setZero(this->numStates, this->numStates);
-    for (uint64_t i = 0; i < numSigmas; i++) {
+    StateVector x_sigma_dev_k1_ = StateVector::Zero();
+    this->P_k1_.setZero();
+    for (int i = 0; i < sigmaCount; i++) {
         /* Compute deviation of sigma from the mean */
         x_sigma_dev_k1_ = this->X_sigma_k1_.col(i) - this->x_hat_k1_;
 
@@ -170,7 +160,8 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
     }
 
     /* Add process noise covariance */
-    this->P_k1_ = this->P_k1_ + this->P_proc;
+    const StateMatrix processNoise = this->P_proc;
+    this->P_k1_ = this->P_k1_ + processNoise;
 }
 
 /*! This method does the UT to the a-priori state to compute the a-priori measurements
@@ -178,44 +169,40 @@ void SmallBodyNavUKF::processUT(uint64_t CurrentSimNanos){
 */
 void SmallBodyNavUKF::measurementUT(){
     /* Compute square root matrix of covariance */
-    Eigen::MatrixXd Psqrt_k1_;
-    Psqrt_k1_ = P_k1_.llt().matrixL();
+    StateMatrix Psqrt_k1_ = P_k1_.llt().matrixL();
 
     /* Assign mean to central sigma point */
     this->X_sigma_k1_.col(0) = this->x_hat_k1_;
 
     /* Loop to generate remaining sigma points */
-    for (uint64_t i = 0; i < this->numStates; i++) {
+    for (int i = 0; i < stateSize; i++) {
         /* Generate sigma points */
         this->X_sigma_k1_.col(i+1) = this->x_hat_k1_
-            - sqrt(this->numStates + this->kappa) * Psqrt_k1_.col(i);
-        this->X_sigma_k1_.col(this->numStates+i+1) = this->x_hat_k1_
-            + sqrt(this->numStates + this->kappa) * Psqrt_k1_.col(i);
+            - sqrt(stateSize + this->kappa) * Psqrt_k1_.col(i);
+        this->X_sigma_k1_.col(stateSize+i+1) = this->x_hat_k1_
+            + sqrt(stateSize + this->kappa) * Psqrt_k1_.col(i);
     }
 
     /* Loop to propagate sigma points and compute mean */
-    Eigen::VectorXd x_sigma_k1_;
-    x_sigma_k1_.setZero(this->numStates);
-    this->y_hat_k1_.setZero(this->numMeas);
-    for (uint64_t i = 0; i < this->numSigmas; i++) {
+    StateVector x_sigma_k1_ = StateVector::Zero();
+    this->y_hat_k1_.setZero();
+    for (int i = 0; i < sigmaCount; i++) {
         /* Extract sigma point */
         x_sigma_k1_ = this->X_sigma_k1_.col(i);
 
         /* Assign correlation between state and measurement */
-        this->Y_sigma_k1_.col(i) = x_sigma_k1_.segment(0,3);
+        this->Y_sigma_k1_.col(i) = x_sigma_k1_.segment<3>(0);
 
         /* Compute average */
         this->y_hat_k1_ = this->y_hat_k1_ + this->wm_sigma(i)*this->Y_sigma_k1_.col(i);
     }
 
     /* Loop to compute measurements covariance and cross-correlation */
-    Eigen::VectorXd x_sigma_dev_k1_;
-    Eigen::VectorXd y_sigma_dev_k1_;
-    x_sigma_dev_k1_.setZero(this->numStates);
-    y_sigma_dev_k1_.setZero(this->numStates);
-    this->R_k1_.setZero(this->numMeas, this->numMeas);
-    this->H.setZero(this->numStates, this->numMeas);
-    for (uint64_t i = 0; i < this->numSigmas; i++) {
+    StateVector x_sigma_dev_k1_ = StateVector::Zero();
+    Eigen::Vector3d y_sigma_dev_k1_ = Eigen::Vector3d::Zero();
+    this->R_k1_.setZero();
+    this->H.setZero();
+    for (int i = 0; i < sigmaCount; i++) {
         /* Compute deviation of measurement sigma from the mean */
         x_sigma_dev_k1_ = this->X_sigma_k1_.col(i) - this->x_hat_k1_;
         y_sigma_dev_k1_ = this->Y_sigma_k1_.col(i) - this->y_hat_k1_;
@@ -231,7 +218,8 @@ void SmallBodyNavUKF::measurementUT(){
     this->dcm_AN = cArray2EigenMatrix3d(*dcm_AN_array);
 
     /* Add process noise covariance */
-    this->R_k1_ = this->R_k1_ + this->dcm_AN * this->R_meas * this->dcm_AN.transpose();
+    const Eigen::Matrix3d measurementNoise = this->R_meas;
+    this->R_k1_ = this->R_k1_ + this->dcm_AN * measurementNoise * this->dcm_AN.transpose();
 }
 
 /*! This method collects the measurements and updates the estimation
@@ -243,17 +231,14 @@ void SmallBodyNavUKF::kalmanUpdate(){
     sigma_AN = cArray2EigenVector3d(asteroidEphemerisInMsgBuffer.sigma_BN);
 
     /* Subtract the asteroid position from the spacecraft position */
-    Eigen::VectorXd y_k1;
-    y_k1.setZero(this->numMeas);
-    y_k1.segment(0, 3) = this->dcm_AN*(cArray2EigenVector3d(navTransInMsgBuffer.r_BN_N) -  cArray2EigenVector3d(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
+    Eigen::Vector3d y_k1 = this->dcm_AN*(cArray2EigenVector3d(navTransInMsgBuffer.r_BN_N)
+        - cArray2EigenVector3d(asteroidEphemerisInMsgBuffer.r_BdyZero_N));
 
     /* Compute Kalman gain */
     this->K = this->H*this->R_k1_.inverse();
 
     /* Compute the Kalman innovation */
-    Eigen::VectorXd w_k1;
-    w_k1.setZero(this->numStates);
-    w_k1 = this->K * (y_k1 - this->y_hat_k1_);
+    StateVector w_k1 = this->K * (y_k1 - this->y_hat_k1_);
 
     /* Update state estimation and covariance */
     this->x_hat_k1 = this->x_hat_k1_ + w_k1;

--- a/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.h
+++ b/src/fswAlgorithms/smallBodyNavigation/smallBodyNavUKF/smallBodyNavUKF.h
@@ -44,6 +44,16 @@ public:
     void UpdateState(uint64_t CurrentSimNanos);  //!< Updates state
 
 private:
+    static constexpr int stateSize = 9;
+    static constexpr int measurementSize = 3;
+    static constexpr int sigmaCount = 2*stateSize + 1;
+    using StateVector = Eigen::Matrix<double, stateSize, 1>;
+    using StateMatrix = Eigen::Matrix<double, stateSize, stateSize>;
+    using SigmaWeightVector = Eigen::Matrix<double, sigmaCount, 1>;
+    using StateSigmaMatrix = Eigen::Matrix<double, stateSize, sigmaCount>;
+    using MeasurementSigmaMatrix = Eigen::Matrix<double, measurementSize, sigmaCount>;
+    using CrossCorrelationMatrix = Eigen::Matrix<double, stateSize, measurementSize>;
+
     void readMessages();  //!< Reads input messages
     void writeMessages(uint64_t CurrentSimNanos);  //!< Writes output messages
     void processUT(uint64_t CurrentSimNanos);  //!< Process unscented transform
@@ -63,11 +73,11 @@ public:
     Eigen::MatrixXd R_meas;  //!< Measurement noise covariance
     Eigen::VectorXd x_hat_k;  //!< Current state estimate
     Eigen::MatrixXd P_k;  //!< Current state estimation covariance
-    
+
     double alpha;  //!< UKF hyper-parameter
     double beta;  //!< UKF hyper-parameter
     double kappa;  //!< UKF hyper-parameter
-    
+
     Eigen::Matrix3d dcm_AN;  //!< Small body dcm
     Eigen::Vector3d omega_AN_A;  //!< Small body angular velocity
 
@@ -76,21 +86,18 @@ private:
     EphemerisMsgPayload asteroidEphemerisInMsgBuffer;  //!< Message buffer for asteroid ephemeris
 
     uint64_t prevTime;  //!< Previous time, ns
-    uint64_t numStates;  //!< Number of states
-    uint64_t numMeas;  //!< Number of measurements
-    uint64_t numSigmas;  //!< Number of sigma points
-    Eigen::VectorXd x_hat_k1_;  //!< Apriori state estimate for time k+1
-    Eigen::VectorXd x_hat_k1;  //!< Update state estimate for time k+1
-    Eigen::VectorXd wm_sigma;  //!< Mean sigma weights for UT
-    Eigen::VectorXd wc_sigma;  //!< Covariance sigma weights for UT
-    Eigen::VectorXd y_hat_k1_;  //!< Apriori measurement estimate for time k+1
-    Eigen::MatrixXd P_k1_;  //!< Apriori state covariance estimate for time k+1
-    Eigen::MatrixXd P_k1;  //!< Update state covariance estimate for time k+1
-    Eigen::MatrixXd X_sigma_k1_;  //!< Apriori state sigma points for time k+1
-    Eigen::MatrixXd R_k1_;  //!< Apriori measurements covariance estimate for time k+1
-    Eigen::MatrixXd Y_sigma_k1_;  //!< Apriori measurements sigma points for time k+1
-    Eigen::MatrixXd H;  //!< State-measurements cross-correlation matrix
-    Eigen::MatrixXd K;  //!< Kalman gain matrix
+    StateVector x_hat_k1_;  //!< Apriori state estimate for time k+1
+    StateVector x_hat_k1;  //!< Update state estimate for time k+1
+    SigmaWeightVector wm_sigma;  //!< Mean sigma weights for UT
+    SigmaWeightVector wc_sigma;  //!< Covariance sigma weights for UT
+    Eigen::Vector3d y_hat_k1_;  //!< Apriori measurement estimate for time k+1
+    StateMatrix P_k1_;  //!< Apriori state covariance estimate for time k+1
+    StateMatrix P_k1;  //!< Update state covariance estimate for time k+1
+    StateSigmaMatrix X_sigma_k1_;  //!< Apriori state sigma points for time k+1
+    Eigen::Matrix3d R_k1_;  //!< Apriori measurements covariance estimate for time k+1
+    MeasurementSigmaMatrix Y_sigma_k1_;  //!< Apriori measurements sigma points for time k+1
+    CrossCorrelationMatrix H;  //!< State-measurements cross-correlation matrix
+    CrossCorrelationMatrix K;  //!< Kalman gain matrix
 };
 
 

--- a/src/simulation/dynamics/MtbEffector/MtbEffector.cpp
+++ b/src/simulation/dynamics/MtbEffector/MtbEffector.cpp
@@ -102,8 +102,6 @@ void MtbEffector::computeForceTorque(double integTime, double timeStep)
     Eigen::Matrix3d dcm_BN;
     Eigen::Vector3d magField_B;
     Eigen::Matrix3d bTilde;
-    Eigen::MatrixXd GtMatrix_B;
-    Eigen::VectorXd muCmd_T;
     Eigen::Vector3d mtbTorque_B;
     Eigen::Vector3d magField_N;
 
@@ -131,13 +129,12 @@ void MtbEffector::computeForceTorque(double integTime, double timeStep)
 
     /*
      * Compute torque produced by magnetic torque bars in body frame components.
-     * Since cArray2EigenMatrixXd expects a column major input, we need to
-     * transpose GtMatrix_B.
+     * Transpose the row-major payload into column-major storage for the Eigen map.
      */
     double GtColMajor[3*MAX_EFF_CNT];
     mSetZero(GtColMajor, 3, this->mtbConfigParams.numMTB);
     mTranspose(this->mtbConfigParams.GtMatrix_B, 3, this->mtbConfigParams.numMTB, GtColMajor);
-    GtMatrix_B = cArray2EigenMatrixXd(GtColMajor, 3, this->mtbConfigParams.numMTB);
+    const Eigen::Map<const Eigen::Matrix3Xd> GtMatrix_B(GtColMajor, 3, this->mtbConfigParams.numMTB);
 
     /* check if dipole commands are saturating the effector */
     for (int i=0; i<this->mtbConfigParams.numMTB; i++) {
@@ -148,8 +145,9 @@ void MtbEffector::computeForceTorque(double integTime, double timeStep)
         }
     }
 
-    muCmd_T = Eigen::Map<Eigen::VectorXd>(this->mtbCmdInMsgBuffer.mtbDipoleCmds, this->mtbConfigParams.numMTB, 1);
-    mtbTorque_B = - bTilde * GtMatrix_B * muCmd_T;
+    const Eigen::Map<const Eigen::VectorXd> muCmd_T(this->mtbCmdInMsgBuffer.mtbDipoleCmds,
+                                                    this->mtbConfigParams.numMTB);
+    mtbTorque_B = -bTilde * (GtMatrix_B * muCmd_T);
     this->torqueExternalPntB_B = mtbTorque_B;
 
     return;

--- a/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/gravityEffector.cpp
@@ -259,7 +259,7 @@ void GravityEffector::updateInertialPosAndVel(Eigen::Vector3d r_BF_N, Eigen::Vec
         Eigen::Vector3d r_CN_N = getEulerSteppedGravBodyPosition(this->centralBody);
         *this->inertialPositionProperty = r_CN_N + r_BF_N;
         *this->inertialVelocityProperty =
-            cArray2EigenMatrixXd(this->centralBody->localPlanet.VelocityVector, 3, 1) + rDot_BF_N;
+            cArray2EigenVector3d(this->centralBody->localPlanet.VelocityVector) + rDot_BF_N;
     }
     else {
         *this->inertialPositionProperty = r_BF_N;

--- a/src/simulation/environment/_GeneralModuleFiles/planetRadiationBase.cpp
+++ b/src/simulation/environment/_GeneralModuleFiles/planetRadiationBase.cpp
@@ -281,7 +281,7 @@ std::vector<PatchResult> PlanetGrid::computePatches(
     // Convert the SPICE J2000->P rotation matrix into an Eigen matrix.
     // Due to row-major/column-major interpretation, this yields J20002Pfixᵀ,
     // i.e. the rotation from planet-fixed frame P to inertial frame N.
-    const Eigen::Matrix3d dcm_NP = cArray2EigenMatrixXd(*J20002Pfix, 3, 3);  // [-]
+    const Eigen::Matrix3d dcm_NP = cArray2EigenMatrix3d(*J20002Pfix).transpose();  // [-]
 
     // Relative position vectors from planet center to satellite and Sun (in inertial N frame)
     const Eigen::Vector3d rs(r_sat_N[0]-r_planet_N[0], r_sat_N[1]-r_planet_N[1], r_sat_N[2]-r_planet_N[2]);  // [m]

--- a/src/simulation/environment/groundMapping/groundMapping.cpp
+++ b/src/simulation/environment/groundMapping/groundMapping.cpp
@@ -171,7 +171,7 @@ void GroundMapping::updateInertialPositions()
     this->r_BP_N = cArray2EigenVector3d(scStateInMsgBuffer.r_BN_N) - this->r_PN_N;
     double dcm_BN[3][3];
     MRP2C(scStateInMsgBuffer.sigma_BN, dcm_BN);
-    this->dcm_NB = cArray2EigenMatrixXd(*dcm_BN, 3, 3);
+    this->dcm_NB = cArray2EigenMatrix3d(*dcm_BN).transpose();
 
     // Get planet frame angular velocity vector
     Eigen::Matrix3d w_tilde_PN = - this->dcm_PN_dot * this->dcm_PN.transpose();

--- a/src/simulation/navigation/planetNav/planetNav.cpp
+++ b/src/simulation/navigation/planetNav/planetNav.cpp
@@ -35,11 +35,11 @@ PlanetNav::PlanetNav()
     this->prevTime = 0;
     this->noisePlanetState = this->ephemerisOutMsg.zeroMsgPayload;
     this->truePlanetState = this->ephemerisOutMsg.zeroMsgPayload;
-    this->PMatrix.resize(12,12);
+    this->PMatrix.resize(this->numStates, this->numStates);
     this->PMatrix.fill(0.0);
-    this->walkBounds.resize(12);
+    this->walkBounds.resize(this->numStates);
     this->walkBounds.fill(0.0);
-    this->errorModel =  GaussMarkov(12, this->RNGSeed);
+    this->errorModel =  GaussMarkov(this->numStates, this->RNGSeed);
 }
 
 /*! Module Destructor */
@@ -59,21 +59,19 @@ void PlanetNav::Reset(uint64_t CurrentSimNanos)
         bskLogger.bskError("PlanetNav.ephemerisInMsg was not linked.");
     }
 
-    int64_t numStates = 12;
-
     //! - Initialize the propagation matrix to default values for use in update
-    this->AMatrix.setIdentity(numStates, numStates);
+    this->AMatrix.setIdentity();
     this->AMatrix(0,3) = this->AMatrix(1,4) = this->AMatrix(2,5) = this->crossTrans ? 1.0 : 0.0;
     this->AMatrix(6,9) = this->AMatrix(7,10) = this->AMatrix(8, 11) = this->crossAtt ? 1.0 : 0.0;
 
     //! - Alert the user and stop if the noise matrix is the wrong size.  That'd be bad.
-    if (this->PMatrix.size() != numStates*numStates) {
+    if (this->PMatrix.size() != this->numStates*this->numStates) {
         bskLogger.bskError("Your process noise matrix (PMatrix) is not 12*12. Size is %ld.  Quitting", this->PMatrix.size());
     }
     //! - Set the matrices of the lower level error propagation (GaussMarkov)
     this->errorModel.setNoiseMatrix(this->PMatrix);
     this->errorModel.setRNGSeed(this->RNGSeed);
-    if (this->walkBounds.size() != numStates) {
+    if (this->walkBounds.size() != this->numStates) {
         bskLogger.bskError("Your walkbounds vector  is not 12 elements. Quitting");
     }
     this->errorModel.setUpperBounds(this->walkBounds);
@@ -117,16 +115,16 @@ void PlanetNav::applyErrors()
 void PlanetNav::computeErrors(uint64_t CurrentSimNanos)
 {
     double timeStep;
-    Eigen::MatrixXd localProp = this->AMatrix;
+    StateMatrix localProp = this->AMatrix;
     //! - Compute timestep since the last call
-    timeStep = (CurrentSimNanos - this->prevTime)*1.0E-9;
+    timeStep = (CurrentSimNanos - this->prevTime) * NANO2SEC;
 
-    localProp(0,3) *= timeStep; //postion/velocity cross correlation terms
-    localProp(1,4) *= timeStep; //postion/velocity cross correlation terms
-    localProp(2,5) *= timeStep; //postion/velocity cross correlation terms
-    localProp(6,9) *= timeStep; //attitude/attitude rate cross correlation terms
-    localProp(7,10) *= timeStep; //attitude/attitude rate cross correlation terms
-    localProp(8,11) *= timeStep; //attitude/attitude rate cross correlation terms
+    localProp(0, 3) *= timeStep; // position/velocity cross correlation terms
+    localProp(1, 4) *= timeStep; // position/velocity cross correlation terms
+    localProp(2, 5) *= timeStep; // position/velocity cross correlation terms
+    localProp(6, 9) *= timeStep; // attitude/attitude rate cross correlation terms
+    localProp(7, 10) *= timeStep; // attitude/attitude rate cross correlation terms
+    localProp(8, 11) *= timeStep; // attitude/attitude rate cross correlation terms
 
     //! - Set the GaussMarkov propagation matrix and compute errors
     this->errorModel.setPropMatrix(localProp);

--- a/src/simulation/navigation/planetNav/planetNav.h
+++ b/src/simulation/navigation/planetNav/planetNav.h
@@ -57,7 +57,9 @@ public:
     BSKLogger bskLogger;              //!< -- BSK Logging
 
 private:
-    Eigen::MatrixXd AMatrix;           //!< -- The matrix used to propagate the state
+    static constexpr int numStates = 12;  //!< -- Number of states
+    using StateMatrix = Eigen::Matrix<double, numStates, numStates>;
+    StateMatrix AMatrix;               //!< -- The matrix used to propagate the state
     GaussMarkov errorModel;            //!< -- Gauss-markov error states
     uint64_t prevTime;                 //!< -- Previous simulation time observed
 

--- a/src/simulation/navigation/simpleNav/simpleNav.cpp
+++ b/src/simulation/navigation/simpleNav/simpleNav.cpp
@@ -35,11 +35,11 @@ SimpleNav::SimpleNav()
     this->trueAttState = this->attOutMsg.zeroMsgPayload;
     this->estTransState = this->transOutMsg.zeroMsgPayload;
     this->trueTransState = this->transOutMsg.zeroMsgPayload;
-    this->PMatrix.resize(18,18);
+    this->PMatrix.resize(this->numStates, this->numStates);
     this->PMatrix.fill(0.0);
-    this->walkBounds.resize(18);
+    this->walkBounds.resize(this->numStates);
     this->walkBounds.fill(0.0);
-    this->errorModel =  GaussMarkov(18, this->RNGSeed);
+    this->errorModel =  GaussMarkov(this->numStates, this->RNGSeed);
 }
 
 /*! Destructor.  Nothing here. */
@@ -69,7 +69,7 @@ void SimpleNav::Reset(uint64_t CurrentSimNanos)
     }
 
     //! - Initialize the propagation matrix to default values for use in update
-    this->AMatrix.setIdentity(this->numStates, this->numStates);
+    this->AMatrix.setIdentity();
     this->AMatrix(0,3) = this->AMatrix(1,4) = this->AMatrix(2,5) = this->crossTrans ? 1.0 : 0.0;
     this->AMatrix(6,9) = this->AMatrix(7,10) = this->AMatrix(8, 11) = this->crossAtt ? 1.0 : 0.0;
 
@@ -169,16 +169,16 @@ void SimpleNav::computeTrueOutput(uint64_t Clock)
 void SimpleNav::computeErrors(uint64_t CurrentSimNanos)
 {
     double timeStep;
-    Eigen::MatrixXd localProp = this->AMatrix;
+    StateMatrix localProp = this->AMatrix;
     //! - Compute timestep since the last call
-    timeStep = (CurrentSimNanos - this->prevTime)*1.0E-9;
+    timeStep = (CurrentSimNanos - this->prevTime) * NANO2SEC;
 
-    localProp(0,3) *= timeStep; //postion/velocity cross correlation terms
-    localProp(1,4) *= timeStep; //postion/velocity cross correlation terms
-    localProp(2,5) *= timeStep; //postion/velocity cross correlation terms
-    localProp(6,9) *= timeStep; //attitude/attitude rate cross correlation terms
-    localProp(7,10) *= timeStep; //attitude/attitude rate cross correlation terms
-    localProp(8,11) *= timeStep; //attitude/attitude rate cross correlation terms
+    localProp(0, 3) *= timeStep; // position/velocity cross correlation terms
+    localProp(1, 4) *= timeStep; // position/velocity cross correlation terms
+    localProp(2, 5) *= timeStep; // position/velocity cross correlation terms
+    localProp(6, 9) *= timeStep; // attitude/attitude rate cross correlation terms
+    localProp(7, 10) *= timeStep; // attitude/attitude rate cross correlation terms
+    localProp(8, 11) *= timeStep; // attitude/attitude rate cross correlation terms
 
     //! - Set the GaussMarkov propagation matrix and compute errors
     if (this->PMatrix.size() != this->numStates*this->numStates) {

--- a/src/simulation/navigation/simpleNav/simpleNav.h
+++ b/src/simulation/navigation/simpleNav/simpleNav.h
@@ -65,10 +65,11 @@ public:
     ReadFunctor<SpicePlanetStateMsgPayload> sunStateInMsg; //!< (optional) sun state input input msg
 
 private:
-    Eigen::MatrixXd AMatrix;           //!< -- The matrix used to propagate the state
+    static constexpr int numStates = 18;  //!< -- Number of states
+    using StateMatrix = Eigen::Matrix<double, numStates, numStates>;
+    StateMatrix AMatrix;               //!< -- The matrix used to propagate the state
     GaussMarkov errorModel;            //!< -- Gauss-markov error states
     uint64_t prevTime;                 //!< -- Previous simulation time observed
-    int64_t numStates = 18;            //!< -- Number of states
 };
 
 

--- a/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
+++ b/src/simulation/sensors/coarseSunSensor/coarseSunSensor.cpp
@@ -167,8 +167,7 @@ void CoarseSunSensor::Reset(uint64_t CurrentSimNanos)
     pMatrixFault(0,0) = 1.0; // propagation matrix
     this->faultNoiseModel.setPropMatrix(pMatrixFault);
 
-    Eigen::MatrixXd satBounds;
-    satBounds.resize(1, 2);
+    Eigen::Matrix<double, 1, 2> satBounds;
     satBounds(0,0) = this->minOutput;
     satBounds(0,1) = this->maxOutput;
     this->saturateUtility.setBounds(satBounds);

--- a/src/simulation/sensors/imuSensor/imuSensor.cpp
+++ b/src/simulation/sensors/imuSensor/imuSensor.cpp
@@ -119,8 +119,7 @@ void ImuSensor::Reset(uint64_t CurrentSimNanos)
     this->errorModelGyro.setNoiseMatrix(this->PMatrixGyro);
     this->errorModelGyro.setRNGSeed(this->RNGSeed);
 
-    Eigen::MatrixXd oSatBounds;
-    oSatBounds.resize(this->numStates, 2);
+    Eigen::Matrix<double, 3, 2> oSatBounds;
     oSatBounds(0,0) = -this->senRotMax;
     oSatBounds(0,1) = this->senRotMax;
     oSatBounds(1,0) = -this->senRotMax;
@@ -129,8 +128,7 @@ void ImuSensor::Reset(uint64_t CurrentSimNanos)
     oSatBounds(2,1) = this->senRotMax;
     this->oSat.setBounds(oSatBounds);
 
-    Eigen::MatrixXd aSatBounds;
-    aSatBounds.resize(this->numStates, 2);
+    Eigen::Matrix<double, 3, 2> aSatBounds;
     aSatBounds(0,0) = -this->senTransMax;
     aSatBounds(0,1) = this->senTransMax;
     aSatBounds(1,0) = -this->senTransMax;

--- a/src/simulation/sensors/magnetometer/magnetometer.cpp
+++ b/src/simulation/sensors/magnetometer/magnetometer.cpp
@@ -104,8 +104,7 @@ void Magnetometer::Reset(uint64_t CurrentSimNanos)
     }
 
     // Set saturation bounds
-    Eigen::MatrixXd satBounds;
-    satBounds.resize(this->numStates, 2);
+    Eigen::Matrix<double, 3, 2> satBounds;
     satBounds(0, 0) = this->minOutput;
     satBounds(0, 1) = this->maxOutput;
     satBounds(1, 0) = this->minOutput;


### PR DESCRIPTION
- **Review:** By commit
- **Merge strategy:** Merge (no squash)

## Description

This PR reduces Eigen heap allocations and unnecessary copies by replacing dynamically sized matrices and vectors with fixed-size or partially fixed-size types where dimensions are known at compile time.

The commits are organized by subsystem:

1. Eigen/C-array conversions and geodetic utilities
2. Common numerical utilities
3. Gauss-Markov propagation
4. SimpleNav and PlanetNav
5. Lambert planning and validation
6. Small-body navigation filters
7. Effector-control algorithms
8. Remaining three-dimensional simulation and control paths
9. Release-note documentation

The changes preserve existing numerical behavior and message interfaces. The SWIG-visible dynamic Eigen conversion functions remain available, while C++ overloads avoid converting fixed-size Eigen expressions to temporary `MatrixXd` objects.

## Verification

- Completed a full incremental C++ and SWIG build.
- Passed 18 Eigen conversion and geodetic CTests.
- Passed 8 targeted state-architecture, small-body EKF, small-body UKF, and MTB Python tests.
- Confirmed `git diff --check` passes.

No tests were added or re-baselined because the changes optimize internal storage and expression evaluation without changing expected results. Existing conversion and module tests exercise the affected behavior.

## Documentation

No module input/output documentation or user-facing configuration was invalidated.

Inline comments describing row-major and column-major conversions were updated for the new implementations. A release-note snippet documents the reduction in Eigen heap allocation across the affected utilities and modules.

## Future work

No required follow-up is anticipated.