### PR TITLE
Address issue #1459 and correct some Monte Carlo issues

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,10 @@ Basilisk Known Issues
 
 Version |release| (July 7, 2026)
 --------------------------------
+- GitHub issue 1459: ``RetentionPolicy.addVariableLog()`` still called the removed
+  ``SimBaseClass.AddVariableForLogging()`` and ``GetLogVariableData()`` methods, causing every
+  Monte Carlo variable-retention request to fail with ``AttributeError``. Variable retention now
+  creates and reads the supported module logger directly.
 - Every state effector acting as a parent published the inertial state of its attachment frame once
   per task step from its own ``UpdateState()``. A child effector therefore evaluated its loads against
   kinematics a full task step old. These are now refreshed within the integration.

--- a/docs/source/Support/bskReleaseNotesSnippets/1459-monte-carlo-variable-retention.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1459-monte-carlo-variable-retention.rst
@@ -1,0 +1,1 @@
+- Fixed ``RetentionPolicy.addVariableLog()`` to retain complete direct module variables through the supported logger API and deprecated its legacy component/type arguments; nested and computed histories require an explicit ``PythonVariableLogger``.

--- a/src/utilities/MonteCarlo/README.md
+++ b/src/utilities/MonteCarlo/README.md
@@ -1,57 +1,80 @@
 # MonteCarlo: Brief Guide
 
-*If you plan to use this it is highly recommended to read the documentation in the `MonteCarlo/Controller.py` source file, the example usage in `examples/scenarioMonteCarloAttRW.py`, and the corresponding test in `src/tests/test_scenarioMonteCarloAttRW.py`. This guide offers only a brief overview of features*
+For complete examples, see `examples/scenarioMonteCarloAttRW.py` and its test in
+`src/tests/test_scenarioMonteCarloAttRW.py`. This guide provides a brief overview of
+the main Monte Carlo features.
 
-A MonteCarlo simulation can be created using the `MonteCarlo` module. This module is used to execute monte carlo simulations, and access retained data from previously executed MonteCarlo runs.
+The Monte Carlo utilities execute a simulation repeatedly while varying random seeds and
+selected initial parameters. `Controller` manages the runs, archives retained data, reloads
+completed runs, and reproduces selected cases from their saved parameters.
 
-First, the `Controller` class is used in order to execute a simulation repeatedly, applying unique random seeds to each run, statistically dispersing initial parameters, executing the simulation run, and compressing and retaining data about the run.
+To create a Monte Carlo simulation, import `Controller`, `RetentionPolicy`, and any
+dispersion classes needed to vary the initial parameters. Then create and configure a
+`Controller` for the run.
 
-Data retained through a MonteCarlo simulation is compressed and saved to disk. The `Controller` class is also used to access this data from each run.  The MonteCarlo `Controller` can reload the directory where data was retained in, and access the retained data, or rerun unusual cases using the same random seeds and initial parameters.
+## Configure the simulation
 
-To create a Monte Carlo simulation, import the `Controller`, `RetentionPolicy`, and other objects described later from the `MonteCarlo` module, along with `Dispersion` classes used to disperse initial parameters. Then create a `Controller` and configure that object for the particular monte carlo run.
+```python
+import matplotlib.pyplot as plt
+import numpy as np
 
-```
-from MonteCarlo.Controller import Controller, RetentionPolicy
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    macros,
+    pythonVariableLogger,
+    simHelpers,
+)
+from Basilisk.utilities.MonteCarlo.Controller import Controller
+from Basilisk.utilities.MonteCarlo.Dispersions import UniformEulerAngleMRPDispersion
+from Basilisk.utilities.MonteCarlo.RetentionPolicy import RetentionPolicy
+
 monteCarlo = Controller()
 ```
 
-Every MonteCarlo simulation must define a function that creates the `SimulationBaseClass` to execute and returns it. Within this function, the simulation is created and configured
+Every Monte Carlo simulation must define and return the `SimBaseClass` instance to run.
 
-```
+```python
 def myCreationFunction():
-   sim = SimulationBaseClass()
-   # modify sim ...
-   return sim
+    sim = SimulationBaseClass.SimBaseClass()
+    # configure sim ...
+    return sim
 
 monteCarlo.setSimulationFunction(myCreationFunction)
 ```
 
+Every Monte Carlo simulation must also define a function that executes the created
+simulation:
 
-Also, every MonteCarlo simulation must define a function which executes the simulation that was created. It could look like this:
-
-```
+```python
 def myExecutionFunction(sim):
-    sim.InitializeSimulationAndDiscover()
+    sim.InitializeSimulation()
     sim.ExecuteSimulation()
 
 monteCarlo.setExecutionFunction(myExecutionFunction)
 ```
 
-Optionally, there is a function that can be used to configure the simulation after random seeds
-have been populated. Non-seed parameter dispersions are applied after this configuration step
+Optionally, a configuration function can adjust the simulation after random seeds have
+been populated. Non-seed parameter dispersions are applied after this configuration step
 and before the execution function runs.
 
-```
+```python
 def myConfigureFunction(sim):
-  # do something with the sim now that random seeds have been applied ...
+    # Configure the sim now that random seeds have been applied ...
+    pass
 
 monteCarlo.setConfigureFunction(myConfigureFunction)
 ```
 
-Statistical dispersions can be applied to initial parameters using the MonteCarlo module. These initial parameters are saved for reference and in order to re-run cases. Various dispersions have been created, and these are not specified here. To see available dispersions, examine `MonteCarlo/Dispersions.py`
+Statistical dispersions can be applied to initial parameters. These parameters are saved
+for reference and to make individual cases reproducible. See `MonteCarlo/Dispersions.py`
+for the available dispersion classes.
 
-```
-monteCarlo.addDispersion(UniformEulerAngleMRPDispersion("taskName.hub.sigma_BNInit"))
+```python
+monteCarlo.addDispersion(
+    UniformEulerAngleMRPDispersion(
+        "TaskList[0].TaskModels[0].hub.sigma_BNInit"
+    )
+)
 ```
 
 Dispersion names can reference nested simulation attributes with dotted names, integer list
@@ -62,82 +85,129 @@ resolves the object returned by `get_DynModel()` before applying the dispersion.
 indices can be used for matrix-like attributes, such as
 `scObject.hub.IHubPntBc_B[0][1]`.
 
-If data is being retained, a archive directory to store retained data must be specified. This directory is later used to reload the retained data from an executed Monte Carlo simulation.
+## Retain simulation data
 
-```
+If data is being retained, an archive directory must be specified. The same directory is
+used to reload retained data after the Monte Carlo execution.
+
+```python
 monteCarlo.setArchiveDir("dirName")
 ```
 
