### PR TITLE
Fix vizInterface streaming memory leaks

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -88,6 +88,14 @@ Version |release| (July 7, 2026)
 - The :ref:`FuelTank` emptying model computed the fuel COM and transverse inertia derivatives
   incorrectly except at the half-full condition, producing wrong high-fidelity depletion torques.
   The derivative equations and their finite-difference coverage are corrected in the current version.
+- :ref:`vizInterface` leaked its protobuffer message on frames that did not reach a successful save-file
+  write, including live-stream-only, broadcast-only, and camera-image early-return paths. It also leaked
+  serialized buffers on broadcast-only frames, during re-serialization after removing the settings block,
+  and while copying synchronization settings, as well as a heap allocation for every Vizard event reply.
+  These leaks are fixed in the current version.
+- :ref:`vizInterface` called ``google::protobuf::ShutdownProtobufLibrary()`` after qualifying successful
+  save-file frames, releasing protobuf's internal state while the module was still running. Other frames
+  skipped the call through guards or early returns. This is fixed in the current version.
 
 
 Version 2.11.0 (July 7, 2026)

--- a/docs/source/Support/bskReleaseNotesSnippets/vizinterface-broadcast-memory-leak.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/vizinterface-broadcast-memory-leak.rst
@@ -1,0 +1,4 @@
+- Fixed :ref:`vizInterface` leaking its protobuffer message when a frame did not reach a successful save-file write, including live-stream-only, broadcast-only, and camera-image early-return paths.
+- Fixed :ref:`vizInterface` leaking the serialized protobuffer buffer on broadcast-only frames and orphaning it when the message was re-serialized after its settings block was removed.
+- Fixed :ref:`vizInterface` leaking the copied synchronization-settings broadcast buffer and a heap allocation for every Vizard event reply.
+- :ref:`vizInterface` no longer calls ``google::protobuf::ShutdownProtobufLibrary()`` after qualifying successful save-file frames, which released protobuf's internal state while the module was still running.

--- a/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
+++ b/src/simulation/vizard/vizInterface/_UnitTest/test_vizInterface.py
@@ -24,11 +24,13 @@
 #   Creation Date:      November 4, 2024
 #
 
+import gc
 import inspect
 import os
 import tempfile
 
 import numpy as np
+import psutil
 import pytest
 
 # Protobuffer-specific modules are generated with vizInterface.
@@ -138,6 +140,68 @@ def test_vizInterface_closes_output_files(tmp_path):
 
     del viz
     second_output.unlink()
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=0)
+def test_vizInterface_broadcast_without_subscriber():
+    r"""Verify that broadcast-only execution remains memory-bounded without a Vizard subscriber.
+
+    This exercises the publisher serialization path and the no-save-file return
+    path over multiple frames. RSS is sampled after an initial warm-up so one-time
+    Python, protobuf, and ZeroMQ allocations are excluded from the measured growth.
+    A subscriber is intentionally absent because a ZeroMQ publisher must be able
+    to operate without one.
+    """
+    taskRate = macros.sec2nano(0.01)  # [ns]
+    warmupFrames = 200
+    measuredFrames = 2000
+    totalFrames = warmupFrames + measuredFrames
+    warmupTime = warmupFrames * taskRate  # [ns]
+    simulationTime = totalFrames * taskRate  # [ns]
+    # Comparable macOS soak runs grew about 0.5 MiB with the fix and more than
+    # 4.5 MiB with the original leak; this limit allows for allocator noise.
+    maxAllowedGrowth = 3.0  # [MiB]
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    testProcess = unitTestSim.CreateNewProcess("broadcastProcess")
+    testProcess.addTask(unitTestSim.CreateNewTask("broadcastTask", taskRate))
+
+    spacecraftModel = spacecraft.Spacecraft()
+    spacecraftModel.ModelTag = "broadcastSat"
+    unitTestSim.AddModelToTask("broadcastTask", spacecraftModel)
+
+    viz = vizSupport.enableUnityVisualization(
+        unitTestSim,
+        "broadcastTask",
+        spacecraftModel,
+        saveFile=None,
+        liveStream=False,
+        broadcastStream=True,
+    )
+
+    viz.pubComAddress = "127.0.0.1"
+    viz.pubPortNumber = "*"
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(warmupTime)
+    unitTestSim.ExecuteSimulation()
+
+    process = psutil.Process(os.getpid())
+    gc.collect()
+    initialMemory = process.memory_info().rss / 1024**2  # [MiB]
+
+    unitTestSim.ConfigureStopTime(simulationTime)
+    unitTestSim.ExecuteSimulation()
+
+    gc.collect()
+    finalMemory = process.memory_info().rss / 1024**2  # [MiB]
+    memoryGrowth = finalMemory - initialMemory  # [MiB]
+
+    assert viz.FrameNumber == totalFrames
+    assert memoryGrowth < maxAllowedGrowth, (
+        f"Broadcast-only RSS grew by {memoryGrowth:.2f} MiB over {measuredFrames} frames; "
+        f"expected less than {maxAllowedGrowth:.2f} MiB."
+    )
 
 
 def vizInterfaceTest(show_plots, accuracy, output_file):

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1237,18 +1237,17 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             zmq_msg_t empty_frame2;
             zmq_msg_t request_buffer;
 
