### PR TITLE
Fix MuJoCo DLL discovery on Windows

### DIFF
--- a/libs/mujoco/conanfile.py
+++ b/libs/mujoco/conanfile.py
@@ -8,6 +8,7 @@ from conan import ConanFile
 
 class MujocoConan(ConanFile):
     name = "mujoco"
+    package_type = "shared-library"
     settings = "os", "arch"
 
     def set_version(self):

--- a/src/tests/test_conan_command.py
+++ b/src/tests/test_conan_command.py
@@ -19,6 +19,7 @@
 
 import argparse
 import importlib
+import importlib.util
 from pathlib import Path
 
 import pytest
@@ -166,6 +167,22 @@ def test_windows_command_omits_c_language_standard(conanfile_module):
     command = conanfile_module.create_conan_build_command(arguments, platform_name="nt")
 
     assert "compiler.cstd=gnu17" not in option_values(command, "-s")
+
+
+def test_mujoco_recipe_declares_shared_library_package():
+    """Expose MuJoCo's DLL directory through Conan's runtime environment."""
+    repo_root = Path(__file__).resolve().parents[2]
+    recipe_path = repo_root / "libs" / "mujoco" / "conanfile.py"
+    recipe_spec = importlib.util.spec_from_file_location(
+        "basilisk_mujoco_conan_recipe",
+        recipe_path,
+    )
+    assert recipe_spec is not None
+    assert recipe_spec.loader is not None
+    recipe_module = importlib.util.module_from_spec(recipe_spec)
+    recipe_spec.loader.exec_module(recipe_module)
+
+    assert recipe_module.MujocoConan.package_type == "shared-library"
 
 
 def test_external_module_path_is_normalized(conanfile_module, tmp_path):


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Fix the Windows cold-cache build failure introduced when MuJoCo package creation errors became fatal.

The MuJoCo Conan recipe now declares `package_type = "shared-library"`. This allows Conan to treat `mujoco.dll` as a runtime dependency and add its `bin` directory to the Windows runtime environment when executing the package test.

A regression test verifies that the MuJoCo recipe retains the required package classification.

## Verification

- Ran `pytest -q src/tests/test_conan_command.py`: 11 tests passed.
- Confirmed `conan inspect libs/mujoco --format=json` reports `package_type: shared-library`.
- Ran pre-commit checks on the modified files.
- Ran `git diff --check`.

The GitHub Windows job will provide the final cold-cache verification.

## Documentation

No user-facing documentation is affected. This change corrects Conan package metadata and its associated test coverage.

## Future work

No additional code changes are anticipated. Confirm the Windows build-cache job succeeds when rebuilding MuJoCo from an empty Conan cache.