### PR TITLE
Add elapsed duration-imaging time to simpleInstrumentController

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/simpleInstrumentController-elapsed-time.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/simpleInstrumentController-elapsed-time.rst
@@ -1,0 +1,1 @@
+- Added the Python-accessible ``elapsedTime`` state to :ref:`simpleInstrumentController` for duration-based imaging attempts.

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
@@ -206,6 +206,7 @@ elapsedTimeTests = [
     (1.0, 3.0, [0, 1, 0, 0, 1], 1.0),  # successful duration imaging stores acquisition duration
     (2.0, 3.0, [0, 0, 1, 0, 0], 1.0),  # second attempt is still accumulating at the final update
     (3.0, 2.0, [0, 0, 0, 0, 0], 2.0),  # failed duration imaging stores the elapsed attempt time
+    (3.0, 1.5, [0, 0, 0, 0, 0], 1.5),  # failed imaging clamps task-step overshoot to the allowed duration
 ]
 
 

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/_UnitTest/test_simpleInstrumentController.py
@@ -200,6 +200,38 @@ def test_simple_instrument_controller_duration_time_window(
     assert testResults < 1, testMessage
 
 
+# Tuple: acquisitionTime [s], allowedTime [s], expected_result [-], expectedElapsedTime [s]
+elapsedTimeTests = [
+    (0.0, 2.0, [1, 0, 0, 1, 0], 0.0),  # zero acquisition duration images immediately
+    (1.0, 3.0, [0, 1, 0, 0, 1], 1.0),  # successful duration imaging stores acquisition duration
+    (2.0, 3.0, [0, 0, 1, 0, 0], 1.0),  # second attempt is still accumulating at the final update
+    (3.0, 2.0, [0, 0, 0, 0, 0], 2.0),  # failed duration imaging stores the elapsed attempt time
+]
+
+
+@pytest.mark.parametrize(
+    "acquisitionTime,allowedTime,expected_result,expectedElapsedTime", elapsedTimeTests
+)
+def test_simple_instrument_controller_elapsed_time_access(
+    show_plots, acquisitionTime, allowedTime, expected_result, expectedElapsedTime
+):
+    r"""
+    **Validation Test Description**
+
+    Verify that duration-based imaging leaves the elapsed valid-constraint duration accessible for immediate,
+    successful, and failed imaging attempts.
+    """
+    [testResults, testMessage] = simpleInstrumentControllerTestFunction(
+        show_plots,
+        useDuration=1,
+        imagingTimes=[acquisitionTime, allowedTime],
+        expected_result=expected_result,
+        expectedElapsedTime=expectedElapsedTime,
+    )
+
+    assert testResults < 1, testMessage
+
+
 def simpleInstrumentControllerTestFunction(
     show_plots,
     use_rate_limit=1,
@@ -213,6 +245,7 @@ def simpleInstrumentControllerTestFunction(
     timeToleranceLower=None,
     timeToleranceUpper=None,
     imagingTime=None,
+    expectedElapsedTime=None,
 ):
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
@@ -309,6 +342,16 @@ def simpleInstrumentControllerTestFunction(
     if not unitTestSupport.isArrayEqual(dataLog.deviceCmd, expected_result, len(expected_result), 1e-12):
         testFailCount += 1
         testMessages.append("FAILED: " + module.ModelTag + " Module failed dataVector" + " unit test at t=" + str(dataLog.times()[0]*macros.NANO2SEC) + "sec\n")
+
+    if expectedElapsedTime is not None:
+        expectedElapsedTimeNano = macros.sec2nano(expectedElapsedTime)  # [ns]
+        if not unitTestSupport.isDoubleEqual(module.elapsedTime, expectedElapsedTimeNano, 1e-12):
+            testFailCount += 1
+            testMessages.append(
+                "FAILED: " + module.ModelTag + " Module failed elapsedTime unit test. "
+                + "Expected " + str(expectedElapsedTimeNano) + " ns but got "
+                + str(module.elapsedTime) + " ns.\n"
+            )
 
     # Plots
     plt.close("all")  # close all prior figures so we start with a clean slate

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
@@ -39,7 +39,8 @@ SelfInit_simpleInstrumentController(simpleInstrumentControllerConfig* configData
     (void) moduleID;
     configData->imaged = 0;
     configData->controllerStatus = 1;
-    configData->constraintStartTime = 0.0;
+    configData->constraintStartTime = 0.0; // [ns]
+    configData->elapsedTime = 0.0; // [ns]
     configData->constraintsActive = 0;
 
     DeviceCmdMsg_C_init(&configData->deviceCmdOutMsg);
@@ -68,7 +69,8 @@ Reset_simpleInstrumentController(simpleInstrumentControllerConfig* configData, u
     // reset the imaged variable to zero
     configData->imaged = 0;
     configData->constraintsActive = 0;
-    configData->constraintStartTime = 0.0;
+    configData->constraintStartTime = 0.0; // [ns]
+    configData->elapsedTime = 0.0; // [ns]
 }
 
 /*! Add a description of what this main Update() routine does for this module
@@ -139,12 +141,13 @@ Update_simpleInstrumentController(simpleInstrumentControllerConfig* configData, 
                 else {
                     if (!configData->constraintsActive) {
                         configData->constraintsActive = 1;
-                        configData->constraintStartTime = (double)callTime; // current sim time
+                        configData->constraintStartTime = (double)callTime; // [ns] current sim time
+                        configData->elapsedTime = 0.0; // [ns]
                     }
 
                     if (configData->acquisitionTime < 0.0) {
                         // Negative acquisitionTime is invalid; cap to zero
-                        configData->acquisitionTime = 0.0;
+                        configData->acquisitionTime = 0.0; // [ns]
                         _bskLog(configData->bskLogger,
                                 BSK_WARNING,
                                 "simpleInstrumentController: acquisitionTime is negative and has been set to zero.");
@@ -152,27 +155,27 @@ Update_simpleInstrumentController(simpleInstrumentControllerConfig* configData, 
 
                     if (configData->allowedTime < 0.0) {
                         // Negative allowedTime is invalid; cap to zero
-                        configData->allowedTime = 0.0;
+                        configData->allowedTime = 0.0; // [ns]
                         _bskLog(configData->bskLogger,
                                 BSK_WARNING,
                                 "simpleInstrumentController: allowedTime is negative and has been set to zero.");
                     }
 
-                    double elapsedTime = (double) callTime - configData->constraintStartTime;
+                    configData->elapsedTime = (double) callTime - configData->constraintStartTime;
 
                     // Determine the effective time to image: cannot exceed allowedTime
                     double effectiveImageTime = (configData->acquisitionTime > configData->allowedTime)
                                                   ? configData->allowedTime
                                                   : configData->acquisitionTime;
 
-                    if (elapsedTime >= effectiveImageTime) {
+                    if (configData->elapsedTime >= effectiveImageTime) {
                         // Capture only while the acquisition and imaging window remain within the allowed duration
                         if (configData->acquisitionTime <= configData->allowedTime && timeControl &&
-                            elapsedTime <= configData->allowedTime) {
+                            configData->elapsedTime <= configData->allowedTime) {
                             configData->imaged = 1; // Success
                             deviceCmdOutMsgBuffer.deviceCmd = 1;
                             configData->constraintsActive = 0; // Reset timer
-                        } else if (elapsedTime >= configData->allowedTime) {
+                        } else if (configData->elapsedTime >= configData->allowedTime) {
                             // Failed because the required acquisition or capture-window wait exceeded the
                             // allowed duration
                             configData->imaged = 0;

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.c
@@ -178,6 +178,7 @@ Update_simpleInstrumentController(simpleInstrumentControllerConfig* configData, 
                         } else if (configData->elapsedTime >= configData->allowedTime) {
                             // Failed because the required acquisition or capture-window wait exceeded the
                             // allowed duration
+                            configData->elapsedTime = configData->allowedTime;
                             configData->imaged = 0;
                             deviceCmdOutMsgBuffer.deviceCmd = 0;
                             configData->controllerStatus = 0;  // Disable further attempts

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.h
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.h
@@ -41,6 +41,7 @@ typedef struct {
     unsigned int useDurationImaging; //!< flag to enable duration-based imaging
     double acquisitionTime; //!< (optional) Duration that constraints must be satisfied [nanoseconds]
     double allowedTime;     //!< (optional) Maximum allowed time for imaging [nanoseconds]
+    double elapsedTime; //!< Elapsed valid-constraint duration for duration-based imaging [nanoseconds]
     unsigned int constraintsActive; //!< flag to track state
     uint64_t timeToleranceLower; //!< Optional lower time tolerance for imaging [nanoseconds]; zero disables lower bound
     uint64_t timeToleranceUpper; //!< Optional upper time tolerance for imaging [nanoseconds]; zero disables upper bound

--- a/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.rst
+++ b/src/fswAlgorithms/sensorInterfaces/simpleInstrumentController/simpleInstrumentController.rst
@@ -60,4 +60,13 @@ imaging time. A nonzero ``timeToleranceLower`` permits imaging no earlier than
 ``imagingTime + timeToleranceUpper``. Each bound is enabled independently; a tolerance of zero disables that bound,
 which preserves the default behavior without time-based constraints.
 
-The ``useDurationImaging`` flag enables duration-based imaging, where the instrument must maintain valid constraints for a specified period before capturing an image. By default, this feature is disabled. The ``acquisitionTime`` (optional, in nanoseconds) specifies how long the constraints must remain satisfied to trigger an image capture. The ``allowedTime`` (optional, in nanoseconds) defines the maximum period during which the system will attempt imaging. If ``acquisitionTime`` is less than or equal to ``allowedTime``, the image will be captured once the required duration is met. If ``acquisitionTime`` exceeds ``allowedTime``, the image will not be captured, although the system will continue attempting for the full ``allowedTime`` period. If either ``acquisitionTime`` or ``allowedTime`` is negative or not set, the value is automatically capped to zero.
+The ``useDurationImaging`` flag enables duration-based imaging, where the instrument must maintain valid
+constraints for a specified period before capturing an image. By default, this feature is disabled. The
+``acquisitionTime`` (optional, in nanoseconds) specifies how long the constraints must remain satisfied to trigger an
+image capture. The ``allowedTime`` (optional, in nanoseconds) defines the maximum period during which the system will
+attempt imaging. The ``elapsedTime`` state variable stores the elapsed duration, in nanoseconds, from the start of the
+current duration-based imaging attempt. This value is accessible from Python and remains available if the attempt does
+not complete. If ``acquisitionTime`` is less than or equal to ``allowedTime``, the image will be captured once the
+required duration is met. If ``acquisitionTime`` exceeds ``allowedTime``, the image will not be captured, although the
+system will continue attempting for the full ``allowedTime`` period. If either ``acquisitionTime`` or ``allowedTime``
+is negative or not set, the value is automatically capped to zero.


### PR DESCRIPTION
* **Tickets addressed:** #1514
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
When duration-based imaging is enabled, an imaging attempt can fail before completion because the allowed time expires or the window closes. Python reward or scheduling code needs to know how much valid imaging time was accumulated, so partial imaging effort can be credited instead of being treated as zero progress.

## Verification
Added parametrized unit test coverage for `elapsedTime`, including immediate imaging, successful duration imaging, multi-update accumulation, and failed partial imaging.

## Documentation
Updated the `simpleInstrumentController` documentation and added a release-note snippet.

## Future work
None.
