### PR TITLE
bskSim model access hardening

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/bsk-sim-model-access-hardening.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/bsk-sim-model-access-hardening.rst
@@ -1,0 +1,1 @@
+- Hardened the BskSim, MultiSat, OpNav, and MuJoCo example master classes against uninitialized, repeated, and failed model setup while preserving their existing getters and direct-read model access.

--- a/examples/BskSim/BSK_masters.py
+++ b/examples/BskSim/BSK_masters.py
@@ -42,6 +42,8 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
 
         self._dynModels = None
         self._fswModels = None
+        self._dynamicsSetupAttempted = False
+        self._fswSetupAttempted = False
         self.DynamicsProcessName = None
         self.FSWProcessName = None
         self.dynProc = None
@@ -75,10 +77,13 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         """Construct and store the dynamics model.
 
         :param dynModel: Module containing the ``BSKDynamicModels`` class.
-        :raises RuntimeError: If a dynamics model has already been added.
+        :raises RuntimeError: If dynamics setup has already been attempted.
         """
-        if self._dynModels is not None:
+        if self._dynamicsSetupAttempted:
+            if self._dynModels is None:
+                raise RuntimeError("A previous dynamics model setup attempt failed")
             raise RuntimeError("A dynamics model has already been added")
+        self._dynamicsSetupAttempted = True
         self.DynamicsProcessName = 'DynamicsProcess'  # Create simulation process name
         self.dynProc = self.CreateNewProcess(self.DynamicsProcessName)  # Create process
         dynModels = dynModel.BSKDynamicModels(self, self.dynRate)  # Create dynamics class
@@ -106,10 +111,15 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         """Construct and store the flight software model.
 
         :param fswModel: Module containing the ``BSKFswModels`` class.
-        :raises RuntimeError: If a flight software model has already been added.
+        :raises RuntimeError: If dynamics has not been added or FSW setup has already been attempted.
         """
-        if self._fswModels is not None:
+        if self._fswSetupAttempted:
+            if self._fswModels is None:
+                raise RuntimeError("A previous flight software model setup attempt failed")
             raise RuntimeError("A flight software model has already been added")
+        if self._dynModels is None:
+            raise RuntimeError("A dynamics model must be added before the flight software model")
+        self._fswSetupAttempted = True
         self.FSWProcessName = "FSWProcess"  # Create simulation process name
         self.fswProc = self.CreateNewProcess(self.FSWProcessName)  # Create process
         fswModels = fswModel.BSKFswModels(self, self.fswRate)  # Create FSW class

--- a/examples/BskSim/BSK_masters.py
+++ b/examples/BskSim/BSK_masters.py
@@ -34,19 +34,19 @@ sys.path.append(path + '/models')
 class BSKSim(SimulationBaseClass.SimBaseClass):
     """Main bskSim simulation class"""
 
-    def __init__(self, fswRate=0.1, dynRate=0.1):
+    def __init__(self, fswRate=0.1, dynRate=0.1):  # [s]
         self.dynRate = dynRate
         self.fswRate = fswRate
         # Create a sim module as an empty container
         SimulationBaseClass.SimBaseClass.__init__(self)
 
-        self.DynModels = []
-        self.FSWModels = []
+        self._dynModels = None
+        self._fswModels = None
         self.DynamicsProcessName = None
         self.FSWProcessName = None
         self.dynProc = None
         self.fswProc = None
-        
+
         self.oneTimeRWFaultFlag = 0
         self.oneTimeFaultTime = -1
         self.repeatRWFaultFlag = 0
@@ -54,25 +54,67 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         self.dynamics_added = False
         self.fsw_added = False
 
+    @property
+    def DynModels(self):
+        """Return the configured dynamics model.
+
+        :raises RuntimeError: If a dynamics model has not been added.
+        """
+        if self._dynModels is None:
+            raise RuntimeError("A dynamics model has not been added yet")
+        return self._dynModels
+
     def get_DynModel(self):
-        assert (self.dynamics_added is True), "It is mandatory to use a dynamics model as an argument"
+        """Return the configured dynamics model.
+
+        :raises RuntimeError: If a dynamics model has not been added.
+        """
         return self.DynModels
 
     def set_DynModel(self, dynModel):
-        self.dynamics_added = True
+        """Construct and store the dynamics model.
+
+        :param dynModel: Module containing the ``BSKDynamicModels`` class.
+        :raises RuntimeError: If a dynamics model has already been added.
+        """
+        if self._dynModels is not None:
+            raise RuntimeError("A dynamics model has already been added")
         self.DynamicsProcessName = 'DynamicsProcess'  # Create simulation process name
         self.dynProc = self.CreateNewProcess(self.DynamicsProcessName)  # Create process
-        self.DynModels = dynModel.BSKDynamicModels(self, self.dynRate)  # Create Dynamics and FSW classes
+        dynModels = dynModel.BSKDynamicModels(self, self.dynRate)  # Create dynamics class
+        self._dynModels = dynModels
+        self.dynamics_added = True
+
+    @property
+    def FSWModels(self):
+        """Return the configured flight software model.
+
+        :raises RuntimeError: If a flight software model has not been added.
+        """
+        if self._fswModels is None:
+            raise RuntimeError("A flight software model has not been added yet")
+        return self._fswModels
 
     def get_FswModel(self):
-        assert (self.fsw_added is True), "A flight software model has not been added yet"
+        """Return the configured flight software model.
+
+        :raises RuntimeError: If a flight software model has not been added.
+        """
         return self.FSWModels
 
     def set_FswModel(self, fswModel):
-        self.fsw_added = True
+        """Construct and store the flight software model.
+
+        :param fswModel: Module containing the ``BSKFswModels`` class.
+        :raises RuntimeError: If a flight software model has already been added.
+        """
+        if self._fswModels is not None:
+            raise RuntimeError("A flight software model has already been added")
         self.FSWProcessName = "FSWProcess"  # Create simulation process name
         self.fswProc = self.CreateNewProcess(self.FSWProcessName)  # Create process
