### PR TITLE
Correct variable-mass mass-property derivative reporting

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -79,8 +79,11 @@ Version |release| (July 7, 2026)
   convergence tests ran at a fraction of the intended measurement noise. The tests now draw noise with
   ``sigma = sqrt(qObsVal)`` from a local seeded generator and check convergence against a noise-appropriate
   tolerance. This is fixed in the current version.
-- A depleting :ref:`FuelTank` with attached fuel slosh particles expelled propellant by a factor of
-  one plus the slosh mass fraction. This is fixed in the current version.
+- A depleting :ref:`FuelTank` with attached fuel slosh particles reported the
+  commanded total outflow as the tank component rate while the slosh
+  effectors reported zero mass rate. The integrated component masses and
+  aggregate outflow were correct, but the reported component derivatives did
+  not match their integrated states. This is fixed in the current version.
 - The :ref:`FuelTank` mass-depletion torque treated the tank-frame fuel COM and inertia derivative
   as body-frame quantities and dropped the tank offset, so a rotated (``dcm_TB``) or offset
   (``r_TB_B``) depleting tank applied a wrong or missing torque about the hub. This is fixed in the
@@ -96,6 +99,15 @@ Version |release| (July 7, 2026)
 - :ref:`vizInterface` called ``google::protobuf::ShutdownProtobufLibrary()`` after qualifying successful
   save-file frames, releasing protobuf's internal state while the module was still running. Other frames
   skipped the call through guards or early returns. This is fixed in the current version.