+            if (zmq_msg_init_size(&request_buffer, serializedMessage.size()) != 0) {
+                bskLogger.bskError("Vizard 2-way request buffer allocation failed.");
+            }
+            memcpy(zmq_msg_data(&request_buffer), serializedMessage.data(), serializedMessage.size());
+
             void* header_message = malloc(10 * sizeof(char));
             memcpy(header_message, "SIM_UPDATE", 10);
-
-            // ZMQ owns this buffer and frees it via message_buffer_deallocate().
-            void* request_message = malloc(serializedMessage.size());
-            memcpy(request_message, serializedMessage.data(), serializedMessage.size());
 
             zmq_msg_init_data(&request_header, header_message, 10, message_buffer_deallocate, NULL);
             zmq_msg_init(&empty_frame1);
             zmq_msg_init(&empty_frame2);
-            zmq_msg_init_data(&request_buffer, request_message, serializedMessage.size(),
-                              message_buffer_deallocate, NULL);
 
             // Send to 2-WAY (REQUESTER) socket
             zmq_msg_send(&request_header, this->requester_socket, ZMQ_SNDMORE);
@@ -1407,70 +1406,64 @@ void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
         void* vizPoint = zmq_msg_data(&viz_response);
 
         // Set up and fill VizInput message
-        vizProtobufferMessage::VizInput* msgRecv = new vizProtobufferMessage::VizInput;
-        msgRecv->ParseFromArray(vizPoint, vizPointSize);
+        vizProtobufferMessage::VizInput msgRecv;
+        msgRecv.ParseFromArray(vizPoint, vizPointSize);
 
         // Set up output VizUserInputMsgPayload message
         VizUserInputMsgPayload outMsgBuffer;
         outMsgBuffer = this->userInputMsg.zeroMsgPayload;
-        outMsgBuffer.frameNumber = static_cast<int>(msgRecv->framenumber());
+        outMsgBuffer.frameNumber = static_cast<int>(msgRecv.framenumber());
 
         // Parse keyboard inputs
-        const std::string& keys = msgRecv->keyinputs().keys();
+        const std::string& keys = msgRecv.keyinputs().keys();
         if (keys.length() > 0) {
             outMsgBuffer.keyboardInput = keys;
         }
 
         // Receive VizBroadcastSyncSettings
-        const vizProtobufferMessage::VizBroadcastSyncSettings* vbss = &(msgRecv->broadcastsyncsettings());
-        // Remove "const"ness for compatibility with protobuffer access methods
-        vizProtobufferMessage::VizBroadcastSyncSettings* vbss_nc;
-        vbss_nc = const_cast<vizProtobufferMessage::VizBroadcastSyncSettings*>(vbss);
+        vizProtobufferMessage::VizBroadcastSyncSettings* broadcastSyncSettings =
+            msgRecv.mutable_broadcastsyncsettings();
 
         // Iterate through VizEventReply objects
