### PR TITLE
Clarify eigen checks

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/1527-clarify-eigen-checks.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1527-clarify-eigen-checks.rst
@@ -1,0 +1,1 @@
+- Tightened ``eigenIsValidInertiaMatrix`` in ``avsEigenSupport`` so an inertia tensor must also be finite, have at most one zero principal inertia, and its principal inertias must satisfy the triangle inequality.

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -346,10 +346,9 @@ double bisectionSolve(double *interval, double accuracy, std::function< double(d
  */
 bool eigenIsRotationMatrix(const Eigen::Matrix3d& dcm, double tolerance)
 {
-    Eigen::Matrix3d shouldBeIdentity = dcm.transpose() * dcm;
-    bool orthonormal = (shouldBeIdentity - Eigen::Matrix3d::Identity()).norm() <= tolerance;
-    bool rightHanded = std::abs(dcm.determinant() - 1.0) <= tolerance;
-    return orthonormal && rightHanded;
+    bool isOrthonormal = (dcm.transpose() * dcm - Eigen::Matrix3d::Identity()).norm() <= tolerance;
+    bool isRightHanded = std::abs(dcm.determinant() - 1.0) <= tolerance;
+    return isOrthonormal && isRightHanded;
 }
 
 /*! This function returns true if the provided 3-vector has unit norm within the

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -364,9 +364,12 @@ bool eigenIsUnitVector(const Eigen::Vector3d& vec, double tolerance)
 }
 
 /*! This function returns true if the provided 3x3 matrix is a valid inertia
-    tensor, i.e. it contains finite values, is symmetric (within tolerance),
-    positive semi-definite (within tolerance), and its principal inertia
-    values are consistent (within tolerance).
+    tensor, i.e.
+    (1) it contains finite values,
+    (2) it is symmetric (within tolerance),
+    (3) it contains at most one zero eigenvalue,
+    (4) it is positive semi-definite (within tolerance),
+    (5) its principal inertia values are consistent (within tolerance).
     @param inertia matrix to test
     @param tolerance allowed deviation in checks
     @return bool
@@ -382,13 +385,14 @@ bool eigenIsValidInertiaMatrix(const Eigen::Matrix3d& inertia, double tolerance)
     if ((inertia - inertia.transpose()).norm() > tolerance) {
         return false;
     }
-    // an inertia tensor must be positive definite; all eigenvalues of the
-    // (symmetric) matrix must be strictly positive
+
+    // Check that at most one eigenvalue can be zero
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigenSolver(inertia);
     if (eigenSolver.info() != Eigen::Success) {
-    if (eigenSolver.eigenvalues().minCoeff() <= 0.0) {
         return false;
     }
+    const Eigen::Vector3d eigenvalues = eigenSolver.eigenvalues();
+    if (eigenvalues[1] <= tolerance * eigenvalues[2]) {
         return false;
     }
 

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -373,7 +373,12 @@ bool eigenIsUnitVector(const Eigen::Vector3d& vec, double tolerance)
  */
 bool eigenIsValidInertiaMatrix(const Eigen::Matrix3d& inertia, double tolerance)
 {
-    // an inertia tensor must be symmetric
+    // Finiteness check
+    if (!inertia.allFinite()) {
+        return false;
+    }
+
+    // Symmetric check
     if ((inertia - inertia.transpose()).norm() > tolerance) {
         return false;
     }

--- a/src/architecture/utilities/avsEigenSupport.cpp
+++ b/src/architecture/utilities/avsEigenSupport.cpp
@@ -364,10 +364,11 @@ bool eigenIsUnitVector(const Eigen::Vector3d& vec, double tolerance)
 }
 
 /*! This function returns true if the provided 3x3 matrix is a valid inertia
-    tensor, i.e. it is symmetric (within tolerance) and positive definite (all
-    eigenvalues strictly greater than zero).
+    tensor, i.e. it contains finite values, is symmetric (within tolerance),
+    positive semi-definite (within tolerance), and its principal inertia
+    values are consistent (within tolerance).
     @param inertia matrix to test
-    @param tolerance allowed deviation from symmetry
+    @param tolerance allowed deviation in checks
     @return bool
  */
 bool eigenIsValidInertiaMatrix(const Eigen::Matrix3d& inertia, double tolerance)
@@ -378,11 +379,22 @@ bool eigenIsValidInertiaMatrix(const Eigen::Matrix3d& inertia, double tolerance)
     }
     // an inertia tensor must be positive definite; all eigenvalues of the
     // (symmetric) matrix must be strictly positive
-    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(inertia);
-    if (solver.info() != Eigen::Success) {
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigenSolver(inertia);
+    if (eigenSolver.info() != Eigen::Success) {
+    if (eigenSolver.eigenvalues().minCoeff() <= 0.0) {
         return false;
     }
-    return solver.eigenvalues().minCoeff() > 0.0;
+        return false;
+    }
+
+    // Principal inertia check - triangle inequality
+    // Also covers positive semi-definite check: eigenvalues are ascending, so
+    // passing this requires eigenvalues[0] >= -tolerance * eigenvalues[2]
+    if (eigenvalues[0] + eigenvalues[1] < eigenvalues[2] * (1.0 - tolerance)) {
+        return false;
+    }
+
+    return true;
 }
 
 /*! This function returns true if the provided 3x3 matrix contains only finite

--- a/src/architecture/utilities/avsEigenSupport.h
+++ b/src/architecture/utilities/avsEigenSupport.h
@@ -90,7 +90,8 @@ Eigen::MRPd eigenC2MRP(Eigen::Matrix3d);
 bool eigenIsRotationMatrix(const Eigen::Matrix3d& dcm, double tolerance = 1e-9);
 //!@brief returns true if the 3-vector has unit norm within the given tolerance
 bool eigenIsUnitVector(const Eigen::Vector3d& vec, double tolerance = 1e-9);
-//!@brief returns true if the 3x3 matrix is a valid inertia tensor (symmetric within tolerance and positive definite)
+//!@brief returns true if the 3x3 matrix is a valid inertia tensor within the given tolerance: finite, symmetric,
+//! positive semi-definite with at most one zero principal inertia, and satisfying the triangle inequality
 bool eigenIsValidInertiaMatrix(const Eigen::Matrix3d& inertia, double tolerance = 1e-9);
 //!@brief returns true if the finite 3x3 matrix is symmetric positive semidefinite within the given tolerance
 bool eigenIsPositiveSemidefiniteMatrix(const Eigen::Matrix3d& matrix, double tolerance = 1e-9);

--- a/src/architecture/utilities/tests/test_avsEigenSupport.cpp
+++ b/src/architecture/utilities/tests/test_avsEigenSupport.cpp
@@ -206,8 +206,28 @@ TEST(avsEigenSupport, PositiveSemidefiniteMatrix) {
     EXPECT_TRUE(eigenIsPositiveSemidefiniteMatrix(Eigen::Matrix3d::Zero()));
     EXPECT_TRUE(eigenIsPositiveSemidefiniteMatrix(positiveDefinite));
     EXPECT_TRUE(eigenIsPositiveSemidefiniteMatrix(positiveSemidefinite));
+
+    // Definiteness, finiteness, symmetric checks
+    EXPECT_TRUE(eigenIsValidInertiaMatrix(positiveDefinite));
+    EXPECT_FALSE(eigenIsValidInertiaMatrix(indefinite));
+    EXPECT_FALSE(eigenIsValidInertiaMatrix(nonfinite));
+    EXPECT_FALSE(eigenIsValidInertiaMatrix(nonsymmetric));
+    // Check that at most one eigenvalue can be zero
+    EXPECT_TRUE(eigenIsValidInertiaMatrix(Eigen::Vector3d(0.0, 1.0, 1.0).asDiagonal()));
     EXPECT_FALSE(eigenIsValidInertiaMatrix(Eigen::Matrix3d::Zero()));
     EXPECT_FALSE(eigenIsValidInertiaMatrix(positiveSemidefinite));
+    // Principal inertia triangle inequality checks
+    EXPECT_TRUE(eigenIsValidInertiaMatrix(Eigen::Vector3d(1.0, 2.0, 3.0).asDiagonal()));
+    EXPECT_FALSE(eigenIsValidInertiaMatrix(Eigen::Vector3d(0.0, 2.0, 3.0).asDiagonal()));
+    EXPECT_FALSE(eigenIsValidInertiaMatrix(Eigen::Vector3d(1.0, 1.0, 3.0).asDiagonal()));
+    // Principal inertia check - triangle inequality - edge cases
+    // Also covers positive semi-definite check: eigenvalues are ascending, so
+    // passing this requires eigenvalues[0] >= -tolerance * eigenvalues[2]
+    EXPECT_TRUE(eigenIsValidInertiaMatrix(Eigen::Vector3d(1e-8, 1.0, 1.0).asDiagonal()));
+    EXPECT_TRUE(eigenIsValidInertiaMatrix(Eigen::Vector3d(-1e-10, 1.0, 1.0).asDiagonal()));
+    EXPECT_TRUE(eigenIsValidInertiaMatrix(Eigen::Vector3d(-1e-9, 1.0, 1.0).asDiagonal()));
+    EXPECT_FALSE(eigenIsValidInertiaMatrix(Eigen::Vector3d(-1e-8, 1.0, 1.0).asDiagonal()));
+
     EXPECT_FALSE(eigenIsPositiveSemidefiniteMatrix(nonsymmetric));
     EXPECT_FALSE(eigenIsPositiveSemidefiniteMatrix(indefinite));
     EXPECT_FALSE(eigenIsPositiveSemidefiniteMatrix(nonfinite));

--- a/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
+++ b/src/simulation/dynamics/_GeneralModuleFiles/hubEffector.cpp
@@ -58,7 +58,8 @@ HubEffector::~HubEffector()
 }
 
 /*! This method verifies the user-supplied hub properties are physically valid. The hub mass
- must be strictly positive and the hub inertia tensor must be symmetric positive definite.
+ must be strictly positive and the hub inertia tensor must be physically realizable
+ (see eigenIsValidInertiaMatrix).
  It is intended to be called by the owning spacecraft at reset time, before the dynamics
  are initialized. */
 void HubEffector::validateConfiguration()
@@ -67,8 +68,7 @@ void HubEffector::validateConfiguration()
         bskLogger.bskError("hubEffector: mHub must be greater than 0. It may not have been set properly by the user.");
     }
     if (!eigenIsValidInertiaMatrix(this->IHubPntBc_B)) {
-        bskLogger.bskError("hubEffector: IHubPntBc_B is not a valid inertia tensor; it must be symmetric and positive"
-                           " definite. It may not have been set properly by the user.");
+        bskLogger.bskError("hubEffector: IHubPntBc_B is not a valid inertia tensor. It may not have been set properly by the user.");
     }
 }
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFStateEffector.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFStateEffector.py
@@ -40,6 +40,17 @@ from Basilisk.simulation import spacecraft, spinningBodyNDOFStateEffector, gravi
 from Basilisk.architecture import messaging
 
 