-Data is retained from a simulation to a unique file for each run. A `RetentionPolicy` is used to define what data from the simulation should be retained. A `RetentionPolicy` is a list of messages and variables to log from each simulation run. It also has a callback, used for plotting/processing the retained data. If a user wanted to create a plot of each run of a simulation message, they would create a retention policy defining the message they want to plot, and a callback that uses that message to draw a plot. This plot can be created any time after the initial execution of the monte carlo run, from the retained data.
+Data is retained from a simulation to a unique file for each run. A `RetentionPolicy`
+defines which recorded message fields, module variables, and custom values are saved.
+It can also provide a callback for plotting or processing the retained data.
 
-```
-# add retention policy that logs a message and plots it
+Message recorders must be created by the simulation creation function and stored in
+`sim.msgRecList`; their sampling interval is set when the recorder is created. A module
+variable is identified in `<ModelTag>.<variableName>` format and must be public or
+available through its standard getter. The scheduled module must support Basilisk's
+standard `logger()` API, and its model tag must be unique. A model tag may contain periods
+because the final period in the identifier separates it from the variable name. `logRate`
+sets the variable logger's nonnegative integer minimum recording period in nanoseconds.
+
+The complete scalar, vector, or array is recorded by default. The first column of every
+retained message or variable array is simulation time in nanoseconds. Multidimensional
+variable samples are flattened in row-major order into the remaining columns.
+
+The legacy `startIndex`, `stopIndex`, and `varType` arguments remain available for
+migration until 2027-08-26. Component indices are inclusive and refer to the flattened
+variable. Output column zero contains time, and the selected components are stored
+consecutively beginning in column one. `varType` is ignored because modern loggers determine
+the value type directly. New code should retain the complete variable and select component
+columns from the resulting NumPy array. To record nested or computed values over time, create a
+`pythonVariableLogger.PythonVariableLogger` during simulation setup, schedule it on the source
+model's task after that model, and store it on the simulation object. Use
+`addRetentionFunction()` to copy its time and value arrays into the retained `custom` data, and
+use `simHelpers.addTimeColumn(logger.times(), logger["valueName"])` when the custom array should
+follow the same time-column convention as message and direct-variable data.
+
+```python
+# Add a retention policy that logs message fields and a module variable.
+# Assume myCreationFunction stores the recorder as sim.msgRecList["spacecraftState"]
+# and adds a module whose ModelTag is "bsk-Sat".
+retainedRate = macros.sec2nano(10.0)  # [ns]
 plotRetentionPolicy = RetentionPolicy()