-        for (int i=0; i<msgRecv->replies_size(); i++) {
-            const vizProtobufferMessage::VizEventReply* ver = &(msgRecv->replies(i));
-
-            // Remove "const"ness for compatibility with protobuffer access methods
-            vizProtobufferMessage::VizEventReply* ver_nc;
-            ver_nc = const_cast<vizProtobufferMessage::VizEventReply*>(ver);
+        for (int i=0; i<msgRecv.replies_size(); i++) {
+            const vizProtobufferMessage::VizEventReply& reply = msgRecv.replies(i);
 
             // Create EventReply containers and pack into userInputMsg
-            VizEventReply* er = new VizEventReply();
-            er->eventHandlerID = *(ver_nc->mutable_eventhandlerid());
-            er->reply = *(ver_nc->mutable_reply());
-            er->eventHandlerDestroyed = ver_nc->eventhandlerdestroyed();
-            outMsgBuffer.vizEventReplies.push_back(*er);
+            VizEventReply eventReply;
+            eventReply.eventHandlerID = reply.eventhandlerid();
+            eventReply.reply = reply.reply();
+            eventReply.eventHandlerDestroyed = reply.eventhandlerdestroyed();
+            outMsgBuffer.vizEventReplies.push_back(eventReply);
 
             // Populate VizEventReply in VizBroadcastSyncSettings
-            vizProtobufferMessage::VizEventReply* ver_nc_bss = vbss_nc->add_dialogevents();
-            ver_nc_bss->set_eventhandlerid(er->eventHandlerID);
-            ver_nc_bss->set_reply(er->reply);
-            ver_nc_bss->set_eventhandlerdestroyed(er->eventHandlerDestroyed);
+            vizProtobufferMessage::VizEventReply* broadcastReply =
+                broadcastSyncSettings->add_dialogevents();
+            broadcastReply->set_eventhandlerid(eventReply.eventHandlerID);
+            broadcastReply->set_reply(eventReply.reply);
+            broadcastReply->set_eventhandlerdestroyed(eventReply.eventHandlerDestroyed);
         }
 
-        // Serialize and send BroadcastSyncSettings*/
-        uint32_t syncByteCount = (uint32_t) vbss_nc->ByteSizeLong();
+        // Serialize and send broadcast synchronization settings
+        const size_t syncByteCount = broadcastSyncSettings->ByteSizeLong();
 
         // Serialize if in broadcastStream mode
         if (syncByteCount > 0 && this->broadcastStream) {
-            void* sync_settings = malloc(syncByteCount);
-            vbss_nc->SerializeToArray(sync_settings, (int) syncByteCount);
+            std::string serializedSyncSettings;
+            broadcastSyncSettings->SerializeToString(&serializedSyncSettings);
 
-            // Send sync settings message to BROADCAST (PUBLISHER) socket */
+            // Send sync settings message to BROADCAST (PUBLISHER) socket
             int sendStatus = zmq_send(this->publisher_socket, "SYNC_SETTINGS", 13, ZMQ_SNDMORE);
             if (sendStatus == -1) {
                 bskLogger.bskError("Broadcast header did not send to socket.");
             }
-            sendStatus = zmq_send(this->publisher_socket, sync_settings, syncByteCount, 0);
+            sendStatus = zmq_send(this->publisher_socket, serializedSyncSettings.data(),
+                                  serializedSyncSettings.size(), 0);
             if (sendStatus == -1) {
                 bskLogger.bskError("Broadcast protobuffer did not send to socket.");
             }
         }
 
         this->userInputMsg.write(&outMsgBuffer, this->moduleID, CurrentSimNanos);
-
-        delete msgRecv;
     }
     else {
         bskLogger.bskError("Vizard 2-way [2]: Did not return a user input message.");

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1318,9 +1318,6 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
         }
         this->outputStream.flush();
     }