+- :ref:`spacecraft` divided the center-of-mass-rate mass term by total mass
+  twice, in both the reported ``centerOfMassPrimeSC`` property and the
+  coupled-depletion equations of motion. The reported property also dropped
+  the per-effector first moments :math:`\dot m_i\mathbf r_i`. This is fixed in
+  the current version, though the coupled-depletion rate still omits those
+  source moments by convention.
+- :ref:`MJSystemCoM` reported mass-weighted material velocity rather than the
+  time derivative of its center-of-mass position when individual MuJoCo body
+  masses changed. This is fixed in the current version.
 
 
 Version 2.11.0 (July 7, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/spacecraft-center-of-mass-rate.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/spacecraft-center-of-mass-rate.rst
@@ -1,0 +1,5 @@
+- Corrected :ref:`spacecraft` center-of-mass derivatives and allowed :ref:`FuelTank` update-only depletion to report retained mass-property derivatives while excluding depletion-dependent rate terms from the equations of motion.
+- Made :ref:`FuelTank` allocate flow from current integration-stage masses before reporting tank and slosh retained mass-property derivatives.
+- Corrected :ref:`MJSystemCoM` to report the time derivative of its center-of-mass position when MuJoCo body masses change.
+- Documented that state effectors using dynamics-rate overrides require direct attachment to :ref:`spacecraft` and reject unsupported nested prescribed-motion configurations.
+- Corrected the :ref:`spacecraft` coupled-depletion center-of-mass rate, which divided its mass-rate term by total mass twice.

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -754,6 +754,80 @@ def test_leakyTankRunsOutOfFuel(tankModelConstructor):
     assert np.any(np.isclose(fuelMassDot, -leakRate, rtol=1e-6))
 
 
+@pytest.mark.parametrize(
+    "sloshConstructor",
+    [
+        linearSpringMassDamper.LinearSpringMassDamper,
+        sphericalPendulum.SphericalPendulum,
+    ],
+)
+def test_attachedSloshMassClampsAtEmpty(sloshConstructor):
+    """Clamp attached slosh mass when a depletion step crosses zero."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    timeStep = 1.0  # [s]
+    process.addTask(
+        simulation.CreateNewTask(taskName, macros.sec2nano(timeStep))
+    )
+
+    dynamics = spacecraft.Spacecraft()
+    dynamics.hub.mHub = 100.0  # [kg]
+    dynamics.hub.IHubPntBc_B = np.diag(
+        [80.0, 90.0, 100.0]
+    )  # [kg*m^2]
+
+    tank = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelConstantVolume()
+    tankModel.propMassInit = 1.0e-4  # [kg]
+    tankModel.radiusTankInit = 0.5  # [m]
+    tank.setTankModel(tankModel)
+    tank.setFuelLeakRate(1.0e-4)  # [kg/s]
+
+    slosh = sloshConstructor()
+    slosh.massInit = 2.5e-5  # [kg]
+    if isinstance(
+        slosh,
+        linearSpringMassDamper.LinearSpringMassDamper,
+    ):
+        slosh.k = 1.0  # [N/m]
+        slosh.c = 0.0  # [N*s/m]
+        slosh.r_PB_B = np.zeros(3)  # [m]
+        slosh.pHat_B = [1.0, 0.0, 0.0]
+        slosh.rhoInit = 0.0  # [m]
+        slosh.rhoDotInit = 0.0  # [m/s]
+    else:
+        slosh.pendulumRadius = 0.5  # [m]
+        slosh.d = np.array([-0.5, 0.0, 0.0])  # [m]
+        slosh.D = np.zeros((3, 3))  # [N*s/m]
+        slosh.phiDotInit = 0.0  # [rad/s]
+        slosh.thetaDotInit = 0.0  # [rad/s]
+
+    tank.pushFuelSloshParticle(slosh)
+    dynamics.addStateEffector(tank)
+    dynamics.addStateEffector(slosh)
+    simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, dynamics)
+    simulation.InitializeSimulation()
+
+    stopTime = 3.0  # [s]
+    simulation.ConfigureStopTime(macros.sec2nano(stopTime))
+    simulation.ExecuteSimulation()
+
+    tankMass = dynamics.dynManager.getStateObject(
+        tank.getNameOfMassState()
+    ).getState()[0][0]
+    sloshMass = dynamics.dynManager.getStateObject(
+        slosh.nameOfMassState
+    ).getState()[0][0]
+    massTolerance = 1.0e-14  # [kg]
+
+    assert np.isclose(tankMass, 0.0, atol=massTolerance)
+    assert np.isclose(sloshMass, 0.0, atol=massTolerance)
+    assert np.isclose(slosh.effProps.mEff, 0.0, atol=massTolerance)
+    assert np.all(np.isfinite(_hubStateDerivatives(dynamics)))
+
+
 @pytest.mark.parametrize("tankModelConstructor", [fuelTank.FuelTankModelConstantVolume,
                                                   fuelTank.FuelTankModelConstantDensity,
                                                   fuelTank.FuelTankModelEmptying,

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -560,7 +560,7 @@ def test_depletionTorqueFollowsTankMounting():
     # Regression value after independently validating the emptying-model derivatives by finite differences.
     np.testing.assert_allclose(
         np.linalg.norm(omega_BN_B),
-        2.6376706988e-04,  # [rad/s]
+        2.6449538196e-04,  # [rad/s]
         rtol=1e-5,
         err_msg="depletion torque magnitude not equal")
 
@@ -629,7 +629,7 @@ def test_depletionTorqueUsesCurrentMassFlowRate():
     # Regression value after independently validating the emptying-model derivatives by finite differences.
     np.testing.assert_allclose(
         np.linalg.norm(omega_BN_B),
-        1.5638822750e-03,  # [rad/s]
+        1.5818171569e-03,  # [rad/s]
         rtol=1e-5,
         err_msg="depletion torque did not use the current mass-flow rate")
 

--- a/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
+++ b/src/simulation/dynamics/FuelTank/_UnitTest/test_mass_depletion.py
@@ -23,9 +23,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from Basilisk.architecture import messaging
+from Basilisk.architecture.bskLogging import BasiliskError
 from Basilisk.simulation import fuelTank
 from Basilisk.simulation import gravityEffector
 from Basilisk.simulation import linearSpringMassDamper
+from Basilisk.simulation import prescribedMotionStateEffector
+from Basilisk.simulation import sphericalPendulum
 from Basilisk.simulation import spacecraft
 from Basilisk.simulation import thrusterDynamicEffector, thrusterStateEffector
 from Basilisk.utilities import RigidBodyKinematics as rbk
@@ -52,6 +55,349 @@ def _configureTankGeometry(tankModel):
         tankModel.radiusTankInit = 1.0  # [m]
     if hasattr(tankModel, "lengthTank"):
         tankModel.lengthTank = 1.0  # [m]
+
+
+def _buildAttachedSloshModel(sloshConstructor, wiring):
+    """Build a tank with one attached slosh particle under a given registration wiring.
+
+    ``wiring`` selects the order the effectors reach Spacecraft: "tankFirst" is the
+    supported order, "sloshFirst" reverses it, and "sloshUnregistered" attaches the
+    particle to the tank without ever adding it to Spacecraft. Returns the objects so
+    the caller keeps them alive for the duration of the simulation.
+    """
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    process.addTask(
+        simulation.CreateNewTask(taskName, macros.sec2nano(0.1))
+    )  # [s]
+
+    dynamics = spacecraft.Spacecraft()
+    tank = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelConstantVolume()
+    tankModel.propMassInit = 20.0  # [kg]
+    tankModel.radiusTankInit = 0.5  # [m]
+    tank.setTankModel(tankModel)
+
+    slosh = sloshConstructor()
+    slosh.massInit = 5.0  # [kg]
+    tank.pushFuelSloshParticle(slosh)
+
+    if wiring == "sloshFirst":
+        dynamics.addStateEffector(slosh)
+        dynamics.addStateEffector(tank)
+    elif wiring == "tankFirst":
+        dynamics.addStateEffector(tank)
+        dynamics.addStateEffector(slosh)
+    elif wiring == "sloshUnregistered":
+        dynamics.addStateEffector(tank)
+    else:
+        raise ValueError(f"unknown wiring {wiring}")
+
+    simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, dynamics)
+    return simulation, dynamics, tank, slosh
+
+
+@pytest.mark.parametrize(
+    "sloshConstructor",
+    [
+        linearSpringMassDamper.LinearSpringMassDamper,
+        sphericalPendulum.SphericalPendulum,
+    ],
+)
+def test_attachedSloshRequiresTankFirst(sloshConstructor):
+    """Reject attached fuel slosh registered before its owning tank."""
+    simulation, _dynamics, _tank, _slosh = _buildAttachedSloshModel(
+        sloshConstructor, "sloshFirst"
+    )
+    with pytest.raises(
+        BasiliskError,
+        match="FuelTank must be added to Spacecraft before",
+    ):
+        simulation.InitializeSimulation()
+
+
+@pytest.mark.parametrize(
+    "sloshConstructor",
+    [
+        linearSpringMassDamper.LinearSpringMassDamper,
+        sphericalPendulum.SphericalPendulum,
+    ],
+)
+def test_attachedSloshRequiresSpacecraftRegistration(sloshConstructor):
+    """Reject attached fuel slosh that never registers states with Spacecraft."""
+    simulation, _dynamics, _tank, _slosh = _buildAttachedSloshModel(
+        sloshConstructor, "sloshUnregistered"
+    )
+    with pytest.raises(
+        BasiliskError,
+        match="never added to Spacecraft",
+    ):
+        simulation.InitializeSimulation()
+
+
+@pytest.mark.parametrize(
+    "sloshConstructor",
+    [
+        linearSpringMassDamper.LinearSpringMassDamper,
+        sphericalPendulum.SphericalPendulum,
+    ],
+)
+def test_repeatedInitializationKeepsAttachedSloshValid(sloshConstructor):
+    """Re-initializing a correctly ordered tank and slosh must not trip the guard."""
+    simulation, _dynamics, _tank, _slosh = _buildAttachedSloshModel(
+        sloshConstructor, "tankFirst"
+    )
+    simulation.InitializeSimulation()
+    simulation.InitializeSimulation()
+
+
+@pytest.mark.parametrize("updateOnly", [True, False])
+def test_prescribedMotionRejectsVariableMassTank(updateOnly):
+    """Reject variable-mass state effectors nested under prescribed motion."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    process.addTask(
+        simulation.CreateNewTask(taskName, macros.sec2nano(0.1))
+    )  # [s]
+
+    dynamics = spacecraft.Spacecraft()
+    prescribedBody = (
+        prescribedMotionStateEffector.PrescribedMotionStateEffector()
+    )
+    prescribedBody.setMass(10.0)  # [kg]
+    prescribedBody.setIPntPc_P(np.diag([2.0, 3.0, 4.0]))  # [kg*m^2]
+
+    tank = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelConstantVolume()
+    tankModel.propMassInit = 20.0  # [kg]
+    tankModel.radiusTankInit = 0.5  # [m]
+    tank.setTankModel(tankModel)
+    tank.setFuelLeakRate(0.1)  # [kg/s]
+    tank.setUpdateOnly(updateOnly)
+    prescribedBody.addStateEffector(tank)
+    dynamics.addStateEffector(prescribedBody)
+
+    simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, prescribedBody)
+    simulation.AddModelToTask(taskName, dynamics)
+    with pytest.raises(
+        BasiliskError,
+        match="does not support nested variable-mass",
+    ):
+        simulation.InitializeSimulation()
+
+
+@pytest.mark.parametrize(
+    "sloshConstructor",
+    [
+        linearSpringMassDamper.LinearSpringMassDamper,
+        sphericalPendulum.SphericalPendulum,
+    ],
+)
+@pytest.mark.parametrize("updateOnly", [True, False])
+def test_attachedSloshReportsComponentRates(sloshConstructor, updateOnly):
+    """Verify attached tank and slosh retained-property derivatives.
+
+    Coupled-depletion accelerations are regression baselines recorded from the
+    current implementation, not analytic variable-mass truth values. The
+    coupled-depletion rate still omits the mass-flow source first moments.
+    """
+    dynamics, tank, slosh = _initializeAttachedSlosh(
+        sloshConstructor,
+        updateOnly,
+        leakRate=1.0,
+    )
+
+    tankMassRate = -0.8  # [kg/s]
+    sloshMassRate = -0.2  # [kg/s]
+    np.testing.assert_allclose(
+        tank.effProps.mEffDot,
+        tankMassRate,
+        rtol=0.0,
+        atol=1.0e-15,
+    )
+    np.testing.assert_allclose(
+        slosh.fuelMassDot,
+        sloshMassRate,
+        rtol=0.0,
+        atol=1.0e-15,
+    )
+    reportedMassRate = np.asarray(
+        dynamics.dynManager.getPropertyReference("mDot_SC")
+    ).reshape(-1)
+    np.testing.assert_allclose(
+        reportedMassRate,
+        [-1.0],
+        rtol=0.0,
+        atol=1.0e-15,
+    )
+
+    offset_B = np.array([0.6, -0.3, 0.2])  # [m]
+    totalMass = 125.0  # [kg]
+    centerOfMass_B = 25.0*offset_B/totalMass  # [m]
+    expectedCenterOfMassPrime_B = (
+        -offset_B/totalMass + centerOfMass_B/totalMass
+    )  # [m/s]
+    centerOfMassPrime_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("centerOfMassPrimeSC")
+    ).reshape(3)
+    np.testing.assert_allclose(
+        centerOfMassPrime_B,
+        expectedCenterOfMassPrime_B,
+        rtol=1.0e-14,
+        atol=1.0e-16,
+    )
+
+    offsetTilde = np.array(
+        [
+            [0.0, -offset_B[2], offset_B[1]],
+            [offset_B[2], 0.0, -offset_B[0]],
+            [-offset_B[1], offset_B[0], 0.0],
+        ]
+    )  # [m]
+    expectedSloshInertiaRate_B = (
+        -sloshMassRate*offsetTilde@offsetTilde
+    )  # [kg*m^2/s]
+    np.testing.assert_allclose(
+        np.asarray(slosh.effProps.IEffPrimePntB_B),
+        expectedSloshInertiaRate_B,
+        rtol=1.0e-14,
+        atol=1.0e-16,
+    )
+
+    if updateOnly:
+        control, _, _ = _initializeAttachedSlosh(
+            sloshConstructor,
+            updateOnly=True,
+            leakRate=0.0,
+        )
+        np.testing.assert_allclose(
+            _hubStateDerivatives(dynamics),
+            _hubStateDerivatives(control),
+            rtol=0.0,
+            atol=1.0e-13,
+        )
+    else:
+        if isinstance(
+            slosh,
+            linearSpringMassDamper.LinearSpringMassDamper,
+        ):
+            expectedVelocityDerivative_N = np.array(
+                [
+                    0.00440480657192980,
+                    0.00124386704106702,
+                    -0.00089226309734675,
+                ]
+            )  # [m/s^2]
+            expectedRateDerivative_B = np.array(
+                [
+                    0.00337915307437880,
+                    0.00416556431825436,
+                    0.00444682568256779,
+                ]
+            )  # [rad/s^2]
+        else:
+            expectedVelocityDerivative_N = np.array(
+                [
+                    0.00527105039614227,
+                    0.00102237938234717,
+                    -0.00073415691683492,
+                ]
+            )  # [m/s^2]
+            expectedRateDerivative_B = np.array(
+                [
+                    0.00337533072997688,
+                    0.00425076546666240,
+                    0.00457131641985391,
+                ]
+            )  # [rad/s^2]
+        hubStateDerivatives = _hubStateDerivatives(dynamics)
+        np.testing.assert_allclose(
+            hubStateDerivatives[:3],
+            expectedVelocityDerivative_N,
+            rtol=1.0e-13,
+            atol=1.0e-15,
+        )
+        np.testing.assert_allclose(
+            hubStateDerivatives[3:],
+            expectedRateDerivative_B,
+            rtol=1.0e-13,
+            atol=1.0e-15,
+        )
+
+
+def _initializeAttachedSlosh(sloshConstructor, updateOnly, leakRate):
+    """Initialize a tank and stationary attached slosh at one offset."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    process.addTask(
+        simulation.CreateNewTask(taskName, macros.sec2nano(0.1))
+    )  # [s]
+
+    dynamics = spacecraft.Spacecraft()
+    dynamics.hub.mHub = 100.0  # [kg]
+    dynamics.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    dynamics.hub.IHubPntBc_B = np.diag(
+        [80.0, 90.0, 100.0]
+    )  # [kg*m^2]
+    dynamics.hub.omega_BN_BInit = [[0.1], [-0.2], [0.15]]  # [rad/s]
+
+    offset_B = np.array([0.6, -0.3, 0.2])  # [m]
+    tank = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelConstantVolume()
+    tankModel.propMassInit = 20.0  # [kg]
+    tankModel.radiusTankInit = 0.5  # [m]
+    tankModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]  # [m]
+    tank.setTankModel(tankModel)
+    tank.setR_TB_B(offset_B)
+    tank.setFuelLeakRate(leakRate)
+    tank.setUpdateOnly(updateOnly)
+
+    slosh = sloshConstructor()
+    slosh.massInit = 5.0  # [kg]
+    if isinstance(
+        slosh,
+        linearSpringMassDamper.LinearSpringMassDamper,
+    ):
+        slosh.k = 1.0  # [N/m]
+        slosh.c = 0.0  # [N*s/m]
+        slosh.r_PB_B = offset_B
+        slosh.pHat_B = [1.0, 0.0, 0.0]
+        slosh.rhoInit = 0.0  # [m]
+        slosh.rhoDotInit = 0.0  # [m/s]
+    else:
+        slosh.pendulumRadius = 0.5  # [m]
+        slosh.d = offset_B - np.array([0.5, 0.0, 0.0])  # [m]
+        slosh.D = np.zeros((3, 3))  # [N*s/m]
+        slosh.phiDotInit = 0.0  # [rad/s]
+        slosh.thetaDotInit = 0.0  # [rad/s]
+
+    tank.pushFuelSloshParticle(slosh)
+    dynamics.addStateEffector(tank)
+    dynamics.addStateEffector(slosh)
+    simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, dynamics)
+    simulation.InitializeSimulation()
+    return dynamics, tank, slosh
+
+
+def _hubStateDerivatives(dynamics):
+    """Return translational and angular hub accelerations."""
+    velocityDerivative_N = np.asarray(
+        dynamics.dynManager.getStateObject(
+            dynamics.hub.nameOfHubVelocity
+        ).getStateDeriv()
+    ).reshape(3)
+    rateDerivative_B = np.asarray(
+        dynamics.dynManager.getStateObject(
+            dynamics.hub.nameOfHubOmega
+        ).getStateDeriv()
+    ).reshape(3)
+    return np.concatenate((velocityDerivative_N, rateDerivative_B))
 
 
 @pytest.mark.parametrize("thrusterConstructor", [thrusterDynamicEffector.ThrusterDynamicEffector,
@@ -276,7 +622,10 @@ def test_leakyTank(sloshMass):
     fuelMass = fuelLog.fuelMass
     fuelMassDot = fuelLog.fuelMassDot
 
-    assert np.allclose(fuelMassDot, -leakRate, rtol=1e-6)
+    expectedTankMassRate = (
+        -leakRate*initialFuelMass/totalPropellant
+    )  # [kg/s]
+    assert np.allclose(fuelMassDot, expectedTankMassRate, rtol=1e-6)
 
     # The tank drains only its share of the flow, so its mass follows
     # m(t) = m(0) * (1 - mDot*t/totalPropellant), which is m(0) - mDot*t when it carries it all.

--- a/src/simulation/dynamics/FuelTank/fuelTank.cpp
+++ b/src/simulation/dynamics/FuelTank/fuelTank.cpp
@@ -121,17 +121,53 @@ void FuelTank::addThrusterSet(ThrusterStateEffector *stateEff) {
 void FuelTank::linkInStates(DynParamManager &statesIn) {
     // Grab access to the hubs omega_BN_N
     this->omegaState = statesIn.getStateObject(this->stateNameOfOmega);
+    for (auto* fuelSloshParticle: this->fuelSloshParticles) {
+        // runs after the whole registerStates pass, so the flag is scoped to one pass
+        fuelSloshParticle->hasRegisteredStates = false;
+    }
 }
 
-/*! Register states. The fuel tank has one state associated with it: mass, and it also has the
- responsibility to call register states for the fuel slosh particles */
+/*! Register the tank mass state before any attached fuel-slosh states. */
 void FuelTank::registerStates(DynParamManager &statesIn) {
+    for (auto* fuelSloshParticle: this->fuelSloshParticles) {
+        if (fuelSloshParticle->hasRegisteredStates) {
+            this->bskLogger.bskLog(
+                BSK_ERROR,
+                "FuelTank must be added to Spacecraft before its attached fuel-slosh effectors.");
+        }
+    }
     // Register the mass state associated with the tank
     Eigen::MatrixXd massMatrix(1, 1);
     this->massState = statesIn.registerState(1, 1, this->getNameOfMassState());
     massMatrix(0, 0) = this->fuelTankModel->propMassInit;
     this->massState->setState(massMatrix);
     this->emptyTankWarningPrinted = false;
+}
+
+/*! Update derivatives of the retained tank mass properties. */
+void FuelTank::updateRetainedMassPropertyDerivatives(double mass,
+                                                     double massRate)
+{
+    this->fuelTankModel->computeTankPropDerivs(mass, massRate);
+    const Eigen::Matrix3d dcm_TBLocal = this->getDcm_TB();
+    this->effProps.rEffPrime_CB_B =
+        dcm_TBLocal.transpose()*this->fuelTankModel->rPrime_TcT_T;
+    const Eigen::Vector3d rPrime_TcB_B = this->effProps.rEffPrime_CB_B;
+    this->effProps.IEffPrimePntB_B =
+        dcm_TBLocal.transpose()
+            * this->fuelTankModel->IPrimeTankPntT_T
+            * dcm_TBLocal
+        + massRate
+            *(this->r_TcB_B.dot(this->r_TcB_B)
+                  * Eigen::Matrix3d::Identity()
+              - this->r_TcB_B*this->r_TcB_B.transpose())
+        + mass
+            *(2.0*this->r_TcB_B.dot(rPrime_TcB_B)
+                  * Eigen::Matrix3d::Identity()
+              - this->r_TcB_B*rPrime_TcB_B.transpose()
+              - rPrime_TcB_B*this->r_TcB_B.transpose());
+    this->effProps.rEffPrime_CB_BDynamics.setZero();
+    this->effProps.IEffPrimePntB_BDynamics.setZero();
 }
 
 /*! Fuel tank add its contributions the mass of the vehicle. */
@@ -153,9 +189,6 @@ void FuelTank::updateEffectorMassProps(double integTime) {
     this->effProps.IEffPntB_B = ITankPntT_B + massLocal * (r_TcB_B.dot(r_TcB_B) * Eigen::Matrix3d::Identity()
                                                            - r_TcB_B * r_TcB_B.transpose());
     this->effProps.rEff_CB_B = this->r_TcB_B;
-
-    // This does not incorporate mEffDot into cPrime for high fidelity mass depletion
-    this->effProps.rEffPrime_CB_B = Eigen::Vector3d::Zero();
 
     // Mass depletion (call thrusters attached to this tank to get their mDot, and contributions)
     this->fuelConsumption = 0.0;
@@ -182,6 +215,7 @@ void FuelTank::updateEffectorMassProps(double integTime) {
          fuelSloshInt++) {
         // Retrieve current mass value of fuelSlosh particle
         (*fuelSloshInt)->retrieveMassValue(integTime);
+        (*fuelSloshInt)->omitMassRateDynamics = this->getUpdateOnly();
         // Add fuelSlosh mass to total mass of tank
         totalMass += (*fuelSloshInt)->fuelMass;
     }
@@ -203,6 +237,9 @@ void FuelTank::updateEffectorMassProps(double integTime) {
         }
         this->tankFuelConsumption = 0.0;  // [kg/s]
         this->effProps.mEffDot = 0.0;  // [kg/s]
+        this->effProps.mEffDotDynamics = 0.0;  // [kg/s]
+        this->updateRetainedMassPropertyDerivatives(massLocal, 0.0);
+        this->effProps.hasMassPropertyRateDynamics = false;
         return;
     }
     // Set mass depletion rate of fuelSloshParticles
@@ -219,10 +256,17 @@ void FuelTank::updateEffectorMassProps(double integTime) {
     for (auto &dynEffector: this->thrDynEffectors) {
         dynEffector->fuelMass = totalMass;
     }
-
     // Set fuel consumption rate of fuelTank (not negative because the negative sign is in the computeDerivatives call
     this->tankFuelConsumption = massLocal / totalMass * (this->fuelConsumption);
-    this->effProps.mEffDot = -this->fuelConsumption;
+    this->effProps.mEffDot = -this->tankFuelConsumption;
+    this->effProps.mEffDotDynamics =
+        this->getUpdateOnly() ? 0.0 : this->effProps.mEffDot;
+    this->updateRetainedMassPropertyDerivatives(
+        massLocal,
+        this->effProps.mEffDot
+    );
+    this->effProps.hasMassPropertyRateDynamics =
+        this->effProps.mEffDot != 0.0;
 }
 
 /*! Fuel tank adds its contributions to the matrices for the back-sub method. */
@@ -242,7 +286,6 @@ void FuelTank::updateContributions(double integTime [[maybe_unused]],
         massLocal = 0.0;  // [kg]
     }
     const double mDotTank = -this->tankFuelConsumption; // [kg/s] tank mass rate this substep
-    this->fuelTankModel->computeTankPropDerivs(massLocal, mDotTank);
     omega_BN_BLocal = this->omegaState->getState();
     if (!this->getUpdateOnly()) {
         const Eigen::Matrix3d dcm_TBLocal = this->getDcm_TB();

--- a/src/simulation/dynamics/FuelTank/fuelTank.h
+++ b/src/simulation/dynamics/FuelTank/fuelTank.h
@@ -288,6 +288,7 @@ private:
     std::shared_ptr<FuelTankModel> fuelTankModel;       //!< -- style of tank to simulate
     Eigen::Matrix3d ITankPntT_B;
     Eigen::Vector3d r_TcB_B;
+    void updateRetainedMassPropertyDerivatives(double mass, double massRate);
     static uint64_t effectorID;                         //!< [] ID number of this fuel tank effector
     bool emptyTankWarningPrinted = false;               //!< -- flag indicating if the empty tank warning has been logged
 

--- a/src/simulation/dynamics/FuelTank/fuelTank.rst
+++ b/src/simulation/dynamics/FuelTank/fuelTank.rst
@@ -82,3 +82,14 @@ A thruster effector can be attached to a tank effector to simulate fuel mass dep
 .. code-block:: python
 
     fuelTankEffector.addThrusterSet(thrustersEffector)
+
+When attaching fuel-slosh particles, add the tank to :ref:`spacecraft` before
+the particles. During each integration stage, the tank reads the current
+particle masses and allocates the total propellant outflow; the particles then
+report their allocated component rates during the same mass-property assembly.
+
+.. code-block:: python
+
+    fuelTankEffector.pushFuelSloshParticle(sloshParticle)
+    spacecraftObject.addStateEffector(fuelTankEffector)
+    spacecraftObject.addStateEffector(sloshParticle)

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
@@ -142,6 +142,12 @@ void LinearSpringMassDamper::retrieveMassValue(double integTime [[maybe_unused]]
     }
     // Read the current RK-stage state before the tank allocates propellant flow.
     this->fuelMass = this->massState->getStateReference()(0, 0);
+    if (this->fuelMass < 0.0) {
+        this->fuelMass = 0.0;  // [kg]
+        Eigen::MatrixXd massMatrix(1, 1);
+        massMatrix(0, 0) = this->fuelMass;
+        this->massState->setState(massMatrix);
+    }
 
     return;
 }
@@ -149,6 +155,19 @@ void LinearSpringMassDamper::retrieveMassValue(double integTime [[maybe_unused]]
 /*! This method is for the SMD to add its contributions to the back-sub method */
 void LinearSpringMassDamper::updateContributions(double integTime [[maybe_unused]], BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N [[maybe_unused]])
 {
+    if (this->massSMD <= 0.0) {
+        this->aRho.setZero();
+        this->bRho.setZero();
+        this->cRho = 0.0;  // [m/s^2]
+        backSubContr.matrixA.setZero();
+        backSubContr.matrixB.setZero();
+        backSubContr.matrixC.setZero();
+        backSubContr.matrixD.setZero();
+        backSubContr.vecTrans.setZero();
+        backSubContr.vecRot.setZero();
+        return;
+    }
+
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_BN;
     Eigen::Matrix3d dcm_BN;

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.cpp
@@ -86,6 +86,7 @@ void LinearSpringMassDamper::registerStates(DynParamManager& states)
     Eigen::MatrixXd massInitMatrix(1,1);
     massInitMatrix(0,0) = this->massInit;
     this->massState->setState(massInitMatrix);
+    this->hasRegisteredStates = true;
 
 	return;
 }
@@ -100,6 +101,9 @@ void LinearSpringMassDamper::updateEffectorMassProps(double integTime [[maybe_un
 
 	// - Update the effectors mass
 	this->effProps.mEff = this->massSMD;
+	this->effProps.mEffDot = this->fuelMassDot;
+	this->effProps.mEffDotDynamics =
+        this->omitMassRateDynamics ? 0.0 : this->fuelMassDot;
 	// - Update the position of CoM
 	this->effProps.rEff_CB_B = this->r_PcB_B;
 	// - Update the inertia about B
@@ -110,11 +114,19 @@ void LinearSpringMassDamper::updateEffectorMassProps(double integTime [[maybe_un
 	this->rhoDot = this->rhoDotState->getStateReference()(0, 0);
 	this->rPrime_PcB_B = this->rhoDot * this->pHat_B;
 	this->effProps.rEffPrime_CB_B = this->rPrime_PcB_B;
+    this->effProps.rEffPrime_CB_BDynamics = this->rPrime_PcB_B;
 
 	// - Update the body time derivative of inertia about B
 	this->rPrimeTilde_PcB_B = eigenTilde(this->rPrime_PcB_B);
-	this->effProps.IEffPrimePntB_B = -this->massSMD*(this->rPrimeTilde_PcB_B*this->rTilde_PcB_B
-                                                                          + this->rTilde_PcB_B*this->rPrimeTilde_PcB_B);
+	const Eigen::Matrix3d inertiaRateFromMotion =
+        -this->massSMD*(this->rPrimeTilde_PcB_B*this->rTilde_PcB_B
+                       + this->rTilde_PcB_B*this->rPrimeTilde_PcB_B);
+    this->effProps.IEffPrimePntB_B =
+        -this->fuelMassDot*this->rTilde_PcB_B*this->rTilde_PcB_B
+        + inertiaRateFromMotion;
+    this->effProps.IEffPrimePntB_BDynamics = inertiaRateFromMotion;
+    this->effProps.hasMassPropertyRateDynamics =
+        this->fuelMassDot != 0.0;
 
     return;
 }
@@ -122,8 +134,14 @@ void LinearSpringMassDamper::updateEffectorMassProps(double integTime [[maybe_un
 /*! This is method is used to pass mass properties information to the fuelTank */
 void LinearSpringMassDamper::retrieveMassValue(double integTime [[maybe_unused]])
 {
-    // Save mass value into the fuelSlosh class variable
-    this->fuelMass = this->massSMD;
+    if (this->massState == nullptr) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "LinearSpringMassDamper was attached to a FuelTank but never added to Spacecraft. Every particle "
+            "passed to pushFuelSloshParticle must also be passed to addStateEffector.");
+    }
+    // Read the current RK-stage state before the tank allocates propellant flow.
+    this->fuelMass = this->massState->getStateReference()(0, 0);
 
     return;
 }

--- a/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.h
+++ b/src/simulation/dynamics/LinearSpringMassDamper/linearSpringMassDamper.h
@@ -42,7 +42,7 @@ public:
 	std::string nameOfMassState;      //!< [-] Identifier for the mass state data container
 	Eigen::Vector3d r_PB_B;        //!< [m] position vector from B point to particle equilibrium, P, in body frame
 	Eigen::Vector3d pHat_B;        //!< [-] particle direction unit vector, in body frame
-	StateData *massState;		   //!< -- state data for the particles mass
+	StateData *massState = nullptr;		   //!< -- state data for the particles mass
 	BSKLogger bskLogger;                      //!< -- BSK Logging
 
 private:

--- a/src/simulation/dynamics/_GeneralModuleFiles/fuelSlosh.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/fuelSlosh.h
@@ -35,6 +35,8 @@ public:
     double fuelMass = 0.0;                 //!< [kg] mass of fuelSlosh particle
     double massToTotalTankMassRatio = 0.0; //!< -- ratio of fuelSlosh particle mass to total mass of fuel tank
     double fuelMassDot = 0.0;              //!< [kg/s] mass depletion rate of fuelSlosh particle
+    bool omitMassRateDynamics = false;      //!< -- substitute zero depletion rates into generic rate-dependent terms
+    bool hasRegisteredStates = false;       //!< -- set after stateful FuelSlosh implementations register their states
 };
 
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.cpp
@@ -29,6 +29,10 @@ StateEffector::StateEffector()
     this->effProps.IEffPrimePntB_B.fill(0.0);
     this->effProps.rEff_CB_B.fill(0.0);
     this->effProps.rEffPrime_CB_B.fill(0.0);
+    this->effProps.hasMassPropertyRateDynamics = false;
+    this->effProps.mEffDotDynamics = 0.0;
+    this->effProps.rEffPrime_CB_BDynamics.fill(0.0);
+    this->effProps.IEffPrimePntB_BDynamics.fill(0.0);
 
     // - set force and torques equal to zero
     this->forceOnBody_B = this->torqueOnBodyPntB_B = this->torqueOnBodyPntC_B.setZero();

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.h
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.h
@@ -41,11 +41,15 @@ struct BackSubMatrices {
  needs to be integrated. For example: reaction wheels, flexing solar panels, fuel slosh etc */
 typedef struct {
     double mEff;                           //!< [kg] Mass of the effector
-    double mEffDot;					   //!< [kg/s] Time derivate of mEff
+    double mEffDot;                        //!< [kg/s] Time derivative of retained effector mass
     Eigen::Matrix3d IEffPntB_B;            //!< [kg m^2] Inertia of effector relative to point B in B frame components
     Eigen::Vector3d rEff_CB_B;             //!< [m] Center of mass of effector with respect to point B in B frame comp
-    Eigen::Vector3d rEffPrime_CB_B;        //!< [m/s] Time derivative with respect to the body of rEff_CB_B
-    Eigen::Matrix3d IEffPrimePntB_B;       //!< [kg m^2/s] Time derivative with respect to the body of IEffPntB_B
+    Eigen::Vector3d rEffPrime_CB_B;        //!< [m/s] Body-frame derivative of the retained effector CoM
+    Eigen::Matrix3d IEffPrimePntB_B;       //!< [kg m^2/s] Body-frame derivative of retained effector inertia
+    bool hasMassPropertyRateDynamics;      //!< -- True when the equations of motion use explicit rate overrides
+    double mEffDotDynamics;                //!< [kg/s] Mass rate substituted into generic rate-dependent terms
+    Eigen::Vector3d rEffPrime_CB_BDynamics; //!< [m/s] CoM derivative used by generic rate terms
+    Eigen::Matrix3d IEffPrimePntB_BDynamics; //!< [kg m^2/s] Inertia rate substituted into generic rate-dependent terms
 }EffectorMassProps;
 
 /*! @brief state effector class */

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.rst
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.rst
@@ -34,6 +34,13 @@ effector center of mass. Effectors that do not set the flag retain the
 established behavior in which the corresponding retained-property rates are
 also used as the dynamics rates.
 
+Dynamics-rate overrides are currently supported only for effectors attached
+directly to :ref:`spacecraft`. ``PrescribedMotionStateEffector`` rejects
+variable-mass nested effectors rather than silently applying incomplete
+variable-mass bookkeeping. The legacy ``SpacecraftSystem`` does not consume
+this override contract and provides no runtime guard for it; use
+:ref:`spacecraft` for effectors that provide dynamics-rate overrides.
+
 The dynamics-only center-of-mass-rate quantity follows the quotient rule on
 the retained mass properties,
 

--- a/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.rst
+++ b/src/simulation/dynamics/_GeneralModuleFiles/stateEffector.rst
@@ -1,2 +1,67 @@
+Executive Summary
+-----------------
 
-Abstract class that is used to implement an effector attached to the dynamicObject that has a state that needs to be integrated. For example: reaction wheels, flexing solar panels, fuel slosh etc
+``StateEffector`` is the abstract base class for effectors with integrated
+states, including reaction wheels, flexible bodies, prescribed motion, and
+fuel slosh. A dynamic object calls each effector during every integrator stage
+to assemble instantaneous mass properties, back-substitution terms, state
+derivatives, and energy and momentum contributions.
+
+Retained Mass-Property Derivatives and Equation-of-Motion Overrides
+-------------------------------------------------------------------
+
+The original ``EffectorMassProps`` fields describe derivatives of the
+retained effector mass properties:
+
+.. math::
+
+    \mathtt{mEffDot},\quad
+    \mathtt{rEffPrime\_CB\_B},\quad
+    \mathtt{IEffPrimePntB\_B}.
+
+They are used for the reported total-mass, center-of-mass, and inertia
+derivatives. The reported center-of-mass derivative follows the complete
+retained first-moment quotient rule.
+
+A variable-mass approximation can intentionally omit generic rate-dependent
+terms from the equations of motion without corrupting the reported
+derivatives. Such an effector sets ``hasMassPropertyRateDynamics`` and fills
+``mEffDotDynamics``, ``rEffPrime_CB_BDynamics``, and
+``IEffPrimePntB_BDynamics``. :ref:`spacecraft`
+uses these overrides only in its equations of motion. The existing
+``rEffPrime_CB_B`` remains the body-frame derivative of the retained
+effector center of mass. Effectors that do not set the flag retain the
+established behavior in which the corresponding retained-property rates are
+also used as the dynamics rates.
+
+The dynamics-only center-of-mass-rate quantity follows the quotient rule on
+the retained mass properties,
+
+.. math::
+
+    \mathbf c'_{\mathrm{dyn}} =
+    \frac{\sum_i m_i\mathbf r'_{i,\mathrm{dyn}}}{M}
+    - \frac{\dot M_{\mathrm{dyn}}}{M}\mathbf c.
+
+This differs from the derivative reported through ``centerOfMassPrimeSC``,
+which additionally carries the source first moments described below.
+
+A complete open-system mass-flow model also requires the position and
+velocity at which mass crosses the selected control-volume boundary. Those
+quantities cannot be reconstructed from retained mass, center-of-mass, and
+inertia rates. The coupled-depletion ``FuelTank.setUpdateOnly(False)`` model
+therefore continues to omit the source first moments
+:math:`\dot m_i\mathbf r_i`, and a model that needs them must supply its own
+momentum-flux loads.
+
+Implementation Requirements
+---------------------------
+
+An effector using explicit equation-of-motion rate overrides must:
+
+* assign ``mEffDotDynamics``, ``rEffPrime_CB_BDynamics``, and
+  ``IEffPrimePntB_BDynamics`` on every call;
+* reset quantities that are zero rather than relying on values from a prior
+  integrator stage;
+* evaluate all values from the current stage state and ``integTime``;
+* document which legacy rate terms are retained or omitted.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.cpp
@@ -193,6 +193,12 @@ void PrescribedMotionStateEffector::registerProperties(DynParamManager& states)
 */
 void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
 {
+    this->effProps.mEffDot = 0.0;
+    this->effProps.mEffDotDynamics = 0.0;
+    this->effProps.rEffPrime_CB_BDynamics.setZero();
+    this->effProps.IEffPrimePntB_BDynamics.setZero();
+    this->effProps.hasMassPropertyRateDynamics = false;
+
     // Update the prescribed states
     double dt = integTime - this->currentSimTimeSec;
     this->r_PM_M = this->rEpoch_PM_M + (this->rPrimeEpoch_PM_M * dt) + (0.5 * this->rPrimePrime_PM_M * dt * dt);
@@ -263,7 +269,14 @@ void PrescribedMotionStateEffector::updateEffectorMassProps(double integTime)
     // Loop through attached state effectors and compute their contributions
     std::vector<StateEffector*>::iterator it;
     for(it = this->stateEffectors.begin(); it != this->stateEffectors.end(); it++) {
+        (*it)->effProps.hasMassPropertyRateDynamics = false;
         (*it)->updateEffectorMassProps(integTime);
+        if ((*it)->effProps.hasMassPropertyRateDynamics
+            || (*it)->effProps.mEffDot != 0.0) {
+            this->bskLogger.bskLog(
+                BSK_ERROR,
+                "PrescribedMotionStateEffector does not support nested variable-mass state effectors.");
+        }
 
         this->effProps.mEff += (*it)->effProps.mEff;
         this->effProps.mEffDot += (*it)->effProps.mEffDot;

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
@@ -77,7 +77,9 @@ Currently, this branching capability has only been configured for the spinningBo
 linearTranslationOneDOF state effectors. See the User Guide section for how to connect these effectors to the
 prescribed motion effector. The scenario scripts :ref:`scenarioPrescribedMotionWithRotationBranching`
 and :ref:`scenarioPrescribedMotionWithTranslationBranching` are more complex examples demonstrating how to connect
-multiple state effectors to the prescribed motion effector.
+multiple state effectors to the prescribed motion effector. Nested
+variable-mass state effectors are not supported and must instead be attached
+directly to :ref:`spacecraft`.
 
 
 Module Testing

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftVariableMassRates.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftVariableMassRates.py
@@ -69,6 +69,224 @@ def test_centerOfMassPrimeMassRateScaling():
     )
 
 
+def test_updateOnlyExcludesDepletionRateTerms():
+    r"""Verify update-only depletion reports derivatives without altering motion.
+
+    ``FuelTank.setUpdateOnly(True)`` updates and reports the retained
+    mass properties while omitting depletion-dependent rate terms from the
+    equations of motion. A stationary leaking tank must therefore report its
+    mass and center-of-mass derivatives while leaving the force-free hub
+    acceleration equal to zero.
+    """
+    dynamics = _initializeUpdateOnlyTank()
+
+    massRate = np.asarray(
+        dynamics.dynManager.getPropertyReference("mDot_SC")
+    ).reshape(-1)
+    velocityDerivative_N = np.asarray(
+        dynamics.dynManager.getStateObject(
+            dynamics.hub.nameOfHubVelocity
+        ).getStateDeriv()
+    ).reshape(3)
+    rateDerivative_B = np.asarray(
+        dynamics.dynManager.getStateObject(
+            dynamics.hub.nameOfHubOmega
+        ).getStateDeriv()
+    ).reshape(3)
+
+    np.testing.assert_allclose(massRate, [-0.25], rtol=0.0, atol=1.0e-15)
+    np.testing.assert_allclose(velocityDerivative_N, np.zeros(3), atol=1.0e-15)
+    np.testing.assert_allclose(rateDerivative_B, np.zeros(3), atol=1.0e-15)
+
+
+def test_mixedUpdateOnlyPreservesLegacyRateDynamics():
+    r"""Verify update-only depletion does not alter another tank's dynamics.
+
+    The first tank uses the legacy coupled-depletion model. The second tank is
+    either a nondepleting control or an update-only depleting tank. Because
+    update-only depletion changes reported retained mass-property derivatives
+    but not the rate terms used by the equations of motion, both cases must
+    produce the same hub accelerations. Absolute acceleration values also pin
+    the established coupled-depletion equations independently of that
+    comparison.
+    """
+    control = _initializeMixedTanks(secondTankLeakRate=0.0)
+    updateOnly = _initializeMixedTanks(secondTankLeakRate=0.1)
+
+    def _stateDerivatives(dynamics):
+        velocityDerivative_N = np.asarray(
+            dynamics.dynManager.getStateObject(
+                dynamics.hub.nameOfHubVelocity
+            ).getStateDeriv()
+        ).reshape(3)
+        rateDerivative_B = np.asarray(
+            dynamics.dynManager.getStateObject(
+                dynamics.hub.nameOfHubOmega
+            ).getStateDeriv()
+        ).reshape(3)
+        return velocityDerivative_N, rateDerivative_B
+
+    controlVelocityDerivative_N, controlRateDerivative_B = (
+        _stateDerivatives(control)
+    )
+    updateVelocityDerivative_N, updateRateDerivative_B = (
+        _stateDerivatives(updateOnly)
+    )
+    # Regression baselines recorded from the current coupled-depletion
+    # implementation, not analytic variable-mass truth values.
+    expectedVelocityDerivative_N = np.array(
+        [0.01177374597473359, 0.00592476336088501, 0.00543057702170967]
+    )  # [m/s^2]
+    expectedRateDerivative_B = np.array(
+        [0.00944849527546575, 0.01310294567357445, 0.01307406994734512]
+    )  # [rad/s^2]
+    np.testing.assert_allclose(
+        controlVelocityDerivative_N,
+        expectedVelocityDerivative_N,
+        rtol=1.0e-13,
+        atol=1.0e-15,
+    )
+    np.testing.assert_allclose(
+        controlRateDerivative_B,
+        expectedRateDerivative_B,
+        rtol=1.0e-13,
+        atol=1.0e-15,
+    )
+    np.testing.assert_allclose(
+        updateVelocityDerivative_N,
+        controlVelocityDerivative_N,
+        rtol=0.0,
+        atol=1.0e-14,
+    )
+    np.testing.assert_allclose(
+        updateRateDerivative_B,
+        controlRateDerivative_B,
+        rtol=0.0,
+        atol=1.0e-14,
+    )
+
+    reportedMassRate = np.asarray(
+        updateOnly.dynManager.getPropertyReference("mDot_SC")
+    ).reshape(-1)
+    np.testing.assert_allclose(
+        reportedMassRate,
+        [-0.35],
+        rtol=0.0,
+        atol=1.0e-15,
+    )
+
+    tankAMass = 20.0  # [kg]
+    tankBMass = 10.0  # [kg]
+    tankAMassRate = -0.25  # [kg/s]
+    tankBMassRate = -0.1  # [kg/s]
+    tankAOffset_B = np.array([2.0, -1.0, 0.5])  # [m]
+    tankBOffset_B = np.array([-0.5, 1.5, 0.75])  # [m]
+    totalMass = 130.0  # [kg]
+    centerOfMass_B = (
+        tankAMass*tankAOffset_B + tankBMass*tankBOffset_B
+    )/totalMass  # [m]
+    expectedCenterOfMassPrime_B = (
+        (
+            tankAMassRate*tankAOffset_B
+            + tankBMassRate*tankBOffset_B
+        )/totalMass
+        - (tankAMassRate + tankBMassRate)
+            * centerOfMass_B/totalMass
+    )  # [m/s]
+    centerOfMassPrime_B = np.asarray(
+        updateOnly.dynManager.getPropertyReference("centerOfMassPrimeSC")
+    ).reshape(3)
+    np.testing.assert_allclose(
+        centerOfMassPrime_B,
+        expectedCenterOfMassPrime_B,
+        rtol=1.0e-14,
+        atol=1.0e-16,
+    )
+
+
+def test_updateOnlyTankDerivativesMatchFiniteDifference():
+    r"""Compare retained tank derivatives with integrated mass properties.
+
+    An emptying tank has a moving retained center of mass and a changing
+    inertia. In update-only mode these derivatives must still be reported,
+    even though their rate-dependent loads are omitted from the equations of
+    motion.
+    """
+    differenceTimeStep = 1.0e-3  # [s]
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    process.addTask(
+        simulation.CreateNewTask(
+            taskName,
+            macros.sec2nano(differenceTimeStep),
+        )
+    )
+
+    dynamics = spacecraft.Spacecraft()
+    dynamics.hub.mHub = 100.0  # [kg]
+    dynamics.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    dynamics.hub.IHubPntBc_B = np.diag(
+        [80.0, 90.0, 100.0]
+    )  # [kg*m^2]
+
+    tank = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelEmptying()
+    tankModel.propMassInit = 40.0  # [kg]
+    tankModel.radiusTankInit = 0.5  # [m]
+    tankModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]  # [m]
+    tank.setTankModel(tankModel)
+    tank.setR_TB_B([2.0, -1.0, 0.5])  # [m]
+    tank.setFuelLeakRate(0.25)  # [kg/s]
+    tank.setUpdateOnly(True)
+    dynamics.addStateEffector(tank)
+
+    simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, dynamics)
+    simulation.InitializeSimulation()
+
+    tankMassState = dynamics.dynManager.getStateObject(
+        tank.getNameOfMassState()
+    )
+    tankMassState.setState([[20.0]])  # [kg]
+    dynamics.equationsOfMotion(0.0, differenceTimeStep)
+
+    centerOfMass_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("centerOfMassSC")
+    ).reshape(3).copy()
+    inertia_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("inertiaSC")
+    ).copy()
+    centerOfMassPrime_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("centerOfMassPrimeSC")
+    ).reshape(3).copy()
+    inertiaPrime_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("inertiaPrimeSC")
+    ).copy()
+
+    simulation.ConfigureStopTime(macros.sec2nano(differenceTimeStep))
+    simulation.ExecuteSimulation()
+    centerOfMassNext_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("centerOfMassSC")
+    ).reshape(3).copy()
+    inertiaNext_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("inertiaSC")
+    ).copy()
+
+    np.testing.assert_allclose(
+        centerOfMassPrime_B,
+        (centerOfMassNext_B - centerOfMass_B)/differenceTimeStep,
+        rtol=2.0e-5,
+        atol=1.0e-10,
+    )
+    np.testing.assert_allclose(
+        inertiaPrime_B,
+        (inertiaNext_B - inertia_B)/differenceTimeStep,
+        rtol=2.0e-5,
+        atol=1.0e-9,
+    )
+
+
 def _initializeUpdateOnlyTank():
     """Initialize a fixed hub with one stationary, leaking offset tank."""
     simulation = SimulationBaseClass.SimBaseClass()
@@ -97,6 +315,52 @@ def _initializeUpdateOnlyTank():
     dynamics.addStateEffector(tank)
 
     simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, dynamics)
+    simulation.InitializeSimulation()
+    return dynamics
+
+
+def _initializeMixedTanks(secondTankLeakRate):
+    """Initialize one coupled-depletion tank and one update-only tank."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    process.addTask(
+        simulation.CreateNewTask(taskName, macros.sec2nano(0.1))
+    )  # [s]
+
+    dynamics = spacecraft.Spacecraft()
+    dynamics.hub.mHub = 100.0  # [kg]
+    dynamics.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    dynamics.hub.IHubPntBc_B = np.diag(
+        [80.0, 90.0, 100.0]
+    )  # [kg*m^2]
+    dynamics.hub.omega_BN_BInit = [[0.1], [-0.2], [0.15]]  # [rad/s]
+
+    tankA = fuelTank.FuelTank()
+    tankAModel = fuelTank.FuelTankModelConstantVolume()
+    tankAModel.propMassInit = 20.0  # [kg]
+    tankAModel.radiusTankInit = 0.5  # [m]
+    tankAModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]  # [m]
+    tankA.setTankModel(tankAModel)
+    tankA.setR_TB_B([2.0, -1.0, 0.5])  # [m]
+    tankA.setFuelLeakRate(0.25)  # [kg/s]
+    tankA.setUpdateOnly(False)
+    dynamics.addStateEffector(tankA)
+
+    tankB = fuelTank.FuelTank()
+    tankBModel = fuelTank.FuelTankModelConstantVolume()
+    tankBModel.propMassInit = 10.0  # [kg]
+    tankBModel.radiusTankInit = 0.4  # [m]
+    tankBModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]  # [m]
+    tankB.setTankModel(tankBModel)
+    tankB.setR_TB_B([-0.5, 1.5, 0.75])  # [m]
+    tankB.setFuelLeakRate(secondTankLeakRate)
+    tankB.setUpdateOnly(True)
+    dynamics.addStateEffector(tankB)
+
+    simulation.AddModelToTask(taskName, tankA)
+    simulation.AddModelToTask(taskName, tankB)
     simulation.AddModelToTask(taskName, dynamics)
     simulation.InitializeSimulation()
     return dynamics