-# log this message
-plotRetentionPolicy.addMessageLog("inertial_state_output", [("v_BN_N", range(3)), ("r_BN_N", range(3)], retainedRate)
+plotRetentionPolicy.addMessageLog(
+    "spacecraftState",
+    ["v_BN_N", "r_BN_N"],
+)
+plotRetentionPolicy.addVariableLog(
+    "bsk-Sat.totOrbEnergy",
+    logRate=retainedRate,
+)
 
-# this is the plot command (for only one run)
+# This callback plots one retained run.
 def myDataCallback(data, retentionPolicy):
-    v_BN_N = np.array(monteCarloData["messages"]["inertial_state_output.v_BN_N"])
-    plt.plot(v_BN_N[:,1], v_BN_N[:,2])
+    r_BN_N = np.asarray(data["messages"]["spacecraftState.r_BN_N"])
+    orbitalEnergy = np.asarray(data["variables"]["bsk-Sat.totOrbEnergy"])
+    plt.figure()
+    plt.plot(r_BN_N[:, 1], r_BN_N[:, 2])
+    plt.figure()
+    plt.plot(orbitalEnergy[:, 0], orbitalEnergy[:, 1])
+
+
 plotRetentionPolicy.setDataCallback(myDataCallback)
 
 monteCarlo.addRetentionPolicy(plotRetentionPolicy)
+```
 
-# now execute the simulations, and the message will be retained
-monteCarlo.executeSimulations()
+## Execute and analyze the runs
 
-# After the simulation has been executed
-# this can be in a different script than the executeSimulations
-# or in the same script this line can be skipped
+Random-seed dispersion is recommended whenever a simulation uses random number generation.
+Seeds are archived so an individual run can be reproduced. Configure the number of runs and,
+optionally, the worker-process count and console verbosity before execution:
+
+```python
+monteCarlo.setShouldDisperseSeeds(True)
+monteCarlo.setExecutionCount(100)
+monteCarlo.setThreadCount(4)
+monteCarlo.setVerbose(False)
+
+failures = monteCarlo.executeSimulations()
+```
+
+`executeSimulations()` returns the indices of failed runs. Once execution is complete, the
+controller and retained data can be reloaded in the same script or a later analysis script:
+
+```python
 monteCarlo = Controller.load("dirName")
 
-# now we can plot all plots for all runs on the same plot
+# Execute callbacks for every run, or select specific runs and policies.
 monteCarlo.executeCallbacks()
-# or plot only this one plot with only the data from runs 4, 6, and 27
-monteCarlo.executeCallbacks([4,6,7], [plotRetentionPolicy])
+# This second form assumes plotRetentionPolicy is available in the analysis script.
+monteCarlo.executeCallbacks([4, 6, 7], [plotRetentionPolicy])
 
 plt.show()
 ```
 
-The simulations can have random seeds of each simulation dispersed randomly. This is recommended to be used when a simulation relies on random number generation. Whether to disperse random seeds on all simulation tasks is controlled via the method `monteCarlo.setShouldDisperseSeeds(True)`. If random seeds are used, the random seeds are saved in case a user wants to rerun a particular run. This is all stored with the initial parameters in an individual json file for each run in the archive directory.
+Retained data from a run is a dictionary containing message, variable, and custom
+data, together with the Monte Carlo run index:
 
-A Monte Carlo simulation must define how many simulation runs to execute for the Monte Carlo using `monteCarlo.setExecutionCount(NUMBER_OF_RUNS)`
-
-Optionally, the number of processes to use for the simulation. If this isn't called use the number of cores on the computer `monteCarlo.setThreadCount(PROCESSES)`
-
-Whether to print more verbose information during the run `monteCarlo.setVerbose(False)`
-
-
-After the monteCarlo run is configured, it is executed. This method returns the list of jobs that failed.
-
-```
-failures = monteCarlo.executeSimulations()
-```
-
-Now in another script (or the current one), the data from this simulation can be easily loaded.
-
-```
-# Test loading data from runs from disk
-monteCarlo = Controller.load(dirName)
+```python
+{
+    "messages": {
+        "recorderName.fieldName": [[time, value1, value2]]
+    },
+    "variables": {
+        "modelTag.variableName": [[time, value1, value2]]
+    },
+    "custom": {
+        "customName": [value1, value2]
+    },
+    "index": 19,
+}
 ```
 
-Then retained data from any run can then be accessed in the form of a dictionary with two sub-dictionaries for messages and variables:
-
-```
-  {
-      "messages": {
-          "messageName": [value1,value2,value3]
-      },
-      "variables": {
-          "variableName": [value1,value2,value3]
-      }
-  }
-```
-
-```
+```python
 retainedData = monteCarlo.getRetainedData(19)
-retainedData["messages"]["inertial_state_output.r_BN_N"]
+retainedData["messages"]["spacecraftState.r_BN_N"]
+orbitalEnergy = retainedData["variables"]["bsk-Sat.totOrbEnergy"]
+
+# Column 0 is time; subsequent columns contain the retained variable components.
+time = orbitalEnergy[:, 0]
+energy = orbitalEnergy[:, 1]
 ```
 
-There are various other methods to get retained initial parameters, which are further documented in the `Controller` class and the test script.
+Additional methods for loading retained parameters and rerunning cases are documented in
+`Controller` and the referenced Monte Carlo example.

--- a/src/utilities/MonteCarlo/RetentionPolicy.py
+++ b/src/utilities/MonteCarlo/RetentionPolicy.py
@@ -1,26 +1,48 @@
-import pandas as pd
-from Basilisk.utilities import simHelpers
+from numbers import Integral
+
+import numpy as np
+
+from Basilisk.utilities import deprecated, simHelpers
+
+
+_DIRECT_VARIABLE_ERROR = (
+    "addVariableLog supports direct module variables only; create a "
+    "PythonVariableLogger during simulation setup for nested or computed time "
+    "histories and retain its output with addRetentionFunction()"
+)
 
 
 class VariableRetentionParameters:
-    """
-    Represents a variable's logging parameters.
+    """Store the configuration and runtime logger for a retained variable.
+
+    :param str varName: Variable identifier in ``<ModelTag>.<variableName>`` format.
+    :param int varRate: Minimum variable recording period in nanoseconds.
+    :param int startIndex: Deprecated first retained component index.
+    :param int stopIndex: Deprecated last retained component index, inclusive.
+    :param str varType: Deprecated legacy C-array type name.
     """
 
-    def __init__(self, varName, varRate, startIndex=0, stopIndex=0, varType='double'):
+    def __init__(
+        self,
+        varName,
+        varRate,
+        startIndex=None,
+        stopIndex=None,
+        varType=None,
+    ):
         self.varName = varName
         self.varRate = varRate
         self.startIndex = startIndex
         self.stopIndex = stopIndex
         self.varType = varType
+        self.logger = None
 
 
 class MessageRetentionParameters:
-    """
-    Represents a message's logging parameters.
-    Args:
-        name: name of the message recorder
-        retainedVars: the message variable to record
+    """Store the configuration for retained message fields.
+
+    :param str name: Name of the message recorder.
+    :param list retainedVars: Message payload fields to retain.
     """
 
     def __init__(self, name, retainedVars):
@@ -29,12 +51,13 @@ class MessageRetentionParameters:
 
 
 class RetentionPolicy:
-    """
-    This policy controls what simulation data is saved and how it is stored.  Note that the simulation data
-    array will have the message time prepended as the first column.
+    """Control which simulation data is retained and how it is stored.
+
+    The first column of each retained message or variable array contains the
+    corresponding simulation time in nanoseconds.
     """
 
-    def __init__(self, rate=int(1E10)):
+    def __init__(self, rate=10_000_000_000):  # [ns]
         self.logRate = rate
         self.messageLogList = []
         self.varLogList = []
@@ -44,18 +67,194 @@ class RetentionPolicy:
     def addMessageLog(self, name, retainedVars):
         self.messageLogList.append(MessageRetentionParameters(name, retainedVars))
 
-    def addVariableLog(self, variableName, startIndex=0, stopIndex=0, varType='double', logRate=None):
+    def addVariableLog(
+        self,
+        variableName,
+        startIndex=None,
+        stopIndex=None,
+        varType=None,
+        logRate=None,
+    ):
+        """Add a module variable to the retained Monte Carlo data.
+
+        The variable identifier must use ``<ModelTag>.<variableName>`` format
+        and refer to a direct public or getter-backed variable on a uniquely
+        tagged module that supports the standard ``logger()`` API. The final
+        period separates the model tag from the variable name, so model tags may
+        contain periods. The complete variable is retained by default;
+        multidimensional samples are flattened in row-major order.
+        ``startIndex``, ``stopIndex``, and ``varType`` are compatibility
+        arguments for the removed legacy variable-logging API and will be
+        removed after 2027-08-26. New code should select component columns from
+        the retained NumPy array instead.
+
+        :param str variableName: Model tag and direct module variable name.
+        :param int startIndex: Deprecated first retained component index.
+        :param int stopIndex: Deprecated last retained component index, inclusive.
+        :param str varType: Deprecated legacy C-array type name; ignored.
+        :param int logRate: Minimum recording period in nanoseconds. The policy
+            default is used when this argument is ``None``.
+        """
+        self._splitVariableName(variableName)
+        startIndex, stopIndex = self._normalizeLegacyIndices(
+            startIndex,
+            stopIndex,
+        )
+        if startIndex is not None or stopIndex is not None or varType is not None:
+            deprecated.deprecationWarn(
+                "RetentionPolicy.addVariableLog legacy arguments",
+                "2027/08/26",
+                "Variable loggers now retain complete values directly. Select "
+                "components from the retained NumPy array instead.",
+            )
+
         if logRate is None:
             logRate = self.logRate
-        varContainer = VariableRetentionParameters(variableName, logRate, startIndex, stopIndex, varType)
-        self.varLogList.append(varContainer)
+        logRate = self._normalizeLogRate(logRate)
+        variableParameters = VariableRetentionParameters(
+            variableName,
+            logRate,
+            startIndex,
+            stopIndex,
+            varType,
+        )
+        self.varLogList.append(variableParameters)
+
+    @staticmethod
+    def _normalizeLegacyIndices(startIndex, stopIndex):
+        """Normalize and validate a deprecated inclusive component range."""
+        if startIndex is None and stopIndex is None:
+            return None, None
+        if startIndex is None:
+            startIndex = 0
+        if stopIndex is None:
+            stopIndex = startIndex
+        if any(
+            isinstance(index, bool) or not isinstance(index, Integral)
+            for index in (startIndex, stopIndex)
+        ):
+            raise TypeError("startIndex and stopIndex must be integers")
+        if startIndex < 0 or stopIndex < startIndex:
+            raise ValueError(
+                "startIndex and stopIndex must define a nonnegative inclusive range"
+            )
+        return int(startIndex), int(stopIndex)
+
+    @staticmethod
+    def _normalizeLogRate(logRate):
+        """Validate and normalize a variable recording period in nanoseconds."""
+        if isinstance(logRate, bool) or not isinstance(logRate, Integral):
+            raise TypeError("logRate must be an integer number of nanoseconds")
+        if logRate < 0:
+            raise ValueError("logRate must be nonnegative")
+        return int(logRate)
+
+    @staticmethod
+    def _splitVariableName(variableName):
+        """Split and validate a retained module variable identifier."""
+        if not isinstance(variableName, str) or variableName == "":
+            raise ValueError("variableName must be a non-empty string")
+
+        modelTag, separator, moduleVariableName = variableName.rpartition(".")
+        if separator == "" or modelTag == "" or moduleVariableName == "":
+            raise ValueError(
+                "variableName must use '<ModelTag>.<variableName>' format"
+            )
+        if any(token in moduleVariableName for token in ("[", "]", "(", ")")):
+            raise ValueError(_DIRECT_VARIABLE_ERROR)
+        return modelTag, moduleVariableName
+
+    @staticmethod
+    def _findModelAndTask(simInstance, modelTag, retainedVariableName):
+        """Return the uniquely tagged model and its owning simulation task."""
+        matches = []
+        prefixModelTags = set()
+        for task in simInstance.TaskList:
+            for model in task.TaskModels:
+                candidateTag = getattr(model, "ModelTag", None)
+                if candidateTag == modelTag:
+                    matches.append((model, task))
+                elif (
+                    isinstance(candidateTag, str)
+                    and candidateTag != ""
+                    and retainedVariableName.startswith(candidateTag + ".")
+                ):
+                    prefixModelTags.add(candidateTag)
+
+        if not matches:
+            if prefixModelTags:
+                matchingTags = ", ".join(sorted(prefixModelTags))
+                raise ValueError(
+                    f"Could not find a model with ModelTag '{modelTag}'. The "
+                    f"identifier extends existing ModelTag(s): {matchingTags}. "
+                    f"{_DIRECT_VARIABLE_ERROR}."
+                )
+            raise ValueError(f"Could not find a model with ModelTag '{modelTag}'")
+        if len(matches) > 1:
+            raise ValueError(
+                f"ModelTag '{modelTag}' is not unique across simulation tasks"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _getLoggerPriority(task):
+        """Return a priority that schedules a logger after existing task models."""
+        priorities = getattr(task, "TaskModelPriorities", None)
+        if priorities is None or len(priorities) != len(task.TaskModels):
+            raise RuntimeError(
+                f"Task '{task.Name}' has inconsistent model-priority metadata"
+            )
+        if not priorities:
+            raise RuntimeError(f"Task '{task.Name}' does not contain any models")
+        # SysModelTask preserves insertion order for models with equal priority.
+        # Reusing the lowest priority therefore places the new logger last.
+        return min(priorities)
 
     def addLogsToSim(self, simInstance):
+        """Create and schedule the variable loggers required by this policy."""
+        RetentionPolicy.addRetentionPoliciesToSim(simInstance, [self])
+
+    def _addLogsToSim(self, simInstance, loggerCache):
+        """Create variable loggers, sharing compatible duplicate requests."""
         for variable in self.varLogList:
-            simInstance.AddVariableForLogging(variable.varName, variable.varRate,
-                                              variable.startIndex, variable.stopIndex, variable.varType)
+            modelTag, moduleVariableName = self._splitVariableName(variable.varName)
+            cachedLogger = loggerCache.get(variable.varName)
+            if cachedLogger is not None:
+                variable.logger = cachedLogger
+                continue
+
+            model, task = self._findModelAndTask(
+                simInstance,
+                modelTag,
+                variable.varName,
+            )
+            loggerFactory = getattr(model, "logger", None)
+            if not callable(loggerFactory):
+                raise TypeError(
+                    f"Model '{modelTag}' does not provide the standard logger() "
+                    "API; create a PythonVariableLogger during simulation setup "
+                    "and retain its output with addRetentionFunction()"
+                )
+
+            variableLogger = loggerFactory(moduleVariableName, variable.varRate)
+            variableLogger.ModelTag = f"RetentionLogger:{variable.varName}"
+            loggerPriority = self._getLoggerPriority(task)
+            simInstance.AddModelToTask(
+                task.Name,
+                variableLogger,
+                ModelPriority=loggerPriority,
+            )
+            variable.logger = variableLogger
+            loggerCache[variable.varName] = variableLogger
 
     def addRetentionFunction(self, function):
+        """Add a callback that returns custom data after simulation execution.
+
+        The callback receives the completed simulation instance and must return
+        a dictionary. Its entries are merged into the retained ``custom`` data.
+
+        :param callable function: Post-simulation data extraction callback.
+        """
         self.retentionFunctions.append(function)
 
     def setDataCallback(self, dataCallback):
@@ -67,57 +266,110 @@ class RetentionPolicy:
 
     @staticmethod
     def addRetentionPoliciesToSim(simInstance, retentionPolicies):
-        """ Adds logs for variables and messages to a simInstance
-        Args:
-            simInstance: The simulation instance to add logs to.
-            retentionPolicies: RetentionPolicy[] list that defines the data to log.
+        """Add the variable loggers from a list of policies to a simulation.
+
+        Compatible duplicate requests share one logger. Requests for the same
+        retained-data key with different rates or component ranges are rejected.
+
+        :param simInstance: Simulation instance receiving the loggers.
+        :param list retentionPolicies: Retention policies defining data to log.
         """
-
+        retentionPolicies = list(retentionPolicies)
+        requestedSignatures = {}
         for retentionPolicy in retentionPolicies:
-            retentionPolicy.addLogsToSim(simInstance)
+            for variable in retentionPolicy.varLogList:
+                loggerSignature = (
+                    variable.varRate,
+                    variable.startIndex,
+                    variable.stopIndex,
+                )
+                existingSignature = requestedSignatures.get(variable.varName)
+                if (
+                    existingSignature is not None
+                    and existingSignature != loggerSignature
+                ):
+                    raise ValueError(
+                        f"Variable '{variable.varName}' has conflicting retention "
+                        "settings"
+                    )
+                requestedSignatures[variable.varName] = loggerSignature
 
-        # TODO handle duplicates somehow?
+        loggerCache = {}
+        for retentionPolicy in retentionPolicies:
+            retentionPolicy._addLogsToSim(simInstance, loggerCache)
+
+    @staticmethod
+    def _getRetainedVariableData(variable):
+        """Return one runtime variable logger as a time-column data array."""
+        if variable.logger is None:
+            raise RuntimeError(
+                f"Variable logger '{variable.varName}' was not added to the simulation"
+            )
+
+        _, moduleVariableName = RetentionPolicy._splitVariableName(variable.varName)
+        logTimes = variable.logger.times()
+        variableData = np.asarray(variable.logger[moduleVariableName])
+        sampleCount = len(logTimes)
+        if sampleCount == 0:
+            componentCount = (
+                variable.stopIndex-variable.startIndex+1
+                if variable.startIndex is not None
+                else 0
+            )
+            emptyData = np.empty((0, componentCount))
+            return simHelpers.addTimeColumn(logTimes, emptyData)
+
+        if variableData.ndim == 0 or variableData.shape[0] != sampleCount:
+            raise RuntimeError(
+                f"Variable logger '{variable.varName}' returned inconsistent sample data"
+            )
+
+        componentCount = variableData.size//sampleCount
+        componentData = variableData.reshape(sampleCount, componentCount)
+        if variable.startIndex is not None:
+            if variable.stopIndex >= componentData.shape[1]:
+                raise IndexError(
+                    f"Legacy component range [{variable.startIndex}, "
+                    f"{variable.stopIndex}] exceeds the width of '{variable.varName}'"
+                )
+            componentData = componentData[
+                :, variable.startIndex:variable.stopIndex+1
+            ]
+
+        return simHelpers.addTimeColumn(logTimes, componentData)
 
     @staticmethod
     def getDataForRetention(simInstance, retentionPolicies):
-        """ Returns the data that should be retained given a simInstance and the retentionPolicies
+        """Return the data selected by a list of retention policies.
 
-        Args:
-            simInstance: The simulation instance to retrieve data from
-            retentionPolicies: A list of RetentionPolicy objects defining the data to retain
+        The returned dictionary contains ``messages``, ``variables``, and
+        ``custom`` sub-dictionaries. Message and variable arrays have simulation
+        time prepended as their first column. Multidimensional variable samples
+        are flattened in row-major order.
 
-        Returns:
-            Retained Data in the form of a dictionary with two sub-dictionaries for messages and variables::
-
-                {
-                    "messages": {
-                        "messageName": [value1,value2,value3]
-                    },
-                    "variables": {
-                        "variableName": [value1,value2,value3]
-                    }
-                }
+        :param simInstance: Simulation instance containing completed recorders.
+        :param list retentionPolicies: Policies defining the data to retain.
+        :return: Retained simulation data grouped by source.
+        :rtype: dict
         """
         data = {"messages": {}, "variables": {}, "custom": {}}
-        df = pd.DataFrame()
-        dataFrames = []
         for retentionPolicy in retentionPolicies:
             for msgParam in retentionPolicy.messageLogList:
-
-                # record the message recording times
-                msgTimes = simInstance.msgRecList[msgParam.msgRecName].times()
-
-                # record the message variables
+                recorder = simInstance.msgRecList[msgParam.msgRecName]
+                msgTimes = recorder.times()
                 for varName in msgParam.retainedVars:
-                    msgData = getattr(simInstance.msgRecList[msgParam.msgRecName], varName)
+                    msgData = getattr(recorder, varName)
                     msgData = simHelpers.addTimeColumn(msgTimes, msgData)
-                    data["messages"][msgParam.msgRecName + "." + varName] = msgData
+                    messageKey = f"{msgParam.msgRecName}.{varName}"
+                    data["messages"][messageKey] = msgData
 
             for variable in retentionPolicy.varLogList:
-                data["variables"][variable.varName] = simInstance.GetLogVariableData(variable.varName)
+                retainedVariableData = RetentionPolicy._getRetainedVariableData(
+                    variable
+                )
+                data["variables"][variable.varName] = retainedVariableData
 
-            for func in retentionPolicy.retentionFunctions:
-                tmpModuleData = func(simInstance)
-                for (key, value) in tmpModuleData.items():
-                    data["custom"][key] = value
+            for retentionFunction in retentionPolicy.retentionFunctions:
+                customData = retentionFunction(simInstance)
+                data["custom"].update(customData)
         return data

--- a/src/utilities/MonteCarlo/_UnitTests/test_retentionPolicy.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_retentionPolicy.py
@@ -1,0 +1,422 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+"""Regression tests for Monte Carlo variable retention."""
+
+import numpy as np
+import pytest
+
+from Basilisk.architecture import sysModel
+from Basilisk.utilities import (
+    SimulationBaseClass,
+    deprecated,
+    macros,
+    pythonVariableLogger,
+    simHelpers,
+)
+from Basilisk.utilities.MonteCarlo.RetentionPolicy import RetentionPolicy
+
+
+class RetainedVariableModel(sysModel.SysModel):
+    """Provide deterministic module variables for retention tests."""
+
+    def __init__(self, modelTag):
+        super().__init__()
+        self.ModelTag = modelTag
+        self.scalarValue = 0.0  # [-]
+        self.vectorOffsets = np.array([0.0, 10.0, 20.0])  # [-]
+        self.vectorValue = self.vectorOffsets.copy()  # [-]
+        self.matrixOffsets = np.array([[0.0, 1.0], [10.0, 11.0]])  # [-]
+        self.matrixValue = self.matrixOffsets.copy()  # [-]
+        self.emptyValue = np.array([])  # [-]
+        self.times = 0.0  # [-]
+        self._getterValue = 0.0  # [-]
+
+    def getGetterValue(self):
+        """Return a value exposed through the standard getter convention."""
+        return self._getterValue
+
+    def UpdateState(self, CurrentSimNanos):
+        """Advance the deterministic values once per task execution."""
+        self.scalarValue += 1.0  # [-]
+        self.vectorValue = self.scalarValue+self.vectorOffsets
+        self.matrixValue = self.scalarValue+self.matrixOffsets
+        self.times = self.scalarValue+30.0  # [-]
+        self._getterValue = self.scalarValue+40.0  # [-]
+
+
+def createVariableSimulation(
+    modelTag="retainedModel",
+    modelPriority=-1,
+    firstStart=0,  # [ns]
+):
+    """Create a short simulation containing one retained-variable model."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    taskName = "retentionTask"
+    taskRate = macros.sec2nano(1.0)  # [ns]
+    process = simulation.CreateNewProcess("retentionProcess")
+    task = simulation.CreateNewTask(taskName, taskRate, FirstStart=firstStart)
+    process.addTask(task)
+
+    model = RetainedVariableModel(modelTag)
+    simulation.AddModelToTask(taskName, model, ModelPriority=modelPriority)
+    stopTime = macros.sec2nano(2.0)  # [ns]
+    simulation.ConfigureStopTime(stopTime)
+    return simulation, task, model, taskRate
+
+
+def executeSimulation(simulation):
+    """Initialize and execute a configured test simulation."""
+    simulation.InitializeSimulation()
+    simulation.ExecuteSimulation()
+
+
+def retainComputedVariable(simulation):
+    """Return a computed logger value in the standard time-column format."""
+    variableLogger = simulation.computedVariableLogger
+    retainedValue = simHelpers.addTimeColumn(
+        variableLogger.times(),
+        variableLogger["doubleScalarValue"],
+    )
+    return {"doubleScalarValue": retainedValue}
+
+
+def test_variable_retention_records_complete_values():
+    """Verify complete scalar, vector, and matrix values include time."""
+    simulation, task, model, taskRate = createVariableSimulation()
+    policy = RetentionPolicy()
+    policy.addVariableLog(f"{model.ModelTag}.scalarValue", logRate=taskRate)
+    policy.addVariableLog(f"{model.ModelTag}.vectorValue", logRate=taskRate)
+    policy.addVariableLog(f"{model.ModelTag}.matrixValue", logRate=taskRate)
+    policy.addVariableLog(f"{model.ModelTag}.times", logRate=taskRate)
+    policy.addVariableLog(f"{model.ModelTag}.getterValue", logRate=taskRate)
+
+    policy.addLogsToSim(simulation)
+    assert len(task.TaskModels) == 6
+    assert all(variable.logger in task.TaskModels for variable in policy.varLogList)
+
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    expectedTimes = np.array([0, taskRate, 2*taskRate])  # [ns]
+    expectedScalars = np.array([1.0, 2.0, 3.0])  # [-]
+    expectedVectors = expectedScalars[:, None]+model.vectorOffsets
+    expectedMatrices = (
+        expectedScalars[:, None]+model.matrixOffsets.reshape(1, -1)
+    )
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.scalarValue"],
+        np.column_stack((expectedTimes, expectedScalars)),
+    )
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.vectorValue"],
+        np.column_stack((expectedTimes, expectedVectors)),
+    )
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.matrixValue"],
+        np.column_stack((expectedTimes, expectedMatrices)),
+    )
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.times"],
+        np.column_stack((expectedTimes, expectedScalars+30.0)),
+    )
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.getterValue"],
+        np.column_stack((expectedTimes, expectedScalars+40.0)),
+    )
+
+
+def test_variable_retention_honors_deprecated_component_range():
+    """Verify legacy inclusive slicing works during its deprecation period."""
+    simulation, _, model, taskRate = createVariableSimulation()
+    policy = RetentionPolicy()
+    with pytest.warns(deprecated.BSKDeprecationWarning, match="complete values"):
+        policy.addVariableLog(
+            f"{model.ModelTag}.vectorValue",
+            startIndex=1,
+            stopIndex=2,
+            varType="double",
+            logRate=taskRate,
+        )
+
+    policy.addLogsToSim(simulation)
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    expectedTimes = np.array([0, taskRate, 2*taskRate])  # [ns]
+    expectedScalars = np.array([1.0, 2.0, 3.0])  # [-]
+    expectedVectors = expectedScalars[:, None]+model.vectorOffsets[1:3]
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.vectorValue"],
+        np.column_stack((expectedTimes, expectedVectors)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("startIndex", "stopIndex", "errorType"),
+    [
+        (-1, 0, ValueError),
+        (2, 1, ValueError),
+        (1.5, 2, TypeError),
+        (True, 1, TypeError),
+    ],
+)
+def test_variable_retention_rejects_invalid_component_range(
+    startIndex,
+    stopIndex,
+    errorType,
+):
+    """Verify deprecated component ranges are valid inclusive indices."""
+    policy = RetentionPolicy()
+
+    with pytest.raises(errorType, match="startIndex and stopIndex"):
+        policy.addVariableLog(
+            "retainedModel.vectorValue",
+            startIndex=startIndex,
+            stopIndex=stopIndex,
+        )
+
+
+def test_variable_retention_handles_no_samples():
+    """Verify a logger whose task never runs returns an empty time-column array."""
+    firstStart = macros.sec2nano(10.0)  # [ns]
+    simulation, _, model, taskRate = createVariableSimulation(
+        firstStart=firstStart
+    )
+    policy = RetentionPolicy()
+    variableName = f"{model.ModelTag}.vectorValue"
+    policy.addVariableLog(variableName, logRate=taskRate)
+
+    policy.addLogsToSim(simulation)
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    assert retainedData["variables"][variableName].shape == (0, 1)
+
+
+def test_variable_retention_handles_zero_component_value():
+    """Verify sampled empty arrays retain their time column without failing."""
+    simulation, _, model, taskRate = createVariableSimulation()
+    policy = RetentionPolicy()
+    variableName = f"{model.ModelTag}.emptyValue"
+    policy.addVariableLog(variableName, logRate=taskRate)
+
+    policy.addLogsToSim(simulation)
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    expectedTimes = np.array([0, taskRate, 2*taskRate])  # [ns]
+    np.testing.assert_array_equal(
+        retainedData["variables"][variableName],
+        expectedTimes[:, None],
+    )
+
+
+def test_custom_variable_logger_retention():
+    """Verify the documented fallback retains a computed variable history."""
+    simulation, task, model, taskRate = createVariableSimulation()
+    simulation.computedVariableLogger = pythonVariableLogger.PythonVariableLogger(
+        {"doubleScalarValue": lambda _: 2.0*model.scalarValue},
+        taskRate,
+    )
+    simulation.AddModelToTask(task.Name, simulation.computedVariableLogger)
+
+    policy = RetentionPolicy()
+    policy.addRetentionFunction(retainComputedVariable)
+
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    expectedTimes = np.array([0, taskRate, 2*taskRate])  # [ns]
+    expectedValues = np.array([2.0, 4.0, 6.0])  # [-]
+    np.testing.assert_array_equal(
+        retainedData["custom"]["doubleScalarValue"],
+        np.column_stack((expectedTimes, expectedValues)),
+    )
+
+
+def test_variable_logger_is_added_only_to_owning_task():
+    """Verify model-tag lookup schedules a logger on the matching task."""
+    simulation = SimulationBaseClass.SimBaseClass()
+    taskRate = macros.sec2nano(1.0)  # [ns]
+    process = simulation.CreateNewProcess("retentionProcess")
+    firstTask = simulation.CreateNewTask("firstTask", taskRate)
+    secondTask = simulation.CreateNewTask("secondTask", taskRate)
+    process.addTask(firstTask)
+    process.addTask(secondTask)
+
+    firstModel = RetainedVariableModel("firstModel")
+    secondModel = RetainedVariableModel("secondModel")
+    simulation.AddModelToTask(firstTask.Name, firstModel)
+    simulation.AddModelToTask(secondTask.Name, secondModel)
+
+    policy = RetentionPolicy()
+    policy.addVariableLog("secondModel.scalarValue", logRate=taskRate)
+    policy.addLogsToSim(simulation)
+
+    variableLogger = policy.varLogList[0].logger
+    assert variableLogger not in firstTask.TaskModels
+    assert variableLogger in secondTask.TaskModels
+
+
+def test_variable_logger_runs_after_negative_priority_model():
+    """Verify retained values are sampled after a low-priority model update."""
+    modelPriority = -10
+    simulation, task, model, taskRate = createVariableSimulation(
+        modelPriority=modelPriority
+    )
+    policy = RetentionPolicy()
+    policy.addVariableLog(f"{model.ModelTag}.scalarValue", logRate=taskRate)
+    policy.addLogsToSim(simulation)
+
+    assert task.TaskModelPriorities[-1] == modelPriority
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    expectedTimes = np.array([0, taskRate, 2*taskRate])  # [ns]
+    expectedScalars = np.array([1.0, 2.0, 3.0])  # [-]
+    np.testing.assert_array_equal(
+        retainedData["variables"][f"{model.ModelTag}.scalarValue"],
+        np.column_stack((expectedTimes, expectedScalars)),
+    )
+
+
+def test_compatible_duplicate_variable_requests_share_logger():
+    """Verify identical requests across policies use one scheduled logger."""
+    simulation, task, model, taskRate = createVariableSimulation()
+    firstPolicy = RetentionPolicy()
+    secondPolicy = RetentionPolicy()
+    variableName = f"{model.ModelTag}.scalarValue"
+    firstPolicy.addVariableLog(variableName, logRate=taskRate)
+    secondPolicy.addVariableLog(variableName, logRate=taskRate)
+
+    RetentionPolicy.addRetentionPoliciesToSim(
+        simulation,
+        [firstPolicy, secondPolicy],
+    )
+
+    firstLogger = firstPolicy.varLogList[0].logger
+    secondLogger = secondPolicy.varLogList[0].logger
+    assert firstLogger is secondLogger
+    assert task.TaskModels.count(firstLogger) == 1
+
+
+def test_conflicting_duplicate_variable_requests_fail():
+    """Verify conflicting settings fail before any logger is scheduled."""
+    simulation, task, model, taskRate = createVariableSimulation()
+    firstPolicy = RetentionPolicy()
+    secondPolicy = RetentionPolicy()
+    variableName = f"{model.ModelTag}.scalarValue"
+    firstPolicy.addVariableLog(variableName, logRate=taskRate)
+    secondPolicy.addVariableLog(variableName, logRate=2*taskRate)
+    initialModelCount = len(task.TaskModels)
+
+    with pytest.raises(ValueError, match="conflicting retention settings"):
+        RetentionPolicy.addRetentionPoliciesToSim(
+            simulation,
+            [firstPolicy, secondPolicy],
+        )
+
+    assert len(task.TaskModels) == initialModelCount
+    assert firstPolicy.varLogList[0].logger is None
+    assert secondPolicy.varLogList[0].logger is None
+
+
+def test_variable_retention_rejects_invalid_identifier_syntax():
+    """Verify invalid identifiers fail before a Monte Carlo run starts."""
+    policy = RetentionPolicy()
+
+    with pytest.raises(ValueError, match="<ModelTag>.<variableName>"):
+        policy.addVariableLog("missingSeparator")
+
+
+def test_variable_retention_supports_dotted_model_tag():
+    """Verify the last period separates a dotted model tag from its variable."""
+    simulation, _, model, taskRate = createVariableSimulation("group.retainedModel")
+    policy = RetentionPolicy()
+    variableName = f"{model.ModelTag}.scalarValue"
+    policy.addVariableLog(variableName, logRate=taskRate)
+
+    policy.addLogsToSim(simulation)
+    executeSimulation(simulation)
+    retainedData = RetentionPolicy.getDataForRetention(simulation, [policy])
+
+    expectedTimes = np.array([0, taskRate, 2*taskRate])  # [ns]
+    expectedScalars = np.array([1.0, 2.0, 3.0])  # [-]
+    np.testing.assert_array_equal(
+        retainedData["variables"][variableName],
+        np.column_stack((expectedTimes, expectedScalars)),
+    )
+
+
+def test_variable_retention_rejects_duplicate_model_tags():
+    """Verify a variable identifier resolves to exactly one scheduled model."""
+    simulation, task, model, taskRate = createVariableSimulation()
+    duplicateModel = RetainedVariableModel(model.ModelTag)
+    simulation.AddModelToTask(task.Name, duplicateModel)
+    policy = RetentionPolicy()
+    policy.addVariableLog(f"{model.ModelTag}.scalarValue", logRate=taskRate)
+
+    with pytest.raises(ValueError, match="not unique"):
+        policy.addLogsToSim(simulation)
+
+
+def test_variable_retention_rejects_nested_variable():
+    """Verify dotted paths below a matching model tag are rejected clearly."""
+    simulation, _, _, _ = createVariableSimulation()
+    policy = RetentionPolicy()
+    policy.addVariableLog("retainedModel.child.value")
+
+    with pytest.raises(ValueError, match="direct module variables only"):
+        policy.addLogsToSim(simulation)
+
+
+@pytest.mark.parametrize(
+    ("logRate", "errorType"),
+    [
+        (-1, ValueError),
+        (1.5, TypeError),
+        (True, TypeError),
+    ],
+)
+def test_variable_retention_rejects_invalid_log_rate(logRate, errorType):
+    """Verify recording periods are nonnegative integer nanoseconds."""
+    policy = RetentionPolicy()
+
+    with pytest.raises(errorType, match="logRate"):
+        policy.addVariableLog("retainedModel.scalarValue", logRate=logRate)
+
+
+@pytest.mark.parametrize(
+    ("variableName", "errorMatch"),
+    [
+        ("missingModel.scalarValue", "Could not find a model"),
+        ("retainedModel.missingVariable", "Cannot log missingVariable"),
+    ],
+)
+def test_variable_retention_rejects_unavailable_model_or_variable(
+    variableName,
+    errorMatch,
+):
+    """Verify unavailable models and variables fail with actionable errors."""
+    simulation, _, _, _ = createVariableSimulation()
+    policy = RetentionPolicy()
+    policy.addVariableLog(variableName)
+
+    with pytest.raises(ValueError, match=errorMatch):
+        policy.addLogsToSim(simulation)

--- a/src/utilities/MonteCarlo/_UnitTests/test_scenarioBasicOrbitMC.py
+++ b/src/utilities/MonteCarlo/_UnitTests/test_scenarioBasicOrbitMC.py
@@ -43,6 +43,8 @@ from Basilisk.simulation import spacecraft
 from Basilisk.utilities import orbitalMotion
 from Basilisk.utilities import simIncludeGravBody
 from Basilisk.utilities import macros
+from Basilisk.utilities import pythonVariableLogger
+from Basilisk.utilities import simHelpers
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities.supportDataTools.dataFetcher import get_path, DataFile
 import shutil
@@ -55,7 +57,9 @@ VERBOSE = True
 PROCESSES = 2
 
 retainedMessageName = "spacecraftStateMsg"
-retainedRate = macros.sec2nano(10)
+retainedRate = macros.sec2nano(10.0)  # [ns]
+retainedVariableName = "bsk-Sat.totOrbEnergy"
+retainedComputedName = "doubleOrbEnergy"
 var1 = "v_BN_N"
 var2 = "r_BN_N"
 
@@ -119,6 +123,11 @@ def myCreationFunction():
     sim.msgRecList = {}
     sim.msgRecList[retainedMessageName] = scObject.scStateOutMsg.recorder(retainedRate)
     sim.AddModelToTask(simTaskName, sim.msgRecList[retainedMessageName])
+    sim.computedVariableLogger = pythonVariableLogger.PythonVariableLogger(
+        {retainedComputedName: lambda _: 2.0*scObject.totOrbEnergy},
+        retainedRate,
+    )
+    sim.AddModelToTask(simTaskName, sim.computedVariableLogger)
 
     #   configure a simulation stop time and execute the simulation run
     sim.ConfigureStopTime(simulationTime)
@@ -130,6 +139,17 @@ def myExecutionFunction(sim):
     """function that executes a simulation"""
     sim.InitializeSimulation()
     sim.ExecuteSimulation()
+
+
+def retainComputedVariable(sim):
+    """Return computed orbital energy in the standard time-column format."""
+    variableLogger = sim.computedVariableLogger
+    return {
+        retainedComputedName: simHelpers.addTimeColumn(
+            variableLogger.times(),
+            variableLogger[retainedComputedName],
+        ),
+    }
 
 
 colorList = ["b", "r", "g", "k"]
@@ -150,6 +170,7 @@ def myDataCallback(monteCarloData, retentionPolicy):
 
 @pytest.mark.slowtest
 def test_MonteCarloSimulation(show_plots):
+    """Verify Monte Carlo retention, archiving, loading, and repeatability."""
     # Test a montecarlo simulation
     dirName = os.path.abspath(os.path.dirname(__file__)) + "/tmp_montecarlo_test"
     monteCarlo = Controller()
@@ -193,6 +214,8 @@ def test_MonteCarloSimulation(show_plots):
     # Add retention policy
     retentionPolicy = RetentionPolicy()
     retentionPolicy.addMessageLog(retainedMessageName, [var1, var2])
+    retentionPolicy.addVariableLog(retainedVariableName, logRate=retainedRate)
+    retentionPolicy.addRetentionFunction(retainComputedVariable)
     retentionPolicy.setDataCallback(myDataCallback)
     monteCarlo.addRetentionPolicy(retentionPolicy)
 
@@ -211,6 +234,22 @@ def test_MonteCarloSimulation(show_plots):
     )
     assert retainedMessageName + ".v_BN_N" in retainedData["messages"], (
         "Retained messages should exist"
+    )
+    assert retainedVariableName in retainedData["variables"], (
+        "Retained module variables should exist"
+    )
+    assert retainedData["variables"][retainedVariableName].shape[1] == 2, (
+        "Retained scalar variables should contain time and value columns"
+    )
+    assert retainedComputedName in retainedData["custom"], (
+        "Computed module variables should be retained as custom data"
+    )
+    directVariableData = retainedData["variables"][retainedVariableName]
+    computedVariableData = retainedData["custom"][retainedComputedName]
+    np.testing.assert_allclose(computedVariableData[:, 0], directVariableData[:, 0])
+    np.testing.assert_allclose(
+        computedVariableData[:, 1],
+        2.0*directVariableData[:, 1],
     )
 
     # rerun the case and it should be the same, because we dispersed random seeds


### PR DESCRIPTION
* **Tickets addressed:** #1459
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Restores Monte Carlo variable retention after removal of the legacy `SimBaseClass.AddVariableForLogging()` and `GetLogVariableData()` APIs.

`RetentionPolicy.addVariableLog()` now:

- Resolves uniquely tagged models and uses their supported `logger()` API.
- Schedules generated loggers on the owning task after existing models.
- Retains complete scalar, vector, and multidimensional values, flattening multidimensional samples in row-major order.
- Shares compatible duplicate requests and rejects conflicting requests before modifying the simulation.
- Supports model tags containing periods.
- Provides actionable errors for unsupported nested or computed expressions.
- Temporarily supports the legacy `startIndex`, `stopIndex`, and `varType` arguments, deprecated for removal after August 26, 2027.

Nested or computed histories should use an explicitly scheduled `PythonVariableLogger` and `addRetentionFunction()`.

The commits are organized for review as follows:

1. `23e124f10f` — implementation and focused regression tests.
2. `98366377b9` — multiprocessing and archive/reload integration coverage.
3. `63ff1acbfc` — user documentation, known-issue update, and release-note snippet.

## Verification

Added focused unit coverage for:

- Scalar, vector, matrix, getter-backed, and zero-component values.
- Row-major flattening and time-column output.
- Legacy component selection and deprecation warnings.
- Dotted and duplicate model tags.
- Missing models, variables, and unsupported nested expressions.
- Invalid rates and component ranges.
- Logger scheduling priority and owning-task selection.
- Compatible and conflicting duplicate requests.
- Empty sample histories.
- Computed-history retention using `PythonVariableLogger`.

The existing Monte Carlo integration test now verifies direct and computed variable retention through multiprocessing, archive creation, controller reload, and retained-data retrieval.

Validation completed:

- 44 Monte Carlo and variable-logger tests passed.
- 87 `SimulationBaseClass` tests passed.
- 22 focused retention tests passed with warnings treated as errors.
- Pre-commit hooks, spelling checks, Python compilation, and `git diff --check` passed.
- Updated RST content parsed successfully and all README Python blocks compiled.

The complete repository test suite and full Sphinx build were not run.

## Documentation

Updated:

- `src/utilities/MonteCarlo/README.md` with the supported retention workflow, output layout, migration guidance, and computed-variable fallback.
- `docs/source/Support/bskKnownIssues.rst` to record the issue and resolution.
- `docs/source/Support/bskReleaseNotesSnippets/1459-monte-carlo-variable-retention.rst` with the user-facing release note.

Reviewers should verify the direct-variable restrictions, legacy-argument migration guidance, logger scheduling requirements, and retained array column conventions.

## Future work

Remove the deprecated `startIndex`, `stopIndex`, and `varType` compatibility arguments after August 26, 2027. No other follow-up work is currently anticipated.