-        self.FSWModels = fswModel.BSKFswModels(self, self.fswRate)  # Create Dynamics and FSW classes
+        fswModels = fswModel.BSKFswModels(self, self.fswRate)  # Create FSW class
+        self._fswModels = fswModels
+        self.fsw_added = True
 
 
 class BSKScenario(object):

--- a/examples/MultiSatBskSim/BSK_MultiSatMasters.py
+++ b/examples/MultiSatBskSim/BSK_MultiSatMasters.py
@@ -48,7 +48,15 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
 
     """
 
-    def __init__(self, numberSpacecraft, relativeNavigation=False, fswRate=0.1, dynRate=0.1, envRate=0.1, relNavRate=0.1):
+    def __init__(
+        self,
+        numberSpacecraft,
+        relativeNavigation=False,
+        fswRate=0.1,  # [s]
+        dynRate=0.1,  # [s]
+        envRate=0.1,  # [s]
+        relNavRate=0.1,  # [s]
+    ):
         self.dynRate = dynRate
         self.fswRate = fswRate
         self.envRate = envRate
@@ -59,9 +67,12 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         SimulationBaseClass.SimBaseClass.__init__(self)
         self.SetProgressBar(True)
 
-        self.EnvModel = []
-        self.DynModels = []
-        self.FSWModels = []
+        self._envModel = None
+        self._dynModels = None
+        self._fswModels = None
+        self._environmentSetupAttempted = False
+        self._dynamicsSetupAttempted = False
+        self._fswSetupAttempted = False
         self.EnvProcessName = None
         self.DynamicsProcessName = []
         self.FSWProcessName = []
@@ -80,43 +91,123 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
             self.relativeNavigationTaskName = None
             self.add_relativeNavigation()
 
+    @property
+    def EnvModel(self):
+        """Return the configured environment model.
+
+        :raises RuntimeError: If an environment model has not been added.
+        """
+        if self._envModel is None:
+            raise RuntimeError("An environment model has not been added yet")
+        return self._envModel
+
     def get_EnvModel(self):
-        assert (self.environment_added is True), "It is mandatory to use an environment model as an argument"
+        """Return the configured environment model.
+
+        :raises RuntimeError: If an environment model has not been added.
+        """
         return self.EnvModel
 
     def set_EnvModel(self, envModel):
-        self.environment_added = True
+        """Construct and store the environment model.
+
+        :param envModel: Module containing the ``BSKEnvironmentModel`` class.
+        :raises RuntimeError: If environment setup has already been attempted.
+        """
+        if self._environmentSetupAttempted:
+            if self._envModel is None:
+                raise RuntimeError("A previous environment model setup attempt failed")
+            raise RuntimeError("An environment model has already been added")
+        self._environmentSetupAttempted = True
         self.EnvProcessName = "EnvironmentProcess"
         self.envProc = self.CreateNewProcess(self.EnvProcessName, 300)
 
         # Add the environment class
-        self.EnvModel = envModel.BSKEnvironmentModel(self, self.envRate)
+        environmentModel = envModel.BSKEnvironmentModel(self, self.envRate)
+        self._envModel = environmentModel
+        self.environment_added = True
+
+    @property
+    def DynModels(self):
+        """Return the configured dynamics models.
+
+        :raises RuntimeError: If dynamics models have not been added.
+        """
+        if self._dynModels is None:
+            raise RuntimeError("Dynamics models have not been added yet")
+        return self._dynModels
 
     def get_DynModel(self):
-        assert (self.dynamics_added is True), "It is mandatory to use a dynamics model as an argument"
+        """Return the configured dynamics models.
+
+        :raises RuntimeError: If dynamics models have not been added.
+        """
         return self.DynModels
 
     def set_DynModel(self, dynModel):
-        self.dynamics_added = True
+        """Construct and store the dynamics models.
+
+        :param dynModel: Modules containing the ``BSKDynamicModels`` class.
+        :raises RuntimeError: If the environment is missing or dynamics setup was already attempted.
+        """
+        if self._dynamicsSetupAttempted:
+            if self._dynModels is None:
+                raise RuntimeError("A previous dynamics model setup attempt failed")
+            raise RuntimeError("Dynamics models have already been added")
+        if self._envModel is None:
+            raise RuntimeError("An environment model must be added before the dynamics models")
+        self._dynamicsSetupAttempted = True
 
         # Add the dynamics classes
+        dynamicsModels = []
         for spacecraftIndex in range(self.numberSpacecraft):
             self.DynamicsProcessName.append("DynamicsProcess" + str(spacecraftIndex))  # Create simulation process name
             self.dynProc.append(self.CreateNewProcess(self.DynamicsProcessName[spacecraftIndex], 200))  # Create process
-            self.DynModels.append(dynModel[spacecraftIndex].BSKDynamicModels(self, self.dynRate, spacecraftIndex))
+            dynamicsModels.append(dynModel[spacecraftIndex].BSKDynamicModels(self, self.dynRate, spacecraftIndex))
+        self._dynModels = dynamicsModels
+        self.dynamics_added = True
+
+    @property
+    def FSWModels(self):
+        """Return the configured flight software models.
+
+        :raises RuntimeError: If flight software models have not been added.
+        """
+        if self._fswModels is None:
+            raise RuntimeError("Flight software models have not been added yet")
+        return self._fswModels
 
     def get_FswModel(self):
-        assert (self.fsw_added is True), "A flight software model has not been added yet"
+        """Return the configured flight software models.
+
+        :raises RuntimeError: If flight software models have not been added.
+        """
         return self.FSWModels
 
     def set_FswModel(self, fswModel):
-        self.fsw_added = True
+        """Construct and store the flight software models.
+
+        :param fswModel: Modules containing the ``BSKFswModels`` class.
+        :raises RuntimeError: If dynamics is missing or FSW setup was already attempted.
+        """
+        if self._fswSetupAttempted:
+            if self._fswModels is None:
+                raise RuntimeError("A previous flight software model setup attempt failed")
+            raise RuntimeError("Flight software models have already been added")
+        if self._dynModels is None:
+            raise RuntimeError("Dynamics models must be added before the flight software models")
+        self._fswSetupAttempted = True
 
         # Add the FSW classes
+        flightSoftwareModels = []
         for spacecraftIndex in range(self.numberSpacecraft):
             self.FSWProcessName.append("FSWProcess" + str(spacecraftIndex))  # Create simulation process name
             self.fswProc.append(self.CreateNewProcess(self.FSWProcessName[spacecraftIndex], 100))  # Create process
-            self.FSWModels.append(fswModel[spacecraftIndex].BSKFswModels(self, self.fswRate, spacecraftIndex))
+            flightSoftwareModels.append(
+                fswModel[spacecraftIndex].BSKFswModels(self, self.fswRate, spacecraftIndex)
+            )
+        self._fswModels = flightSoftwareModels
+        self.fsw_added = True
 
     def add_relativeNavigation(self):
         processName = "RelativeNavigation"

--- a/examples/OpNavScenarios/BSK_OpNav.py
+++ b/examples/OpNavScenarios/BSK_OpNav.py
@@ -127,7 +127,7 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
     """
     BSK Simulation base class for opNav scenarios
     """
-    def __init__(self, fswRate=0.1, dynRate=0.1):
+    def __init__(self, fswRate=0.1, dynRate=0.1):  # [s]
         self.dynRate = dynRate
         self.fswRate = fswRate
         # Create a sim module as an empty container
@@ -135,8 +135,8 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         self.SetProgressBar(True)
 
         self.vizPath = appPath
-        self.DynModels = []
-        self.FSWModels = []
+        self._dynModels = None
+        self._fswModels = None
         self.DynamicsProcessName = None
         self.dynProc = None
         self.FSWProcessName = None
@@ -145,25 +145,67 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         self.dynamics_added = False
         self.fsw_added = False
 
+    @property
+    def DynModels(self):
+        """Return the configured dynamics model.
+
+        :raises RuntimeError: If a dynamics model has not been added.
+        """
+        if self._dynModels is None:
+            raise RuntimeError("A dynamics model has not been added yet")
+        return self._dynModels
+
     def get_DynModel(self):
-        assert (self.dynamics_added is True), "It is mandatory to use a dynamics model as an argument"
+        """Return the configured dynamics model.
+
+        :raises RuntimeError: If a dynamics model has not been added.
+        """
         return self.DynModels
 
     def set_DynModel(self, dynModel):
-        self.dynamics_added = True
+        """Construct and store the dynamics model.
+
+        :param dynModel: Module containing the ``BSKDynamicModels`` class.
+        :raises RuntimeError: If a dynamics model has already been added.
+        """
+        if self._dynModels is not None:
+            raise RuntimeError("A dynamics model has already been added")
         self.DynamicsProcessName = 'DynamicsProcess'  # Create simulation process name
         self.dynProc = self.CreateNewProcess(self.DynamicsProcessName, 100)  # Create process
-        self.DynModels = dynModel.BSKDynamicModels(self, self.dynRate)  # Create Dynamics and FSW classes
+        dynModels = dynModel.BSKDynamicModels(self, self.dynRate)  # Create dynamics class
+        self._dynModels = dynModels
+        self.dynamics_added = True
+
+    @property
+    def FSWModels(self):
+        """Return the configured flight software model.
+
+        :raises RuntimeError: If a flight software model has not been added.
+        """
+        if self._fswModels is None:
+            raise RuntimeError("A flight software model has not been added yet")
+        return self._fswModels
 
     def get_FswModel(self):
-        assert (self.fsw_added is True), "A flight software model has not been added yet"
+        """Return the configured flight software model.
+
+        :raises RuntimeError: If a flight software model has not been added.
+        """
         return self.FSWModels
 
     def set_FswModel(self, fswModel):
-        self.fsw_added = True
+        """Construct and store the flight software model.
+
+        :param fswModel: Module containing the ``BSKFswModels`` class.
+        :raises RuntimeError: If a flight software model has already been added.
+        """
+        if self._fswModels is not None:
+            raise RuntimeError("A flight software model has already been added")
         self.FSWProcessName = "FSWProcess"  # Create simulation process name
         self.fswProc = self.CreateNewProcess(self.FSWProcessName, 10)  # Create process
-        self.FSWModels = fswModel.BSKFswModels(self, self.fswRate)  # Create Dynamics and FSW classes
+        fswModels = fswModel.BSKFswModels(self, self.fswRate)  # Create FSW class
+        self._fswModels = fswModels
+        self.fsw_added = True
 
 
 class BSKScenario(object):

--- a/examples/OpNavScenarios/BSK_OpNav.py
+++ b/examples/OpNavScenarios/BSK_OpNav.py
@@ -137,6 +137,8 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         self.vizPath = appPath
         self._dynModels = None
         self._fswModels = None
+        self._dynamicsSetupAttempted = False
+        self._fswSetupAttempted = False
         self.DynamicsProcessName = None
         self.dynProc = None
         self.FSWProcessName = None
@@ -166,10 +168,13 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         """Construct and store the dynamics model.
 
         :param dynModel: Module containing the ``BSKDynamicModels`` class.