--- a/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftVariableMassRates.py
+++ b/src/simulation/dynamics/spacecraft/_UnitTest/test_spacecraftVariableMassRates.py
@@ -1,0 +1,102 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import numpy as np
+
+from Basilisk.simulation import fuelTank
+from Basilisk.simulation import spacecraft
+from Basilisk.utilities import SimulationBaseClass
+from Basilisk.utilities import macros
+
+
+def test_centerOfMassPrimeMassRateScaling():
+    r"""Test the complete reported first-moment quotient rule.
+
+    Let the spacecraft first mass moment and center of mass be
+
+    .. math::
+
+        \mathbf{q}_B = \sum_i m_i\mathbf{r}_{iB},
+        \qquad
+        \mathbf{c}_B = \frac{\mathbf{q}_B}{M}.
+
+    Their body-frame derivatives must satisfy
+
+    .. math::
+
+        \mathbf{c}'_B =
+        \frac{\mathbf{q}'_B}{M}
+        - \frac{\dot{M}}{M}\mathbf{c}_B.
+
+    For the fixed hub and stationary offset tank used here,
+    :math:`\mathbf{q}'_B=\dot m_T\mathbf r_{T/B}`. The first term moves the
+    center of mass toward the hub as the tank drains. The second is the
+    denominator contribution and contains one division by total mass.
+    """
+    dynamics = _initializeUpdateOnlyTank()
+
+    tankMass = 20.0  # [kg]
+    tankMassRate = -0.25  # [kg/s]
+    tankOffset_B = np.array([2.0, -1.0, 0.5])  # [m]
+    totalMass = 120.0  # [kg]
+    centerOfMass_B = tankMass*tankOffset_B/totalMass  # [m]
+    expectedCenterOfMassPrime_B = (
+        tankMassRate*tankOffset_B/totalMass
+        - tankMassRate*centerOfMass_B/totalMass
+    )  # [m/s]
+    centerOfMassPrime_B = np.asarray(
+        dynamics.dynManager.getPropertyReference("centerOfMassPrimeSC")
+    ).reshape(3)
+
+    np.testing.assert_allclose(
+        centerOfMassPrime_B,
+        expectedCenterOfMassPrime_B,
+        rtol=1.0e-14,
+        atol=1.0e-16,
+    )
+
+
+def _initializeUpdateOnlyTank():
+    """Initialize a fixed hub with one stationary, leaking offset tank."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("testProcess")
+    taskName = "testTask"
+    process.addTask(
+        simulation.CreateNewTask(taskName, macros.sec2nano(0.1))
+    )  # [s]
+
+    dynamics = spacecraft.Spacecraft()
+    dynamics.hub.mHub = 100.0  # [kg]
+    dynamics.hub.r_BcB_B = [[0.0], [0.0], [0.0]]  # [m]
+    dynamics.hub.IHubPntBc_B = np.diag(
+        [80.0, 90.0, 100.0]
+    )  # [kg*m^2]
+
+    tank = fuelTank.FuelTank()
+    tankModel = fuelTank.FuelTankModelConstantVolume()
+    tankModel.propMassInit = 20.0  # [kg]
+    tankModel.radiusTankInit = 0.5  # [m]
+    tankModel.r_TcT_TInit = [[0.0], [0.0], [0.0]]  # [m]
+    tank.setTankModel(tankModel)
+    tank.setR_TB_B([2.0, -1.0, 0.5])  # [m]
+    tank.setFuelLeakRate(0.25)  # [kg/s]
+    tank.setUpdateOnly(True)
+    dynamics.addStateEffector(tank)
+
+    simulation.AddModelToTask(taskName, tank)
+    simulation.AddModelToTask(taskName, dynamics)
+    simulation.InitializeSimulation()
+    return dynamics

--- a/src/simulation/dynamics/spacecraft/spacecraft.cpp
+++ b/src/simulation/dynamics/spacecraft/spacecraft.cpp
@@ -355,6 +355,9 @@ void Spacecraft::updateSCMassProps(double time)
     (*this->cPrime_B).setZero();
     (*this->cDot_B).setZero();
     (*this->ISCPntBPrime_B).setZero();
+    this->mDotDynamics = 0.0;
+    this->cPrimeEffectorDynamics_B.setZero();
+    this->ISCPntBPrimeDynamics_B.setZero();
 
     // Add in hubs mass props to the spacecraft mass props
     this->hub.updateEffectorMassProps(time);
@@ -366,21 +369,40 @@ void Spacecraft::updateSCMassProps(double time)
     std::vector<StateEffector*>::iterator it;
     for(it = this->states.begin(); it != this->states.end(); it++)
     {
+        (*it)->effProps.hasMassPropertyRateDynamics = false;
         (*it)->updateEffectorMassProps(time);
         // - Add in effectors mass props into mass props of spacecraft
         (*this->m_SC)(0,0) += (*it)->effProps.mEff;
-        (*this->mDot_SC)(0,0) += (*it)->effProps.mEffDot;
         (*this->ISCPntB_B) += (*it)->effProps.IEffPntB_B;
         (*this->c_B) += (*it)->effProps.mEff*(*it)->effProps.rEff_CB_B;
+        (*this->mDot_SC)(0,0) += (*it)->effProps.mEffDot;
         (*this->ISCPntBPrime_B) += (*it)->effProps.IEffPrimePntB_B;
-        (*this->cPrime_B) += (*it)->effProps.mEff*(*it)->effProps.rEffPrime_CB_B;
-        // For high fidelity mass depletion, this is left out: += (*it)->effProps.mEffDot*(*it)->effProps.rEff_CB_B
+        (*this->cPrime_B) +=
+            (*it)->effProps.mEff*(*it)->effProps.rEffPrime_CB_B
+            + (*it)->effProps.mEffDot*(*it)->effProps.rEff_CB_B;
+        const bool hasDynamicsRates =
+            (*it)->effProps.hasMassPropertyRateDynamics;
+        const double effectorMassRateDynamics =
+            hasDynamicsRates
+                ? (*it)->effProps.mEffDotDynamics
+                : (*it)->effProps.mEffDot;
+        this->mDotDynamics += effectorMassRateDynamics;
+        this->cPrimeEffectorDynamics_B +=
+            (*it)->effProps.mEff
+            *(hasDynamicsRates
+                  ? (*it)->effProps.rEffPrime_CB_BDynamics
+                  : (*it)->effProps.rEffPrime_CB_B);
+        this->ISCPntBPrimeDynamics_B +=
+            hasDynamicsRates
+                ? (*it)->effProps.IEffPrimePntB_BDynamics
+                : (*it)->effProps.IEffPrimePntB_B;
     }
 
     // Divide c_B and cPrime_B by the total mass of the spaceCraft to finalize c_B and cPrime_B
     (*this->c_B) = (*this->c_B)/(*this->m_SC)(0,0);
     (*this->cPrime_B) = (*this->cPrime_B)/(*this->m_SC)(0,0)
-                                             - (*this->mDot_SC)(0,0)*(*this->c_B)/(*this->m_SC)(0,0)/(*this->m_SC)(0,0);
+                                             - (*this->mDot_SC)(0,0)*(*this->c_B)/(*this->m_SC)(0,0);
+    this->cPrimeEffectorDynamics_B /= (*this->m_SC)(0,0);
     Eigen::Vector3d omegaLocal_BN_B = hubOmega_BN_B->getStateReference();
     Eigen::Vector3d cLocal_B = (*this->c_B);
     (*this->cDot_B) = (*this->cPrime_B) + omegaLocal_BN_B.cross(cLocal_B);
@@ -532,7 +554,12 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     Eigen::Vector3d cLocal_B;
     Eigen::Vector3d cPrimeLocal_B;
     cLocal_B = *this->c_B;
-    cPrimeLocal_B = *cPrime_B;
+    const double mDotLocal = this->mDotDynamics;
+    const Eigen::Matrix3d& inertiaRateLocal_B = this->ISCPntBPrimeDynamics_B;
+    // source first moments remain omitted from the dynamics rate
+    cPrimeLocal_B =
+        this->cPrimeEffectorDynamics_B
+        - mDotLocal*cLocal_B/(*this->m_SC)(0,0);
 
     Eigen::Matrix3d intermediateMatrix;
     Eigen::Vector3d intermediateVector;
@@ -544,9 +571,11 @@ void Spacecraft::equationsOfMotion(double integTimeSeconds, double timeStep)
     this->hub.hubBackSubMatrices.matrixD += *ISCPntB_B;
     this->hub.hubBackSubMatrices.vecTrans += -2.0*(*this->m_SC)(0, 0)*omegaLocalBN_B.cross(cPrimeLocal_B)
     - (*this->m_SC)(0, 0)*omegaLocalBN_B.cross(omegaLocalBN_B.cross(cLocal_B))
-    - 2.0*(*mDot_SC)(0,0)*(cPrimeLocal_B+omegaLocalBN_B.cross(cLocal_B));
+    - 2.0*mDotLocal*(cPrimeLocal_B+omegaLocalBN_B.cross(cLocal_B));
     intermediateVector = *ISCPntB_B*omegaLocalBN_B;
-    this->hub.hubBackSubMatrices.vecRot += -omegaLocalBN_B.cross(intermediateVector) - *ISCPntBPrime_B*omegaLocalBN_B;
+    this->hub.hubBackSubMatrices.vecRot +=
+        -omegaLocalBN_B.cross(intermediateVector)
+        - inertiaRateLocal_B*omegaLocalBN_B;
 
     // - Map external force_N to the body frame
     Eigen::Vector3d sumForceExternalMappedToB;

--- a/src/simulation/dynamics/spacecraft/spacecraft.h
+++ b/src/simulation/dynamics/spacecraft/spacecraft.h
@@ -134,6 +134,9 @@ private:
     Eigen::MatrixXd *ISCPntBPrime_B;     //!< [kg m^2/s] Body time derivative of ISCPntB_B
     Eigen::MatrixXd *g_N;                //!< [m/s^2] Gravitational acceleration in N frame components
     Eigen::MatrixXd *sysTime;            //!< [s] System time
+    double mDotDynamics = 0.0;           //!< [kg/s] Aggregate mass rate substituted into generic rate-dependent terms
+    Eigen::Vector3d cPrimeEffectorDynamics_B = Eigen::Vector3d::Zero(); //!< [m/s] Dynamics effector CoM rate
+    Eigen::Matrix3d ISCPntBPrimeDynamics_B = Eigen::Matrix3d::Zero(); //!< [kg m^2/s] Dynamics inertia rate
 
     Eigen::Vector3d oldOmega_BN_B;       //!< [r/s] prior angular rate of B wrt N in the Body frame
 

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
@@ -109,6 +109,7 @@ void SphericalPendulum::registerStates(DynParamManager& states)
     Eigen::MatrixXd massInitMatrix(1,1);
     massInitMatrix(0,0) = this->massInit;
     this->massState->setState(massInitMatrix);
+    this->hasRegisteredStates = true;
 
 	return;
 }
@@ -163,6 +164,9 @@ void SphericalPendulum::updateEffectorMassProps(double integTime [[maybe_unused]
 
 	// - Update the effectors mass
 	this->effProps.mEff = this->massFSP;
+	this->effProps.mEffDot = this->fuelMassDot;
+	this->effProps.mEffDotDynamics =
+        this->omitMassRateDynamics ? 0.0 : this->fuelMassDot;
 	// - Update the position of CoM
 	this->effProps.rEff_CB_B = this->r_PcB_B;
 	// - Update the inertia about B
@@ -182,11 +186,19 @@ void SphericalPendulum::updateEffectorMassProps(double integTime [[maybe_unused]
 
 	this->rPrime_PcB_B = this->lPrime_B;
 	this->effProps.rEffPrime_CB_B = this->rPrime_PcB_B;
+    this->effProps.rEffPrime_CB_BDynamics = this->rPrime_PcB_B;
 
 	// - Update the body time derivative of inertia about B
 	this->rPrimeTilde_PcB_B = eigenTilde(this->rPrime_PcB_B);
-	this->effProps.IEffPrimePntB_B = -this->massFSP*(this->rPrimeTilde_PcB_B*this->rTilde_PcB_B
-                                                                          + this->rTilde_PcB_B*this->rPrimeTilde_PcB_B);
+	const Eigen::Matrix3d inertiaRateFromMotion =
+        -this->massFSP*(this->rPrimeTilde_PcB_B*this->rTilde_PcB_B
+                       + this->rTilde_PcB_B*this->rPrimeTilde_PcB_B);
+    this->effProps.IEffPrimePntB_B =
+        -this->fuelMassDot*this->rTilde_PcB_B*this->rTilde_PcB_B
+        + inertiaRateFromMotion;
+    this->effProps.IEffPrimePntB_BDynamics = inertiaRateFromMotion;
+    this->effProps.hasMassPropertyRateDynamics =
+        this->fuelMassDot != 0.0;
 
     return;
 }
@@ -194,8 +206,14 @@ void SphericalPendulum::updateEffectorMassProps(double integTime [[maybe_unused]
 /*! This is method is used to pass mass properties information to the fuelTank */
 void SphericalPendulum::retrieveMassValue(double integTime [[maybe_unused]])
 {
-    // Save mass value into the fuelSlosh class variable
-    this->fuelMass = this->massFSP;
+    if (this->massState == nullptr) {
+        this->bskLogger.bskLog(
+            BSK_ERROR,
+            "SphericalPendulum was attached to a FuelTank but never added to Spacecraft. Every particle "
+            "passed to pushFuelSloshParticle must also be passed to addStateEffector.");
+    }
+    // Read the current RK-stage state before the tank allocates propellant flow.
+    this->fuelMass = this->massState->getStateReference()(0, 0);
 
     return;
 }

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.cpp
@@ -214,6 +214,12 @@ void SphericalPendulum::retrieveMassValue(double integTime [[maybe_unused]])
     }
     // Read the current RK-stage state before the tank allocates propellant flow.
     this->fuelMass = this->massState->getStateReference()(0, 0);
+    if (this->fuelMass < 0.0) {
+        this->fuelMass = 0.0;  // [kg]
+        Eigen::MatrixXd massMatrix(1, 1);
+        massMatrix(0, 0) = this->fuelMass;
+        this->massState->setState(massMatrix);
+    }
 
     return;
 }
@@ -221,6 +227,21 @@ void SphericalPendulum::retrieveMassValue(double integTime [[maybe_unused]])
 /*! This method is for the FSP to add its contributions to the back-sub method */
 void SphericalPendulum::updateContributions(double integTime [[maybe_unused]], BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N [[maybe_unused]])
 {
+    if (this->massFSP <= 0.0) {
+        this->aPhi.setZero();
+        this->bPhi.setZero();
+        this->aTheta.setZero();
+        this->bTheta.setZero();
+        this->cPhi = 0.0;  // [rad/s^2]
+        this->cTheta = 0.0;  // [rad/s^2]
+        backSubContr.matrixA.setZero();
+        backSubContr.matrixB.setZero();
+        backSubContr.matrixC.setZero();
+        backSubContr.matrixD.setZero();
+        backSubContr.vecTrans.setZero();
+        backSubContr.vecRot.setZero();
+        return;
+    }
 
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_BN;

--- a/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.h
+++ b/src/simulation/dynamics/sphericalPendulum/sphericalPendulum.h
@@ -43,7 +43,7 @@ public:
     std::string nameOfThetaDotState; //!< [-] Identifier for the thetaDot state data container
 	std::string nameOfMassState;   //!< [-] Identifier for the mass state data container
 	Eigen::Vector3d d;        //!< [m] position vector from B point to tank center , T, in body frame
-	StateData *massState;		   //!< -- state data for the pendulums mass
+	StateData *massState = nullptr;		   //!< -- state data for the pendulums mass
     Eigen::Vector3d pHat_01;      //!<-- first vector of the P0 frame in B frame components
     Eigen::Vector3d pHat_02;       //!<-- second vector of the P0 frame in  B frame components
     Eigen::Vector3d pHat_03;        //!<-- third vector of the P0 frame in B frame components

--- a/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.cpp
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.cpp
@@ -42,6 +42,20 @@ void MJSystemCoM::Reset(uint64_t CurrentSimNanos [[maybe_unused]])
     if (!scene) {
         bskLogger.bskError("MJSystemCoM: scene pointer not set!");
     }
+
+    const mjModel* model = scene->getMujocoModel();
+    if (!model) {
+        bskLogger.bskError("MJSystemCoM: MuJoCo model not available in Reset()");
+    }
+
+    this->namedBodies.clear();
+    for (int i = 1; i < model->nbody; ++i) {
+        const char* bodyName = mj_id2name(model, mjOBJ_BODY, i);
+        if (bodyName == nullptr) {
+            continue;
+        }
+        this->namedBodies.emplace_back(i, &scene->getBody(bodyName));
+    }
 }
 
 
@@ -73,7 +87,9 @@ void MJSystemCoM::UpdateState(uint64_t CurrentSimNanos)
         r_CN_N += mi * ri;
     }
 
-    // calculate CoM velocity
+    // Calculate the derivative of the reported CoM position. The Jacobian
+    // term is the mass-weighted body velocity; changing body masses add
+    // sum(mDot_i*(r_i - r_C))/M.
     if (model->nv > 0 && massSC > 0.0) {
         // jacp = linear 3×nv, jacr = angular 3×nv
         const size_t jacobianSize = static_cast<size_t>(3 * model->nv);
@@ -99,6 +115,19 @@ void MJSystemCoM::UpdateState(uint64_t CurrentSimNanos)
             const Eigen::Vector3d vi = Jp * qv;   // linear COM velocity of body i
 
             v_CN_N += mi * vi;
+        }
+    }
+    if (massSC > 0.0) {
+        const Eigen::Vector3d centerOfMass_N = r_CN_N/massSC;
+        for (const auto& [bodyIndex, body] : this->namedBodies) {
+            if (model->body_mass[bodyIndex] <= 0.0) continue;
+            auto& massRateInMsg = body->derivativeMassPropertiesInMsg;
+            if (massRateInMsg.isLinked()) {
+                const double massRate = massRateInMsg().massSC;  // [kg/s]
+                const Eigen::Vector3d ri =
+                    Eigen::Map<const Eigen::Vector3d>(data->xipos + 3*bodyIndex);
+                v_CN_N += massRate*(ri - centerOfMass_N);
+            }
         }
     }
 

--- a/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.h
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.h
@@ -28,6 +28,8 @@
 #include "simulation/mujocoDynamics/_GeneralModuleFiles/MJScene.h"
 #include "architecture/utilities/avsEigenSupport.h"
 #include <Eigen/Dense>
+#include <utility>
+#include <vector>
 
 
 /*! @brief This is a C++ module to extract the system CoM position and velocity from Mujoco
@@ -50,6 +52,9 @@ public:
 
     BSKLogger bskLogger;              //!< BSK Logging
 
+private:
+
+    std::vector<std::pair<int, MJBody*>> namedBodies;  //!< MuJoCo body index paired with its scene body, resolved in Reset
 
 };
 

--- a/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.rst
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/MJSystemCoM.rst
@@ -1,6 +1,19 @@
 Executive Summary
 -----------------
-The ``MJSystemCoM`` module extracts the total system CoM position and velocity from a Mujoco scene with a single spacecraft.
+The ``MJSystemCoM`` module extracts the total system CoM position and velocity
+from a MuJoCo scene with a single spacecraft. For variable-mass bodies, the
+reported velocity is the time derivative of the reported center-of-mass
+position,
+
+.. math::
+
+    \dot{\mathbf r}_C =
+    \frac{\sum_i m_i\mathbf v_i}{M}
+    + \frac{\sum_i\dot m_i(\mathbf r_i-\mathbf r_C)}{M}.
+
+The second term is read from each body's
+``derivativeMassPropertiesInMsg``. It is a mass-property bookkeeping term,
+not an additional generalized force in the MuJoCo equations of motion.
 
 Message Connection Descriptions
 -------------------------------
@@ -25,7 +38,7 @@ This section is to outline the steps needed to setup the ``MJSystemCoM`` module 
 
     from Basilisk.simulation import MJSystemCoM
 
-#. Enable extra EOM call when building the Mujoco scene::
+#. Enable extra EOM call when building the MuJoCo scene::
 
     scene.extraEoMCall = True
 
@@ -39,6 +52,6 @@ This section is to outline the steps needed to setup the ``MJSystemCoM`` module 
 
 #. The MJSystemCoM output message is ``comStatesOutMsg``.
 
-#. Add the module to the Mujoco scene dynamics task::
+#. Add the module to the MuJoCo scene dynamics task::
 
     scene.AddModelToDynamicsTask(module)

--- a/src/simulation/mujocoDynamics/MJSystemCoM/_UnitTest/test_MJSystemCoM.py
+++ b/src/simulation/mujocoDynamics/MJSystemCoM/_UnitTest/test_MJSystemCoM.py
@@ -116,6 +116,28 @@ def _xml_angled():
 </mujoco>
 """
 