-
-    google::protobuf::ShutdownProtobufLibrary();
-
 }
 
 /*! Update this module at the task rate

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -1171,10 +1171,9 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
 
     {
 
-        // Serialize message (as is)
-        uint32_t byteCount = (uint32_t) message->ByteSizeLong();
-        void* serialized_message = malloc(byteCount);
-        message->SerializeToArray(serialized_message, (int) byteCount);
+        // Serialize message (as is). zmq_send() copies, so this buffer stays ours.
+        std::string serializedMessage;
+        message->SerializeToString(&serializedMessage);
 
         // BROADCAST MODE
         if (this->broadcastStream) {
@@ -1183,7 +1182,7 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             if (sendStatus == -1) {
                 bskLogger.bskError("Broadcast header did not send to socket.");
             }
-            sendStatus = zmq_send(this->publisher_socket, serialized_message, byteCount, 0);
+            sendStatus = zmq_send(this->publisher_socket, serializedMessage.data(), serializedMessage.size(), 0);
             if (sendStatus == -1) {
                 bskLogger.bskError("Broadcast protobuffer did not send to socket.");
             }
@@ -1201,15 +1200,14 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
 
             // Re-serialize
             google::protobuf::uint8 varIntBuffer[4];
-            byteCount = (uint32_t) message->ByteSizeLong();
+            uint32_t byteCount = (uint32_t) message->ByteSizeLong();
             google::protobuf::uint8 *end = google::protobuf::io::CodedOutputStream::WriteVarint32ToArray(byteCount, varIntBuffer);
             unsigned long varIntBytes = (unsigned long) (end - varIntBuffer);
             // Save message to file if saveFile flag is true, and if Vizard is not being terminated
             if (this->saveFile && !this->liveSettings.terminateVizard) {
                 this->outputStream.write(reinterpret_cast<char*>(varIntBuffer), static_cast<int>(varIntBytes));
             }
-            serialized_message = malloc(byteCount);
-            message->SerializeToArray(serialized_message, (int) byteCount);
+            message->SerializeToString(&serializedMessage);
         }
 
         // Check whether noDisplay mode should generate imagery from Vizard at this timestep
@@ -1242,10 +1240,15 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             void* header_message = malloc(10 * sizeof(char));
             memcpy(header_message, "SIM_UPDATE", 10);
 
+            // ZMQ owns this buffer and frees it via message_buffer_deallocate().
+            void* request_message = malloc(serializedMessage.size());
+            memcpy(request_message, serializedMessage.data(), serializedMessage.size());
+
             zmq_msg_init_data(&request_header, header_message, 10, message_buffer_deallocate, NULL);
             zmq_msg_init(&empty_frame1);
             zmq_msg_init(&empty_frame2);
-            zmq_msg_init_data(&request_buffer, serialized_message, byteCount, message_buffer_deallocate, NULL);
+            zmq_msg_init_data(&request_buffer, request_message, serializedMessage.size(),
+                              message_buffer_deallocate, NULL);
 
             // Send to 2-WAY (REQUESTER) socket
             zmq_msg_send(&request_header, this->requester_socket, ZMQ_SNDMORE);

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "vizInterface.h"
@@ -501,7 +502,7 @@ void VizInterface::ReadBSKMessages()
  */
 void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
 {
-    vizProtobufferMessage::VizMessage* message = new vizProtobufferMessage::VizMessage;
+    auto message = std::make_unique<vizProtobufferMessage::VizMessage>();
 
     /*! Send the Vizard settings according to interval set by broadcastSettingsSendDelay field */
     this->now = time(0);
@@ -1315,7 +1316,6 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
         this->outputStream.flush();
     }
 
-    delete message;
     google::protobuf::ShutdownProtobufLibrary();
 
 }

--- a/src/simulation/vizard/vizInterface/vizInterface.cpp
+++ b/src/simulation/vizard/vizInterface/vizInterface.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 #include <string>
 
@@ -31,7 +32,43 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "architecture/utilities/astroConstants.h"
 
-void message_buffer_deallocate(void *data, void *hint);
+namespace {
+
+/*! Scoped owner for an initialized ZeroMQ message. */
+class ZmqMessage {
+public:
+    ZmqMessage() : initialized(zmq_msg_init(&this->message) == 0) {}
+
+    explicit ZmqMessage(size_t size) : initialized(zmq_msg_init_size(&this->message, size) == 0) {}
+
+    ZmqMessage(const void* data, size_t size) : ZmqMessage(size)
+    {
+        if (this->initialized) {
+            std::memcpy(this->data(), data, size);
+        }
+    }
+
+    ~ZmqMessage()
+    {
+        if (this->initialized) {
+            zmq_msg_close(&this->message);
+        }
+    }
+
+    ZmqMessage(const ZmqMessage&) = delete;
+    ZmqMessage& operator=(const ZmqMessage&) = delete;
+
+    bool isInitialized() const { return this->initialized; }
+    void* data() { return zmq_msg_data(&this->message); }
+    size_t size() const { return zmq_msg_size(&this->message); }
+    zmq_msg_t* get() { return &this->message; }
+
+private:
+    zmq_msg_t message;
+    bool initialized;
+};
+
+}  // namespace
 
 /*! VizInterface Constructor
  */