+def randomValidInertia():
+    r"""Generate a random diagonal inertia tensor that is physically realizable."""
+    secondMoments = np.random.uniform(2.5, 50.0, 3)  # [kg m^2]
+    principalInertias = np.array([
+        secondMoments[1] + secondMoments[2],
+        secondMoments[0] + secondMoments[2],
+        secondMoments[0] + secondMoments[1]
+    ])  # [kg m^2]
+    return np.diag(principalInertias)
+
+
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
 # @pytest.mark.skipif(conditionstring)
 # uncomment this line if this test has an expected failure, adjust message as needed
@@ -105,9 +116,7 @@ def spinningBodyNoInput(show_plots):
     # Define properties of spinning bodies
     spinningBody1 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody1.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody1.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody1.setISPntSc_S(randomValidInertia())
     spinningBody1.setDCM_S0P([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
     spinningBody1.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -123,9 +132,7 @@ def spinningBodyNoInput(show_plots):
 
     spinningBody2 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody2.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody2.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody2.setISPntSc_S(randomValidInertia())
     spinningBody2.setDCM_S0P([[0.0, -1.0, 0.0], [0.0, .0, -1.0], [1.0, 0.0, 0.0]])
     spinningBody2.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -141,9 +148,7 @@ def spinningBodyNoInput(show_plots):
 
     spinningBody3 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody3.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody3.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody3.setISPntSc_S(randomValidInertia())
     spinningBody3.setDCM_S0P([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]])
     spinningBody3.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -159,9 +164,7 @@ def spinningBodyNoInput(show_plots):
 
     spinningBody4 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody4.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody4.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody4.setISPntSc_S(randomValidInertia())
     spinningBody4.setDCM_S0P([[0.0, 1.0, 0.0], [0.0, .0, 1.0], [1.0, 0.0, 0.0]])
     spinningBody4.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -358,9 +361,7 @@ def spinningBodyLockAxis(show_plots):
     # Define properties of spinning bodies
     spinningBody1 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody1.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody1.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody1.setISPntSc_S(randomValidInertia())
     spinningBody1.setDCM_S0P([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
     spinningBody1.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -376,9 +377,7 @@ def spinningBodyLockAxis(show_plots):
 
     spinningBody2 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody2.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody2.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody2.setISPntSc_S(randomValidInertia())
     spinningBody2.setDCM_S0P([[0.0, -1.0, 0.0], [0.0, .0, -1.0], [1.0, 0.0, 0.0]])
     spinningBody2.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -394,9 +393,7 @@ def spinningBodyLockAxis(show_plots):
 
     spinningBody3 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody3.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody3.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody3.setISPntSc_S(randomValidInertia())
     spinningBody3.setDCM_S0P([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]])
     spinningBody3.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -412,9 +409,7 @@ def spinningBodyLockAxis(show_plots):
 
     spinningBody4 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody4.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody4.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody4.setISPntSc_S(randomValidInertia())
     spinningBody4.setDCM_S0P([[0.0, 1.0, 0.0], [0.0, .0, 1.0], [1.0, 0.0, 0.0]])
     spinningBody4.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -617,9 +612,7 @@ def spinningBodyCommandedTorque(show_plots):
     # Define properties of spinning bodies
     spinningBody1 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody1.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody1.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody1.setISPntSc_S(randomValidInertia())
     spinningBody1.setDCM_S0P([[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]])
     spinningBody1.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -635,9 +628,7 @@ def spinningBodyCommandedTorque(show_plots):
 
     spinningBody2 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody2.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody2.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody2.setISPntSc_S(randomValidInertia())
     spinningBody2.setDCM_S0P([[0.0, -1.0, 0.0], [0.0, .0, -1.0], [1.0, 0.0, 0.0]])
     spinningBody2.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -653,9 +644,7 @@ def spinningBodyCommandedTorque(show_plots):
 
     spinningBody3 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody3.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody3.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody3.setISPntSc_S(randomValidInertia())
     spinningBody3.setDCM_S0P([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]])
     spinningBody3.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],