+
+def _xml_variable_mass(rotated):
+    hubPose = (
+        'pos="4 -2 1" quat="0.9238795325112867 0 0 '
+        '0.3826834323650898"'
+        if rotated else ""
+    )
+    return f"""<mujoco>
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="hub" {hubPose}>
+      <freejoint/>
+      <inertial pos="0 0 0" mass="10" diaginertia="1 1 1"/>
+      <body name="tank" pos="3 0 0">
+        <inertial pos="0 0 0" mass="2" diaginertia="0.1 0.1 0.1"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
 def _write_temp_xml(xml_text: str, basename: str) -> str:
     tmpdir = tempfile.mkdtemp(prefix="mjcom_")
     path = os.path.join(tmpdir, f"{basename}.xml")
@@ -158,6 +180,98 @@ def _expected_com(model: str, r_root, v_root):
         raise ValueError("unknown model")
 
     return rC, vC
+
+
+@pytest.mark.parametrize("rotated", [False, True])
+def test_variable_mass_velocity_is_com_position_derivative(rotated):
+    r"""Include the quotient-rule term in the reported CoM velocity.
+
+    A 10 kg hub and a 2 kg tank translate together, with the tank positioned
+    by a fixed inertial offset :math:`\mathbf d` from the hub and depleting at
+    0.5 kg/s. Their center of mass is
+
+    .. math::
+
+        \mathbf r_C(t) =
+        \mathbf r_H(0) + \mathbf v_Ht
+        + \frac{m(t)}{10+m(t)}\mathbf d, \qquad
+        m(t) = 2 - 0.5t,
+
+    so
+
+    .. math::
+
+        \dot{\mathbf r}_C(t) =
+        \mathbf v_H + \frac{10\dot m}{(10+m(t))^2}\mathbf d.
+
+    The second term distinguishes the position derivative from the
+    mass-weighted body velocity. The rotated case ensures that the
+    correction uses inertial body positions rather than MJCF-local offsets.
+    """
+    timeStep = 1.0e-3  # [s]
+    finalTime = 2.0e-3  # [s]
+    tankMassRate = -0.5  # [kg/s]
+    rootPosition = (
+        np.array([4.0, -2.0, 1.0]) if rotated else np.zeros(3)
+    )  # [m]
+    tankOffset = (
+        np.array([3.0/np.sqrt(2.0), 3.0/np.sqrt(2.0), 0.0])
+        if rotated else np.array([3.0, 0.0, 0.0])
+    )  # [m]
+    rootVelocity = np.array([1.0, -0.5, 0.25])  # [m/s]
+
+    simulation = SimulationBaseClass.SimBaseClass()
+    process = simulation.CreateNewProcess("process")
+    process.addTask(
+        simulation.CreateNewTask("task", macros.sec2nano(timeStep))
+    )
+    scene = mujoco.MJScene(_xml_variable_mass(rotated))
+    scene.extraEoMCall = True
+    simulation.AddModelToTask("task", scene)
+
+    massRatePayload = messaging.SCMassPropsMsgPayload()
+    massRatePayload.massSC = tankMassRate
+    massRateMsg = messaging.SCMassPropsMsg().write(massRatePayload)
+    scene.getBody("tank").derivativeMassPropertiesInMsg.subscribeTo(
+        massRateMsg
+    )
+
+    module = MJSystemCoM.MJSystemCoM()
+    module.scene = scene
+    scene.AddModelToDynamicsTask(module)
+    recorder = module.comStatesOutMsg.recorder()
+    simulation.AddModelToTask("task", recorder)
+
+    simulation.InitializeSimulation()
+    scene.getBody("hub").setVelocity(rootVelocity)
+    simulation.ConfigureStopTime(macros.sec2nano(finalTime))
+    simulation.ExecuteSimulation()
+
+    times = np.asarray(recorder.times())*macros.NANO2SEC  # [s]
+    tankMass = 2.0 + tankMassRate*times  # [kg]
+    expectedPosition = (
+        rootPosition
+        + times[:, None]*rootVelocity
+        + tankMass[:, None]/(10.0 + tankMass[:, None])*tankOffset
+    )  # [m]
+    expectedVelocity = (
+        rootVelocity
+        + 10.0*tankMassRate
+        /(10.0 + tankMass[:, None])**2*tankOffset
+    )  # [m/s]
+    np.testing.assert_allclose(
+        recorder.r_CN_N,
+        expectedPosition,
+        rtol=0.0,
+        atol=2.0e-12,
+    )
+    np.testing.assert_allclose(
+        recorder.v_CN_N,
+        expectedVelocity,
+        rtol=0.0,
+        atol=2.0e-12,
+    )
+
 
 @pytest.mark.parametrize("model", ["single", "straight", "angled"])
 @pytest.mark.parametrize("moving", [True, False])

--- a/src/simulation/power/ReactionWheelPower/_UnitTest/test_unitReactionWheelPower.py
+++ b/src/simulation/power/ReactionWheelPower/_UnitTest/test_unitReactionWheelPower.py
@@ -98,9 +98,6 @@ def test_module(show_plots, setRwMsg, setDeviceStatusMsg, setEta_e2m, OmegaValue
 
 
 def powerRW(show_plots, setRwMsg, setDeviceStatusMsg, setEta_e2m, OmegaValue, setEta_m2c, accuracy):
-    if not setRwMsg:
-        bskLogging.setDefaultLogLevel(bskLogging.ERROR)
-
     """Module Unit Test"""
     testFailCount = 0                       # zero unit test result counter
     testMessages = []                       # create empty array to store test log messages
@@ -117,6 +114,8 @@ def powerRW(show_plots, setRwMsg, setDeviceStatusMsg, setEta_e2m, OmegaValue, se
 
     # create the rw power test module
     testModule = ReactionWheelPower.ReactionWheelPower()
+    if not setRwMsg:
+        testModule.bskLogger.setLogLevel(bskLogging.ERROR)
     testModule.ModelTag = "bskSat"
     testModule.basePowerNeed = 10.   # baseline power draw, Watts
     rwMsg = messaging.RWConfigLogMsg()


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Correct variable-mass mass-property derivative reporting without changing the established coupled-depletion equations of motion.

The first commit applies the retained first-moment quotient rule in `Spacecraft` and separates reported mass-property derivatives from optional dynamics-rate overrides. The second corrects `FuelTank` and attached fuel-slosh component derivatives, preserves update-only dynamics, and rejects unsupported ordering and prescribed-motion nesting. The third makes `MJSystemCoM` velocity equal the time derivative of its reported center-of-mass position when body masses change. The final commit updates known issues and release notes.

The dynamics-rate split is intentional: retained mass-property derivatives must match the integrated states, while the existing coupled-depletion approximation remains unchanged for compatibility and is documented as a limitation.

## Verification
The C++ project was rebuilt with MuJoCo enabled.

The focused regression suite passes with 110 tests covering analytic quotient-rule results, finite-difference mass-property derivatives, update-only and coupled-depletion compatibility, linear and spherical fuel slosh, invalid attachment configurations, `MJSystemCoM`, prescribed motion, and the extension ABI.

## Documentation
Updated the `StateEffector`, `FuelTank`, prescribed-motion, and `MJSystemCoM` documentation. Updated the known-issues entry to distinguish corrected reporting from the retained coupled-depletion approximation, and added `spacecraft-center-of-mass-rate.rst` to the release-note snippets.

## Future work
A general open-system mass-flow model should derive momentum-flux loads from an explicit control-volume convention. The deprecated `SpacecraftSystem` does not consume the new dynamics-rate override contract and is explicitly outside this change.