@@ -118,20 +155,18 @@ void VizInterface::Reset(uint64_t CurrentSimNanos [[maybe_unused]])
             bskLogger.bskError("%s", text.c_str());
         }
 
-        void* message = malloc(4 * sizeof(char));
-        memcpy(message, "PING", 4);
-        zmq_msg_t request;
-
         text = "Waiting for Vizard at " + this->reqComProtocol + "://" + this->reqComAddress + ":" + this->reqPortNumber;
         bskLogger.bskLog(BSK_INFORMATION, "%s", text.c_str());
 
-        zmq_msg_init_data(&request, message, 4, message_buffer_deallocate, NULL);
-        zmq_msg_send(&request, this->requester_socket, 0);
+        ZmqMessage request("PING", 4);
+        if (!request.isInitialized()) {
+            bskLogger.bskError("Failed to initialize the Vizard connection request.");
+        }
+        zmq_msg_send(request.get(), this->requester_socket, 0);
         char buffer[4];
         zmq_recv (this->requester_socket, buffer, 4, 0);
         zmq_send (this->requester_socket, "PING", 4, 0);
         bskLogger.bskLog(BSK_INFORMATION, "Basilisk-Vizard connection made");
-        zmq_msg_close(&request);
     }
 
     std::vector<VizSpacecraftData>::iterator scIt;
@@ -1226,39 +1261,36 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
             if (this->firstPass < 11){
                 this->firstPass++;
             }
-            zmq_msg_t receive_buffer;
-            zmq_msg_init(&receive_buffer);
-            zmq_msg_recv (&receive_buffer, requester_socket, 0);
-            zmq_msg_close(&receive_buffer);
+            ZmqMessage receiveBuffer;
+            if (!receiveBuffer.isInitialized()) {
+                bskLogger.bskError("Failed to initialize the Vizard receive buffer.");
+            }
+            zmq_msg_recv(receiveBuffer.get(), requester_socket, 0);
 
             /*! - Normal sim step by sending protobuffers */
