### PR TITLE
set imaging time

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1506-simpleInstrumentController-time-window.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1506-simpleInstrumentController-time-window.rst
@@ -1,0 +1,1 @@
+- Added optional desired-time bounds to :ref:`simpleInstrumentController` for constraining when an image may be captured.

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
@@ -165,6 +165,7 @@ def test_simple_instrument_controller_time_window(
 durationTimeWindowTests = [
     (1.0, 3.0, [0, 0, 1, 0, 0]),  # acquisition completes before the capture window opens
     (2.0, 3.0, [0, 0, 1, 0, 0]),  # acquisition completes inside the capture window
+    (1.0, 1.5, [0, 0, 0, 0, 0]),  # allowed time expires before the capture window opens
     (
         3.0,
         4.0,
@@ -183,8 +184,8 @@ def test_simple_instrument_controller_duration_time_window(
     **Validation Test Description**
 
     Verify that duration-based imaging accumulates valid constraints before the capture window opens. An acquisition
-    that completes before or inside the [1.5, 2.5] second window must capture, while one that completes after it closes
-    must not.
+    that completes before or inside the [1.5, 2.5] second window must capture, while an acquisition that completes
+    after the window closes or whose allowed time expires before the window opens must not.
     """
     [testResults, testMessage] = simpleInstrumentControllerTestFunction(
         show_plots,

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
@@ -104,8 +104,115 @@ def test_simple_instrument_controller(show_plots, use_rate_limit, rate_limit, om
 
     assert testResults < 1, testMessage
 
+# Tuple: timeToleranceLower [s], timeToleranceUpper [s], imagingTime [s], expected_result
+timeWindowTests = [
+    (0.0, 0.0, 2.0, [1, 0, 0, 1, 0]),  # zero tolerances disable the time criteria
+    (
+        1.0,
+        0.0,
+        2.0,
+        [0, 1, 0, 1, 0],
+    ),  # lower tolerance only: image at or after imagingTime - lower
+    (
+        0.0,
+        0.5,
+        2.0,
+        [1, 0, 0, 0, 0],
+    ),  # upper tolerance only: do not image after imagingTime + upper
+    (1.0, 1.0, 2.0, [0, 1, 0, 1, 0]),  # two-sided interval: image within [1s, 3s]
+    (
+        3.0,
+        1.0,
+        2.0,
+        [1, 0, 0, 1, 0],
+    ),  # lower tolerance larger than imagingTime should not underflow
+]
 
-def simpleInstrumentControllerTestFunction(show_plots, use_rate_limit=1, rate_limit=0.01, omega_mag=0.001, deviceStatus=None, controlStatus=None, useDuration=None, imagingTimes=None, expected_result=None):
+
+@pytest.mark.parametrize(
+    "timeToleranceLower,timeToleranceUpper,imagingTime,expected_result", timeWindowTests
+)
+def test_simple_instrument_controller_time_window(
+    show_plots, timeToleranceLower, timeToleranceUpper, imagingTime, expected_result
+):
+    r"""
+    **Validation Test Description**
+
+    Unit test for simpleInstrumentController time-interval imaging criteria. The unit test covers:
+
+    1. If zero lower and upper tolerances preserve the prior behavior and do not constrain imaging time
+
+    2. If a lower tolerance prevents imaging before the desired imaging window
+
+    3. If an upper tolerance prevents imaging after the desired imaging window
+
+    4. If lower and upper tolerances create an inclusive two-sided imaging window
+
+    5. If a lower tolerance larger than the desired imaging time does not cause unsigned integer underflow
+    """
+    [testResults, testMessage] = simpleInstrumentControllerTestFunction(
+        show_plots,
+        timeToleranceLower=timeToleranceLower,
+        timeToleranceUpper=timeToleranceUpper,
+        imagingTime=imagingTime,
+        expected_result=expected_result,
+    )
+
+    assert testResults < 1, testMessage
+
+
+# Tuple: acquisitionTime [s], allowedTime [s], expected_result
+durationTimeWindowTests = [
+    (1.0, 3.0, [0, 0, 1, 0, 0]),  # acquisition completes before the capture window opens
+    (2.0, 3.0, [0, 0, 1, 0, 0]),  # acquisition completes inside the capture window
+    (
+        3.0,
+        4.0,
+        [0, 0, 0, 0, 0],
+    ),  # acquisition completes after the capture window closes
+]
+
+
+@pytest.mark.parametrize(
+    "acquisitionTime,allowedTime,expected_result", durationTimeWindowTests
+)
+def test_simple_instrument_controller_duration_time_window(
+    show_plots, acquisitionTime, allowedTime, expected_result
+):
+    r"""
+    **Validation Test Description**
+
+    Verify that duration-based imaging accumulates valid constraints before the capture window opens. An acquisition
+    that completes before or inside the [1.5, 2.5] second window must capture, while one that completes after it closes
+    must not.
+    """
+    [testResults, testMessage] = simpleInstrumentControllerTestFunction(
+        show_plots,
+        useDuration=1,
+        imagingTimes=[acquisitionTime, allowedTime],
+        timeToleranceLower=0.5,
+        timeToleranceUpper=0.5,
+        imagingTime=2.0,
+        expected_result=expected_result,
+    )
+
+    assert testResults < 1, testMessage
+
+
+def simpleInstrumentControllerTestFunction(
+    show_plots,
+    use_rate_limit=1,
+    rate_limit=0.01,
+    omega_mag=0.001,
+    deviceStatus=None,
+    controlStatus=None,
+    useDuration=None,
+    imagingTimes=None,
+    expected_result=None,
+    timeToleranceLower=None,
+    timeToleranceUpper=None,
+    imagingTime=None,
+):
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
     unitTaskName = "unitTask"
@@ -161,6 +268,13 @@ def simpleInstrumentControllerTestFunction(show_plots, use_rate_limit=1, rate_li
         allowedTime = imagingTimes[1]
         module.acquisitionTime = macros.sec2nano(acquisitionTime)  # convert to nanoseconds
         module.allowedTime = macros.sec2nano(allowedTime)  # convert to nanoseconds
+
+    if timeToleranceLower is not None:
+        module.timeToleranceLower = macros.sec2nano(timeToleranceLower)
+    if timeToleranceUpper is not None:
+        module.timeToleranceUpper = macros.sec2nano(timeToleranceUpper)
+    if imagingTime is not None:
+        module.imagingTime = macros.sec2nano(imagingTime)
 
     # Setup logging on the test module output message so that we get all the writes to it
     dataLog = module.deviceCmdOutMsg.recorder()

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
@@ -163,18 +163,18 @@ Update_simpleInstrumentController(simpleInstrumentControllerConfig* configData, 
                                                   : configData->acquisitionTime;
 
                     if (elapsedTime >= effectiveImageTime) {
-                        // If full effective duration passed, set imaged
-                        if (configData->acquisitionTime <= configData->allowedTime) {
-                            if (timeControl) {
-                                configData->imaged = 1; // Success
-                                deviceCmdOutMsgBuffer.deviceCmd = 1;
-                                configData->constraintsActive = 0; // Reset timer
-                            }
-                        } else {
-                            // Failed because required time > allowed duration
+                        // Capture only while the acquisition and imaging window remain within the allowed duration
+                        if (configData->acquisitionTime <= configData->allowedTime && timeControl &&
+                            elapsedTime <= configData->allowedTime) {
+                            configData->imaged = 1; // Success
+                            deviceCmdOutMsgBuffer.deviceCmd = 1;
+                            configData->constraintsActive = 0; // Reset timer
+                        } else if (elapsedTime >= configData->allowedTime) {
+                            // Failed because the required acquisition or capture-window wait exceeded the
+                            // allowed duration
                             configData->imaged = 0;
                             deviceCmdOutMsgBuffer.deviceCmd = 0;
-                            configData->controllerStatus = 0; // Disable further attempts
+                            configData->controllerStatus = 0;  // Disable further attempts
                             configData->constraintsActive = 0; // Reset timer
                         }
                     }

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
@@ -33,7 +33,8 @@
  @param configData The configuration data associated with this module
  @param moduleID The module identifier
  */
-void SelfInit_simpleInstrumentController(simpleInstrumentControllerConfig *configData, int64_t moduleID)
+void
+SelfInit_simpleInstrumentController(simpleInstrumentControllerConfig* configData, int64_t moduleID)
 {
     configData->imaged = 0;
     configData->controllerStatus = 1;
@@ -50,7 +51,8 @@ void SelfInit_simpleInstrumentController(simpleInstrumentControllerConfig *confi
  @param callTime [ns] time the method is called
  @param moduleID The module identifier
 */
-void Reset_simpleInstrumentController(simpleInstrumentControllerConfig *configData, uint64_t callTime, int64_t moduleID)
+void
+Reset_simpleInstrumentController(simpleInstrumentControllerConfig* configData, uint64_t callTime, int64_t moduleID)
 {
     // check if the required message has not been connected
     if (!AccessMsg_C_isLinked(&configData->locationAccessInMsg)) {
@@ -72,16 +74,17 @@ void Reset_simpleInstrumentController(simpleInstrumentControllerConfig *configDa
  @param callTime The clock time at which the function was called (nanoseconds)
  @param moduleID The module identifier
 */
-void Update_simpleInstrumentController(simpleInstrumentControllerConfig *configData, uint64_t callTime, int64_t moduleID)
+void
+Update_simpleInstrumentController(simpleInstrumentControllerConfig* configData, uint64_t callTime, int64_t moduleID)
 {
     double sigma_BR_norm; //!< Norm of sigma_BR
     double omega_BR_norm; //!< Norm of omega_BR
 
     /* Local copies of the msg buffers*/
-    AccessMsgPayload accessInMsgBuffer;  //!< local copy of input message buffer
-    AttGuidMsgPayload attGuidInMsgBuffer;  //!< local copy of output message buffer
+    AccessMsgPayload accessInMsgBuffer;             //!< local copy of input message buffer
+    AttGuidMsgPayload attGuidInMsgBuffer;           //!< local copy of output message buffer
     DeviceStatusMsgPayload deviceStatusInMsgBuffer; //!< local copy of input message buffer
-    DeviceCmdMsgPayload deviceCmdOutMsgBuffer;  //!< local copy of output message buffer
+    DeviceCmdMsgPayload deviceCmdOutMsgBuffer;      //!< local copy of output message buffer
 
     // zero output buffer
     deviceCmdOutMsgBuffer = DeviceCmdMsg_C_zeroMsgPayload();
@@ -100,61 +103,80 @@ void Update_simpleInstrumentController(simpleInstrumentControllerConfig *configD
     sigma_BR_norm = v3Norm(attGuidInMsgBuffer.sigma_BR);
     omega_BR_norm = v3Norm(attGuidInMsgBuffer.omega_BR_B);
 
-    // If the controller is active
+    // If non-zero time tolerances are provided, require callTime to fall inside
+    // [imagingTime - timeToleranceLower, imagingTime + timeToleranceUpper].
+    int timeControl = 1;
+    if (configData->timeToleranceLower > 0) {
+        if (callTime < configData->imagingTime && configData->imagingTime - callTime > configData->timeToleranceLower) {
+            timeControl = 0;
+        }
+    }
+    if (configData->timeToleranceUpper > 0) {
+        if (callTime > configData->imagingTime && callTime - configData->imagingTime > configData->timeToleranceUpper) {
+            timeControl = 0;
+        }
+    }
     if (configData->controllerStatus) {
         // If the target has not been imaged
         if (!configData->imaged) {
             unsigned int constraintsMet =
-                (sigma_BR_norm <= configData->attErrTolerance)
-                && (!configData->useRateTolerance || (omega_BR_norm <= configData->rateErrTolerance))
-                && (accessInMsgBuffer.hasAccess);
+              (sigma_BR_norm <= configData->attErrTolerance) &&
+              (!configData->useRateTolerance || (omega_BR_norm <= configData->rateErrTolerance)) &&
+              (accessInMsgBuffer.hasAccess);
 
             if (constraintsMet) {
                 // Default: immediate imaging
                 if (!configData->useDurationImaging) {
-                    deviceCmdOutMsgBuffer.deviceCmd = 1;
-                    configData->imaged = 1;
+                    if (timeControl) {
+                        deviceCmdOutMsgBuffer.deviceCmd = 1;
+                        configData->imaged = 1;
+                    }
                 }
                 // Duration-based imaging
                 else {
                     if (!configData->constraintsActive) {
                         configData->constraintsActive = 1;
-                        configData->constraintStartTime = (double) callTime;  // current sim time
+                        configData->constraintStartTime = (double)callTime; // current sim time
                     }
 
                     if (configData->acquisitionTime < 0.0) {
                         // Negative acquisitionTime is invalid; cap to zero
                         configData->acquisitionTime = 0.0;
-                        _bskLog(configData->bskLogger, BSK_WARNING,
-                            "simpleInstrumentController: acquisitionTime is negative and has been set to zero.");
+                        _bskLog(configData->bskLogger,
+                                BSK_WARNING,
+                                "simpleInstrumentController: acquisitionTime is negative and has been set to zero.");
                     }
 
                     if (configData->allowedTime < 0.0) {
                         // Negative allowedTime is invalid; cap to zero
                         configData->allowedTime = 0.0;
-                        _bskLog(configData->bskLogger, BSK_WARNING,
-                            "simpleInstrumentController: allowedTime is negative and has been set to zero.");
+                        _bskLog(configData->bskLogger,
+                                BSK_WARNING,
+                                "simpleInstrumentController: allowedTime is negative and has been set to zero.");
                     }
 
                     double elapsedTime = callTime - configData->constraintStartTime;
 
                     // Determine the effective time to image: cannot exceed allowedTime
                     double effectiveImageTime = (configData->acquisitionTime > configData->allowedTime)
-                                                ? configData->allowedTime
-                                                : configData->acquisitionTime;
+                                                  ? configData->allowedTime
+                                                  : configData->acquisitionTime;
 
                     if (elapsedTime >= effectiveImageTime) {
                         // If full effective duration passed, set imaged
                         if (configData->acquisitionTime <= configData->allowedTime) {
-                            configData->imaged = 1;  // Success
-                            deviceCmdOutMsgBuffer.deviceCmd = 1;
+                            if (timeControl) {
+                                configData->imaged = 1; // Success
+                                deviceCmdOutMsgBuffer.deviceCmd = 1;
+                                configData->constraintsActive = 0; // Reset timer
+                            }
                         } else {
                             // Failed because required time > allowed duration
                             configData->imaged = 0;
                             deviceCmdOutMsgBuffer.deviceCmd = 0;
                             configData->controllerStatus = 0; // Disable further attempts
+                            configData->constraintsActive = 0; // Reset timer
                         }
-                        configData->constraintsActive = 0;  // Reset timer
                     }
                 }
             } else {

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.h
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.h
@@ -42,6 +42,9 @@ typedef struct {
     double acquisitionTime; //!< (optional) Duration that constraints must be satisfied [nanoseconds]
     double allowedTime;     //!< (optional) Maximum allowed time for imaging [nanoseconds]
     unsigned int constraintsActive; //!< flag to track state
+    uint64_t timeToleranceLower; //!< Optional lower time tolerance for imaging [nanoseconds]; zero disables lower bound
+    uint64_t timeToleranceUpper; //!< Optional upper time tolerance for imaging [nanoseconds]; zero disables upper bound
+    uint64_t imagingTime; //!< Desired imaging time [nanoseconds]
 
     /* declare module IO interfaces */
     AccessMsg_C locationAccessInMsg;                   //!< Ground location access input message

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.rst
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.rst
@@ -54,4 +54,10 @@ If the user desires to make the instrument controller inactive, the ``controller
 This may be done if the controller is to match the status of corresponding instrument data and power modules. This
 may also be accomplished by writing out a :ref:`DeviceStatusMsgPayload` to the ``deviceStatusInMsg``.
 
+Optionally, imaging can be limited to a desired time window. Set ``imagingTime`` in nanoseconds as the desired
+imaging time. A nonzero ``timeToleranceLower`` permits imaging no earlier than
+``imagingTime - timeToleranceLower``, while a nonzero ``timeToleranceUpper`` permits imaging no later than
+``imagingTime + timeToleranceUpper``. Each bound is enabled independently; a tolerance of zero disables that bound,
+which preserves the default behavior without time-based constraints.
+
 The ``useDurationImaging`` flag enables duration-based imaging, where the instrument must maintain valid constraints for a specified period before capturing an image. By default, this feature is disabled. The ``acquisitionTime`` (optional, in nanoseconds) specifies how long the constraints must remain satisfied to trigger an image capture. The ``allowedTime`` (optional, in nanoseconds) defines the maximum period during which the system will attempt imaging. If ``acquisitionTime`` is less than or equal to ``allowedTime``, the image will be captured once the required duration is met. If ``acquisitionTime`` exceeds ``allowedTime``, the image will not be captured, although the system will continue attempting for the full ``allowedTime`` period. If either ``acquisitionTime`` or ``allowedTime`` is negative or not set, the value is automatically capped to zero.


### PR DESCRIPTION
* **Tickets addressed:** #1506 
* **Review:** By commit 
* **Merge strategy:** Merge (no squash)

## Description
The module allows specifying a desired imaging time with lower and upper tolerances. Each tolerance can be specified individually. The default behavior is preserved if tolerances are not specifies (or set to zero).

## Verification
Test was updated to verify the new feature.

## Documentation
Module documentation was updated and a release note snippet was added.