-        :raises RuntimeError: If a dynamics model has already been added.
+        :raises RuntimeError: If dynamics setup has already been attempted.
         """
-        if self._dynModels is not None:
+        if self._dynamicsSetupAttempted:
+            if self._dynModels is None:
+                raise RuntimeError("A previous dynamics model setup attempt failed")
             raise RuntimeError("A dynamics model has already been added")
+        self._dynamicsSetupAttempted = True
         self.DynamicsProcessName = 'DynamicsProcess'  # Create simulation process name
         self.dynProc = self.CreateNewProcess(self.DynamicsProcessName, 100)  # Create process
         dynModels = dynModel.BSKDynamicModels(self, self.dynRate)  # Create dynamics class
@@ -197,10 +202,15 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         """Construct and store the flight software model.
 
         :param fswModel: Module containing the ``BSKFswModels`` class.
-        :raises RuntimeError: If a flight software model has already been added.
+        :raises RuntimeError: If dynamics has not been added or FSW setup has already been attempted.
         """
-        if self._fswModels is not None:
+        if self._fswSetupAttempted:
+            if self._fswModels is None:
+                raise RuntimeError("A previous flight software model setup attempt failed")
             raise RuntimeError("A flight software model has already been added")
+        if self._dynModels is None:
+            raise RuntimeError("A dynamics model must be added before the flight software model")
+        self._fswSetupAttempted = True
         self.FSWProcessName = "FSWProcess"  # Create simulation process name
         self.fswProc = self.CreateNewProcess(self.FSWProcessName, 10)  # Create process
         fswModels = fswModel.BSKFswModels(self, self.fswRate)  # Create FSW class

--- a/examples/mujoco/BSK_mujocoMasters.py
+++ b/examples/mujoco/BSK_mujocoMasters.py
@@ -42,6 +42,8 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
 
         self._dynModels = None
         self._fswModels = None
+        self._dynamicsSetupAttempted = False
+        self._fswSetupAttempted = False
         self.DynamicsProcessName = None
         self.FSWProcessName = None
         self.dynProc = None
@@ -71,10 +73,13 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         """Construct and store the dynamics model.
 
         :param dynModel: Module containing the ``BSKMujocoDynamicsModels`` class.
