### PR TITLE
[#1510] Fix defects in the state effector branching path

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- State effectors wound their static ``effectorID`` counter back in the destructor, so destroying
+  one effector made a later one reuse an identifier still held by a live effector. This is fixed
+  in the current version, and the counter now only ever increases.
 - The :ref:`linearTranslationOneDOFStateEffector` published two of its inertial properties incorrectly.
   The translating frame velocity omitted the hub's inertial velocity entirely, and the translating frame
   angular velocity was rotated by the transpose of ``dcm_FB``. This is fixed in the current version.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,8 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`dualHingedRigidBodyStateEffector` computed panel 2's inertial angular velocity with
+  panel 1's attitude and omitted the first hinge rate. This is fixed in the current version.
 - The :ref:`dualHingedRigidBodyStateEffector` wrote its panel center-of-mass velocities into the panel
   configuration log without rotating the hub-relative terms into inertial components, so the logged panel
   velocities were wrong for any non-identity hub attitude. This is fixed in the current version.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,8 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`hingedRigidBodyStateEffector` added body-frame relative velocity terms directly onto the
+  inertial hub velocity when forming both its logged velocities. This is fixed in the current version.
 - :ref:`vizInterface` left its protobuf output stream open after the module was destroyed. On Windows, this could
   prevent saved Vizard data files from being removed until the Python process exited. The stream is now owned and
   closed automatically by the module. This is fixed in the current version.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,8 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`dualHingedRigidBodyStateEffector` applied the second hinge's motor torque to panel 2 without
+  the equal and opposite reaction on panel 1. This is fixed in the current version.
 - The :ref:`dualHingedRigidBodyStateEffector` computed panel 2's inertial angular velocity with
   panel 1's attitude and omitted the first hinge rate. This is fixed in the current version.
 - The :ref:`dualHingedRigidBodyStateEffector` wrote its panel center-of-mass velocities into the panel

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`hingedRigidBodyStateEffector` built its published panel velocity and angular velocity
+  from a hub angular velocity cached during back-substitution, so the logged values lagged the
+  integrated state by a step. This is fixed in the current version.
 - The :ref:`hingedRigidBodyStateEffector` added body-frame relative velocity terms directly onto the
   inertial hub velocity when forming both its logged velocities. This is fixed in the current version.
 - :ref:`vizInterface` left its protobuf output stream open after the module was destroyed. On Windows, this could

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- Every state effector acting as a parent published the inertial state of its attachment frame once
+  per task step from its own ``UpdateState()``. A child effector therefore evaluated its loads against
+  kinematics a full task step old. These are now refreshed within the integration.
 - State effectors wound their static ``effectorID`` counter back in the destructor, so destroying
   one effector made a later one reuse an identifier still held by a live effector. This is fixed
   in the current version, and the counter now only ever increases.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`spinningBodyTwoDOFStateEffector` applied an attached dynamic effector's torque on the upper
+  spinning body to the lower spinning body's equation of motion with the wrong sign. This is fixed in
+  the current version.
 - The :ref:`dualHingedRigidBodyStateEffector` applied the second hinge's motor torque to panel 2 without
   the equal and opposite reaction on panel 1. This is fixed in the current version.
 - The :ref:`dualHingedRigidBodyStateEffector` computed panel 2's inertial angular velocity with

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`dualHingedRigidBodyStateEffector` wrote its panel center-of-mass velocities into the panel
+  configuration log without rotating the hub-relative terms into inertial components, so the logged panel
+  velocities were wrong for any non-identity hub attitude. This is fixed in the current version.
 - The :ref:`hingedRigidBodyStateEffector` built its published panel velocity and angular velocity
   from a hub angular velocity cached during back-substitution, so the logged values lagged the
   integrated state by a step. This is fixed in the current version.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- The :ref:`linearTranslationOneDOFStateEffector` published two of its inertial properties incorrectly.
+  The translating frame velocity omitted the hub's inertial velocity entirely, and the translating frame
+  angular velocity was rotated by the transpose of ``dcm_FB``. This is fixed in the current version.
 - The :ref:`spinningBodyTwoDOFStateEffector` applied an attached dynamic effector's torque on the upper
   spinning body to the lower spinning body's equation of motion with the wrong sign. This is fixed in
   the current version.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -6,3 +6,4 @@
 - Fixed the sign of an attached effector's upper body torque in the :ref:`spinningBodyTwoDOFStateEffector` lower body equation of motion.
 - Fixed the :ref:`linearTranslationOneDOFStateEffector` inertial velocity and angular velocity properties, which were wrong for attached effectors.
 - Fixed state effector identifier reuse that could give two live effectors colliding state names.
+- Branching parents now publish their attachment frame kinematics at the current integrator substep rather than once per task step.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -1,3 +1,4 @@
 - Fixed the :ref:`hingedRigidBodyStateEffector` panel and hinge velocity outputs, which were wrong for a rotated spacecraft hub.
 - Fixed the :ref:`hingedRigidBodyStateEffector` published panel kinematics, which were built on a hub angular velocity a step old.
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` panel velocity outputs, which were wrong for a rotated spacecraft hub.
+- Fixed the :ref:`dualHingedRigidBodyStateEffector` panel 2 angular velocity output, which used panel 1's attitude and omitted the first hinge rate.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -3,3 +3,4 @@
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` panel velocity outputs, which were wrong for a rotated spacecraft hub.
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` panel 2 angular velocity output, which used panel 1's attitude and omitted the first hinge rate.
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` second hinge motor torque, which was applied without its reaction on panel 1.
+- Fixed the sign of an attached effector's upper body torque in the :ref:`spinningBodyTwoDOFStateEffector` lower body equation of motion.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -1,0 +1,1 @@
+- Fixed the :ref:`hingedRigidBodyStateEffector` panel and hinge velocity outputs, which were wrong for a rotated spacecraft hub.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -1,2 +1,3 @@
 - Fixed the :ref:`hingedRigidBodyStateEffector` panel and hinge velocity outputs, which were wrong for a rotated spacecraft hub.
 - Fixed the :ref:`hingedRigidBodyStateEffector` published panel kinematics, which were built on a hub angular velocity a step old.
+- Fixed the :ref:`dualHingedRigidBodyStateEffector` panel velocity outputs, which were wrong for a rotated spacecraft hub.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -4,3 +4,4 @@
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` panel 2 angular velocity output, which used panel 1's attitude and omitted the first hinge rate.
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` second hinge motor torque, which was applied without its reaction on panel 1.
 - Fixed the sign of an attached effector's upper body torque in the :ref:`spinningBodyTwoDOFStateEffector` lower body equation of motion.
+- Fixed the :ref:`linearTranslationOneDOFStateEffector` inertial velocity and angular velocity properties, which were wrong for attached effectors.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -1,1 +1,2 @@
 - Fixed the :ref:`hingedRigidBodyStateEffector` panel and hinge velocity outputs, which were wrong for a rotated spacecraft hub.
+- Fixed the :ref:`hingedRigidBodyStateEffector` published panel kinematics, which were built on a hub angular velocity a step old.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -7,3 +7,4 @@
 - Fixed the :ref:`linearTranslationOneDOFStateEffector` inertial velocity and angular velocity properties, which were wrong for attached effectors.
 - Fixed state effector identifier reuse that could give two live effectors colliding state names.
 - Branching parents now publish their attachment frame kinematics at the current integrator substep rather than once per task step.
+- Attached dynamic effectors' inertial-frame force is now applied by every state effector that can act as a parent.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -2,3 +2,4 @@
 - Fixed the :ref:`hingedRigidBodyStateEffector` published panel kinematics, which were built on a hub angular velocity a step old.
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` panel velocity outputs, which were wrong for a rotated spacecraft hub.
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` panel 2 angular velocity output, which used panel 1's attitude and omitted the first hinge rate.
+- Fixed the :ref:`dualHingedRigidBodyStateEffector` second hinge motor torque, which was applied without its reaction on panel 1.

--- a/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst
@@ -5,3 +5,4 @@
 - Fixed the :ref:`dualHingedRigidBodyStateEffector` second hinge motor torque, which was applied without its reaction on panel 1.
 - Fixed the sign of an attached effector's upper body torque in the :ref:`spinningBodyTwoDOFStateEffector` lower body equation of motion.
 - Fixed the :ref:`linearTranslationOneDOFStateEffector` inertial velocity and angular velocity properties, which were wrong for attached effectors.
+- Fixed state effector identifier reuse that could give two live effectors colliding state names.

--- a/examples/scenarioConstrainedDynamicsComponentAnalysis.py
+++ b/examples/scenarioConstrainedDynamicsComponentAnalysis.py
@@ -589,17 +589,23 @@ def log_data(scSim, component_list):
         scSim.AddModelToTask(scSim.simTaskName, scSim.sp4Log)
 
     if "slosh" in component_list:
+        rho1Name = scSim.particle1.nameOfRhoState
+        rho2Name = scSim.particle2.nameOfRhoState
+        rho3Name = scSim.particle3.nameOfRhoState
         scSim.rhoLog = pythonVariableLogger.PythonVariableLogger({
-            "rho1": lambda _: scSim.scObject1.dynManager.getStateObject('linearSpringMassDamperRho1').getState(),
-            "rho2": lambda _: scSim.scObject1.dynManager.getStateObject('linearSpringMassDamperRho2').getState(),
-            "rho3": lambda _: scSim.scObject1.dynManager.getStateObject('linearSpringMassDamperRho3').getState(),
+            "rho1": lambda _: scSim.scObject1.dynManager.getStateObject(rho1Name).getState(),
+            "rho2": lambda _: scSim.scObject1.dynManager.getStateObject(rho2Name).getState(),
+            "rho3": lambda _: scSim.scObject1.dynManager.getStateObject(rho3Name).getState(),
         })
         scSim.AddModelToTask(scSim.simTaskName, scSim.rhoLog)
 
+        rho4Name = scSim.particle4.nameOfRhoState
+        rho5Name = scSim.particle5.nameOfRhoState
+        rho6Name = scSim.particle6.nameOfRhoState
         scSim.rhoTLog = pythonVariableLogger.PythonVariableLogger({
-            "rho4": lambda _: scSim.scObjectT.dynManager.getStateObject('linearSpringMassDamperRho4').getState(),
-            "rho5": lambda _: scSim.scObjectT.dynManager.getStateObject('linearSpringMassDamperRho5').getState(),
-            "rho6": lambda _: scSim.scObjectT.dynManager.getStateObject('linearSpringMassDamperRho6').getState(),
+            "rho4": lambda _: scSim.scObjectT.dynManager.getStateObject(rho4Name).getState(),
+            "rho5": lambda _: scSim.scObjectT.dynManager.getStateObject(rho5Name).getState(),
+            "rho6": lambda _: scSim.scObjectT.dynManager.getStateObject(rho6Name).getState(),
         })
         scSim.AddModelToTask(scSim.simTaskName, scSim.rhoTLog)
 

--- a/examples/scenarioFuelSlosh.py
+++ b/examples/scenarioFuelSlosh.py
@@ -327,9 +327,11 @@ def run(show_plots, damping_parameter, timeStep):
 
     damperRhoLog = None
     if damping_parameter != 0.0:
+        rhoNames = [scSim.particle1.nameOfRhoState, scSim.particle2.nameOfRhoState,
+                    scSim.particle3.nameOfRhoState]
+
         def get_rho(CurrentSimNanos, i):
-            stateName = f'linearSpringMassDamperRho{i}'
-            return scObject.dynManager.getStateObject(stateName).getState()[0][0]
+            return scObject.dynManager.getStateObject(rhoNames[i - 1]).getState()[0][0]
 
         damperRhoLog = pythonVariableLogger.PythonVariableLogger({
                 "damperRho1": lambda CurrentSimNanos: get_rho(CurrentSimNanos, 1),

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -40,7 +40,6 @@ FuelTank::FuelTank() {
 uint64_t FuelTank::effectorID = 1;
 
 FuelTank::~FuelTank() {
-    FuelTank::effectorID = 1;
 }
 
 /*! optionally set the name of the mass state to be used by the state manager */

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -440,11 +440,10 @@ void HingedRigidBodyStateEffector::computePanelInertialStates()
 
     // inertial velocity vector
     this->v_SN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
-                  + this->d * this->thetaDot * this->sHat3_P - this->d * (omega_BN_B.cross(this->sHat1_P))
-                  + omega_BN_B.cross(this->r_HP_P);
+                  + dcm_NP * (this->rPrime_SP_P + omega_BN_B.cross(this->r_SP_P));
 
     *this->v_HN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty)
-                  + omega_BN_B.cross(this->r_HP_P);
+                  + dcm_NP * omega_BN_B.cross(this->r_HP_P);
 
     return;
 }

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -248,7 +248,8 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     {
         // - Compute the force and torque contributions from the dynamicEffectors
         (*dynIt)->computeForceTorque(integTime, double(0.0));
-        attBodyForce_S += (*dynIt)->forceExternal_B; // here parent frame is S, not B because dynamic effector attached to state effector not hub
+        // a child's "_B" loads are already in this parent's S frame, so only "_N" is rotated
+        attBodyForce_S += (*dynIt)->forceExternal_B + this->dcm_SP * dcm_PN * (*dynIt)->forceExternal_N;
         attBodyTorquePntS_S+= (*dynIt)->torqueExternalPntB_B;
     }
 

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -322,8 +322,9 @@ void HingedRigidBodyStateEffector::updateEnergyMomContributions(double integTime
                                                                 double & rotEnergyContr, Eigen::Vector3d omega_BN_B)
 {
     // - Get the current omega state
+    this->omega_BN_B = omega_BN_B;
     Eigen::Vector3d omegaLocal_PN_P;
-    omegaLocal_PN_P = omega_BN_B;
+    omegaLocal_PN_P = this->omega_BN_B;
 
     // - Find rotational angular momentum contribution from hub
     Eigen::Vector3d omega_SP_P;

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -61,7 +61,6 @@ uint64_t HingedRigidBodyStateEffector::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 HingedRigidBodyStateEffector::~HingedRigidBodyStateEffector()
 {
-    this->effectorID = 1;    /* reset the panel ID*/
     return;
 }
 

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.cpp
@@ -72,6 +72,7 @@ HingedRigidBodyStateEffector::~HingedRigidBodyStateEffector()
  */
 void HingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computePanelInertialStates();
 
     if (this->hingedRigidBodyOutMsg.isLinked()) {
         this->HRBoutputStates = this->hingedRigidBodyOutMsg.zeroMsgPayload;
@@ -114,6 +115,7 @@ void HingedRigidBodyStateEffector::linkInStates(DynParamManager& statesIn)
 
     this->inertialPositionProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + this->propName_inertialPosition);
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + this->propName_inertialVelocity);
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 
     return;
 }
@@ -232,6 +234,11 @@ void HingedRigidBodyStateEffector::updateContributions(double integTime, BackSub
     Eigen::Vector3d g_P;
     gLocal_N = g_N;
     g_P = dcm_PN*gLocal_N;
+
+    if (!this->dynEffectors.empty()) {
+        this->omega_BN_B = omega_BN_B;
+        this->computePanelInertialStates();
+    }
 
     // Loop through to collect forces and torques from any connected dynamic effectors
     Eigen::Vector3d attBodyForce_S = Eigen::Vector3d::Zero();
@@ -361,9 +368,6 @@ void HingedRigidBodyStateEffector::UpdateState(uint64_t CurrentSimNanos)
         this->thetaDotRef = incomingRefBuffer.thetaDot;
     }
 
-    /* compute panel inertial states */
-    this->computePanelInertialStates();
-
     this->writeOutputStateMessages(CurrentSimNanos);
 
     return;
@@ -418,9 +422,11 @@ void HingedRigidBodyStateEffector::calcForceTorqueOnBody(double integTime [[mayb
  */
 void HingedRigidBodyStateEffector::computePanelInertialStates()
 {
-    // inertial attitude
-    Eigen::MRPd sigmaBN;
-    sigmaBN = this->sigma_BN;
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        this->sigma_BN = Eigen::MRPd(this->hubSigmaState->getStateReference().data());
+    }
+    Eigen::MRPd sigmaBN = this->sigma_BN;
     Eigen::Matrix3d dcm_NP = sigmaBN.toRotationMatrix();  // assumes P and B are idential
     Eigen::Matrix3d dcm_SN;
     dcm_SN = this->dcm_SP*dcm_NP.transpose();

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.h
@@ -113,6 +113,7 @@ private:
     Eigen::MatrixXd* omega_SN_S;      //!< [rad/s] inertial panel frame angular velocity vector
 
     // Hub properties
+    StateData* hubSigmaState = nullptr;  //!< hub attitude state, read live for the published kinematics
     Eigen::MatrixXd* inertialPositionProperty;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialVelocityProperty;  //!< [m] v_N inertial velocity relative to system spice zeroBase/refBase
 

--- a/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
+++ b/src/simulation/dynamics/LinearSpringMassDamper/_UnitTest/test_linearSpringMassDamper.py
@@ -191,10 +191,13 @@ def fuelSloshTest(show_plots,useFlag,testCase):
     unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
     if testCase == 'MassDepletion':
+        mass1Name = unitTestSim.particle1.nameOfMassState
+        mass2Name = unitTestSim.particle2.nameOfMassState
+        mass3Name = unitTestSim.particle3.nameOfMassState
         stateLog = pythonVariableLogger.PythonVariableLogger({
-            "mass1": lambda _: scObject.dynManager.getStateObject('linearSpringMassDamperMass1').getState(),
-            "mass2": lambda _: scObject.dynManager.getStateObject('linearSpringMassDamperMass2').getState(),
-            "mass3": lambda _: scObject.dynManager.getStateObject('linearSpringMassDamperMass3').getState(),
+            "mass1": lambda _: scObject.dynManager.getStateObject(mass1Name).getState(),
+            "mass2": lambda _: scObject.dynManager.getStateObject(mass2Name).getState(),
+            "mass3": lambda _: scObject.dynManager.getStateObject(mass3Name).getState(),
         })
         unitTestSim.AddModelToTask(unitTaskName, stateLog)
 

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
@@ -52,7 +52,6 @@ uint64_t LinearSpringMassDamper::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 LinearSpringMassDamper::~LinearSpringMassDamper()
 {
-    this->effectorID = 1;    /* reset the panel ID*/
     return;
 }
 

--- a/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
@@ -174,9 +174,11 @@ def nHingedRigidBody(show_plots, testCase):
     scObjectLog = scObject.logger(["totOrbEnergy", "totOrbAngMomPntN_N", "totRotAngMomPntC_N", "totRotEnergy"])
     unitTestSim.AddModelToTask(unitTaskName, scObjectLog)
 
+    theta1Name = unitTestSim.effector1.nameOfThetaState
+    theta2Name = unitTestSim.effector2.nameOfThetaState
     stateLog = pythonVariableLogger.PythonVariableLogger({
-        "theta1": lambda _: scObject.dynManager.getStateObject(f'nHingedRigidBody1Theta').getState(),
-        "theta2": lambda _: scObject.dynManager.getStateObject(f'nHingedRigidBody2Theta').getState(),
+        "theta1": lambda _: scObject.dynManager.getStateObject(theta1Name).getState(),
+        "theta2": lambda _: scObject.dynManager.getStateObject(theta2Name).getState(),
     })
     unitTestSim.AddModelToTask(unitTaskName, stateLog)
 

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -44,7 +44,6 @@ uint64_t NHingedRigidBodyStateEffector::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 NHingedRigidBodyStateEffector::~NHingedRigidBodyStateEffector()
 {
-    this->effectorID = 1;    /* reset the panel ID*/
     return;
 }
 

--- a/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
+++ b/src/simulation/dynamics/Thrusters/thrusterStateEffector/thrusterStateEffector.cpp
@@ -65,8 +65,6 @@ ThrusterStateEffector::~ThrusterStateEffector()
         delete this->thrusterOutMsgs.at(c);
     }
 
-    this->effectorID = 1;    /* reset the panel ID*/
-
     return;
 }
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -67,6 +67,9 @@ from Basilisk.simulation import ( # dynamic effectors
 )
 from Basilisk.architecture import messaging
 
+COARSE_TIMESTEP = 0.001  # [s]
+FINE_TIMESTEP = 0.0005  # [s]
+
 # uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)
 # uncomment this line if this test has an expected failure, adjust message as needed
@@ -188,6 +191,40 @@ def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dy
     :math:`{}^{\mathcal{N}}\mathbf{r}_{Pc_j/N}`, :math:`[\mathcal{NP}_j]`, and
     :math:`{}^{\mathcal{P}_j}\mathbf{r}_{Pc_j/P_j}` come from the state effector module.
 
+    Neither of those checks can see an error inside the parent's own equations of motion. The
+    parent's back-substitution stays internally consistent even when one of its terms is wrong, so
+    the momentum it hands the hub still matches the momentum its own coordinates lose. Energy is
+    not blind in the same way: a wrong generalized force does work that the applied load does not
+    account for. All state effector dampers are therefore set to zero, and the change in the
+    vehicle's rotational energy is compared against the work the child does about the vehicle
+    center of mass,
+
+    .. math::
+
+        \Delta T_{\text{rot}} = \int_{t_0}^{t} \left[
+        [\mathcal{NP}_j] {}^{\mathcal{P}_j}\!\boldsymbol{\tau}_{\text{ext},P_j}
+        \cdot {}^{\mathcal{N}}\boldsymbol{\omega}_{\mathcal{P}_j/\mathcal{N}}
+        + [\mathcal{NP}_j] {}^{\mathcal{P}_j}\mathbf{F}_{P_j} \cdot \left(
+        {}^{\mathcal{N}}\mathbf{v}_{P_j/N} - {}^{\mathcal{N}}\mathbf{v}_{C/N}
+        \right) \right] dt
+
+    where the attachment point velocity is recovered from the logged segment center of mass,
+    :math:`\mathbf{v}_{P_j/N} = \mathbf{v}_{Pc_j/N} + \boldsymbol{\omega}_{\mathcal{P}_j/\mathcal{N}}
+    \times \left( - [\mathcal{NP}_j] {}^{\mathcal{P}_j}\mathbf{r}_{Pc_j/P_j} \right)`.
+
+    Asserting only that this residual is small would be weak: the residual also carries
+    discretization error, so the tolerance has a floor and any defect smaller than that floor is
+    invisible unless the applied loads are raised until it clears. The test therefore asserts
+    convergence instead. The residual is dominated by the trapezoid rule used for the work integral
+    above, which is second order, so halving the step must drop it to roughly a quarter. A wrong
+    term in the equations of motion contributes a residual that does not shrink with the step at
+    all, and the ratio moves from a quarter towards one. The ratio is therefore required to sit
+    near 0.25 rather than merely to decrease. The lower bound matters too: a ratio well under 0.25
+    means the residual is falling faster than a trapezoid allows, which in practice means it has
+    reached a floor and the check has stopped measuring the equations of motion. This criterion is
+    independent of the load magnitude, so it does not have to be re-tuned when the loads or the
+    step change.
+
     The accumulated delta V is compared against the internally computed delta V of the spacecraft
     center of mass.
 
@@ -201,9 +238,21 @@ def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dy
     the spacecraft module.
     """
 
-    effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamicEffector, isChild)
+    coarseResidual = effectorBranchingIntegratedTest(show_plots, stateEffector, isParent,
+                                                    dynamicEffector, isChild)
+    if coarseResidual is None:
+        return
 
-def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamicEffector, isChild):
+    fineResidual = effectorBranchingIntegratedTest(False, stateEffector, isParent,
+                                                  dynamicEffector, isChild, timestep=FINE_TIMESTEP)
+    ratio = fineResidual / coarseResidual
+    assert 0.20 < ratio < 0.35, (
+        "branching energy work balance does not converge at second order: "
+        "%.4e J at 1 ms and %.4e J at 0.5 ms, ratio %.3f rather than 0.25"
+        % (coarseResidual, fineResidual, ratio))
+
+def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamicEffector, isChild,
+                                    timestep=COARSE_TIMESTEP):
     unitTaskName = "unitTask"  # arbitrary name (don't change)
     unitProcessName = "TestProcess"  # arbitrary name (don't change)
 
@@ -212,7 +261,6 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     unitTestSim.SetProgressBar(True)
 
     # Create test thread
-    timestep = 0.001
     testProcessRate = macros.sec2nano(timestep)  # update process rate update time
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
@@ -379,12 +427,15 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     totAccumDV_N = datLog.TotalAccumDV_CN_N # total accumulated deltaV of the total vehicle COM
 
     r_ScN_N_log = inertialPropLog.r_BN_N
+    v_ScN_N_log = inertialPropLog.v_BN_N
+    omega_SN_log = inertialPropLog.omega_BN_B
+    rotEnergy = scObjectLog.totRotEnergy
 
     # Grab effector's attitude properties
     sigma_SN_log = inertialPropLog.sigma_BN
 
     # Compute conservation quantities using the state and dynamic effector's logged properties
-    n = rotAngMom_N.shape[0]-1 # length of log minus 1 as the inertial property log lags by a timestep
+    n = rotAngMom_N.shape[0]-1  # length of log minus one so the trapezoid integrals line up
     extTorque = np.empty((n,3))
     dV = np.empty((n,3))
     for idx in range(n):
@@ -396,18 +447,23 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
             dV[idx,:] = (dV[idx-1,:] + (dcm_NS @ np.array(dynamicEff.extForce_B).flatten())
                        / (scObject.hub.mHub + stateEffProps.totalMass) * timestep)
         # Compute the total external torque on the vehicle
-        if stateEffector == "linearTranslationBodiesOneDOF" or stateEffector == "linearTranslationBodiesNDOF":
-            extTorque[idx,:] = (dcm_NS @ np.array(dynamicEff.extTorquePntB_B).flatten()
-                                + np.cross(r_ScN_N_log[idx+1,:] - dcm_NS
-                                @ np.array(stateEffProps.r_PcP_P).flatten()
-                                - datLog.r_CN_N[idx,:], dcm_NS
-                                @ np.array(dynamicEff.extForce_B).flatten()))
-        else:
-            extTorque[idx,:] = (dcm_NS @ np.array(dynamicEff.extTorquePntB_B).flatten()
-                                + np.cross(r_ScN_N_log[idx+1,:] - dcm_NS
-                                @ np.array(stateEffProps.r_PcP_P).flatten()
-                                - datLog.r_CN_N[idx,:], dcm_NS
-                                @ np.array(dynamicEff.extForce_B).flatten()))
+        extTorque[idx,:] = (dcm_NS @ np.array(dynamicEff.extTorquePntB_B).flatten()
+                            + np.cross(r_ScN_N_log[idx,:] - dcm_NS
+                            @ np.array(stateEffProps.r_PcP_P).flatten()
+                            - datLog.r_CN_N[idx,:], dcm_NS
+                            @ np.array(dynamicEff.extForce_B).flatten()))
+
+    rotPower = np.empty(n)
+    for idx in range(n):
+        dcm_NS = np.transpose(rbk.MRP2C(sigma_SN_log[idx,:]))
+        F_N = dcm_NS @ np.array(dynamicEff.extForce_B).flatten()
+        tau_N = dcm_NS @ np.array(dynamicEff.extTorquePntB_B).flatten()
+        omega_SN_N = dcm_NS @ omega_SN_log[idx,:]
+        # the load acts at the parent frame origin, r_PcP_P from the segment center of mass
+        v_PN_N = (v_ScN_N_log[idx,:]
+                  + np.cross(omega_SN_N, -dcm_NS @ np.array(stateEffProps.r_PcP_P).flatten()))
+        rotPower[idx] = tau_N.dot(omega_SN_N) + F_N.dot(v_PN_N - datLog.v_CN_N[idx,:])
+    dErot = np.concatenate(([0.0], np.cumsum(0.5*(rotPower[1:] + rotPower[:-1])*timestep)))
 
     # Integrate the torque to find accumulated change in angular momentum
     dx = np.ones(n-1)*timestep
@@ -460,20 +516,21 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     plt.close("all")
 
     # Check angular momentum difference against sim truth
-    angMom_accuracy = 1e-3
-    # np.testing.assert_allclose(np.linalg.norm(rotAngMom_N[:-1,:]-rotAngMom_N[0,:] - dH, axis=1), 0, atol=angMom_accuracy,
-    #                            err_msg="angular momentum difference beyond accuracy limits")
-    np.testing.assert_allclose(rotAngMom_N[:-1,:]-rotAngMom_N[0,:], dH, atol=angMom_accuracy,
+    angMom_accuracy = 1e-5  # [kg*m^2/s]
+    np.testing.assert_allclose(rotAngMom_N[:-1,:]-rotAngMom_N[0,:], dH, 0, atol=angMom_accuracy,
                                err_msg="angular momentum difference beyond accuracy limits")
 
+    rotEnergy_accuracy = 5e-2  # [J]
+    np.testing.assert_allclose((rotEnergy[:n] - rotEnergy[0]), dErot, atol=rotEnergy_accuracy,
+                               err_msg="branching energy work balance beyond accuracy limits")
+    energyResidual = abs((rotEnergy[n-1] - rotEnergy[0]) - dErot[-1])
+
     # Check deltaV difference against sim truth
-    deltaV_accuracy = 1e-6
-    # np.testing.assert_allclose(np.linalg.norm(totAccumDV_N[:-1,:] - dV, axis=1), 0, atol=deltaV_accuracy,
-    #                            err_msg="deltaV difference beyond accuracy limits")
+    deltaV_accuracy = 1e-6  # [m/s]
     np.testing.assert_allclose(totAccumDV_N[:-1,:], dV, 0, atol=deltaV_accuracy,
                                err_msg="deltaV difference beyond accuracy limits")
 
-    return
+    return energyResidual
 
 def getDynEffInertialPropName(dynamicEffector, dynamicEff, propType):
     if dynamicEffector == "multiEffector":
@@ -650,7 +707,7 @@ def setup_spinningBodiesOneDOF():
     spinningBody.thetaInit = 5.0 * macros.D2R
     spinningBody.thetaDotInit = -1.0 * macros.D2R
     spinningBody.k = 100.0
-    spinningBody.c = 50
+    spinningBody.c = 0.0  # [N-m-s/rad]
     spinningBody.ModelTag = "SpinningBody"
 
     # Compute COM offset contribution, to be divided by the hub mass
@@ -685,8 +742,8 @@ def setup_spinningBodiesTwoDOF():
     spinningBody.theta2DotInit = 1.0 * macros.D2R
     spinningBody.k1 = 1000.0
     spinningBody.k2 = 500.0
-    spinningBody.c1 = 500
-    spinningBody.c2 = 200
+    spinningBody.c1 = 0.0  # [N-m-s/rad]
+    spinningBody.c2 = 0.0  # [N-m-s/rad]
     spinningBody.ModelTag = "SpinningBody"
 
     # Compute COM offset contribution, to be divided by the hub mass
@@ -736,7 +793,7 @@ def setup_spinningBodiesNDOF():
         spinningBody.setThetaInit(2.0 * macros.D2R)
         spinningBody.setThetaDotInit(-0.5 * macros.D2R)
         spinningBody.setK(10)
-        spinningBody.setC(8)
+        spinningBody.setC(0.0)  # [N-m-s/rad]
         spinningBodyEffector.addSpinningBody(spinningBody)
         r_ScB_B += dcm_SB.transpose() @ spinningBody.getR_SP_P()
         dcm_SB = rbk.PRV2C(spinningBody.getThetaInit() * np.array(spinningBody.getSHat_S())) @ spinningBody.getDCM_S0P() @ dcm_SB
@@ -755,7 +812,7 @@ def setup_spinningBodiesNDOF():
         spinningBody.setThetaInit(2.0 * macros.D2R)
         spinningBody.setThetaDotInit(-0.5 * macros.D2R)
         spinningBody.setK(1)
-        spinningBody.setC(0.8)
+        spinningBody.setC(0.0)  # [N-m-s/rad]
         spinningBodyEffector.addSpinningBody(spinningBody)
         dcm_SB = rbk.PRV2C(spinningBody.getThetaInit() * np.array(spinningBody.getSHat_S())) @ spinningBody.getDCM_S0P() @ dcm_SB
 
@@ -781,7 +838,7 @@ def setup_hingedRigidBodyStateEffector():
     hingedBody.IPntS_S = [[50.0, 0.0, 0.0], [0.0, 30.0, 0.0], [0.0, 0.0, 40.0]]
     hingedBody.d = 1.0
     hingedBody.k = 100.0
-    hingedBody.c = 50.0
+    hingedBody.c = 0.0  # [N-m-s/rad]
     hingedBody.dcm_HB = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     hingedBody.r_HB_B = [[0.5], [-1.5], [-0.5]]
     hingedBody.thetaInit = 5 * macros.D2R
@@ -809,7 +866,7 @@ def setup_translatingBodiesOneDOF():
     # Define properties of translating body
     translatingBody.setMass(20.0)
     translatingBody.setK(100.0)
-    translatingBody.setC(50.0)
+    translatingBody.setC(0.0)  # [N-s/m]
     translatingBody.setRhoInit(1.0)
     translatingBody.setRhoDotInit(0.05)
     translatingBody.setFHat_B([[3.0 / 5.0], [4.0 / 5.0], [0.0]])
@@ -840,7 +897,7 @@ def setup_linearSpringMassDamper():
     linearSpring = linearSpringMassDamper.LinearSpringMassDamper()
     linearSpring.massInit = 50.0
     linearSpring.k = 100.0
-    linearSpring.c = 50.0
+    linearSpring.c = 0.0  # [N-s/m]
     linearSpring.r_PB_B = [[1.0], [0.0], [0.0]]
     linearSpring.pHat_B = [[1.0], [0.0], [0.0]]
     linearSpring.rhoInit = 0.0

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -24,6 +24,7 @@
 
 import inspect
 import os
+import re
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -339,11 +340,15 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     # Check that properties are being handed correctly from state effector to dynamic effector
     if (stateEffector == "spinningBodiesNDOF" or stateEffector == "linearTranslationBodiesOneDOF"
         or stateEffector == "linearTranslationBodiesNDOF"):
-        # Newer effector classes keep all variables private and so we check with the dynParamManager
-        positionName = getModernStateEffInertialPropName(scObject, segment, stateEff, "Position")
-        velocityName = getModernStateEffInertialPropName(scObject, segment, stateEff, "Velocity")
-        attitudeName = getModernStateEffInertialPropName(scObject, segment, stateEff, "Attitude")
-        angvelocityName = getModernStateEffInertialPropName(scObject, segment, stateEff, "AngVelocity")
+        # newer effector classes keep their names private, so validate the name handed to the child
+        positionName = getModernStateEffInertialPropName(
+            scObject, segment, "Position", getDynEffInertialPropName(dynamicEffector, dynamicEff, "Position"))
+        velocityName = getModernStateEffInertialPropName(
+            scObject, segment, "Velocity", getDynEffInertialPropName(dynamicEffector, dynamicEff, "Velocity"))
+        attitudeName = getModernStateEffInertialPropName(
+            scObject, segment, "Attitude", getDynEffInertialPropName(dynamicEffector, dynamicEff, "Attitude"))
+        angvelocityName = getModernStateEffInertialPropName(
+            scObject, segment, "AngVelocity", getDynEffInertialPropName(dynamicEffector, dynamicEff, "AngVelocity"))
     else:
         # older effector classes have public variable names that are simply checked directly
         positionName = getStateEffInertialPropName(segment, stateEff, "Position")
@@ -484,25 +489,20 @@ def getStateEffInertialPropName(segment, stateEff, propType):
         return getattr(stateEff, f"nameOfInertial{propType}Property")
     elif segment == 2:
         return getattr(stateEff, f"nameOfInertial{propType}Property2")
-    elif segment == 4:
-        try:
-            propName = stateEff.ModelTag + "Inertial" + propType + "1_4"
-            scObject.dynManager.getPropertyReference(propName)
-        except BasiliskError:
-            return "notHandedCorrectly"
-        return propName
 
-def getModernStateEffInertialPropName(scObject, segment, stateEff, propType):
+def getModernStateEffInertialPropName(scObject, segment, propType, handedPropName):
+    # a generated name ends in a process-global counter, so validate the handed name instead of rebuilding it
+    if segment == 1:
+        pattern = "linearTranslationInertial" + propType + r"[0-9]+"
+    else:
+        pattern = "spinningBodyInertial" + propType + r"[0-9]+_" + str(segment)
     try:
-        if segment == 1:
-            propName = stateEff.ModelTag + "Inertial" + propType + "1"
-            scObject.dynManager.getPropertyReference(propName)
-        elif segment == 4:
-            propName = stateEff.ModelTag + "Inertial" + propType + "1_4"
-            scObject.dynManager.getPropertyReference(propName)
+        scObject.dynManager.getPropertyReference(handedPropName)
     except BasiliskError:
         return "notHandedCorrectly"
-    return propName
+    if re.fullmatch(pattern, handedPropName) is None:
+        return "notHandedCorrectly"
+    return handedPropName
 
 def setup_extForceTorque():
     extFT = extForceTorque.ExtForceTorque()

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -251,6 +251,99 @@ def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dy
         "%.4e J at 1 ms and %.4e J at 0.5 ms, ratio %.3f rather than 0.25"
         % (coarseResidual, fineResidual, ratio))
 
+
+@pytest.mark.parametrize("stateEffector", [
+    "spinningBodiesOneDOF",
+    "spinningBodiesTwoDOF",
+    "spinningBodiesNDOF",
+    "linearTranslationBodiesOneDOF",
+])
+def test_parentPublishesCurrentVelocityToChild(stateEffector):
+    r"""
+    **Validation Test Description**
+
+    This test checks that a branching parent's published inertial velocity is current at the
+    integrator substep on which its child evaluates, rather than at the previous task step.
+
+    **Description of Variables Being Tested**
+
+    The conservation checks in the test above cannot see an error here. They drive the parent with
+    :ref:`extForceTorque`, whose load is constant, so a wrong published velocity reaches neither
+    the trajectory nor the work integral. This test therefore attaches a child whose load is a
+    function of that velocity, namely a :ref:`constraintDynamicEffector` between the parent's first
+    segment and the hub of the same spacecraft, with its stiffness suppressed so that only the
+    velocity feedback term contributes,
+
+    .. math::
+
+        \boldsymbol{\psi}' = {}^{\mathcal{N}}\dot{\mathbf{r}}_{P_2/P_1}
+        - \boldsymbol{\omega}_{\mathcal{P}_1/\mathcal{N}} \times \mathbf{r}_{P_2/P_1}
+
+    The parent's first segment is locked and started at rest, which makes that segment and the hub
+    one rigid body. Both attachment points are then fixed in that body and
+    :math:`\boldsymbol{\omega}_{\mathcal{P}_1/\mathcal{N}}` equals the hub rate, so the two terms
+    cancel identically and the constraint force is zero for any hub attitude and rate. A published
+    velocity that lags the current substep leaves the cancellation incomplete, and the residual
+    appears as a force of order :math:`|\boldsymbol{\omega}_{\mathcal{B}/\mathcal{N}}|
+    \, |\mathbf{r}_{P_1/B}|`. The assertion is therefore against zero rather than against a
+    tolerance scaled to the step size or to the applied load.
+
+    The hinged rigid bodies are absent because they expose no lock, so their panel always rotates
+    relative to the hub and no such rigid configuration exists.
+    """
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.SetProgressBar(False)
+    testProc = unitTestSim.CreateNewProcess("TestProcess")
+    testProc.addTask(unitTestSim.CreateNewTask("unitTask", macros.sec2nano(COARSE_TIMESTEP)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    integratorObject = svIntegrators.svIntegratorRKF45(scObject)
+    scObject.setIntegrator(integratorObject)
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+    scObject.hub.r_CN_NInit = [[-4020338.690396649], [7490566.741852513], [5248299.211589362]]  # [m]
+    scObject.hub.v_CN_NInit = [[-5199.77710904224], [-3436.681645356935], [1041.576797498721]]  # [m/s]
+    scObject.hub.omega_BN_BInit = [[0.1], [0.1], [0.1]]  # [rad/s]
+
+    earthGravBody = gravityEffector.GravBodyData()
+    earthGravBody.planetName = "earth_planet_data"
+    earthGravBody.mu = 0.3986004415E+15  # [m^3/s^2]
+    earthGravBody.isCentralBody = True
+    scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+
+    setupByName = {
+        "spinningBodiesOneDOF": setup_spinningBodiesOneDOF,
+        "spinningBodiesTwoDOF": setup_spinningBodiesTwoDOF,
+        "spinningBodiesNDOF": setup_spinningBodiesNDOF,
+        "linearTranslationBodiesOneDOF": setup_translatingBodiesOneDOF,
+    }
+    stateEff, stateEffProps = setupByName[stateEffector]()
+    weldParentSegmentToHub(stateEffector, stateEff)
+    scObject.hub.r_BcB_B = stateEffProps.mr_PcB_B / scObject.hub.mHub  # [m]
+
+    constraintEffector = setup_velocityConstraintEffector()
+    # attach to the parent first so the constraint links its first property set to that segment
+    stateEff.addDynamicEffector(constraintEffector, 1)
+    scObject.addDynamicEffector(constraintEffector)
+    scObject.addStateEffector(stateEff)
+
+    unitTestSim.AddModelToTask("unitTask", stateEff)
+    unitTestSim.AddModelToTask("unitTask", scObject)
+    unitTestSim.AddModelToTask("unitTask", constraintEffector)
+    constraintLog = constraintEffector.constraintElements.recorder()
+    unitTestSim.AddModelToTask("unitTask", constraintLog)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(10 * COARSE_TIMESTEP))
+    unitTestSim.ExecuteSimulation()
+
+    forceAccuracy = 1e-7  # [N]
+    np.testing.assert_allclose(
+        constraintLog.Fc_N, 0.0, atol=forceAccuracy,
+        err_msg="child evaluated its load against a stale parent velocity property")
+
+
 def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamicEffector, isChild,
                                     timestep=COARSE_TIMESTEP):
     unitTaskName = "unitTask"  # arbitrary name (don't change)
@@ -607,6 +700,44 @@ def setup_constraintEffector(scObject1):
     scObject2.gravField.gravBodies = scObject1.gravField.gravBodies
 
     return scObject2
+
+
+def weldParentSegmentToHub(stateEffector, stateEff):
+    # start the first segment at rest and lock it, so it and the hub move as one rigid body
+    if stateEffector == "spinningBodiesOneDOF":
+        stateEff.thetaDotInit = 0.0  # [rad/s]
+        numberOfDegreesOfFreedom = 1
+    elif stateEffector == "spinningBodiesTwoDOF":
+        stateEff.theta1DotInit = 0.0  # [rad/s]
+        numberOfDegreesOfFreedom = 2
+    elif stateEffector == "spinningBodiesNDOF":
+        numberOfDegreesOfFreedom = len(stateEff.spinningBodyOutMsgs)
+        stateEff.getSpinningBody(0).setThetaDotInit(0.0)  # [rad/s]
+    elif stateEffector == "linearTranslationBodiesOneDOF":
+        stateEff.setRhoDotInit(0.0)  # [m/s]
+        numberOfDegreesOfFreedom = 1
+    else:
+        pytest.fail("Weld requested for a state effector that exposes no lock.")
+
+    lockArray = messaging.ArrayEffectorLockMsgPayload()
+    lockArray.effectorLockFlag = [1] + [0] * (numberOfDegreesOfFreedom - 1)
+    lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
+    stateEff.motorLockInMsg.subscribeTo(lockMsg)
+
+
+def setup_velocityConstraintEffector():
+    constraintEffector = constraintDynamicEffector.ConstraintDynamicEffector()
+    constraintEffector.ModelTag = "velocityConstraintEffector"
+    # body 1 is the parent segment and body 2 is the hub, each attached at its own frame origin
+    constraintEffector.setR_P1B1_B1(np.zeros(3))  # [m]
+    constraintEffector.setR_P2B2_B2(np.zeros(3))  # [m]
+    constraintEffector.setR_P2P1_B1Init(np.zeros(3))  # [m]
+    # stiffness suppressed so that only the velocity feedback term reaches the reported force
+    constraintEffector.setK_d(1e-12)  # [N/m]
+    constraintEffector.setC_d(1.0)  # [N*s/m]
+
+    return constraintEffector
+
 
 def setup_constraintEffectorOneHub(scObjecty, stateEffProps):
     constraintEffector = constraintDynamicEffector.ConstraintDynamicEffector()

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -444,19 +444,22 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
         if idx == 0:
             dV[idx,:] = [0.0, 0.0, 0.0]
         else:
-            dV[idx,:] = (dV[idx-1,:] + (dcm_NS @ np.array(dynamicEff.extForce_B).flatten())
+            dV[idx,:] = (dV[idx-1,:] + (dcm_NS @ np.array(dynamicEff.extForce_B).flatten()
+                        + np.array(dynamicEff.extForce_N).flatten())
                        / (scObject.hub.mHub + stateEffProps.totalMass) * timestep)
         # Compute the total external torque on the vehicle
         extTorque[idx,:] = (dcm_NS @ np.array(dynamicEff.extTorquePntB_B).flatten()
                             + np.cross(r_ScN_N_log[idx,:] - dcm_NS
                             @ np.array(stateEffProps.r_PcP_P).flatten()
                             - datLog.r_CN_N[idx,:], dcm_NS
-                            @ np.array(dynamicEff.extForce_B).flatten()))
+                            @ np.array(dynamicEff.extForce_B).flatten()
+                            + np.array(dynamicEff.extForce_N).flatten()))
 
     rotPower = np.empty(n)
     for idx in range(n):
         dcm_NS = np.transpose(rbk.MRP2C(sigma_SN_log[idx,:]))
-        F_N = dcm_NS @ np.array(dynamicEff.extForce_B).flatten()
+        F_N = (dcm_NS @ np.array(dynamicEff.extForce_B).flatten()
+               + np.array(dynamicEff.extForce_N).flatten())
         tau_N = dcm_NS @ np.array(dynamicEff.extTorquePntB_B).flatten()
         omega_SN_N = dcm_NS @ omega_SN_log[idx,:]
         # the load acts at the parent frame origin, r_PcP_P from the segment center of mass
@@ -564,6 +567,7 @@ def getModernStateEffInertialPropName(scObject, segment, propType, handedPropNam
 def setup_extForceTorque():
     extFT = extForceTorque.ExtForceTorque()
     extFT.extForce_B = [[1.0], [1.0], [1.0]]
+    extFT.extForce_N = [[1.0], [1.0], [1.0]]  # [N]
     extFT.extTorquePntB_B = [[1.0], [1.0], [1.0]]
     extFT.ModelTag = "extForceTorque"
 

--- a/src/simulation/dynamics/dualHingedRigidBodies/_UnitTest/test_dualhingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/dualHingedRigidBodies/_UnitTest/test_dualhingedRigidBodyStateEffector.py
@@ -390,7 +390,7 @@ def dualHingedRigidBodyMotorTorque(show_plots, useScPlus):
     unitTestSim.AddModelToTask(unitTaskName, data21Log)
 
     if useScPlus:
-        scLog = scObject.logger("totRotAngMomPntC_N")
+        scLog = scObject.logger(["totRotAngMomPntC_N", "totOrbEnergy", "totRotEnergy"])
     else:
         scLog = pythonVariableLogger.PythonVariableLogger({
             "totRotAngMomPntC_N": lambda _: scObject.primaryCentralSpacecraft.totRotAngMomPntC_N
@@ -420,6 +420,16 @@ def dualHingedRigidBodyMotorTorque(show_plots, useScPlus):
     oB2N = data21Log.omega_BN_B[0]
 
     rotAngMom_N = simHelpers.addTimeColumn(scLog.times(), scLog.totRotAngMomPntC_N)
+
+    # Momentum is blind to a missing motor reaction, energy is not. Motor power is torque times
+    # the relative hinge rate, and with no dampers it must match the mechanical energy change.
+    if useScPlus:
+        motorPower = (motorMsgData.motorTorque[0] * numpy.array(dataPanel10Log.thetaDot)
+                      + motorMsgData.motorTorque[1] * numpy.array(dataPanel11Log.thetaDot))
+        dt = numpy.diff(dataPanel10Log.times()) * macros.NANO2SEC
+        motorWork = numpy.sum(0.5 * (motorPower[1:] + motorPower[:-1]) * dt)
+        totalEnergy = numpy.array(scLog.totOrbEnergy) + numpy.array(scLog.totRotEnergy)
+        deltaEnergy = totalEnergy[-1] - totalEnergy[0]
 
     # Get the last sigma and position
     dataPos = [rOut_CN_N[-1]]
@@ -490,6 +500,12 @@ def dualHingedRigidBodyMotorTorque(show_plots, useScPlus):
         if not unitTestSupport.isArrayEqual(dataPos[i], truePos[i], 3, accuracy):
             testFailCount += 1
             testMessages.append("FAILED:  Hinged Rigid Body integrated test failed position test")
+
+    # tolerance is set by the trapezoid error on the work integral at this 10 ms step
+    if useScPlus and abs(deltaEnergy - motorWork) > 1e-5 * abs(motorWork):
+        testFailCount += 1
+        testMessages.append("FAILED: Dual Hinged Rigid Body motor torque energy work balance, "
+                            "dE = %.6f J but the motors did %.6f J of work" % (deltaEnergy, motorWork))
 
     for i in range(0, len(initialRotAngMom_N)):
         # check a vector values

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -116,6 +116,7 @@ void DualHingedRigidBodyStateEffector::linkInStates(DynParamManager& statesIn)
     this->inertialPositionProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + this->propName_inertialPosition);
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + this->propName_inertialVelocity);
     this->v_BN_NState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfVelocity);
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 
     return;
 }
@@ -382,6 +383,7 @@ void DualHingedRigidBodyStateEffector::updateEnergyMomContributions(double integ
  */
 void DualHingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computePanelInertialStates();
 
     HingedRigidBodyMsgPayload panelOutputStates;  //!< instance of messaging system message struct
 
@@ -423,9 +425,6 @@ void DualHingedRigidBodyStateEffector::UpdateState(uint64_t CurrentSimNanos)
         this->u2 = incomingCmdBuffer.motorTorque[1];
     }
 
-    /* compute panel inertial states */
-    this->computePanelInertialStates();
-
     this->writeOutputStateMessages(CurrentSimNanos);
 
     return;
@@ -436,9 +435,11 @@ void DualHingedRigidBodyStateEffector::UpdateState(uint64_t CurrentSimNanos)
  */
 void DualHingedRigidBodyStateEffector::computePanelInertialStates()
 {
-    // inertial attitudes
-    Eigen::MRPd sigmaPN;
-    sigmaPN = this->sigma_BN;
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        this->sigma_BN = Eigen::MRPd(this->hubSigmaState->getStateReference().data());
+    }
+    Eigen::MRPd sigmaPN = this->sigma_BN;
     Eigen::Matrix3d dcm_NP = sigmaPN.toRotationMatrix();
     this->sigma_SN[0] = eigenC2MRP(this->dcm_S1P*dcm_NP.transpose());
     this->sigma_SN[1] = eigenC2MRP(this->dcm_S2P*dcm_NP.transpose());

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -457,15 +457,16 @@ void DualHingedRigidBodyStateEffector::computePanelInertialStates()
     this->r_SN_N[1] = (dcm_NP * this->r_S2P_P) + r_PN_N;
 
     // inertial velocity vectors
+    Eigen::Vector3d v_PN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty);
     Eigen::Vector3d omega_S1N_P = this->theta1Dot * this->sHat12_P + omega_PN_P;
-    this->v_SN_N[0] = (Eigen::Vector3d)(*this->inertialVelocityProperty)
-                    + omega_S1N_P.cross( -this->d1 * this->sHat11_P)
-                    + omega_PN_P.cross(this->r_H1P_P);
     Eigen::Vector3d omega_S2N_P = this->theta2Dot * this->sHat22_P + omega_S1N_P;
-    this->v_SN_N[1] = (Eigen::Vector3d)(*this->inertialVelocityProperty)
-                    + omega_S2N_P.cross( -this->d2 * this->sHat21_P)
-                    + omega_S1N_P.cross( -this->l1 * this->sHat11_P)
-                    + omega_PN_P.cross(this->r_H1P_P);
+    Eigen::Vector3d rDot_H1P_P = omega_PN_P.cross(this->r_H1P_P);
+    Eigen::Vector3d rDot_H2P_P = rDot_H1P_P + omega_S1N_P.cross( -this->l1 * this->sHat11_P);
+
+    this->v_SN_N[0] = v_PN_N + Eigen::Vector3d(dcm_NP * (rDot_H1P_P
+                    + omega_S1N_P.cross( -this->d1 * this->sHat11_P)));
+    this->v_SN_N[1] = v_PN_N + Eigen::Vector3d(dcm_NP * (rDot_H2P_P
+                    + omega_S2N_P.cross( -this->d2 * this->sHat21_P)));
 
     return;
 }

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -254,7 +254,7 @@ void DualHingedRigidBodyStateEffector::updateContributions(double integTime [[ma
                                  - this->mass2*this->d2*this->sHat23_P.cross(this->r_S2P_P).transpose());
 
     this->vectorVDHRB(0) =  -(this->IPntS1_S1(0,0) - this->IPntS1_S1(2,2))*this->omega_PN_S1(2)*this->omega_PN_S1(0)
-                            + this->u1 - this->k1*this->theta1 - this->c1*this->theta1Dot + this->k2*this->theta2 + this->c2*this->theta2Dot + this->sHat12_P.dot(gravTorquePan1PntH1) + this->l1*this->sHat13_P.dot(gravForcePan2) -
+                            + this->u1 - this->u2 - this->k1*this->theta1 - this->c1*this->theta1Dot + this->k2*this->theta2 + this->c2*this->theta2Dot + this->sHat12_P.dot(gravTorquePan1PntH1) + this->l1*this->sHat13_P.dot(gravForcePan2) -
                             this->mass1*this->d1*this->sHat13_P.dot(2*this->omega_PNLoc_P.cross(this->rPrimeS1P_P)
                             + this->omega_PNLoc_P.cross(this->omega_PNLoc_P.cross(this->r_S1P_P)))
                             - this->mass2*this->l1*this->sHat13_P.dot(2*this->omega_PNLoc_P.cross(this->rPrimeS2P_P)

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -448,7 +448,7 @@ void DualHingedRigidBodyStateEffector::computePanelInertialStates()
     Eigen::Vector3d omega_PN_P;
     omega_PN_P = this->omega_BN_B;
     this->omega_SN_S[0] = this->dcm_S1P * ( omega_PN_P + this->theta1Dot*this->sHat12_P);
-    this->omega_SN_S[1] = this->dcm_S1P * ( omega_PN_P + this->theta2Dot*this->sHat22_P);
+    this->omega_SN_S[1] = this->dcm_S2P * ( omega_PN_P + this->theta1Dot*this->sHat12_P + this->theta2Dot*this->sHat22_P);
 
     // inertial position vectors
     Eigen::Vector3d r_PN_N;

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.cpp
@@ -84,7 +84,6 @@ DualHingedRigidBodyStateEffector::~DualHingedRigidBodyStateEffector()
         delete this->dualHingedRigidBodyConfigLogOutMsgs.at(c);
     }
 
-    this->effectorID = 1;    /* reset the panel ID*/
     return;
 }
 

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.h
@@ -134,6 +134,7 @@ private:
     Eigen::MRPd sigma_BN{0.0, 0.0, 0.0};        //!< Hub/Inertial attitude represented by MRP of body relative to inertial frame
     Eigen::Vector3d omega_BN_B{0.0, 0.0, 0.0};  //!< Hub/Inertial angular velocity vector in B frame components
     StateData *v_BN_NState;           //!< Hub/Inertial velocity vector in inertial frame components
+    StateData* hubSigmaState = nullptr;  //!< hub attitude state, read live for the published kinematics
     Eigen::MatrixXd *inertialPositionProperty;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd *inertialVelocityProperty;  //!< [m] v_N inertial velocity relative to system spice zeroBase/refBase
     Eigen::MatrixXd *g_N;             //!< [m/s^2] Gravitational acceleration in N frame components

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -42,7 +42,6 @@ uint64_t LinearTranslationNDOFStateEffector::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 LinearTranslationNDOFStateEffector::~LinearTranslationNDOFStateEffector()
 {
-    LinearTranslationNDOFStateEffector::effectorID --;    /* reset the panel ID*/
 }
 
 void TranslatingBody::setMass(double mass) {

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -154,6 +154,8 @@ void LinearTranslationNDOFStateEffector::readInputMessages()
 /*! This method takes the computed rho states and outputs them to the messaging system. */
 void LinearTranslationNDOFStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computeTranslatingBodyInertialStates();
+
     // Write out the translating body output messages
     size_t i = 0;
     LinearTranslationRigidBodyMsgPayload translatingBodyBuffer;
@@ -500,6 +502,5 @@ void LinearTranslationNDOFStateEffector::computeTranslatingBodyInertialStates()
 void LinearTranslationNDOFStateEffector::UpdateState(uint64_t CurrentSimNanos)
 {
     this->readInputMessages();
-    this->computeTranslatingBodyInertialStates();
     this->writeOutputStateMessages(CurrentSimNanos);
 }

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -489,7 +489,7 @@ void LinearTranslationNDOFStateEffector::computeTranslatingBodyInertialStates()
         Eigen::Matrix3d dcm_FN;
         dcm_FN = translatingBody->dcm_FB * this->dcm_BN;
         translatingBody->sigma_FN = eigenC2MRP(dcm_FN);
-        translatingBody->omega_FN_F = translatingBody->dcm_FB.transpose().transpose() * translatingBody->omega_FN_B;
+        translatingBody->omega_FN_F = translatingBody->dcm_FB * translatingBody->omega_FN_B;
 
         // Compute the translation properties
         translatingBody->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * translatingBody->r_FcB_B;

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -395,13 +395,14 @@ void LinearTranslationOneDOFStateEffector::computeTranslatingBodyInertialStates(
     Eigen::Matrix3d dcm_FN = this->dcm_FB * this->dcm_BN;
     const Eigen::MRPd sigma_FN = eigenC2MRP(dcm_FN);
     *this->sigma_FN = sigma_FN.coeffs();
-    *this->omega_FN_F = this->dcm_FB.transpose() * this->omega_BN_B;
+    *this->omega_FN_F = this->dcm_FB * this->omega_BN_B;
 
     this->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * this->r_FcB_B;
     *this->r_FN_N = this->r_FcN_N - dcm_FN.transpose() * this->r_FcF_F;
     Eigen::Vector3d rDot_FcB_B = this->rPrime_FcB_B + this->omega_BN_B.cross(this->r_FcB_B);
     this->v_FcN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * rDot_FcB_B;
-    *this->v_FN_N = this->dcm_BN.transpose() * (this->rPrime_FcB_B + this->omega_BN_B.cross(
+    *this->v_FN_N = (Eigen::Vector3d)*this->inertialVelocityProperty
+                    + this->dcm_BN.transpose() * (this->rPrime_FcB_B + this->omega_BN_B.cross(
                     this->r_FcB_B - this->dcm_FB.transpose() * this->r_FcF_F));
 }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -253,7 +253,8 @@ void LinearTranslationOneDOFStateEffector::computeBackSubContributions(BackSubMa
     {
         // - Compute the force and torque contributions from the dynamicEffectors
         (*dynIt)->computeForceTorque(integTime, double(0.0));
-        attBodyForce_F += (*dynIt)->forceExternal_B;
+        // a child's "_B" loads are already in this parent's F frame, so only "_N" is rotated
+        attBodyForce_F += (*dynIt)->forceExternal_B + this->dcm_FB * this->dcm_BN * (*dynIt)->forceExternal_N;
         attBodyTorquePntF_F += (*dynIt)->torqueExternalPntB_B;
     }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -87,6 +87,7 @@ void LinearTranslationOneDOFStateEffector::linkInStates(DynParamManager& statesI
     // Get access to properties needed for dynamic coupling (Hub or prescribed)
     this->inertialPositionProperty = statesIn.getPropertyReference(this->propName_inertialPosition);
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->propName_inertialVelocity);
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
     this->g_N = statesIn.getPropertyReference("g_N");
 }
 
@@ -170,6 +171,8 @@ void LinearTranslationOneDOFStateEffector::readInputMessages()
 
 void LinearTranslationOneDOFStateEffector::writeOutputStateMessages(uint64_t currentSimNanos)
 {
+    this->computeTranslatingBodyInertialStates();
+
     if (this->translatingBodyOutMsg.isLinked()) {
         LinearTranslationRigidBodyMsgPayload translatingBodyBuffer;
         translatingBodyBuffer = this->translatingBodyOutMsg.zeroMsgPayload;
@@ -238,6 +241,10 @@ void LinearTranslationOneDOFStateEffector::computeBackSubContributions(BackSubMa
                                                                        const Eigen::Vector3d& F_g,
                                                                        double integTime)
 {
+    if (!this->dynEffectors.empty()) {
+        this->computeTranslatingBodyInertialStates();
+    }
+
     // Loop through to collect forces and torques from any connected dynamic effectors
     Eigen::Vector3d attBodyForce_F = Eigen::Vector3d::Zero();
     Eigen::Vector3d attBodyTorquePntF_F = Eigen::Vector3d::Zero();
@@ -391,6 +398,12 @@ void LinearTranslationOneDOFStateEffector::updateEnergyMomContributions(double i
 
 void LinearTranslationOneDOFStateEffector::computeTranslatingBodyInertialStates()
 {
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        const Eigen::MRPd sigmaHub_BN(this->hubSigmaState->getStateReference().data());
+        this->dcm_BN = sigmaHub_BN.toRotationMatrix().transpose();
+    }
+
     Eigen::Matrix3d dcm_FN = this->dcm_FB * this->dcm_BN;
     const Eigen::MRPd sigma_FN = eigenC2MRP(dcm_FN);
     *this->sigma_FN = sigma_FN.coeffs();
@@ -408,6 +421,5 @@ void LinearTranslationOneDOFStateEffector::computeTranslatingBodyInertialStates(
 void LinearTranslationOneDOFStateEffector::UpdateState(uint64_t currentSimNanos)
 {
     this->readInputMessages();
-    this->computeTranslatingBodyInertialStates();
     this->writeOutputStateMessages(currentSimNanos);
 }

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -41,7 +41,6 @@ uint64_t LinearTranslationOneDOFStateEffector::effectorID = 1;
 
 LinearTranslationOneDOFStateEffector::~LinearTranslationOneDOFStateEffector()
 {
-    LinearTranslationOneDOFStateEffector::effectorID = 1;
 }
 
 void LinearTranslationOneDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]]) {

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
@@ -100,7 +100,7 @@ private:
     Eigen::Vector3d r_FcF_F = Eigen::Vector3d::Zero();        //!< [m] vector pointing from location F to FC in F frame components
     Eigen::Vector3d r_F0B_B = Eigen::Vector3d::Zero();        //!< [m] vector pointing from body frame B origin to point to F0 origin of F frame in B frame components
     Eigen::Matrix3d IPntFc_F = Eigen::Matrix3d::Identity();   //!< [kg-m^2] Inertia of pc about point Fc in F frame component
-    Eigen::Matrix3d dcm_FB = Eigen::Matrix3d::Identity();     //!< DCM from the F frame to the body frame
+    Eigen::Matrix3d dcm_FB = Eigen::Matrix3d::Identity();     //!< DCM from the body frame to the F frame
     std::string nameOfRhoState{};     //!< Identifier for the rho state data container
     std::string nameOfRhoDotState{};  //!< Identifier for the rhoDot state data container
     std::string nameOfInertialPositionProperty;                      //!< -- identifier for the inertial position property

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
@@ -134,6 +134,7 @@ private:
     StateData *rhoState = nullptr;		    //!< state data for displacement from equilibrium
     StateData *rhoDotState = nullptr;	    //!< state data for time derivative of rho;
     Eigen::MatrixXd *g_N = nullptr;         //!< [m/s^2] gravitational acceleration in N frame components
+    StateData* hubSigmaState = nullptr;  //!< hub attitude state, read live for the published kinematics
     Eigen::MatrixXd* inertialPositionProperty = nullptr;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialVelocityProperty = nullptr;  //!< [m] v_N inertial velocity relative to system spice zeroBase/refBase
     static uint64_t effectorID;    //!< ID number of this panel

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -76,7 +76,6 @@ uint64_t PrescribedMotionStateEffector::effectorID = 1;
 /*! This is the destructor. */
 PrescribedMotionStateEffector::~PrescribedMotionStateEffector()
 {
-    PrescribedMotionStateEffector::effectorID = 1;
 }
 
 /*! This method is used to reset the module.

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -490,6 +490,10 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
 
     this->gravField.computeGravityField(rLocal_CN_N, vLocal_CN_N);
 
+    // - refresh so effectors publish inertial properties at the current substep
+    this->gravField.updateInertialPosAndVel(this->hubR_N->getStateReference(),
+                                            this->hubV_N->getStateReference());
+
     // - Loop through dynEffectors to compute force and torque on the s/c
     std::vector<DynamicEffector*>::iterator dynIt;
     for(dynIt = this->dynEffectors.begin(); dynIt != this->dynEffectors.end(); dynIt++)

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
@@ -63,7 +63,6 @@ uint64_t SphericalPendulum::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 SphericalPendulum::~SphericalPendulum()
 {
-    this->effectorID = 1;    /* reset the panel ID*/
 	return;
 }
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -363,9 +363,9 @@ void SpinningBodyNDOFStateEffector::updateContributions(double integTime,
         }
     }
     if (hasAttachedEffectors) {
-        // - the per-body inertial rates are not refreshed until after the children are called
         for (auto& spinningBody : this->spinningBodyVec) {
             spinningBody->omega_SN_B = spinningBody->omega_SB_B + this->omega_BN_B;
+            spinningBody->rDot_ScB_B = spinningBody->rPrime_ScB_B + this->omega_BN_B.cross(spinningBody->r_ScB_B);
         }
         this->computeSpinningBodyInertialStates();
     }
@@ -613,14 +613,13 @@ void SpinningBodyNDOFStateEffector::computeDerivatives(double integTime [[maybe_
 void SpinningBodyNDOFStateEffector::updateEnergyMomContributions(double integTime [[maybe_unused]], Eigen::Vector3d & rotAngMomPntCContr_B, double & rotEnergyContr, Eigen::Vector3d omega_BN_B)
 {
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
 
     rotAngMomPntCContr_B = Eigen::Vector3d::Zero();
     rotEnergyContr = 0.0;
 
     for(auto& spinningBody: this->spinningBodyVec) {
         spinningBody->omega_SN_B = spinningBody->omega_SB_B + this->omega_BN_B;
-        spinningBody->rDot_ScB_B = spinningBody->rPrime_ScB_B + this->omegaTilde_BN_B * spinningBody->r_ScB_B;
+        spinningBody->rDot_ScB_B = spinningBody->rPrime_ScB_B + this->omega_BN_B.cross(spinningBody->r_ScB_B);
 
         rotAngMomPntCContr_B += spinningBody->ISPntSc_B * spinningBody->omega_SN_B + spinningBody->mass * spinningBody->rTilde_ScB_B * spinningBody->rDot_ScB_B;
         rotEnergyContr += 1.0 / 2.0 * spinningBody->omega_SN_B.dot(spinningBody->ISPntSc_B * spinningBody->omega_SN_B)

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -155,6 +155,8 @@ void SpinningBodyNDOFStateEffector::readInputMessages()
 
 void SpinningBodyNDOFStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computeSpinningBodyInertialStates();
+
     size_t spinningBodyIndex = 0;
     for(auto& spinningBody: this->spinningBodyVec) {
         if (this->spinningBodyOutMsgs[spinningBodyIndex]->isLinked()) {
@@ -189,6 +191,7 @@ void SpinningBodyNDOFStateEffector::linkInStates(DynParamManager& statesIn)
 {
     this->inertialPositionProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + "r_BN_N");
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + "v_BN_N");
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 }
 
 void SpinningBodyNDOFStateEffector::registerStates(DynParamManager& states)
@@ -351,6 +354,21 @@ void SpinningBodyNDOFStateEffector::updateContributions(double integTime,
     Eigen::MatrixX3d AThetaStar = Eigen::MatrixX3d::Zero(this->numberOfDegreesOfFreedom, 3);
     Eigen::MatrixX3d BThetaStar = Eigen::MatrixX3d::Zero(this->numberOfDegreesOfFreedom, 3);
     Eigen::VectorXd CThetaStar = Eigen::VectorXd::Zero(this->numberOfDegreesOfFreedom);
+
+    bool hasAttachedEffectors = false;
+    for (const auto& spinningBody : this->spinningBodyVec) {
+        if (!spinningBody->dynEffectors.empty()) {
+            hasAttachedEffectors = true;
+            break;
+        }
+    }
+    if (hasAttachedEffectors) {
+        // - the per-body inertial rates are not refreshed until after the children are called
+        for (auto& spinningBody : this->spinningBodyVec) {
+            spinningBody->omega_SN_B = spinningBody->omega_SB_B + this->omega_BN_B;
+        }
+        this->computeSpinningBodyInertialStates();
+    }
 
     this->computeDependentEffectors(backSubContr, integTime);
 
@@ -612,6 +630,12 @@ void SpinningBodyNDOFStateEffector::updateEnergyMomContributions(double integTim
 
 void SpinningBodyNDOFStateEffector::computeSpinningBodyInertialStates()
 {
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        const Eigen::MRPd sigmaHub_BN(this->hubSigmaState->getStateReference().data());
+        this->dcm_BN = sigmaHub_BN.toRotationMatrix().transpose();
+    }
+
     for(auto& spinningBody: this->spinningBodyVec) {
         // Compute the rotational properties
         Eigen::Matrix3d dcm_SN = spinningBody->dcm_BS.transpose() * this->dcm_BN;
@@ -632,6 +656,5 @@ void SpinningBodyNDOFStateEffector::computeSpinningBodyInertialStates()
 void SpinningBodyNDOFStateEffector::UpdateState(uint64_t CurrentSimNanos)
 {
     this->readInputMessages();
-    this->computeSpinningBodyInertialStates();
     this->writeOutputStateMessages(CurrentSimNanos);
 }

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -394,7 +394,8 @@ void SpinningBodyNDOFStateEffector::computeDependentEffectors(BackSubMatrices& b
         auto& spinningBody = *it;
         for (auto& dynEffector : spinningBody->dynEffectors) {
             dynEffector->computeForceTorque(integTime, double(0.0));
-            force_S += dynEffector->forceExternal_B;
+            // a child's "_B" loads are already in this parent's S frame, so only "_N" is rotated
+            force_S += dynEffector->forceExternal_B + spinningBody->dcm_BS.transpose() * this->dcm_BN * dynEffector->forceExternal_N;
             torquePntS_S += dynEffector->torqueExternalPntB_B;
         }
         spinningBody->extForce_S = force_S;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -41,7 +41,6 @@ uint64_t SpinningBodyNDOFStateEffector::effectorID = 1;
 
 SpinningBodyNDOFStateEffector::~SpinningBodyNDOFStateEffector()
 {
-    SpinningBodyNDOFStateEffector::effectorID --;    /* reset the panel ID*/
 }
 
 void SpinningBodyNDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]])

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
@@ -190,7 +190,6 @@ private:
     Eigen::MRPd sigma_BN;
     StateData* hubSigmaState = nullptr;    //!< hub attitude state, read live for the published kinematics
     Eigen::Matrix3d dcm_BN = Eigen::Matrix3d::Zero();
-    Eigen::Matrix3d omegaTilde_BN_B = Eigen::Matrix3d::Zero();
 
     Eigen::MatrixXd* inertialPositionProperty = nullptr;
     Eigen::MatrixXd* inertialVelocityProperty = nullptr;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
@@ -188,6 +188,7 @@ private:
 
     Eigen::Vector3d omega_BN_B = Eigen::Vector3d::Zero();
     Eigen::MRPd sigma_BN;
+    StateData* hubSigmaState = nullptr;    //!< hub attitude state, read live for the published kinematics
     Eigen::Matrix3d dcm_BN = Eigen::Matrix3d::Zero();
     Eigen::Matrix3d omegaTilde_BN_B = Eigen::Matrix3d::Zero();
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -40,7 +40,6 @@ SpinningBodyOneDOFStateEffector::SpinningBodyOneDOFStateEffector()
     this->dcm_BS.setIdentity();
     this->rTilde_ScB_B.setZero();
     this->omegaTilde_SB_B.setZero();
-    this->omegaTilde_BN_B.setZero();
     this->dcm_BS.setIdentity();
     this->dcm_BN.setIdentity();
     this->IPntSc_B.setIdentity();
@@ -259,7 +258,6 @@ void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
 {
     // Define omega_SN_B
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
     this->omega_SN_B = this->omega_SB_B + this->omega_BN_B;
 
     // Define IPntS_B for compactness
@@ -279,6 +277,8 @@ void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
     this->mTheta = this->sHat_B.transpose() * IPntS_B * this->sHat_B;
 
     if (!this->dynEffectors.empty()) {
+        this->rDot_SB_B = this->omega_BN_B.cross(this->r_SB_B);
+        this->rDot_ScB_B = this->rPrime_ScB_B + this->omega_BN_B.cross(this->r_ScB_B);
         this->computeSpinningBodyInertialStates();
     }
 
@@ -451,11 +451,10 @@ void SpinningBodyOneDOFStateEffector::updateEnergyMomContributions(double integT
 {
     // Update omega_BN_B and omega_SN_B
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
     this->omega_SN_B = this->omega_SB_B + this->omega_BN_B;
 
     // Compute rDot_ScB_B
-    this->rDot_ScB_B = this->rPrime_ScB_B + this->omegaTilde_BN_B * this->r_ScB_B;
+    this->rDot_ScB_B = this->rPrime_ScB_B + this->omega_BN_B.cross(this->r_ScB_B);
 
     // Find rotational angular momentum contribution
     rotAngMomPntCContr_B = this->IPntSc_B * this->omega_SN_B + this->mass * this->rTilde_ScB_B * this->rDot_ScB_B;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -59,7 +59,6 @@ uint64_t SpinningBodyOneDOFStateEffector::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 SpinningBodyOneDOFStateEffector::~SpinningBodyOneDOFStateEffector()
 {
-    SpinningBodyOneDOFStateEffector::effectorID = 1;
 }
 
 /*! This method is used to reset the module. */

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -93,6 +93,8 @@ void SpinningBodyOneDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused
 /*! This method takes the computed theta states and outputs them to the messaging system. */
 void SpinningBodyOneDOFStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computeSpinningBodyInertialStates();
+
     // Write out the spinning body output messages
     if (this->spinningBodyOutMsg.isLinked()) {
         HingedRigidBodyMsgPayload spinningBodyBuffer;
@@ -132,6 +134,7 @@ void SpinningBodyOneDOFStateEffector::linkInStates(DynParamManager& statesIn)
     // Get access to properties needed for dynamic coupling (Hub or prescribed)
     this->inertialPositionProperty = statesIn.getPropertyReference(this->propName_inertialPosition);
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->propName_inertialVelocity);
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 }
 
 /*! This method is used to link prescribed motion properties */
@@ -274,6 +277,10 @@ void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
 
     // Define auxiliary variable mTheta
     this->mTheta = this->sHat_B.transpose() * IPntS_B * this->sHat_B;
+
+    if (!this->dynEffectors.empty()) {
+        this->computeSpinningBodyInertialStates();
+    }
 
     // Loop through to collect forces and torques from any connected dynamic effectors
     Eigen::Vector3d attBodyForce_S = Eigen::Vector3d::Zero();  // sum of external forces in S frame components
@@ -461,6 +468,12 @@ void SpinningBodyOneDOFStateEffector::updateEnergyMomContributions(double integT
 /*! This method computes the spinning body states relative to the inertial frame */
 void SpinningBodyOneDOFStateEffector::computeSpinningBodyInertialStates()
 {
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        const Eigen::MRPd sigmaHub_BN(this->hubSigmaState->getStateReference().data());
+        this->dcm_BN = sigmaHub_BN.toRotationMatrix().transpose();
+    }
+
     // inertial attitude
     Eigen::Matrix3d dcm_SN;
     dcm_SN = (this->dcm_BS).transpose() * this->dcm_BN;
@@ -501,9 +514,6 @@ void SpinningBodyOneDOFStateEffector::UpdateState(uint64_t CurrentSimNanos)
         this->thetaRef = incomingRefBuffer.theta;
         this->thetaDotRef = incomingRefBuffer.thetaDot;
     }
-
-    /* Compute spinning body inertial states */
-    this->computeSpinningBodyInertialStates();
 
     this->writeOutputStateMessages(CurrentSimNanos);
 }

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -290,8 +290,9 @@ void SpinningBodyOneDOFStateEffector::updateContributions(double integTime,
     {
         // Compute the force and torque contributions from the dynamicEffectors in parent frame
         (*dynIt)->computeForceTorque(integTime, double(0.0));
-        attBodyForce_S += (*dynIt)->forceExternal_B; // here parent frame is S, not B
-        attBodyTorquePntS_S += (*dynIt)->torqueExternalPntB_B; // here parent frame is S, not B
+        // a child's "_B" loads are already in this parent's S frame, so only "_N" is rotated
+        attBodyForce_S += (*dynIt)->forceExternal_B + this->dcm_BS.transpose() * this->dcm_BN * (*dynIt)->forceExternal_N;
+        attBodyTorquePntS_S += (*dynIt)->torqueExternalPntB_B;
     }
 
     // Lock the axis if the flag is set to 1

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
@@ -138,6 +138,7 @@ private:
     // States
     double theta = 0.0;                           //!< [rad] spinning body angle
     double thetaDot = 0.0;                        //!< [rad/s] spinning body angle rate
+    StateData* hubSigmaState = nullptr;  //!< hub attitude state, read live for the published kinematics
     Eigen::MatrixXd* inertialPositionProperty = nullptr;  //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialVelocityProperty = nullptr;  //!< [m/s] v_N inertial velocity relative to system spice zeroBase/refBase
     StateData* thetaState = nullptr;              //!< -- state manager of theta for spinning body

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.h
@@ -122,7 +122,6 @@ private:
     // Matrix quantities
     Eigen::Matrix3d rTilde_ScB_B;       //!< [m] tilde matrix of r_ScB_B
     Eigen::Matrix3d omegaTilde_SB_B;    //!< [rad/s] tilde matrix of omega_SB_B
-    Eigen::Matrix3d omegaTilde_BN_B;    //!< [rad/s] tilde matrix of omega_BN_B
     Eigen::Matrix3d dcm_BS;             //!< -- DCM from spinner frame to body frame
     Eigen::Matrix3d dcm_BN;             //!< -- DCM from inertial frame to body frame
     Eigen::Matrix3d IPntSc_B;           //!< [kg-m^2] inertia of spinning body about point Sc in B frame components

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -122,6 +122,8 @@ void SpinningBodyTwoDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused
 /*! This method takes the computed theta states and outputs them to the messaging system. */
 void SpinningBodyTwoDOFStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computeSpinningBodyInertialStates();
+
     // Write out the spinning body output messages
     HingedRigidBodyMsgPayload spinningBodyBuffer;
     if (this->spinningBodyOutMsgs[0]->isLinked()) {
@@ -180,6 +182,7 @@ void SpinningBodyTwoDOFStateEffector::linkInStates(DynParamManager& statesIn)
 
     this->inertialPositionProperty = statesIn.getPropertyReference(this->propName_inertialPosition);
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->propName_inertialVelocity);
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 }
 
 /*! This method is used to link prescribed motion properties */
@@ -355,6 +358,16 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
     gLocal_N = g_N;
     g_B = this->dcm_BN * gLocal_N;
 
+    // Update omega_BN_B
+    this->omega_BN_B = omega_BN_B;
+    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
+    this->omega_S1N_B = this->omega_S1B_B + this->omega_BN_B;
+    this->omega_S2N_B = this->omega_S2B_B + this->omega_BN_B;
+
+    if (!this->dynEffectors.empty()) {
+        this->computeSpinningBodyInertialStates();
+    }
+
     // Loop through to collect forces and torques from any connected dynamic effectors
     Eigen::Vector3d attBodyForce_S1 = Eigen::Vector3d::Zero();
     Eigen::Vector3d attBodyTorquePntS1_S1 = Eigen::Vector3d::Zero();
@@ -376,12 +389,6 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
             attBodyTorquePntS2_S2 += (*dynIt)->torqueExternalPntB_B;
         }
     }
-
-    // Update omega_BN_B
-    this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
-    this->omega_S1N_B = this->omega_S1B_B + this->omega_BN_B;
-    this->omega_S2N_B = this->omega_S2B_B + this->omega_BN_B;
 
     // Define auxiliary position vectors
     Eigen::Vector3d r_ScS1_B = (this->mass1 * this->r_Sc1S1_B + this->mass2 * this->r_Sc2S1_B) / this->mass;
@@ -686,6 +693,12 @@ void SpinningBodyTwoDOFStateEffector::updateEnergyMomContributions(double integT
 /*! This method computes the spinning body states relative to the inertial frame */
 void SpinningBodyTwoDOFStateEffector::computeSpinningBodyInertialStates()
 {
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        const Eigen::MRPd sigmaHub_BN(this->hubSigmaState->getStateReference().data());
+        this->dcm_BN = sigmaHub_BN.toRotationMatrix().transpose();
+    }
+
     // Compute the inertial attitude
     Eigen::Matrix3d dcm_S1N;
     Eigen::Matrix3d dcm_S2N;
@@ -745,9 +758,6 @@ void SpinningBodyTwoDOFStateEffector::UpdateState(uint64_t CurrentSimNanos)
         this->theta2Ref = incomingRefBuffer.theta;
         this->theta2DotRef = incomingRefBuffer.thetaDot;
     }
-
-    /* Compute spinning body inertial states */
-    this->computeSpinningBodyInertialStates();
 
     /* Write output messages*/
     this->writeOutputStateMessages(CurrentSimNanos);

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -442,7 +442,7 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
         + this->omega_BN_B.cross(r_Sc2S1_B.cross(this->rPrime_Sc2S1_B)))
         + this->mass2 * r_Sc2S1_B.cross(this->omega_S2S1_B.cross(this->rPrime_Sc2S2_B))
         + this->mass * r_ScS1_B.cross(this->omega_BN_B.cross(rDot_S1B_B))
-        - this->dcm_BS1 * attBodyTorquePntS1_S1 + this->dcm_BS2 * attBodyTorquePntS2_S2
+        - this->dcm_BS1 * attBodyTorquePntS1_S1 - this->dcm_BS2 * attBodyTorquePntS2_S2
         - this->r_S2S1_B.cross(this->dcm_BS2 * attBodyForce_S2);
     Eigen::Vector3d cThetaTerm1_B = IPrimeS2PntS2_B * this->omega_S2N_B
         + this->omega_BN_B.cross(IS2PntS2_B * this->omega_S2N_B)

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -72,7 +72,6 @@ uint64_t SpinningBodyTwoDOFStateEffector::effectorID = 1;
 /*! This is the destructor, nothing to report here */
 SpinningBodyTwoDOFStateEffector::~SpinningBodyTwoDOFStateEffector()
 {
-    SpinningBodyTwoDOFStateEffector::effectorID --;    /* reset the panel ID*/
 }
 
 /*! This method is used to reset the module. */

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -43,7 +43,6 @@ SpinningBodyTwoDOFStateEffector::SpinningBodyTwoDOFStateEffector()
     this->rTilde_Sc2B_B.setZero();
     this->omegaTilde_S1B_B.setZero();
     this->omegaTilde_S2B_B.setZero();
-    this->omegaTilde_BN_B.setZero();
     this->dcm_BS1.setIdentity();
     this->dcm_BS2.setIdentity();
     this->dcm_BN.setIdentity();
@@ -328,10 +327,6 @@ void SpinningBodyTwoDOFStateEffector::updateEffectorMassProps(double integTime [
     this->rPrime_ScB_B = (this->mass1 * this->rPrime_Sc1B_B + this->mass2 * this->rPrime_Sc2B_B) / this->mass;
     this->effProps.rEffPrime_CB_B = this->rPrime_ScB_B;
 
-    // Compute the effector's velocity properties
-    this->rDot_S1B_B = this->omegaTilde_BN_B * this->r_S1B_B;
-    this->rDot_S2B_B = this->rDot_S1B_B + this->rPrime_S2S1_B + this->omegaTilde_BN_B * this->r_S2S1_B;
-
     // Find the body-frame time derivative of the inertias of each spinner
     this->IPrimeS1PntSc1_B = this->omegaTilde_S1B_B * this->IS1PntSc1_B - this->IS1PntSc1_B * this->omegaTilde_S1B_B;
     this->IPrimeS2PntSc2_B = this->omegaTilde_S2B_B * this->IS2PntSc2_B - this->IS2PntSc2_B * this->omegaTilde_S2B_B;
@@ -360,11 +355,14 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
 
     // Update omega_BN_B
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
     this->omega_S1N_B = this->omega_S1B_B + this->omega_BN_B;
     this->omega_S2N_B = this->omega_S2B_B + this->omega_BN_B;
 
     if (!this->dynEffectors.empty()) {
+        this->rDot_S1B_B = this->omega_BN_B.cross(this->r_S1B_B);
+        this->rDot_S2B_B = this->rDot_S1B_B + this->rPrime_S2S1_B + this->omega_BN_B.cross(this->r_S2S1_B);
+        this->rDot_Sc1B_B = this->rPrime_Sc1B_B + this->omega_BN_B.cross(this->r_Sc1B_B);
+        this->rDot_Sc2B_B = this->rPrime_Sc2B_B + this->omega_BN_B.cross(this->r_Sc2B_B);
         this->computeSpinningBodyInertialStates();
     }
 
@@ -673,13 +671,14 @@ void SpinningBodyTwoDOFStateEffector::updateEnergyMomContributions(double integT
 {
     // Update omega_BN_B and omega_SN_B
     this->omega_BN_B = omega_BN_B;
-    this->omegaTilde_BN_B = eigenTilde(this->omega_BN_B);
     this->omega_S1N_B = this->omega_S1B_B + this->omega_BN_B;
     this->omega_S2N_B = this->omega_S2B_B + this->omega_BN_B;
 
-    // Compute rDot_ScB_B
-    this->rDot_Sc1B_B = this->rPrime_Sc1B_B + this->omegaTilde_BN_B * this->r_Sc1B_B;
-    this->rDot_Sc2B_B = this->rPrime_Sc2B_B + this->omegaTilde_BN_B * this->r_Sc2B_B;
+    // Compute the rDot terms
+    this->rDot_Sc1B_B = this->rPrime_Sc1B_B + this->omega_BN_B.cross(this->r_Sc1B_B);
+    this->rDot_Sc2B_B = this->rPrime_Sc2B_B + this->omega_BN_B.cross(this->r_Sc2B_B);
+    this->rDot_S1B_B = this->omega_BN_B.cross(this->r_S1B_B);
+    this->rDot_S2B_B = this->rDot_S1B_B + this->rPrime_S2S1_B + this->omega_BN_B.cross(this->r_S2S1_B);
 
     // Find rotational angular momentum contribution from hub
     rotAngMomPntCContr_B = this->IS1PntSc1_B * this->omega_S1N_B + this->mass1 * this->rTilde_Sc1B_B * this->rDot_Sc1B_B

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -379,13 +379,13 @@ void SpinningBodyTwoDOFStateEffector::updateContributions(double integTime, Back
         // Compute the force and torque contributions from the dynamicEffectors in parent frame
         (*dynIt)->computeForceTorque(integTime, double(0.0));
         if ((*dynIt)->getPropName_inertialPosition() == this->nameOfInertialPositionProperty1) {
-            // for inner segment parent frame is S1, not B
-            attBodyForce_S1 += (*dynIt)->forceExternal_B;
+            // a child's "_B" loads are already in the lower body's S1 frame, so only "_N" is rotated
+            attBodyForce_S1 += (*dynIt)->forceExternal_B + this->dcm_BS1.transpose() * this->dcm_BN * (*dynIt)->forceExternal_N;
             attBodyTorquePntS1_S1 += (*dynIt)->torqueExternalPntB_B;
         }
         else if ((*dynIt)->getPropName_inertialPosition() == this->nameOfInertialPositionProperty2) {
-            // for outer segment parent frame is S2, not B
-            attBodyForce_S2 += (*dynIt)->forceExternal_B;
+            // a child's "_B" loads are already in the upper body's S2 frame, so only "_N" is rotated
+            attBodyForce_S2 += (*dynIt)->forceExternal_B + this->dcm_BS2.transpose() * this->dcm_BN * (*dynIt)->forceExternal_N;
             attBodyTorquePntS2_S2 += (*dynIt)->torqueExternalPntB_B;
         }
     }

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
@@ -176,7 +176,6 @@ private:
     Eigen::Matrix3d rTilde_Sc2B_B;      //!< [m] tilde matrix of r_Sc2B_B
     Eigen::Matrix3d omegaTilde_S1B_B;   //!< [rad/s] tilde matrix of omega_S1B_B
     Eigen::Matrix3d omegaTilde_S2B_B;   //!< [rad/s] tilde matrix of omega_S2B_B
-    Eigen::Matrix3d omegaTilde_BN_B;    //!< [rad/s] tilde matrix of omega_BN_B
     Eigen::Matrix3d dcm_BS1;            //!< -- DCM from lower spinner frame to body frame
     Eigen::Matrix3d dcm_BS2;            //!< -- DCM from upper spinner frame to body frame
     Eigen::Matrix3d dcm_BN;             //!< -- DCM from inertial frame to body frame

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.h
@@ -204,6 +204,7 @@ private:
     double theta1Dot = 0.0;             //!< [rad/s] first axis angle rate
     double theta2 = 0.0;                //!< [rad] second axis angle
     double theta2Dot = 0.0;             //!< [rad/s] second axis angle rate
+    StateData* hubSigmaState = nullptr;  //!< hub attitude state, read live for the published kinematics
     Eigen::MatrixXd* inertialPositionProperty = nullptr;    //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialVelocityProperty = nullptr;    //!< [m] v_N inertial velocity relative to system spice zeroBase/refBase
     StateData* theta1State = nullptr;    //!< -- state manager of theta1 for spinning body


### PR DESCRIPTION
* **Tickets addressed:** #1510
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

The path by which a state effector parents a dynamic effector carried several independent defects. All are pre-existing on `develop` rather than regressions, and all were found while adding branching support to `dualHingedRigidBodyStateEffector` under #1151. They are split out here because they stand alone, and because the constraint effector work should not have to wait on that feature.

The defects fall into three groups. The inertial states a parent publishes for its children were built in the wrong frame in four modules, were a full task step stale in all of them, and lagged by a further step in the 1DOF hinged body. Two equation of motion terms were wrong, one in sign and one missing outright. Thirteen state effectors wound a static identifier counter back in their destructors, ten resetting it and three decrementing it, which let two live effectors register colliding state names.

One capability rides along, in the final commit. A child can emit `forceExternal_N` as well as `forceExternal_B`, and only the body frame force was ever mapped into a parent's equations. This was a gap rather than a defect, but `constraintDynamicEffector` reports its constraint force only in inertial components, so attached to a state effector it had no translational effect at all.

Commits are organized module by module first, in ascending degrees of freedom within each family, then the two changes that cut across every parent, then the capability:

1. `hingedRigidBodyStateEffector` inertial velocity outputs
2. `hingedRigidBodyStateEffector` published kinematics built on a stale hub rate
3. `dualHingedRigidBodyStateEffector` panel velocity outputs
4. `dualHingedRigidBodyStateEffector` panel 2 angular velocity
5. `dualHingedRigidBodyStateEffector` second hinge motor reaction
6. `spinningBodyTwoDOFStateEffector` upper body torque sign
7. `linearTranslationOneDOFStateEffector` inertial velocity and angular velocity
8. `linearTranslationNDOFStateEffector` double transpose
9. State effector identifier reuse, across thirteen effectors
10. Substep publishing of branching parent kinematics, with the test that pins it
11. Attached effector inertial force in every branching parent, with the test that exercises it

Two things reviewers should be aware of. Commit 9 is API visible: the counter is now monotonic, so a script that looks a state object up by its generated name has to ask the effector for that name instead, and two shipped scenarios did exactly that and are corrected in the same commit. Commit 10 touches `spacecraft.cpp`, the only change here inside the back-substitution core, adding one call that refreshes the hub inertial position and velocity within `equationsOfMotion`.

## Verification

Four commits add test capabilities, and one of them covers the whole set. Commit 10 adds an energy work balance to the branching integrated test: the work a child does about the vehicle center of mass must equal the change in rotational energy, which unlike the momentum check the test already made can see an error inside a parent's own equations of motion. It is asserted on convergence rather than on a tolerance, so no load magnitude can fake it, and the ratio is required to sit near 0.25 rather than merely to decrease, since the residual is dominated by the second order trapezoid work integral. That assertion is a general net over every parent's published kinematics and equations of motion, and it is not theoretical: it is what surfaced the first-order term that became commit 2. Every parent now measures 0.250 to three digits.

The other three tests are narrower. Commit 5 adds an energy work balance to the dual hinged body motor torque test, since momentum cannot detect a missing motor reaction: the pair is internal and the back-substitution stays self-consistent either way. This is not something we do for other modules currently, but felt like a compelling addition proposed by an AI reviewer so I've added it here for consideration. Without the reaction the check reads 8.94 J against 2.99 J of work. Commit 9 is caught by `test_scenarioFuelSlosh`, which fails on its own second and third parameter sets without the accompanying scenario fix. Commit 11 gives the attached effector an inertial frame force alongside its body frame one, so every parent the branching test covers is checked on that path.

The remaining commits add no test of their own. Each corrects a published output or a single equation of motion term whose error the branching test's assertions now bound.

## Documentation

* `docs/source/Support/bskKnownIssues.rst` gains nine entries under the current release section, one per defect.
* `docs/source/Support/bskReleaseNotesSnippets/1510-effector-branching-path.rst` carries ten bullets, the nine fixes plus the capability.

One header comment was corrected rather than invalidated. `linearTranslationOneDOFStateEffector.h` described `dcm_FB` as the DCM from the F frame to the body frame, whereas the module treats it as body to F everywhere it is used, including the `dcm_FN` built two lines from the corrected line. That comment was the only documentation agreeing with the transpose this branch removes.

## Future work

#1358 builds directly on this branch, making `dualHingedRigidBodyStateEffector` able to parent dynamic effectors.

Every parent's published kinematics still depend on `updateEnergyMomContributions` having run after integration and having stored the hub rate into the member rather than a local. Nothing documents that coupling, and commit 2 is what happens when one module does not honor it. Reading the rate from the state engine inside each publisher would remove the dependence, at the cost of touching six modules for no numerical change.

`linearTranslationNDOFStateEffector` has no dynamic effector plumbing and so cannot yet act as a parent. Adding that is a natural next step, and commit 10 already refreshes its published states on the same schedule as the parents.

The identifier scheme itself remains fragile. Generated state names come from a process global counter, so they are only stable within one interpreter and only when nothing else constructs the same effector type first. Deriving them from `ModelTag`, which the user controls, would remove the class of breakage commit 9 exposes rather than working around it.