@@ -671,9 +660,7 @@ def spinningBodyCommandedTorque(show_plots):
 
     spinningBody4 = spinningBodyNDOFStateEffector.SpinningBody()
     spinningBody4.setMass(np.random.uniform(5.0, 50.0))
-    spinningBody4.setISPntSc_S([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    spinningBody4.setISPntSc_S(randomValidInertia())
     spinningBody4.setDCM_S0P([[0.0, 1.0, 0.0], [0.0, .0, 1.0], [1.0, 0.0, 0.0]])
     spinningBody4.setR_ScS_S([[np.random.uniform(-1.0, 1.0)],
                               [np.random.uniform(-1.0, 1.0)],

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -55,7 +55,7 @@ void SpinningBodyNDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]]
         }
         // A massless body legitimately carries a zero inertia tensor, so only check when its mass > 0.
         if (body->mass > 0.0 && !eigenIsValidInertiaMatrix(body->ISPntSc_S)) {
-            bskLogger.bskError("spinningBodyNDOFStateEffector: a spinning body's ISPntSc_S is not a valid inertia tensor; it must be symmetric and positive definite. It may not have been set properly by the user.");
+            bskLogger.bskError("spinningBodyNDOFStateEffector: a spinning body's ISPntSc_S is not a valid inertia tensor. It may not have been set properly by the user.");
         }
     }
 }

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.cpp
@@ -81,10 +81,10 @@ void SpinningBodyOneDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused
         bskLogger.bskError("spinningBodyOneDOFStateEffector: mass must be greater than or equal to 0. It may not have been set properly by the user.");
     }
 