-            zmq_msg_t request_header;
-            zmq_msg_t empty_frame1;
-            zmq_msg_t empty_frame2;
-            zmq_msg_t request_buffer;
+            {
+                ZmqMessage requestHeader("SIM_UPDATE", 10);
+                if (!requestHeader.isInitialized()) {
+                    bskLogger.bskError("Failed to initialize the Vizard request header.");
+                }
 
-            if (zmq_msg_init_size(&request_buffer, serializedMessage.size()) != 0) {
-                bskLogger.bskError("Vizard 2-way request buffer allocation failed.");
+                ZmqMessage emptyFrame1;
+                ZmqMessage emptyFrame2;
+                if (!emptyFrame1.isInitialized() || !emptyFrame2.isInitialized()) {
+                    bskLogger.bskError("Failed to initialize the Vizard request delimiter frames.");
+                }
+
+                ZmqMessage requestBuffer(serializedMessage.data(), serializedMessage.size());
+                if (!requestBuffer.isInitialized()) {
+                    bskLogger.bskError("Failed to initialize the Vizard request buffer.");
+                }
+
+                // Send to 2-WAY (REQUESTER) socket
+                zmq_msg_send(requestHeader.get(), this->requester_socket, ZMQ_SNDMORE);
+                zmq_msg_send(emptyFrame1.get(), this->requester_socket, ZMQ_SNDMORE);
+                zmq_msg_send(emptyFrame2.get(), this->requester_socket, ZMQ_SNDMORE);
+                zmq_msg_send(requestBuffer.get(), this->requester_socket, 0);
             }
-            memcpy(zmq_msg_data(&request_buffer), serializedMessage.data(), serializedMessage.size());
-
-            void* header_message = malloc(10 * sizeof(char));
-            memcpy(header_message, "SIM_UPDATE", 10);
-
-            zmq_msg_init_data(&request_header, header_message, 10, message_buffer_deallocate, NULL);
-            zmq_msg_init(&empty_frame1);
-            zmq_msg_init(&empty_frame2);
-
-            // Send to 2-WAY (REQUESTER) socket
-            zmq_msg_send(&request_header, this->requester_socket, ZMQ_SNDMORE);
-            zmq_msg_send(&empty_frame1, this->requester_socket, ZMQ_SNDMORE);
-            zmq_msg_send(&empty_frame2, this->requester_socket, ZMQ_SNDMORE);
-            zmq_msg_send(&request_buffer, this->requester_socket, 0);
-
-            zmq_msg_close(&request_header);
-            zmq_msg_close(&empty_frame1);
-            zmq_msg_close(&empty_frame2);
-            zmq_msg_close(&request_buffer);
 
             // Receive status message from Vizard after SIM_UPDATE
             if (this->liveSettings.terminateVizard) {
@@ -1267,13 +1299,15 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                 this->noDisplay = false;
             }
             else {
-                zmq_msg_t receiveOK;
-                zmq_msg_init(&receiveOK);
-                int receive_status = zmq_msg_recv(&receiveOK, this->requester_socket, 0);
+                ZmqMessage receiveOK;
+                if (!receiveOK.isInitialized()) {
+                    bskLogger.bskError("Failed to initialize the Vizard status response.");
+                }
+                int receive_status = zmq_msg_recv(receiveOK.get(), this->requester_socket, 0);
                 if (receive_status) {
                     // Make sure "OK" was received from Vizard
-                    void* msgData = zmq_msg_data(&receiveOK);
-                    size_t msgSize = zmq_msg_size(&receiveOK);
+                    void* msgData = receiveOK.data();
+                    size_t msgSize = receiveOK.size();
                     std::string receiveOKStr (static_cast<char*>(msgData), msgSize);
                     std::string errStatusStr = "OK";
                     if (receiveOKStr.compare(errStatusStr) != 0) {
@@ -1283,7 +1317,6 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                 else {
                     bskLogger.bskError("Vizard: Did not return a status (OK) message during SIM_UPDATE.");
                 }
-                zmq_msg_close(&receiveOK);
 
                 // Only handle user input if in liveStream mode (and not in noDisplay mode)
                 if (this->liveStream) {
@@ -1300,12 +1333,11 @@ void VizInterface::WriteProtobuffer(uint64_t CurrentSimNanos)
                 }
                 if (returnCamImgStatus) {
                     /*! -- Ping the Viz back to continue the lock-step */
-                    void* keep_alive = malloc(4 * sizeof(char));
-                    memcpy(keep_alive, "PING", 4);
-                    zmq_msg_t request_life;
-                    zmq_msg_init_data(&request_life, keep_alive, 4, message_buffer_deallocate, NULL);
-                    zmq_msg_send(&request_life, this->requester_socket, 0);
-                    zmq_msg_close(&request_life);
+                    ZmqMessage requestLife("PING", 4);
+                    if (!requestLife.isInitialized()) {
+                        bskLogger.bskError("Failed to initialize the Vizard keep-alive request.");
+                    }
+                    zmq_msg_send(requestLife.get(), this->requester_socket, 0);
                     return;
                 }
             }
@@ -1369,18 +1401,19 @@ void VizInterface::addCamMsgToModule(Message<CameraConfigMsgPayload> *tmpMsg)
 void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
 
     // Send "REQUEST_INPUT" to elicit a response from Vizard
-    void* request_input_str = malloc(13 * sizeof(char));
-    memcpy(request_input_str, "REQUEST_INPUT", 13);
-    zmq_msg_t request_input_msg;
-    zmq_msg_init_data(&request_input_msg, request_input_str, 13, message_buffer_deallocate, NULL);
-    zmq_msg_send(&request_input_msg, this->requester_socket, 0);
-    zmq_msg_close(&request_input_msg);
+    ZmqMessage requestInput("REQUEST_INPUT", 13);
+    if (!requestInput.isInitialized()) {
+        bskLogger.bskError("Failed to initialize the Vizard user-input request.");
+    }
+    zmq_msg_send(requestInput.get(), this->requester_socket, 0);
 
     /* Expect Vizard to send a status string on the socket, then the protobuffer
             Status string can be: "VIZARD_INPUT" or "ERROR" */
-    zmq_msg_t viz_response;
-    zmq_msg_init(&viz_response);
-    int receive_status = zmq_msg_recv(&viz_response, this->requester_socket, 0);
+    ZmqMessage vizResponse;
+    if (!vizResponse.isInitialized()) {
+        bskLogger.bskError("Failed to initialize the Vizard user-input response.");
+    }
+    int receive_status = zmq_msg_recv(vizResponse.get(), this->requester_socket, 0);
 
     // If socket was empty, throw an error and exit
     if (receive_status == -1) {
@@ -1388,8 +1421,8 @@ void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
     }
     // Else, parse the status string and ensure Vizard did not send "ERROR"
     else {
-        void* msgData = zmq_msg_data(&viz_response);
-        size_t msgSize = zmq_msg_size(&viz_response);
+        void* msgData = vizResponse.data();
+        size_t msgSize = vizResponse.size();
         std::string receive_status_str (static_cast<char*>(msgData), msgSize);
         std::string err_status_str = "ERROR";
         if (receive_status_str.compare(err_status_str) == 0) {
@@ -1398,12 +1431,12 @@ void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
     }
 
     // Retrieve protobuffer from socket
-    receive_status = zmq_msg_recv(&viz_response, this->requester_socket, 0);
+    receive_status = zmq_msg_recv(vizResponse.get(), this->requester_socket, 0);
 
     if (receive_status != -1) {
         // Extract message size and data pointer from socket
-        int vizPointSize = (int)zmq_msg_size(&viz_response);
-        void* vizPoint = zmq_msg_data(&viz_response);
+        int vizPointSize = (int)vizResponse.size();
+        void* vizPoint = vizResponse.data();
 
         // Set up and fill VizInput message
         vizProtobufferMessage::VizInput msgRecv;
@@ -1468,9 +1501,6 @@ void VizInterface::receiveUserInput(uint64_t CurrentSimNanos){
     else {
         bskLogger.bskError("Vizard 2-way [2]: Did not return a user input message.");
     }
-
-    zmq_msg_close(&viz_response);
-
 }
 
 
@@ -1481,36 +1511,32 @@ void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
     /*! -- Send request */
     std::string cmdMsg = "REQUEST_IMAGE_";
     cmdMsg += std::to_string(this->cameraConfigBuffers[camCounter].cameraID);
-    void* img_message = malloc(cmdMsg.length() * sizeof(char));
-    memcpy(img_message, cmdMsg.c_str(), cmdMsg.length());
-    zmq_msg_t img_request;
-    zmq_msg_init_data(&img_request, img_message, cmdMsg.length(), message_buffer_deallocate, NULL);
-    zmq_msg_send(&img_request, this->requester_socket, 0);
-    zmq_msg_close(&img_request);
+    ZmqMessage imageRequest(cmdMsg.data(), cmdMsg.size());
+    if (!imageRequest.isInitialized()) {
+        bskLogger.bskError("Failed to initialize the Vizard image request.");
+    }
+    zmq_msg_send(imageRequest.get(), this->requester_socket, 0);
 
-    zmq_msg_t length;
-    zmq_msg_t image;
-    zmq_msg_init(&length);
-    zmq_msg_init(&image);
+    ZmqMessage length;
+    ZmqMessage image;
+    if (!length.isInitialized() || !image.isInitialized()) {
+        bskLogger.bskError("Failed to initialize the Vizard image response.");
+    }
     if (this->bskImagePtrs[camCounter] != NULL) {
         /*! If the permanent image buffer is not populated, it will be equal to null*/
         free(this->bskImagePtrs[camCounter]);
         this->bskImagePtrs[camCounter] = NULL;
     }
-    if (zmq_msg_recv(&length, this->requester_socket, 0) == -1
-        || zmq_msg_recv(&image, this->requester_socket, 0) == -1) {
-        zmq_msg_close(&length);
-        zmq_msg_close(&image);
+    if (zmq_msg_recv(length.get(), this->requester_socket, 0) == -1
+        || zmq_msg_recv(image.get(), this->requester_socket, 0) == -1) {
         bskLogger.bskError("Vizard image response was not received.");
     }
-    if (zmq_msg_size(&length) < sizeof(int32_t)) {
-        zmq_msg_close(&length);
-        zmq_msg_close(&image);
+    if (length.size() < sizeof(int32_t)) {
         bskLogger.bskError("Vizard image response length field is invalid.");
     }
 
-    int32_t *lengthPoint= (int32_t *)zmq_msg_data(&length);
-    void *imagePoint= zmq_msg_data(&image);
+    int32_t *lengthPoint= (int32_t *)length.data();
+    void *imagePoint= image.data();
     const uint32_t lengthUnswapped = static_cast<uint32_t>(*lengthPoint);
     /*! --  Endianness switch for the length of the buffer */
     const uint32_t imageBufferLengthUnsigned =((lengthUnswapped>>24)&0xffU) | // move byte 3 to byte 0
@@ -1519,9 +1545,7 @@ void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
                                                ((lengthUnswapped<<24)&0xff000000U); // byte 0 to byte 3
 
     if (imageBufferLengthUnsigned > static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) ||
-        static_cast<size_t>(imageBufferLengthUnsigned) != zmq_msg_size(&image)) {
-        zmq_msg_close(&length);
-        zmq_msg_close(&image);
+        static_cast<size_t>(imageBufferLengthUnsigned) != image.size()) {
         bskLogger.bskError("Vizard image response buffer length is invalid.");
     }
     const int32_t imageBufferLength = static_cast<int32_t>(imageBufferLengthUnsigned);
@@ -1531,8 +1555,6 @@ void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
     if (imageBufferLength > 0) {
         this->bskImagePtrs[camCounter] = malloc(imageBufferSize * sizeof(char));
         if (this->bskImagePtrs[camCounter] == NULL) {
-            zmq_msg_close(&length);
-            zmq_msg_close(&image);
             bskLogger.bskError("Vizard image response buffer allocation failed.");
         }
         memcpy(this->bskImagePtrs[camCounter], imagePoint, imageBufferSize * sizeof(char));
@@ -1548,19 +1570,4 @@ void VizInterface::requestImage(size_t camCounter, uint64_t CurrentSimNanos)
     imageData.imageType = 4;
     if (imageBufferLength>0){imageData.valid = 1;}
     this->opnavImageOutMsgs[camCounter]->write(&imageData, this->moduleID, CurrentSimNanos);
-
-    /*! -- Clean the messages to avoid memory leaks */
-    zmq_msg_close(&length);
-    zmq_msg_close(&image);
-}
-
-
-
-/*! A cleaning method to ensure the message buffers are wiped clean.
- @param data The current sim time in nanoseconds
- @param hint
- */
-void message_buffer_deallocate(void *data, void * hint [[maybe_unused]])
-{
-    free (data);
 }


### PR DESCRIPTION
* **Tickets addressed:** #1517
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

Fixes #1517.
Closes #1518 as superseded by this PR.

## Description

This PR supersedes #1518 and preserves the original developer’s authorship while incorporating the additional fixes and review improvements developed on this branch.

The implementation replaces manual ownership in `vizInterface` with scoped C++ ownership:

- Owns each `VizMessage` with `std::unique_ptr`, ensuring cleanup on every return path.
- Serializes protobuf messages into owning `std::string` buffers.
- Removes per-timestep calls to `google::protobuf::ShutdownProtobufLibrary()`.
- Eliminates additional leaks in two-way streaming, synchronization settings, and event replies.
- Introduces a local `ZmqMessage` RAII wrapper so initialized `zmq_msg_t` resources are closed on normal and error exits.
- Adds memory-regression coverage for broadcast operation without a Vizard subscriber.

The commits are organized for review by intent: primary message ownership, serialized-buffer ownership, protobuf shutdown, remaining streaming leaks, ZeroMQ RAII, regression coverage, and documentation.

## Verification

- Built the `vizInterface` target successfully with strict compiler warnings enabled.
- Ran the focused `vizInterface` test suite: 4 tests passed.
- Ran the same suite with two pytest-xdist workers: 4 tests passed.
- Added a broadcast-only regression test that:
  - Requires no Vizard subscriber.
  - Uses a ZeroMQ wildcard endpoint to remain parallel-safe.
  - Excludes one-time initialization allocations through a warm-up period.
  - Verifies frame execution and bounded resident-memory growth over 2,000 measured frames.
- Ran the repository pre-commit checks successfully.
- No tests were removed or re-baselined.

## Documentation

Updated the current unreleased section of `bskKnownIssues.rst` to describe the affected ownership paths and protobuf shutdown behavior.

Added `bskReleaseNotesSnippets/vizinterface-broadcast-memory-leak.rst` covering the user-visible memory leaks and their resolution.

No public API documentation was invalidated.

## Future work

No additional work is required to resolve #1517. Automated coverage exercises the reported broadcast-only failure mode; live two-way communication and image exchange still require a Vizard peer for full integration testing.