### PR TITLE
[#1482] Harden optional wheel packaging against runner version drift

### DIFF
--- a/.github/scripts/build_optional_bsk_wheel.py
+++ b/.github/scripts/build_optional_bsk_wheel.py
@@ -39,6 +39,7 @@ from pathlib import Path, PurePosixPath
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_VERSION_FILE = REPO_ROOT / "docs/source/bskVersion.txt"
 BASE_DISTRIBUTION = "bsk"
+BUILD_ABI_DATA_PATH = "Basilisk/_buildAbiData.py"
 BUILD_INFO_DATA_PATH = "Basilisk/_buildInfoData.py"
 BUILD_FEATURE_ENTRY_POINT_GROUP = "basilisk.build_features"
 NATIVE_PAYLOAD_SUFFIXES = (".a", ".dll", ".dylib", ".lib", ".pyd", ".so")
@@ -58,6 +59,8 @@ PRE_RELEASE_VERSION_PATTERN = re.compile(
     r"(?P<label>a|alpha|b|beta|c|pre|preview|rc)(?P<number>\d*))$",
     re.IGNORECASE,
 )
+VERSION_MAJOR_MINOR_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.|$)")
+COMPILER_VERSION_FIELDS = ("version", "simulatedVersion")
 
 
 @dataclass(frozen=True)
@@ -256,34 +259,266 @@ def warn_changed_native_payloads(changed: list[str]) -> None:
     )
 
 
-def parse_build_info_data(data: bytes) -> dict[str, object]:
-    """Parse the generated build-information dictionary without executing it."""
-    tree = ast.parse(data.decode("utf-8"), filename=BUILD_INFO_DATA_PATH)
+def compatible_major_minor_version(
+    base_version: object,
+    component_version: object,
+) -> str | None:
+    """Return the shared major/minor version for compatible diagnostics."""
+    if not isinstance(base_version, str) or not isinstance(component_version, str):
+        return None
+    if base_version == component_version:
+        return None
+
+    base_match = VERSION_MAJOR_MINOR_PATTERN.match(base_version)
+    component_match = VERSION_MAJOR_MINOR_PATTERN.match(component_version)
+    if base_match is None or component_match is None:
+        return None
+
+    base_prefix = (base_match.group("major"), base_match.group("minor"))
+    component_prefix = (
+        component_match.group("major"),
+        component_match.group("minor"),
+    )
+    if base_prefix != component_prefix:
+        return None
+    return ".".join(base_prefix)
+
+
+def normalize_compatible_version_field(
+    base_values: dict[str, object],
+    component_values: dict[str, object],
+    field: str,
+    path: str,
+    differences: list[str],
+) -> None:
+    """Normalize one compatible diagnostic version and record its warning."""
+    base_version = base_values.get(field)
+    component_version = component_values.get(field)
+    compatible_version = compatible_major_minor_version(
+        base_version,
+        component_version,
+    )
+    if compatible_version is None:
+        return
+
+    base_values[field] = compatible_version
+    component_values[field] = compatible_version
+    differences.append(f"{path}: {base_version!r} versus {component_version!r}")
+
+
+def normalize_compatible_diagnostic_versions(
+    base_build_info: dict[str, object],
+    component_build_info: dict[str, object],
+) -> list[str]:
+    """Normalize compatible patch/build differences in diagnostic versions.
+
+    Optional wheel inputs are built by independent GitHub runners. During a
+    runner-image rollout, those machines can carry different patch releases of
+    otherwise compatible compilers and build tools. ABI-relevant metadata is
+    still compared exactly by :func:`validate_build_feature_metadata`.
+    """
+    differences: list[str] = []
+    base_diagnostics = base_build_info.get("diagnostics")
+    component_diagnostics = component_build_info.get("diagnostics")
+    if not isinstance(base_diagnostics, dict) or not isinstance(
+        component_diagnostics,
+        dict,
+    ):
+        return differences
+
+    base_compilers = base_diagnostics.get("compilers")
+    component_compilers = component_diagnostics.get("compilers")
+    if isinstance(base_compilers, dict) and isinstance(component_compilers, dict):
+        for compiler_name in sorted(base_compilers.keys() & component_compilers.keys()):
+            base_compiler = base_compilers[compiler_name]
+            component_compiler = component_compilers[compiler_name]
+            if not isinstance(base_compiler, dict) or not isinstance(
+                component_compiler,
+                dict,
+            ):
+                continue
+            for field in COMPILER_VERSION_FIELDS:
+                normalize_compatible_version_field(
+                    base_compiler,
+                    component_compiler,
+                    field,
+                    f"diagnostics.compilers.{compiler_name}.{field}",
+                    differences,
+                )
+
+    base_tools = base_diagnostics.get("tools")
+    component_tools = component_diagnostics.get("tools")
+    if isinstance(base_tools, dict) and isinstance(component_tools, dict):
+        for tool_name in sorted(base_tools.keys() & component_tools.keys()):
+            normalize_compatible_version_field(
+                base_tools,
+                component_tools,
+                tool_name,
+                f"diagnostics.tools.{tool_name}",
+                differences,
+            )
+
+    return differences
+
+
+def warn_compatible_diagnostic_versions(differences: list[str]) -> None:
+    """Report compatible compiler and build-tool version differences."""
+    if not differences:
+        return
+
+    details = "\n  ".join(differences)
+    print(
+        "warning: base and component wheels use compatible patch/build "
+        "versions from independent runners:\n"
+        f"  {details}",
+        file=sys.stderr,
+    )
+
+
+def parse_generated_dictionary(
+    data: bytes,
+    path: str,
+    variable: str,
+) -> dict[str, object]:
+    """Parse one generated dictionary assignment without executing it."""
+    tree = ast.parse(data.decode("utf-8"), filename=path)
     assignments = [
         node
         for node in tree.body
         if isinstance(node, ast.Assign)
         and len(node.targets) == 1
         and isinstance(node.targets[0], ast.Name)
-        and node.targets[0].id == "buildInfoData"
+        and node.targets[0].id == variable
     ]
     if len(assignments) != 1:
-        raise ValueError(
-            f"Expected one buildInfoData assignment in {BUILD_INFO_DATA_PATH}."
-        )
+        raise ValueError(f"Expected one {variable} assignment in {path}.")
 
-    build_info = ast.literal_eval(assignments[0].value)
-    if not isinstance(build_info, dict):
-        raise ValueError(f"Expected a dictionary in {BUILD_INFO_DATA_PATH}.")
-    return build_info
+    value = ast.literal_eval(assignments[0].value)
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a dictionary in {path}.")
+    return value
+
+
+def parse_build_info_data(data: bytes) -> dict[str, object]:
+    """Parse the generated build-information dictionary without executing it."""
+    return parse_generated_dictionary(data, BUILD_INFO_DATA_PATH, "buildInfoData")
+
+
+def parse_build_abi_data(data: bytes) -> dict[str, object]:
+    """Parse the generated ABI dictionary without executing it."""
+    return parse_generated_dictionary(data, BUILD_ABI_DATA_PATH, "buildAbiData")
+
+
+def normalize_compatible_abi_compiler_versions(
+    base_abi: dict[str, object],
+    component_abi: dict[str, object],
+) -> list[str]:
+    """Normalize raw compiler build revisions with equal ABI version fields."""
+    differences: list[str] = []
+    compatibility_fields = ("id", "majorVersion", "minorVersion")
+    for language in ("c", "cxx"):
+        base_language = base_abi.get(language)
+        component_language = component_abi.get(language)
+        if not isinstance(base_language, dict) or not isinstance(
+            component_language,
+            dict,
+        ):
+            continue
+
+        base_compiler = base_language.get("compiler")
+        component_compiler = component_language.get("compiler")
+        if not isinstance(base_compiler, dict) or not isinstance(
+            component_compiler,
+            dict,
+        ):
+            continue
+        if any(
+            base_compiler.get(field) != component_compiler.get(field)
+            for field in compatibility_fields
+        ):
+            continue
+
+        base_patch_version = base_compiler.get("patchVersion")
+        component_patch_version = component_compiler.get("patchVersion")
+        if (
+            isinstance(base_patch_version, int)
+            and isinstance(component_patch_version, int)
+            and base_patch_version != component_patch_version
+        ):
+            base_compiler["patchVersion"] = 0
+            component_compiler["patchVersion"] = 0
+            differences.append(
+                f"{BUILD_ABI_DATA_PATH}:{language}.compiler.patchVersion: "
+                f"{base_patch_version!r} versus {component_patch_version!r}"
+            )
+
+        base_version = base_compiler.get("version")
+        component_version = component_compiler.get("version")
+        if (
+            isinstance(base_version, str)
+            and isinstance(component_version, str)
+            and base_version != component_version
+        ):
+            base_compiler["version"] = "compatible-build-version"
+            component_compiler["version"] = "compatible-build-version"
+            differences.append(
+                f"{BUILD_ABI_DATA_PATH}:{language}.compiler.version: "
+                f"{base_version!r} versus {component_version!r}"
+            )
+
+        base_full_version = base_compiler.get("msvcFullVersion")
+        component_full_version = component_compiler.get("msvcFullVersion")
+        msvc_abi_matches = (
+            base_compiler.get("abiFamily") == "msvc"
+            and component_compiler.get("abiFamily") == "msvc"
+            and base_compiler.get("abiVersion")
+            == component_compiler.get("abiVersion")
+        )
+        if (
+            msvc_abi_matches
+            and isinstance(base_full_version, int)
+            and isinstance(component_full_version, int)
+            and base_full_version > 0
+            and component_full_version > 0
+            and base_full_version != component_full_version
+        ):
+            base_compiler["msvcFullVersion"] = 0
+            component_compiler["msvcFullVersion"] = 0
+            differences.append(
+                f"{BUILD_ABI_DATA_PATH}:{language}.compiler.msvcFullVersion: "
+                f"{base_full_version!r} versus {component_full_version!r}"
+            )
+
+    return differences
+
+
+def validate_build_abi_metadata(
+    base_archive: zipfile.ZipFile,
+    component_archive: zipfile.ZipFile,
+) -> list[str]:
+    """Validate ABI metadata and return compatible compiler revisions."""
+    base_abi = parse_build_abi_data(base_archive.read(BUILD_ABI_DATA_PATH))
+    component_abi = parse_build_abi_data(component_archive.read(BUILD_ABI_DATA_PATH))
+    normalized_base_abi = copy.deepcopy(base_abi)
+    normalized_component_abi = copy.deepcopy(component_abi)
+    version_differences = normalize_compatible_abi_compiler_versions(
+        normalized_base_abi,
+        normalized_component_abi,
+    )
+    if normalized_component_abi != normalized_base_abi:
+        raise ValueError(
+            f"{BUILD_ABI_DATA_PATH} differs between the base and component builds "
+            "beyond compatible compiler patch/build versions."
+        )
+    return version_differences
 
 
 def validate_build_feature_metadata(
     base_archive: zipfile.ZipFile,
     component_archive: zipfile.ZipFile,
     component: OptionalComponent,
-) -> None:
-    """Validate the intentional feature difference between wheel build inputs."""
+) -> list[str]:
+    """Validate feature metadata and return compatible diagnostic revisions."""
     base_build_info = parse_build_info_data(base_archive.read(BUILD_INFO_DATA_PATH))
     component_build_info = parse_build_info_data(
         component_archive.read(BUILD_INFO_DATA_PATH)
@@ -311,16 +546,22 @@ def validate_build_feature_metadata(
             "and enabled in the component build."
         )
 
+    normalized_base_info = copy.deepcopy(base_build_info)
     normalized_component_info = copy.deepcopy(component_build_info)
     normalized_component_info["features"] = {
         **component_features,
         component.build_feature: base_enabled,
     }
-    if normalized_component_info != base_build_info:
+    version_differences = normalize_compatible_diagnostic_versions(
+        normalized_base_info,
+        normalized_component_info,
+    )
+    if normalized_component_info != normalized_base_info:
         raise ValueError(
             f"{BUILD_INFO_DATA_PATH} differs between the base and component builds "
             f"beyond the expected {component.build_feature!r} feature value."
         )
+    return version_differences
 
 
 def validate_common_payloads(
@@ -337,7 +578,23 @@ def validate_common_payloads(
         raise ValueError(
             f"Both wheel build inputs must contain {BUILD_INFO_DATA_PATH}."
         )
-    validate_build_feature_metadata(base_archive, component_archive, component)
+    version_differences = validate_build_feature_metadata(
+        base_archive,
+        component_archive,
+        component,
+    )
+    base_has_abi_data = BUILD_ABI_DATA_PATH in base_payload
+    component_has_abi_data = BUILD_ABI_DATA_PATH in component_payload
+    if base_has_abi_data != component_has_abi_data:
+        raise ValueError(
+            f"Both wheel build inputs must contain {BUILD_ABI_DATA_PATH} when "
+            "either input provides it."
+        )
+    if base_has_abi_data:
+        version_differences.extend(
+            validate_build_abi_metadata(base_archive, component_archive)
+        )
+    warn_compatible_diagnostic_versions(version_differences)
 
     changed = []
     for name in sorted(base_payload & component_payload):
@@ -352,6 +609,8 @@ def validate_common_payloads(
 
     if BUILD_INFO_DATA_PATH in non_native_changed:
         non_native_changed.remove(BUILD_INFO_DATA_PATH)
+    if BUILD_ABI_DATA_PATH in non_native_changed:
+        non_native_changed.remove(BUILD_ABI_DATA_PATH)
 
     if non_native_changed:
         details = "\n  ".join(non_native_changed)

--- a/conanfile.py
+++ b/conanfile.py
@@ -164,6 +164,26 @@ def clean_rust_target_artifacts(root: Optional[Path] = None,
     return removed_target_directories
 
 
+def should_scan_windows_dll_directory(root: str, build_folder: str) -> bool:
+    """Return whether a build directory can contain runtime DLLs.
+
+    Cargo's target tree contains build-time procedural-macro DLLs. They are
+    loaded only by ``rustc`` and must not be copied into the Basilisk wheel.
+    """
+    normalized_root = os.path.normcase(os.path.abspath(root))
+    excluded_roots = (
+        os.path.normcase(os.path.abspath(os.path.join(build_folder, "Basilisk"))),
+        os.path.normcase(os.path.abspath(os.path.join(build_folder, "cargo"))),
+    )
+    for excluded_root in excluded_roots:
+        try:
+            if os.path.commonpath([normalized_root, excluded_root]) == excluded_root:
+                return False
+        except ValueError:
+            continue
+    return True
+
+
 def resolve_py_limited_api(opt_value: Optional[str]) -> str:
     """Use explicit --pyLimitedAPI if provided, else cp39."""
     if opt_value:
@@ -492,9 +512,10 @@ class BasiliskConan(ConanFile):
                             self.output.warning(f"Failed to copy DLLs from {src}: {e}")
 
                 # As a fallback, scan the build tree for any remaining DLLs.
-                for root, _dirs, files in os.walk(self.build_folder):
-                    # Skip the destination to avoid self-copy
-                    if os.path.commonpath([root, basilisk_dst_root]) == basilisk_dst_root:
+                for root, dirs, files in os.walk(self.build_folder):
+                    # Skip the destination and Cargo's build-only proc-macro DLLs.
+                    if not should_scan_windows_dll_directory(root, self.build_folder):
+                        dirs.clear()
                         continue
                     if any(f.lower().endswith(".dll") for f in files):
                         try:

--- a/src/tests/test_conan_clean.py
+++ b/src/tests/test_conan_clean.py
@@ -105,3 +105,25 @@ def test_clean_rust_target_artifacts(tmp_path, monkeypatch):
     for crate_directory in crate_directories:
         assert not (crate_directory / "target").exists()
     assert unrelated_target.exists()
+
+
+def test_windows_dll_scan_excludes_cargo_build_artifacts(tmp_path, monkeypatch):
+    """The Windows wheel scan ignores Cargo compiler plugins and its output."""
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.chdir(repo_root)
+    monkeypatch.syspath_prepend(str(repo_root))
+    conanfile = importlib.import_module("conanfile")
+    build_folder = tmp_path / "dist3"
+
+    assert conanfile.should_scan_windows_dll_directory(
+        str(build_folder / "bin"),
+        str(build_folder),
+    )
+    assert not conanfile.should_scan_windows_dll_directory(
+        str(build_folder / "Basilisk"),
+        str(build_folder),
+    )
+    assert not conanfile.should_scan_windows_dll_directory(
+        str(build_folder / "cargo" / "workspace" / "release" / "deps"),
+        str(build_folder),
+    )

--- a/src/tests/test_optionalWheelBuilder.py
+++ b/src/tests/test_optionalWheelBuilder.py
@@ -61,7 +61,7 @@ WHEEL_BUILDER = _loadWheelBuilder()
 WHEEL_TESTER = _loadWheelTester()
 
 
-def _buildInfoData(opNavEnabled, *, schemaVersion=4):
+def _buildInfoData(opNavEnabled, *, schemaVersion=4, diagnostics=None):
     buildInfo = {
         "schemaVersion": schemaVersion,
         "artifact": {"basiliskVersion": "test-version"},
@@ -71,14 +71,69 @@ def _buildInfoData(opNavEnabled, *, schemaVersion=4):
             "mujoco": True,
         },
     }
+    if diagnostics is not None:
+        buildInfo["diagnostics"] = diagnostics
     return f"buildInfoData = {buildInfo!r}\n".encode("utf-8")
 
 
+def _windowsBuildDiagnostics(msvcVersion, rustVersion, cargoVersion):
+    return {
+        "target": {"system": "Windows", "processor": "AMD64"},
+        "build": {"configuration": "Release", "generator": "Ninja"},
+        "compilers": {
+            "c": {"id": "MSVC", "version": msvcVersion},
+            "cxx": {"id": "MSVC", "version": msvcVersion, "standard": "17"},
+            "rust": {
+                "id": "rustc",
+                "version": rustVersion,
+                "target": "x86_64-pc-windows-msvc",
+            },
+        },
+        "tools": {"cargo": cargoVersion, "cmake": "4.3.2"},
+    }
+
+
+def _windowsBuildAbiData(msvcFullVersion, patchVersion=0):
+    compilerVersion = str(msvcFullVersion)
+    return (
+        "buildAbiData = "
+        + repr({
+            "target": {"system": "Windows", "architecture": "x86_64"},
+            "c": {
+                "compiler": {
+                    "id": "MSVC",
+                    "version": compilerVersion,
+                    "majorVersion": 19,
+                    "minorVersion": 51,
+                    "patchVersion": patchVersion,
+                    "msvcVersion": 1951,
+                },
+            },
+            "cxx": {
+                "compiler": {
+                    "id": "MSVC",
+                    "version": compilerVersion,
+                    "majorVersion": 19,
+                    "minorVersion": 51,
+                    "patchVersion": patchVersion,
+                    "abiFamily": "msvc",
+                    "abiVersion": 1951,
+                    "msvcFullVersion": msvcFullVersion,
+                },
+                "layoutCanaries": {"stdStringSize": 32},
+            },
+        })
+        + "\n"
+    ).encode("utf-8")
+
+
 @contextmanager
-def _buildInfoArchive(data):
+def _buildInfoArchive(data, abiData=None):
     with io.BytesIO() as buffer:
         with zipfile.ZipFile(buffer, "w") as archive:
             archive.writestr(WHEEL_BUILDER.BUILD_INFO_DATA_PATH, data)
+            if abiData is not None:
+                archive.writestr(WHEEL_BUILDER.BUILD_ABI_DATA_PATH, abiData)
         buffer.seek(0)
         with zipfile.ZipFile(buffer) as archive:
             yield archive
@@ -98,6 +153,134 @@ def test_expected_build_feature_metadata_difference():
                 payload,
                 component,
             )
+
+
+def test_patch_build_tool_version_differences_warn(capsys):
+    """Compatible runner-image version drift emits a warning and continues."""
+    payload = {WHEEL_BUILDER.BUILD_INFO_DATA_PATH}
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    baseData = _buildInfoData(
+        False,
+        diagnostics=_windowsBuildDiagnostics(
+            "19.51.36252.0",
+            "1.97.1",
+            "1.97.1",
+        ),
+    )
+    componentData = _buildInfoData(
+        True,
+        diagnostics=_windowsBuildDiagnostics(
+            "19.51.36248.0",
+            "1.97.0",
+            "1.97.0",
+        ),
+    )
+
+    with _buildInfoArchive(baseData) as baseArchive:
+        with _buildInfoArchive(componentData) as componentArchive:
+            WHEEL_BUILDER.validate_common_payloads(
+                baseArchive,
+                componentArchive,
+                payload,
+                payload,
+                component,
+            )
+
+    warning = capsys.readouterr().err
+    assert "compatible patch/build versions" in warning
+    assert "19.51.36252.0" in warning
+    assert "19.51.36248.0" in warning
+    assert "1.97.1" in warning
+    assert "1.97.0" in warning
+
+
+def test_patch_abi_compiler_version_differences_warn(capsys):
+    """Equivalent compiler ABI metadata permits raw build-number drift."""
+    payload = {
+        WHEEL_BUILDER.BUILD_ABI_DATA_PATH,
+        WHEEL_BUILDER.BUILD_INFO_DATA_PATH,
+    }
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    baseAbiData = _windowsBuildAbiData(195136252)
+    componentAbiData = _windowsBuildAbiData(195136248, patchVersion=1)
+
+    with _buildInfoArchive(
+        _buildInfoData(False),
+        baseAbiData,
+    ) as baseArchive:
+        with _buildInfoArchive(
+            _buildInfoData(True),
+            componentAbiData,
+        ) as componentArchive:
+            WHEEL_BUILDER.validate_common_payloads(
+                baseArchive,
+                componentArchive,
+                payload,
+                payload,
+                component,
+            )
+
+    warning = capsys.readouterr().err
+    assert "compatible patch/build versions" in warning
+    assert "195136252" in warning
+    assert "195136248" in warning
+    assert "patchVersion: 0 versus 1" in warning
+
+
+def test_abi_layout_difference_fails():
+    """A changed ABI layout canary remains incompatible."""
+    payload = {
+        WHEEL_BUILDER.BUILD_ABI_DATA_PATH,
+        WHEEL_BUILDER.BUILD_INFO_DATA_PATH,
+    }
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    baseAbiData = _windowsBuildAbiData(195136252)
+    componentAbiData = _windowsBuildAbiData(195136248).replace(
+        b"'stdStringSize': 32",
+        b"'stdStringSize': 40",
+    )
+
+    with _buildInfoArchive(
+        _buildInfoData(False),
+        baseAbiData,
+    ) as baseArchive:
+        with _buildInfoArchive(
+            _buildInfoData(True),
+            componentAbiData,
+        ) as componentArchive:
+            with pytest.raises(ValueError, match="beyond compatible compiler"):
+                WHEEL_BUILDER.validate_common_payloads(
+                    baseArchive,
+                    componentArchive,
+                    payload,
+                    payload,
+                    component,
+                )
+
+
+def test_build_tool_minor_version_difference_fails():
+    """A different build-tool major/minor release remains incompatible."""
+    payload = {WHEEL_BUILDER.BUILD_INFO_DATA_PATH}
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    baseData = _buildInfoData(
+        False,
+        diagnostics=_windowsBuildDiagnostics("19.51.1", "1.97.1", "1.97.1"),
+    )
+    componentData = _buildInfoData(
+        True,
+        diagnostics=_windowsBuildDiagnostics("19.51.2", "1.98.0", "1.98.0"),
+    )
+
+    with _buildInfoArchive(baseData) as baseArchive:
+        with _buildInfoArchive(componentData) as componentArchive:
+            with pytest.raises(ValueError, match="beyond the expected 'opNav'"):
+                WHEEL_BUILDER.validate_common_payloads(
+                    baseArchive,
+                    componentArchive,
+                    payload,
+                    payload,
+                    component,
+                )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR makes nightly and release optional-wheel packaging robust to compatible patch-level differences between independently scheduled GitHub runners.

The core and opNav wheel inputs are built in separate jobs. During a Windows runner-image rollout, those jobs repeatedly received different MSVC and Rust patch revisions. Both wheels built successfully, but the optional-wheel assembler rejected their diagnostic metadata.

## Changes

- Permit compiler and build-tool patch/build revision differences when their major and minor versions match.
- Emit a warning containing the exact differing versions.
- Continue requiring exact agreement for:
  - Compiler identity
  - Target platform and architecture
  - Build configuration and runtime
  - Language standards
  - Basilisk source revision
  - Extension ABI
  - ABI layout canaries
  - All unexpected build-feature differences
- Apply the same compatibility policy to `_buildInfoData.py` and `_buildAbiData.py`.
- Exclude Cargo’s build-time procedural-macro DLLs from Windows wheels.
- Add regression tests based on the exact MSVC, Rust, and Cargo versions observed in the failed nightly runs.

Because nightly and release workflows use the same optional-wheel builder, this correction applies to both workflows.

## Motivation

Two attempts of the same Windows nightly build received opposite runner revisions:

- MSVC `19.51.36248.0` and `19.51.36252.0`
- Rust/Cargo `1.97.0` and `1.97.1`

The versions swapped between the core and opNav jobs on the second attempt, confirming that the failure came from runner allocation rather than a build incompatibility.

The Rust version difference also changed the hashed filenames of `bsk_macros` and `serde_derive` procedural-macro DLLs. These are compiler plugins used only during the Cargo build and should not be packaged as Basilisk runtime dependencies.

## Verification

- `16 passed` in the focused optional-wheel and Conan-clean test suites.
- Repository pre-commit checks pass.
- Python compilation checks pass.
- The optional opNav wheel was successfully generated from copies of the failed Windows artifacts after removing the build-only DLLs, producing the expected compatibility warning.