-    // Verify that the inertia tensor is physically valid (symmetric and positive definite).
+    // Verify that the inertia tensor is physically realizable (see eigenIsValidInertiaMatrix).
     // A massless body legitimately carries a zero inertia tensor, so only check when mass > 0.
     if (this->mass > 0.0 && !eigenIsValidInertiaMatrix(this->IPntSc_S)) {
-        bskLogger.bskError("spinningBodyOneDOFStateEffector: IPntSc_S is not a valid inertia tensor; it must be symmetric and positive definite. It may not have been set properly by the user.");
+        bskLogger.bskError("spinningBodyOneDOFStateEffector: IPntSc_S is not a valid inertia tensor. It may not have been set properly by the user.");
     }
 }
 

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.cpp
@@ -107,13 +107,13 @@ void SpinningBodyTwoDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused
         bskLogger.bskError("spinningBodyTwoDOFStateEffector: mass2 must be greater than or equal to 0. It may not have been set properly by the user.");
     }
 
-    // Verify the inertia tensors are physically valid (symmetric and positive definite).
+    // Verify the inertia tensors are physically realizable (see eigenIsValidInertiaMatrix).
     // A massless body legitimately carries a zero inertia tensor, so only check when its mass > 0.
     if (this->mass1 > 0.0 && !eigenIsValidInertiaMatrix(this->IS1PntSc1_S1)) {
-        bskLogger.bskError("spinningBodyTwoDOFStateEffector: IS1PntSc1_S1 is not a valid inertia tensor; it must be symmetric and positive definite. It may not have been set properly by the user.");
+        bskLogger.bskError("spinningBodyTwoDOFStateEffector: IS1PntSc1_S1 is not a valid inertia tensor. It may not have been set properly by the user.");
     }
     if (this->mass2 > 0.0 && !eigenIsValidInertiaMatrix(this->IS2PntSc2_S2)) {
-        bskLogger.bskError("spinningBodyTwoDOFStateEffector: IS2PntSc2_S2 is not a valid inertia tensor; it must be symmetric and positive definite. It may not have been set properly by the user.");
+        bskLogger.bskError("spinningBodyTwoDOFStateEffector: IS2PntSc2_S2 is not a valid inertia tensor. It may not have been set properly by the user.");
     }
 }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash) 

## Description
This PR adds a principal inertia triangle inequality check to the `eigenIsValidInertiaMatrix` helper method in the first commit. The clarity of the `eigenIsRotationMatrix` is improved in the second commit.


## Verification
N/A

## Documentation
N/A

## Future work
N/A