-        :raises RuntimeError: If a dynamics model has already been added.
+        :raises RuntimeError: If dynamics setup has already been attempted.
         """
-        if self._dynModels is not None:
+        if self._dynamicsSetupAttempted:
+            if self._dynModels is None:
+                raise RuntimeError("A previous dynamics model setup attempt failed")
             raise RuntimeError("A dynamics model has already been added")
+        self._dynamicsSetupAttempted = True
         self.DynamicsProcessName = 'DynamicsProcess'  # Create simulation process name
         self.dynProc = self.CreateNewProcess(self.DynamicsProcessName)  # Create process
         dynModels = dynModel.BSKMujocoDynamicsModels(self, self.dynRate)  # Create dynamics class
@@ -102,10 +107,15 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         """Construct and store the flight software model.
 
         :param fswModel: Module containing the ``BSKMujocoFSWModels`` class.
-        :raises RuntimeError: If a flight software model has already been added.
+        :raises RuntimeError: If dynamics has not been added or FSW setup has already been attempted.
         """
-        if self._fswModels is not None:
+        if self._fswSetupAttempted:
+            if self._fswModels is None:
+                raise RuntimeError("A previous flight software model setup attempt failed")
             raise RuntimeError("A flight software model has already been added")
+        if self._dynModels is None:
+            raise RuntimeError("A dynamics model must be added before the flight software model")
+        self._fswSetupAttempted = True
         self.FSWProcessName = "FSWProcess"  # Create simulation process name
         self.fswProc = self.CreateNewProcess(self.FSWProcessName)  # Create process
         fswModels = fswModel.BSKMujocoFSWModels(self, self.fswRate)  # Create FSW class

--- a/examples/mujoco/BSK_mujocoMasters.py
+++ b/examples/mujoco/BSK_mujocoMasters.py
@@ -34,14 +34,14 @@ sys.path.append(path + '/mujocoModels')
 class BSKSim(SimulationBaseClass.SimBaseClass):
     """Main bskSim simulation class"""
 
-    def __init__(self, fswRate=0.01, dynRate=0.01):
+    def __init__(self, fswRate=0.01, dynRate=0.01):  # [s]
         self.dynRate = dynRate
         self.fswRate = fswRate
         # Create a sim module as an empty container
         SimulationBaseClass.SimBaseClass.__init__(self)
 
-        self.DynModels = []
-        self.FSWModels = []
+        self._dynModels = None
+        self._fswModels = None
         self.DynamicsProcessName = None
         self.FSWProcessName = None
         self.dynProc = None
@@ -50,25 +50,67 @@ class BSKSim(SimulationBaseClass.SimBaseClass):
         self.dynamics_added = False
         self.fsw_added = False
 
+    @property
+    def DynModels(self):
+        """Return the configured dynamics model.
+
+        :raises RuntimeError: If a dynamics model has not been added.
+        """
+        if self._dynModels is None:
+            raise RuntimeError("A dynamics model has not been added yet")
+        return self._dynModels
+
     def get_DynModel(self):
-        assert (self.dynamics_added is True), "It is mandatory to use a dynamics model as an argument"
+        """Return the configured dynamics model.
+
+        :raises RuntimeError: If a dynamics model has not been added.
+        """
         return self.DynModels
 
     def set_DynModel(self, dynModel):
-        self.dynamics_added = True
+        """Construct and store the dynamics model.
+
+        :param dynModel: Module containing the ``BSKMujocoDynamicsModels`` class.
+        :raises RuntimeError: If a dynamics model has already been added.
+        """
+        if self._dynModels is not None:
+            raise RuntimeError("A dynamics model has already been added")
         self.DynamicsProcessName = 'DynamicsProcess'  # Create simulation process name
         self.dynProc = self.CreateNewProcess(self.DynamicsProcessName)  # Create process
-        self.DynModels = dynModel.BSKMujocoDynamicsModels(self, self.dynRate)  # Create Dynamics class
+        dynModels = dynModel.BSKMujocoDynamicsModels(self, self.dynRate)  # Create dynamics class
+        self._dynModels = dynModels
+        self.dynamics_added = True
+
+    @property
+    def FSWModels(self):
+        """Return the configured flight software model.
+
+        :raises RuntimeError: If a flight software model has not been added.
+        """
+        if self._fswModels is None:
+            raise RuntimeError("A flight software model has not been added yet")
+        return self._fswModels
 
     def get_FswModel(self):
-        assert (self.fsw_added is True), "A flight software model has not been added yet"
+        """Return the configured flight software model.
+
+        :raises RuntimeError: If a flight software model has not been added.
+        """
         return self.FSWModels
 
     def set_FswModel(self, fswModel):
-        self.fsw_added = True
+        """Construct and store the flight software model.
+
+        :param fswModel: Module containing the ``BSKMujocoFSWModels`` class.
+        :raises RuntimeError: If a flight software model has already been added.
+        """
+        if self._fswModels is not None:
+            raise RuntimeError("A flight software model has already been added")
         self.FSWProcessName = "FSWProcess"  # Create simulation process name
         self.fswProc = self.CreateNewProcess(self.FSWProcessName)  # Create process
-        self.FSWModels = fswModel.BSKMujocoFSWModels(self, self.fswRate)  # Create FSW class
+        fswModels = fswModel.BSKMujocoFSWModels(self, self.fswRate)  # Create FSW class
+        self._fswModels = fswModels
+        self.fsw_added = True
 
 
 class BSKScenario(object):

--- a/src/tests/test_bskSimModelAccess.py
+++ b/src/tests/test_bskSimModelAccess.py
@@ -1,0 +1,169 @@
+#
+#  ISC License
+#
+#  Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+#  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+#  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MASTER_CONFIGURATIONS = (
+    (
+        "BskSim",
+        REPOSITORY_ROOT / "examples/BskSim/BSK_masters.py",
+        "BSKDynamicModels",
+        "BSKFswModels",
+    ),
+    (
+        "OpNav",
+        REPOSITORY_ROOT / "examples/OpNavScenarios/BSK_OpNav.py",
+        "BSKDynamicModels",
+        "BSKFswModels",
+    ),
+    (
+        "MuJoCo",
+        REPOSITORY_ROOT / "examples/mujoco/BSK_mujocoMasters.py",
+        "BSKMujocoDynamicsModels",
+        "BSKMujocoFSWModels",
+    ),
+)
+
+
+def loadMasterClass(masterName, masterPath):
+    """Load and return a ``BSKSim`` class from an example master file."""
+    moduleName = f"test_{masterName}_master"
+    moduleSpec = importlib.util.spec_from_file_location(moduleName, masterPath)
+    module = importlib.util.module_from_spec(moduleSpec)
+    moduleSpec.loader.exec_module(module)
+    return module.BSKSim
+
+
+def makeModelModule(dynClassName, fswClassName):
+    """Create lightweight model factories for exercising the master classes."""
+
+    class DynamicsModel:
+        def __init__(self, simBase, dynRate):
+            self.simBase = simBase
+            self.rate = dynRate
+
+    class FswModel:
+        def __init__(self, simBase, fswRate):
+            self.simBase = simBase
+            self.rate = fswRate
+            self.dynModels = simBase.DynModels
+
+    modelModule = SimpleNamespace()
+    setattr(modelModule, dynClassName, DynamicsModel)
+    setattr(modelModule, fswClassName, FswModel)
+    return modelModule
+
+
+@pytest.mark.parametrize(
+    "masterName, masterPath, dynClassName, fswClassName",
+    MASTER_CONFIGURATIONS,
+    ids=[configuration[0] for configuration in MASTER_CONFIGURATIONS],
+)
+def test_modelAccessRequiresInitialization(masterName, masterPath, dynClassName, fswClassName):
+    """Verify that both access styles reject uninitialized model access."""
+    del dynClassName, fswClassName
+    masterClass = loadMasterClass(masterName, masterPath)
+    simulation = masterClass()
+
+    with pytest.raises(RuntimeError, match="dynamics model has not been added"):
+        _ = simulation.DynModels
+    with pytest.raises(RuntimeError, match="dynamics model has not been added"):
+        simulation.get_DynModel()
+    with pytest.raises(RuntimeError, match="flight software model has not been added"):
+        _ = simulation.FSWModels
+    with pytest.raises(RuntimeError, match="flight software model has not been added"):
+        simulation.get_FswModel()
+
+
+@pytest.mark.parametrize(
+    "masterName, masterPath, dynClassName, fswClassName",
+    MASTER_CONFIGURATIONS,
+    ids=[configuration[0] for configuration in MASTER_CONFIGURATIONS],
+)
+def test_modelReferencesAreReadOnlyAndSingleUse(masterName, masterPath, dynClassName, fswClassName):
+    """Verify model references cannot be replaced or initialized more than once."""
+    masterClass = loadMasterClass(masterName, masterPath)
+    simulation = masterClass(fswRate=0.25, dynRate=0.5)  # [s]
+    modelModule = makeModelModule(dynClassName, fswClassName)
+
+    simulation.set_DynModel(modelModule)
+    dynModels = simulation.DynModels
+    assert simulation.get_DynModel() is dynModels
+    assert dynModels.rate == simulation.dynRate
+    assert simulation.dynamics_added is True
+
+    simulation.set_FswModel(modelModule)
+    fswModels = simulation.FSWModels
+    assert simulation.get_FswModel() is fswModels
+    assert fswModels.dynModels is dynModels
+    assert fswModels.rate == simulation.fswRate
+    assert simulation.fsw_added is True
+
+    with pytest.raises(AttributeError):
+        simulation.DynModels = object()
+    with pytest.raises(AttributeError):
+        simulation.FSWModels = object()
+    with pytest.raises(RuntimeError, match="dynamics model has already been added"):
+        simulation.set_DynModel(modelModule)
+    with pytest.raises(RuntimeError, match="flight software model has already been added"):
+        simulation.set_FswModel(modelModule)
+
+
+@pytest.mark.parametrize(
+    "masterName, masterPath, dynClassName, fswClassName",
+    MASTER_CONFIGURATIONS,
+    ids=[configuration[0] for configuration in MASTER_CONFIGURATIONS],
+)
+def test_failedConstructionDoesNotPublishModel(masterName, masterPath, dynClassName, fswClassName):
+    """Verify failed constructors leave the corresponding model unpublished."""
+    masterClass = loadMasterClass(masterName, masterPath)
+    modelModule = makeModelModule(dynClassName, fswClassName)
+
+    class FailingDynamicsModel:
+        def __init__(self, simBase, dynRate):
+            del simBase, dynRate
+            raise ValueError("dynamics construction failed")
+
+    setattr(modelModule, dynClassName, FailingDynamicsModel)
+    simulation = masterClass()
+    with pytest.raises(ValueError, match="dynamics construction failed"):
+        simulation.set_DynModel(modelModule)
+    assert simulation.dynamics_added is False
+    with pytest.raises(RuntimeError, match="dynamics model has not been added"):
+        _ = simulation.DynModels
+
+    class FailingFswModel:
+        def __init__(self, simBase, fswRate):
+            del simBase, fswRate
+            raise ValueError("flight software construction failed")
+
+    modelModule = makeModelModule(dynClassName, fswClassName)
+    setattr(modelModule, fswClassName, FailingFswModel)
+    simulation = masterClass()
+    simulation.set_DynModel(modelModule)
+    with pytest.raises(ValueError, match="flight software construction failed"):
+        simulation.set_FswModel(modelModule)
+    assert simulation.fsw_added is False
+    with pytest.raises(RuntimeError, match="flight software model has not been added"):
+        _ = simulation.FSWModels

--- a/src/tests/test_bskSimModelAccess.py
+++ b/src/tests/test_bskSimModelAccess.py
@@ -17,6 +17,7 @@
 #
 
 import importlib.util
+from functools import cache
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -30,22 +31,33 @@ MASTER_CONFIGURATIONS = (
         REPOSITORY_ROOT / "examples/BskSim/BSK_masters.py",
         "BSKDynamicModels",
         "BSKFswModels",
+        None,
     ),
     (
         "OpNav",
         REPOSITORY_ROOT / "examples/OpNavScenarios/BSK_OpNav.py",
         "BSKDynamicModels",
         "BSKFswModels",
+        None,
     ),
     (
         "MuJoCo",
         REPOSITORY_ROOT / "examples/mujoco/BSK_mujocoMasters.py",
         "BSKMujocoDynamicsModels",
         "BSKMujocoFSWModels",
+        None,
+    ),
+    (
+        "MultiSat",
+        REPOSITORY_ROOT / "examples/MultiSatBskSim/BSK_MultiSatMasters.py",
+        "BSKDynamicModels",
+        "BSKFswModels",
+        2,
     ),
 )
 
 
+@cache
 def loadMasterClass(masterName, masterPath):
     """Load and return a ``BSKSim`` class from an example master file."""
     moduleName = f"test_{masterName}_master"
@@ -55,115 +67,218 @@ def loadMasterClass(masterName, masterPath):
     return module.BSKSim
 
 
-def makeModelModule(dynClassName, fswClassName):
-    """Create lightweight model factories for exercising the master classes."""
+def makeSimulation(masterClass, numberSpacecraft, customRates=False):
+    """Create a single- or multi-spacecraft master simulation."""
+    rates = {"fswRate": 0.25, "dynRate": 0.5} if customRates else {}  # [s]
+    if numberSpacecraft is None:
+        return masterClass(**rates)
+    if customRates:
+        rates["envRate"] = 0.75  # [s]
+    return masterClass(numberSpacecraft, **rates)
+
+
+def makeModelInputs(dynClassName, fswClassName, numberSpacecraft):
+    """Create lightweight model inputs for exercising the master classes."""
+
+    class EnvironmentModel:
+        def __init__(self, simBase, envRate):
+            self.simBase = simBase
+            self.rate = envRate
 
     class DynamicsModel:
-        def __init__(self, simBase, dynRate):
+        def __init__(self, simBase, dynRate, spacecraftIndex=None):
             self.simBase = simBase
             self.rate = dynRate
+            self.spacecraftIndex = spacecraftIndex
 
     class FswModel:
-        def __init__(self, simBase, fswRate):
+        def __init__(self, simBase, fswRate, spacecraftIndex=None):
             self.simBase = simBase
             self.rate = fswRate
+            self.spacecraftIndex = spacecraftIndex
             self.dynModels = simBase.DynModels
 
-    modelModule = SimpleNamespace()
+    modelModule = SimpleNamespace(BSKEnvironmentModel=EnvironmentModel)
     setattr(modelModule, dynClassName, DynamicsModel)
     setattr(modelModule, fswClassName, FswModel)
-    return modelModule
+    if numberSpacecraft is None:
+        return modelModule, modelModule, modelModule
+    modelModules = [modelModule] * numberSpacecraft
+    return modelModule, modelModules, modelModules
+
+
+def setEnvironmentModel(simulation, environmentInput, numberSpacecraft):
+    """Set the environment model when exercising the MultiSat master."""
+    if numberSpacecraft is not None:
+        simulation.set_EnvModel(environmentInput)
 
 
 @pytest.mark.parametrize(
-    "masterName, masterPath, dynClassName, fswClassName",
+    "masterName, masterPath, dynClassName, fswClassName, numberSpacecraft",
     MASTER_CONFIGURATIONS,
     ids=[configuration[0] for configuration in MASTER_CONFIGURATIONS],
 )
-def test_modelAccessRequiresInitialization(masterName, masterPath, dynClassName, fswClassName):
+def test_modelAccessRequiresInitialization(
+    masterName, masterPath, dynClassName, fswClassName, numberSpacecraft
+):
     """Verify that both access styles reject uninitialized model access."""
     del dynClassName, fswClassName
     masterClass = loadMasterClass(masterName, masterPath)
-    simulation = masterClass()
+    simulation = makeSimulation(masterClass, numberSpacecraft)
 
-    with pytest.raises(RuntimeError, match="dynamics model has not been added"):
+    if numberSpacecraft is not None:
+        with pytest.raises(RuntimeError, match="not been added"):
+            _ = simulation.EnvModel
+        with pytest.raises(RuntimeError, match="not been added"):
+            simulation.get_EnvModel()
+    with pytest.raises(RuntimeError, match="not been added"):
         _ = simulation.DynModels
-    with pytest.raises(RuntimeError, match="dynamics model has not been added"):
+    with pytest.raises(RuntimeError, match="not been added"):
         simulation.get_DynModel()
-    with pytest.raises(RuntimeError, match="flight software model has not been added"):
+    with pytest.raises(RuntimeError, match="not been added"):
         _ = simulation.FSWModels
-    with pytest.raises(RuntimeError, match="flight software model has not been added"):
+    with pytest.raises(RuntimeError, match="not been added"):
         simulation.get_FswModel()
 
 
 @pytest.mark.parametrize(
-    "masterName, masterPath, dynClassName, fswClassName",
+    "masterName, masterPath, dynClassName, fswClassName, numberSpacecraft",
     MASTER_CONFIGURATIONS,
     ids=[configuration[0] for configuration in MASTER_CONFIGURATIONS],
 )
-def test_modelReferencesAreReadOnlyAndSingleUse(masterName, masterPath, dynClassName, fswClassName):
+def test_modelReferencesAreReadOnlyAndSingleUse(
+    masterName, masterPath, dynClassName, fswClassName, numberSpacecraft
+):
     """Verify model references cannot be replaced or initialized more than once."""
     masterClass = loadMasterClass(masterName, masterPath)
-    simulation = masterClass(fswRate=0.25, dynRate=0.5)  # [s]
-    modelModule = makeModelModule(dynClassName, fswClassName)
+    simulation = makeSimulation(masterClass, numberSpacecraft, customRates=True)
+    environmentInput, dynamicsInput, fswInput = makeModelInputs(
+        dynClassName, fswClassName, numberSpacecraft
+    )
 
-    simulation.set_DynModel(modelModule)
+    if numberSpacecraft is not None:
+        simulation.set_EnvModel(environmentInput)
+        assert simulation.get_EnvModel() is simulation.EnvModel
+        assert simulation.EnvModel.rate == simulation.envRate
+        assert simulation.environment_added is True
+        with pytest.raises(AttributeError):
+            simulation.EnvModel = object()
+        with pytest.raises(RuntimeError, match="already been added"):
+            simulation.set_EnvModel(environmentInput)
+
+    processCount = len(simulation.procList)
+    with pytest.raises(RuntimeError, match="must be added before"):
+        simulation.set_FswModel(fswInput)
+    assert len(simulation.procList) == processCount
+
+    simulation.set_DynModel(dynamicsInput)
     dynModels = simulation.DynModels
     assert simulation.get_DynModel() is dynModels
-    assert dynModels.rate == simulation.dynRate
+    dynModelList = dynModels if numberSpacecraft is not None else [dynModels]
+    assert all(model.rate == simulation.dynRate for model in dynModelList)
     assert simulation.dynamics_added is True
 
-    simulation.set_FswModel(modelModule)
+    simulation.set_FswModel(fswInput)
     fswModels = simulation.FSWModels
     assert simulation.get_FswModel() is fswModels
-    assert fswModels.dynModels is dynModels
-    assert fswModels.rate == simulation.fswRate
+    fswModelList = fswModels if numberSpacecraft is not None else [fswModels]
+    assert all(model.dynModels is dynModels for model in fswModelList)
+    assert all(model.rate == simulation.fswRate for model in fswModelList)
     assert simulation.fsw_added is True
 
     with pytest.raises(AttributeError):
         simulation.DynModels = object()
     with pytest.raises(AttributeError):
         simulation.FSWModels = object()
-    with pytest.raises(RuntimeError, match="dynamics model has already been added"):
-        simulation.set_DynModel(modelModule)
-    with pytest.raises(RuntimeError, match="flight software model has already been added"):
-        simulation.set_FswModel(modelModule)
+    with pytest.raises(RuntimeError, match="already been added"):
+        simulation.set_DynModel(dynamicsInput)
+    with pytest.raises(RuntimeError, match="already been added"):
+        simulation.set_FswModel(fswInput)
 
 
 @pytest.mark.parametrize(
-    "masterName, masterPath, dynClassName, fswClassName",
+    "masterName, masterPath, dynClassName, fswClassName, numberSpacecraft",
     MASTER_CONFIGURATIONS,
     ids=[configuration[0] for configuration in MASTER_CONFIGURATIONS],
 )
-def test_failedConstructionDoesNotPublishModel(masterName, masterPath, dynClassName, fswClassName):
-    """Verify failed constructors leave the corresponding model unpublished."""
+def test_failedConstructionIsTerminal(masterName, masterPath, dynClassName, fswClassName, numberSpacecraft):
+    """Verify failed constructors leave models unpublished and block unsafe retries."""
     masterClass = loadMasterClass(masterName, masterPath)
-    modelModule = makeModelModule(dynClassName, fswClassName)
+
+    if numberSpacecraft is not None:
+        environmentInput, _, _ = makeModelInputs(dynClassName, fswClassName, numberSpacecraft)
+
+        class FailingEnvironmentModel:
+            def __init__(self, simBase, envRate):
+                del simBase, envRate
+                raise ValueError("environment construction failed")
+
+        environmentInput.BSKEnvironmentModel = FailingEnvironmentModel
+        simulation = makeSimulation(masterClass, numberSpacecraft)
+        processCount = len(simulation.procList)
+        with pytest.raises(ValueError, match="environment construction failed"):
+            simulation.set_EnvModel(environmentInput)
+        assert len(simulation.procList) == processCount + 1
+        with pytest.raises(RuntimeError, match="previous environment model setup attempt failed"):
+            simulation.set_EnvModel(environmentInput)
+        assert len(simulation.procList) == processCount + 1
+        assert simulation.environment_added is False
+        with pytest.raises(RuntimeError, match="not been added"):
+            _ = simulation.EnvModel
+
+    environmentInput, dynamicsInput, _ = makeModelInputs(
+        dynClassName, fswClassName, numberSpacecraft
+    )
 
     class FailingDynamicsModel:
-        def __init__(self, simBase, dynRate):
+        def __init__(self, simBase, dynRate, spacecraftIndex=None):
             del simBase, dynRate
-            raise ValueError("dynamics construction failed")
+            if spacecraftIndex is None or spacecraftIndex == numberSpacecraft - 1:
+                raise ValueError("dynamics construction failed")
 
-    setattr(modelModule, dynClassName, FailingDynamicsModel)
-    simulation = masterClass()
+    if numberSpacecraft is None:
+        setattr(dynamicsInput, dynClassName, FailingDynamicsModel)
+    else:
+        for modelModule in dynamicsInput:
+            setattr(modelModule, dynClassName, FailingDynamicsModel)
+    simulation = makeSimulation(masterClass, numberSpacecraft)
+    setEnvironmentModel(simulation, environmentInput, numberSpacecraft)
+    processCount = len(simulation.procList)
+    setupProcessCount = numberSpacecraft or 1
     with pytest.raises(ValueError, match="dynamics construction failed"):
-        simulation.set_DynModel(modelModule)
+        simulation.set_DynModel(dynamicsInput)
+    assert len(simulation.procList) == processCount + setupProcessCount
+    with pytest.raises(RuntimeError, match="previous dynamics model setup attempt failed"):
+        simulation.set_DynModel(dynamicsInput)
+    assert len(simulation.procList) == processCount + setupProcessCount
     assert simulation.dynamics_added is False
-    with pytest.raises(RuntimeError, match="dynamics model has not been added"):
+    with pytest.raises(RuntimeError, match="not been added"):
         _ = simulation.DynModels
 
     class FailingFswModel:
-        def __init__(self, simBase, fswRate):
+        def __init__(self, simBase, fswRate, spacecraftIndex=None):
             del simBase, fswRate
-            raise ValueError("flight software construction failed")
+            if spacecraftIndex is None or spacecraftIndex == numberSpacecraft - 1:
+                raise ValueError("flight software construction failed")
 
-    modelModule = makeModelModule(dynClassName, fswClassName)
-    setattr(modelModule, fswClassName, FailingFswModel)
-    simulation = masterClass()
-    simulation.set_DynModel(modelModule)
+    environmentInput, dynamicsInput, fswInput = makeModelInputs(
+        dynClassName, fswClassName, numberSpacecraft
+    )
+    if numberSpacecraft is None:
+        setattr(fswInput, fswClassName, FailingFswModel)
+    else:
+        for modelModule in fswInput:
+            setattr(modelModule, fswClassName, FailingFswModel)
+    simulation = makeSimulation(masterClass, numberSpacecraft)
+    setEnvironmentModel(simulation, environmentInput, numberSpacecraft)
+    simulation.set_DynModel(dynamicsInput)
+    processCount = len(simulation.procList)
     with pytest.raises(ValueError, match="flight software construction failed"):
-        simulation.set_FswModel(modelModule)
+        simulation.set_FswModel(fswInput)
+    assert len(simulation.procList) == processCount + setupProcessCount
+    with pytest.raises(RuntimeError, match="previous flight software model setup attempt failed"):
+        simulation.set_FswModel(fswInput)
+    assert len(simulation.procList) == processCount + setupProcessCount
     assert simulation.fsw_added is False
-    with pytest.raises(RuntimeError, match="flight software model has not been added"):
+    with pytest.raises(RuntimeError, match="not been added"):
         _ = simulation.FSWModels

--- a/src/tests/test_bskSimModelAccess.py
+++ b/src/tests/test_bskSimModelAccess.py
@@ -141,6 +141,29 @@ def test_modelAccessRequiresInitialization(
         simulation.get_FswModel()
 
 
+def test_multiSatDynamicsRequiresEnvironment():
+    """Verify MultiSat dynamics setup requires the environment to be added first."""
+    masterPath = REPOSITORY_ROOT / "examples/MultiSatBskSim/BSK_MultiSatMasters.py"
+    masterClass = loadMasterClass("MultiSat", masterPath)
+    simulation = makeSimulation(masterClass, 2)
+    environmentInput, dynamicsInput, _ = makeModelInputs(
+        "BSKDynamicModels", "BSKFswModels", 2
+    )
+
+    processCount = len(simulation.procList)
+    with pytest.raises(
+        RuntimeError,
+        match="An environment model must be added before the dynamics models",
+    ):
+        simulation.set_DynModel(dynamicsInput)
+    assert len(simulation.procList) == processCount
+    assert simulation.dynamics_added is False
+
+    simulation.set_EnvModel(environmentInput)
+    simulation.set_DynModel(dynamicsInput)
+    assert simulation.dynamics_added is True
+
+
 @pytest.mark.parametrize(
     "masterName, masterPath, dynClassName, fswClassName, numberSpacecraft",
     MASTER_CONFIGURATIONS,


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

This branch hardens model ownership and initialization in the BskSim, OpNav, MuJoCo, and MultiSat example master classes.

The existing `DynModels`, `FSWModels`, and MultiSat `EnvModel` direct-read APIs are retained as read-only properties backed by private attributes. Existing getter methods remain available for compatibility.

The changes also:

- Replace empty-list initialization sentinels with `None`.
- Raise explicit `RuntimeError` exceptions instead of relying on assertions.
- Enforce environment → dynamics → FSW initialization order where applicable.
- Reject repeated setup attempts before additional processes can be created.
- Treat failed model construction as terminal for that simulation instance.
- Publish MultiSat model lists only after all requested models construct successfully.

The commits are organized so that the initial BskSim, OpNav, and MuJoCo hardening is reviewed first, followed by the MultiSat extension and its additional tests. The release-note snippet is isolated in the final commit.

## Verification

A parameterized regression suite was added in `src/tests/test_bskSimModelAccess.py`. It covers all four master implementations and verifies:

- Access before initialization through properties and getters.
- Preservation of direct-read and getter access after initialization.
- Read-only model references.
- Required initialization ordering.
- Rejection of repeated setup.
- Failed-construction behavior.
- Prevention of duplicate process creation after failure.
- Publication of MultiSat model lists only after complete construction.

Verification results:

- Focused model-access suite: 12 tests passed in approximately 0.9 seconds.
- Existing BskSim, MultiSat, and MuJoCo scenario coverage: 18 tests passed.
- Repository pre-commit hooks passed.
- Modified Python files passed compilation checks.
- `git diff --check` passed.

The focused OpNav master behavior is covered without launching Vizard. Full OpNav/Vizard execution remains dependent on the optional local visualization environment.

## Documentation

Method and property docstrings were added or updated to document the new initialization errors and setup requirements.

A release-note snippet was added at:

`docs/source/Support/bskReleaseNotesSnippets/bsk-sim-model-access-hardening.rst`

No standalone user documentation was invalidated. Existing getter and direct-read access remain supported; direct reassignment of model references is now intentionally rejected.

## Future work

No follow-up work is currently planned. Additional changes would only be necessary if platform CI or optional OpNav/Vizard integration testing identifies an environment-specific issue.