### PR TITLE
Augment NDOF Hinged Rigid Bodies for Branching Dynamics

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
@@ -220,8 +220,8 @@ special case of prescribed effector branching explained in :ref:`prescribedMotio
         </tr>
         <tr>
           <td class="label">N Hinged Rigid Bodies</td>
-          <td class="yellow"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="yellow"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
+          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
         </tr>

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -14,6 +14,10 @@ Version |release| (July 7, 2026)
   ``SimBaseClass.AddVariableForLogging()`` and ``GetLogVariableData()`` methods, causing every
   Monte Carlo variable-retention request to fail with ``AttributeError``. Variable retention now
   creates and reads the supported module logger directly.
+- The :ref:`nHingedRigidBodyStateEffector` equations of motion are derived for a chain of identical
+  panels, but the module accepted a per-panel mass and hinge to center of mass distance and
+  integrated silently wrong dynamics when either varied along the chain. Initialization now rejects
+  such a chain.
 - Every state effector acting as a parent published the inertial state of its attachment frame once
   per task step from its own ``UpdateState()``. A child effector therefore evaluated its loads against
   kinematics a full task step old. These are now refreshed within the integration.

--- a/docs/source/Support/bskReleaseNotesSnippets/1152-n-hinged-rigid-body-branching.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1152-n-hinged-rigid-body-branching.rst
@@ -1,0 +1,3 @@
+- Added support for :ref:`nHingedRigidBodyStateEffector` to be the parent for dynamic effectors.
+- Added panel state and panel configuration log output messages to :ref:`nHingedRigidBodyStateEffector`.
+- :ref:`nHingedRigidBodyStateEffector` now rejects a massless panel and a panel chain whose panels differ in mass or length.

--- a/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
@@ -35,6 +35,8 @@ from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import simHelpers
 from Basilisk.simulation import spacecraft
+from Basilisk.simulation import dualHingedRigidBodyStateEffector
+from Basilisk.simulation import extForceTorque
 from Basilisk.simulation import nHingedRigidBodyStateEffector
 from Basilisk.simulation import gravityEffector
 from Basilisk.utilities import macros
@@ -89,19 +91,153 @@ values have all been confirmed to be conserved.
     assert testResults < 1, testMessage
 
 
-@pytest.mark.parametrize("chain", ['UnequalMass', 'UnequalDistance', 'NoPanels'])
-def test_nHingedRigidBodyRejectsUnevenChain(chain):
+def test_nHingedRigidBodyOutputMessagesMatchDual():
+    """
+    Verify both output-message vectors against the equivalent dual-hinged model.
+
+    A two-panel N-hinged effector and a dual-hinged effector are given identical geometry, mass
+    properties, and initial states on the same spacecraft. The hub starts with a non-identity
+    attitude and nonzero translational and angular velocity so that every inertial transformation
+    contributes. The test runs for two steps and compares each panel's angle, angle rate, inertial
+    position, inertial velocity, attitude, and angular velocity.
+    """
+    timeStep = 0.01  # [s]
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.SetProgressBar(False)
+    unitTestSim.CreateNewProcess("TestProcess").addTask(
+        unitTestSim.CreateNewTask("unitTask", macros.sec2nano(timeStep)))
+
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+    scObject.hub.r_CN_NInit = [[1000.0], [-2000.0], [3000.0]]  # [m]
+    scObject.hub.v_CN_NInit = [[-2.0], [3.0], [1.0]]  # [m/s]
+    scObject.hub.sigma_BNInit = [[0.1], [-0.2], [0.05]]  # [-]
+    scObject.hub.omega_BN_BInit = [[0.1], [-0.1], [0.2]]  # [rad/s]
+
+    panelMass = 50.0  # [kg]
+    panelHalfLength = 0.75  # [m]
+    panelInertia = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]  # [kg*m^2]
+    springConstant = 100.0  # [N*m/rad]
+    dampingCoefficient = 0.0  # [N*m*s/rad]
+    thetaInit = [0.1, -0.2]  # [rad]
+    thetaDotInit = [-0.01, 0.02]  # [rad/s]
+    hingePosition_B = [[0.5], [-1.5], [-0.5]]  # [m]
+    dcm_HB = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]  # [-]
+
+    nHinged = nHingedRigidBodyStateEffector.NHingedRigidBodyStateEffector()
+    nHinged.r_HB_B = hingePosition_B
+    nHinged.dcm_HB = dcm_HB
+    for panelIndex in range(2):
+        panel = nHingedRigidBodyStateEffector.HingedPanel()
+        panel.mass = panelMass
+        panel.d = panelHalfLength
+        panel.k = springConstant
+        panel.c = dampingCoefficient
+        panel.IPntS_S = panelInertia
+        panel.thetaInit = thetaInit[panelIndex]
+        panel.thetaDotInit = thetaDotInit[panelIndex]
+        panel.theta_0 = 0.0  # [rad]
+        nHinged.addHingedPanel(panel)
+
+    dualHinged = dualHingedRigidBodyStateEffector.DualHingedRigidBodyStateEffector()
+    dualHinged.mass1 = panelMass
+    dualHinged.mass2 = panelMass
+    dualHinged.d1 = panelHalfLength
+    dualHinged.d2 = panelHalfLength
+    dualHinged.l1 = 2.0 * panelHalfLength  # [m]
+    dualHinged.thetaH2S1 = 0.0  # [rad] the N hinged chain carries no fixed offset between hinges
+    dualHinged.k1 = springConstant
+    dualHinged.k2 = springConstant
+    dualHinged.c1 = dampingCoefficient
+    dualHinged.c2 = dampingCoefficient
+    dualHinged.IPntS1_S1 = panelInertia
+    dualHinged.IPntS2_S2 = panelInertia
+    dualHinged.theta1Init = thetaInit[0]
+    dualHinged.theta2Init = thetaInit[1]
+    dualHinged.theta1DotInit = thetaDotInit[0]
+    dualHinged.theta2DotInit = thetaDotInit[1]
+    dualHinged.r_H1B_B = hingePosition_B
+    dualHinged.dcm_H1B = dcm_HB
+
+    scObject.addStateEffector(nHinged)
+    scObject.addStateEffector(dualHinged)
+    unitTestSim.AddModelToTask("unitTask", scObject)
+
+    nStateRecorders = [message.recorder() for message in nHinged.nHingedRigidBodyOutMsgs]
+    nConfigRecorders = [message.recorder() for message in nHinged.nHingedRigidBodyConfigLogOutMsgs]
+    dualStateRecorders = [message.recorder() for message in dualHinged.dualHingedRigidBodyOutMsgs]
+    dualConfigRecorders = [message.recorder() for message in dualHinged.dualHingedRigidBodyConfigLogOutMsgs]
+    for recorder in nStateRecorders + nConfigRecorders + dualStateRecorders + dualConfigRecorders:
+        unitTestSim.AddModelToTask("unitTask", recorder)
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(2.0 * timeStep))
+    unitTestSim.ExecuteSimulation()
+
+    accuracy = 1e-13
+    for panelIndex in range(2):
+        numpy.testing.assert_allclose(
+            nStateRecorders[panelIndex].theta, dualStateRecorders[panelIndex].theta,
+            rtol=0.0, atol=accuracy)
+        numpy.testing.assert_allclose(
+            nStateRecorders[panelIndex].thetaDot, dualStateRecorders[panelIndex].thetaDot,
+            rtol=0.0, atol=accuracy)
+        for fieldName in ("r_BN_N", "v_BN_N", "sigma_BN", "omega_BN_B"):
+            numpy.testing.assert_allclose(
+                getattr(nConfigRecorders[panelIndex], fieldName),
+                getattr(dualConfigRecorders[panelIndex], fieldName),
+                rtol=0.0, atol=accuracy)
+
+
+@pytest.mark.parametrize("segment, shouldRaise", [(1, False), (3, False), (0, True), (4, True)])
+def test_nHingedRigidBodyDynamicEffectorSegmentBounds(segment, shouldRaise):
+    """
+    Verify that dynamic effectors can attach only to existing panels.
+
+    A three-panel chain accepts its first and last panel numbers and rejects the adjacent values
+    outside the valid one-based range.
+
+    **Test Parameters:**
+
+    - segment: [int]
+        one-based panel number supplied to ``addDynamicEffector``
+    - shouldRaise: [bool]
+        whether the panel number is outside the valid range
+    """
+    effector = nHingedRigidBodyStateEffector.NHingedRigidBodyStateEffector()
+    for _ in range(3):
+        effector.addHingedPanel(nHingedRigidBodyStateEffector.HingedPanel())
+
+    child = extForceTorque.ExtForceTorque()
+    if shouldRaise:
+        with pytest.raises(BasiliskError, match="non-existent panel"):
+            effector.addDynamicEffector(child, segment)
+    else:
+        effector.addDynamicEffector(child, segment)
+
+
+@pytest.mark.parametrize("chain, expectedError", [
+    ('UnequalMass', "same mass and the same hinge"),
+    ('UnequalDistance', "same mass and the same hinge"),
+    ('NoPanels', "at least one hinged panel"),
+    ('MasslessPanels', "panel mass must be greater than 0"),
+    ('UnequalInertia', None),
+])
+def test_nHingedRigidBodyPanelValidation(chain, expectedError):
     """
 The equations of motion are derived for a chain of identical panels, factoring one panel mass and
-one hinge to center of mass distance out of the sums that run over the chain. A chain that violates
-that assumption integrates without complaint, so this test asserts that initialization rejects it
-instead. This is a separate test from the conservation test above because it asserts an error
-rather than a conserved quantity, and because a rejected configuration never reaches integration.
+one hinge to center of mass distance out of the sums that run over the chain. An uneven chain
+integrates without complaint and a massless one reaches the hub states as NaN, so initialization
+must reject both. The inertia is not factored out, so dissimilar inertia tensors must initialize.
 
 **Test Parameters:**
 
 - chain: [string]
-    which requirement the panel chain violates (UnequalMass, UnequalDistance, or NoPanels)
+    panel-chain configuration to initialize
+- expectedError: [string]
+    text the rejection message must carry, or None when the chain must initialize
     """
     scObject = spacecraft.Spacecraft()
     scObject.ModelTag = "spacecraftBody"
@@ -112,11 +248,13 @@ rather than a conserved quantity, and because a rejected configuration never rea
     if chain != 'NoPanels':
         for factor in [1.0, 2.0]:
             panel = nHingedRigidBodyStateEffector.HingedPanel()
-            panel.mass = 50.0 * (factor if chain == 'UnequalMass' else 1.0)  # [kg]
+            massScale = 0.0 if chain == 'MasslessPanels' else (factor if chain == 'UnequalMass' else 1.0)  # [-]
+            panel.mass = 50.0 * massScale  # [kg]
             panel.d = 0.75 * (factor if chain == 'UnequalDistance' else 1.0)  # [m]
             panel.k = 500.0  # [N*m/rad]
             panel.c = 0.0  # [N*m*s/rad]
-            panel.IPntS_S = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]  # [kg*m^2]
+            inertiaScale = factor if chain == 'UnequalInertia' else 1.0  # [-]
+            panel.IPntS_S = (inertiaScale * numpy.diag([50.0, 25.0, 25.0])).tolist()  # [kg*m^2]
             effector.addHingedPanel(panel)
     scObject.addStateEffector(effector)
 
@@ -125,7 +263,10 @@ rather than a conserved quantity, and because a rejected configuration never rea
         unitTestSim.CreateNewTask("unitTask", macros.sec2nano(0.0001)))
     unitTestSim.AddModelToTask("unitTask", scObject)
 
-    with pytest.raises(BasiliskError):
+    if expectedError is not None:
+        with pytest.raises(BasiliskError, match=expectedError):
+            unitTestSim.InitializeSimulation()
+    else:
         unitTestSim.InitializeSimulation()
 
 

--- a/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
+++ b/src/simulation/dynamics/NHingedRigidBodies/_UnitTest/test_nHingedRigidBodyStateEffector.py
@@ -30,6 +30,7 @@ splitPath = path.split('SimCode')
 sys.path.append(splitPath[0] + '/modules')
 sys.path.append(splitPath[0] + '/PythonModules')
 
+from Basilisk.architecture.bskLogging import BasiliskError
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import unitTestSupport
 from Basilisk.utilities import simHelpers
@@ -86,6 +87,47 @@ values have all been confirmed to be conserved.
     """
     [testResults, testMessage] = nHingedRigidBody(show_plots, testCase)
     assert testResults < 1, testMessage
+
+
+@pytest.mark.parametrize("chain", ['UnequalMass', 'UnequalDistance', 'NoPanels'])
+def test_nHingedRigidBodyRejectsUnevenChain(chain):
+    """
+The equations of motion are derived for a chain of identical panels, factoring one panel mass and
+one hinge to center of mass distance out of the sums that run over the chain. A chain that violates
+that assumption integrates without complaint, so this test asserts that initialization rejects it
+instead. This is a separate test from the conservation test above because it asserts an error
+rather than a conserved quantity, and because a rejected configuration never reaches integration.
+
+**Test Parameters:**
+
+- chain: [string]
+    which requirement the panel chain violates (UnequalMass, UnequalDistance, or NoPanels)
+    """
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+
+    effector = nHingedRigidBodyStateEffector.NHingedRigidBodyStateEffector()
+    if chain != 'NoPanels':
+        for factor in [1.0, 2.0]:
+            panel = nHingedRigidBodyStateEffector.HingedPanel()
+            panel.mass = 50.0 * (factor if chain == 'UnequalMass' else 1.0)  # [kg]
+            panel.d = 0.75 * (factor if chain == 'UnequalDistance' else 1.0)  # [m]
+            panel.k = 500.0  # [N*m/rad]
+            panel.c = 0.0  # [N*m*s/rad]
+            panel.IPntS_S = [[50.0, 0.0, 0.0], [0.0, 25.0, 0.0], [0.0, 0.0, 25.0]]  # [kg*m^2]
+            effector.addHingedPanel(panel)
+    scObject.addStateEffector(effector)
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.CreateNewProcess("TestProcess").addTask(
+        unitTestSim.CreateNewTask("unitTask", macros.sec2nano(0.0001)))
+    unitTestSim.AddModelToTask("unitTask", scObject)
+
+    with pytest.raises(BasiliskError):
+        unitTestSim.InitializeSimulation()
+
 
 def nHingedRigidBody(show_plots, testCase):
     # The __tracebackhide__ setting influences pytest showing of tracebacks:

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -19,6 +19,7 @@
 
 #include "nHingedRigidBodyStateEffector.h"
 #include "architecture/utilities/avsEigenSupport.h"
+#include <cmath>
 
 /*! This is the constructor, setting variables to default values */
 NHingedRigidBodyStateEffector::NHingedRigidBodyStateEffector()
@@ -64,9 +65,38 @@ void NHingedRigidBodyStateEffector::linkInStates(DynParamManager& statesIn)
     return;
 }
 
+/*! This method checks that the panel chain is one the equations of motion can represent */
+void
+NHingedRigidBodyStateEffector::checkPanelUniformity()
+{
+    if (this->PanelVec.empty()) {
+        this->bskLogger.bskError("NHingedRigidBodyStateEffector: at least one hinged panel is required.");
+    }
+
+    // the equations of motion factor one panel mass and one half-length out of the sums over the
+    // chain, so an uneven chain integrates silently wrong dynamics rather than failing
+    const double relativeTolerance = 1e-9; // [-]
+    const double mass = this->PanelVec.front().mass;
+    const double d = this->PanelVec.front().d;
+    std::vector<HingedPanel>::iterator PanelIt;
+    for (PanelIt = this->PanelVec.begin(); PanelIt != this->PanelVec.end(); PanelIt++) {
+        if (PanelIt->mass <= 0.0) {
+            this->bskLogger.bskError("NHingedRigidBodyStateEffector: every panel mass must be greater than 0.");
+        }
+        if (std::abs(PanelIt->mass - mass) > relativeTolerance * std::abs(mass) ||
+            std::abs(PanelIt->d - d) > relativeTolerance * std::abs(d)) {
+            this->bskLogger.bskError("NHingedRigidBodyStateEffector: every panel must carry the same "
+                                     "mass and the same hinge to center of mass distance d. Model an "
+                                     "uneven chain with dualHingedRigidBodyStateEffector or "
+                                     "spinningBodyNDOFStateEffector instead.");
+        }
+    }
+}
+
 /*! This method allows the HRB state effector to register its states: theta and thetaDot with the dyn param manager */
 void NHingedRigidBodyStateEffector::registerStates(DynParamManager& states)
 {
+    this->checkPanelUniformity();
 
     // - Register the states associated with hinged rigid bodies - theta and thetaDot
     Eigen::MatrixXd thetaInitMatrix(this->PanelVec.size(),1);

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -222,6 +222,7 @@ NHingedRigidBodyStateEffector::addDynamicEffector(DynamicEffector* newDynamicEff
     HingedPanel& panel = this->PanelVec[(size_t)(segment - 1)];
     panel.assignStateParamNames<DynamicEffector*>(newDynamicEffector);
     panel.dynEffectors.push_back(newDynamicEffector);
+    this->hasAttachedEffectors = true;
 }
 
 /*! This method registers the panel inertial properties with the dynamic parameter manager and links
@@ -354,7 +355,7 @@ double NHingedRigidBodyStateEffector::HeaviFunc(double cond)
 
 /*! This method allows the HRB state effector to give its contributions to the matrices needed for the back-sub
  method */
-void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe_unused]], BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N [[maybe_unused]])
+void NHingedRigidBodyStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N [[maybe_unused]])
 {
     // - Find dcm_BN
     Eigen::MRPd sigmaLocal_BN;
@@ -376,6 +377,30 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
     std::vector<HingedPanel>::iterator PanelIt;
     for(PanelIt=this->PanelVec.begin(); PanelIt!=this->PanelVec.end(); PanelIt++){
         PanelIt->omega_BN_S = PanelIt->dcm_SB*this->omegaLoc_BN_B;
+    }
+
+    if (this->hasAttachedEffectors) {
+        this->computePanelInertialStates();
+    }
+
+    // Loop through to collect forces and torques from any connected dynamic effectors
+    Eigen::Vector3d attBodyForce_B = Eigen::Vector3d::Zero();
+    Eigen::Vector3d attBodyTorquePntB_B = Eigen::Vector3d::Zero();
+    for(PanelIt=this->PanelVec.begin(); PanelIt!=this->PanelVec.end(); PanelIt++){
+        PanelIt->extForce_B.setZero();
+        PanelIt->extTorquePntH_B.setZero();
+        std::vector<DynamicEffector*>::iterator dynIt;
+        for(dynIt = PanelIt->dynEffectors.begin(); dynIt != PanelIt->dynEffectors.end(); dynIt++)
+        {
+            // - Compute the force and torque contributions from the dynamicEffectors
+            (*dynIt)->computeForceTorque(integTime, double(0.0));
+            // a child's "_B" loads are already in this panel's S frame, so only "_N" is rotated
+            PanelIt->extForce_B += PanelIt->dcm_SB.transpose()*(*dynIt)->forceExternal_B
+                                   + dcm_BN*(*dynIt)->forceExternal_N;
+            PanelIt->extTorquePntH_B += PanelIt->dcm_SB.transpose()*(*dynIt)->torqueExternalPntB_B;
+        }
+        attBodyForce_B += PanelIt->extForce_B;
+        attBodyTorquePntB_B += PanelIt->extTorquePntH_B + PanelIt->r_HB_B.cross(PanelIt->extForce_B);
     }
 
     // - Define A matrix for the panel equations
@@ -452,10 +477,12 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
     this->vectorVDHRB.resize((int) this->PanelVec.size());
     this->vectorVDHRB.setZero();
     double massOfCurrentPanelAndBefore = 0; // Summation of all of prior panels masses and the current panels mass
+    Eigen::Vector3d extForceCurrentPanelAndBefore = Eigen::Vector3d::Zero();
     j = 1;
     for(PanelIt=this->PanelVec.begin(); PanelIt!=this->PanelVec.end(); PanelIt++){
         // Add current panel to mass
         massOfCurrentPanelAndBefore += PanelIt->mass;
+        extForceCurrentPanelAndBefore += PanelIt->extForce_B;
         double sumTerm1;
         Eigen::Vector3d sumTerm2;
         sumTerm2.setZero();
@@ -503,8 +530,11 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
         double remainingMass;
         remainingMass = this->totalMass - massOfCurrentPanelAndBefore;
         gravForceRestOfPanels = remainingMass*g_B;
-        this->vectorVDHRB(j-1) = sumTerm1 + PanelIt->sHat2_B.dot(gravTorqueCurPanel)
-        + 2.0*PanelIt->d*PanelIt->sHat3_B.dot(gravForceRestOfPanels);
+        // an attached effector's torque on a panel outboard of j cancels between the row j and row
+        // j+1 balances, so only the moment arm of its force survives here
+        Eigen::Vector3d extForceRestOfPanels = attBodyForce_B - extForceCurrentPanelAndBefore;
+        this->vectorVDHRB(j-1) = sumTerm1 + PanelIt->sHat2_B.dot(gravTorqueCurPanel + PanelIt->extTorquePntH_B)
+        + 2.0*PanelIt->d*PanelIt->sHat3_B.dot(gravForceRestOfPanels + extForceRestOfPanels);
         j += 1;
     }
 
@@ -536,6 +566,7 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
         backSubContr.vecTrans += -sumTerm2 - sumTerm1 * (eRow * this->vectorVDHRB);
         j += 1;
     }
+    backSubContr.vecTrans += attBodyForce_B;
 
     // - Rotational contributions
     backSubContr.matrixC.setZero();
@@ -582,6 +613,7 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
         backSubContr.vecRot += -sumTerm2 - sumTerm1 * (eRow * this->vectorVDHRB);
         j += 1;
     }
+    backSubContr.vecRot += attBodyTorquePntB_B;
 
 
     return;

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -19,7 +19,6 @@
 
 #include "nHingedRigidBodyStateEffector.h"
 #include "architecture/utilities/avsEigenSupport.h"
-#include <iostream>
 
 /*! This is the constructor, setting variables to default values */
 NHingedRigidBodyStateEffector::NHingedRigidBodyStateEffector()
@@ -43,14 +42,6 @@ uint64_t NHingedRigidBodyStateEffector::effectorID = 1;
 
 /*! This is the destructor, nothing to report here */
 NHingedRigidBodyStateEffector::~NHingedRigidBodyStateEffector()
-{
-    return;
-}
-
-
-/*! This method reads necessary input messages
-  */
-void NHingedRigidBodyStateEffector::readInputMessages()
 {
     return;
 }
@@ -131,7 +122,6 @@ void NHingedRigidBodyStateEffector::updateEffectorMassProps(double integTime [[m
         PanelIt->thetaDot = thetaDotVector(it, 0);
         // - Next find the sHat unit vectors
         sum_Theta += PanelIt->theta;
-        PanelIt->dcm_SS_prev = eigenM2(PanelIt->theta);
         PanelIt->dcm_SB = eigenM2(sum_Theta)*this->dcm_HB;
         PanelIt->sHat1_B = PanelIt->dcm_SB.row(0);
         PanelIt->sHat2_B = PanelIt->dcm_SB.row(1);
@@ -386,11 +376,6 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
         backSubContr.vecTrans += -sumTerm2 - sumTerm1 * (eRow * this->vectorVDHRB);
         j += 1;
     }
-    Eigen::Vector3d aTheta;
-    Eigen::Vector3d bTheta;
-
-    aTheta = this->matrixEDHRB.row(0)*this->matrixFDHRB;
-    bTheta = this->matrixEDHRB.row(0)*this->matrixGDHRB;
 
     // - Rotational contributions
     backSubContr.matrixC.setZero();

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -34,6 +34,7 @@ NHingedRigidBodyStateEffector::NHingedRigidBodyStateEffector()
     this->dcm_HB.setIdentity();
     this->nameOfThetaState ="nHingedRigidBody" + std::to_string(this->effectorID) + "Theta";
     this->nameOfThetaDotState = "nHingedRigidBody" + std::to_string(this->effectorID) + "ThetaDot";
+    this->propertyNameIndex = std::to_string(this->effectorID); // preserves effectorID for later adding panels
     this->effectorID++;
 
     return;
@@ -63,6 +64,13 @@ NHingedRigidBodyStateEffector::addHingedPanel(HingedPanel NewPanel)
     this->nHingedRigidBodyOutMsgs.push_back(new Message<HingedRigidBodyMsgPayload>);
     this->nHingedRigidBodyConfigLogOutMsgs.push_back(new Message<SCStatesMsgPayload>);
 
+    const std::string panelSuffix = this->propertyNameIndex + "_" + std::to_string(this->PanelVec.size());
+    HingedPanel& panel = this->PanelVec.back();
+    panel.nameOfInertialPositionProperty = "nHingedRigidBodyInertialPosition" + panelSuffix;
+    panel.nameOfInertialVelocityProperty = "nHingedRigidBodyInertialVelocity" + panelSuffix;
+    panel.nameOfInertialAttitudeProperty = "nHingedRigidBodyInertialAttitude" + panelSuffix;
+    panel.nameOfInertialAngVelocityProperty = "nHingedRigidBodyInertialAngVelocity" + panelSuffix;
+
     return;
 }
 
@@ -90,8 +98,8 @@ NHingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
             // Note, logging the panel frame S is the body frame B of that object
             eigenVector3d2CArray(PanelIt->r_ScN_N, configLogMsg.r_BN_N);
             eigenVector3d2CArray(PanelIt->v_ScN_N, configLogMsg.v_BN_N);
-            eigenMRPd2CArray(PanelIt->sigma_SN, configLogMsg.sigma_BN);
-            eigenVector3d2CArray(PanelIt->omega_SN_S, configLogMsg.omega_BN_B);
+            eigenMatrixXd2CArray(*PanelIt->sigma_SN, configLogMsg.sigma_BN);
+            eigenMatrixXd2CArray(*PanelIt->omega_SN_S, configLogMsg.omega_BN_B);
             this->nHingedRigidBodyConfigLogOutMsgs[panelIndex]->write(&configLogMsg, this->moduleID, CurrentClock);
         }
         panelIndex++;
@@ -115,11 +123,15 @@ NHingedRigidBodyStateEffector::computePanelInertialStates()
 
     std::vector<HingedPanel>::iterator PanelIt;
     for (PanelIt = this->PanelVec.begin(); PanelIt != this->PanelVec.end(); PanelIt++) {
-        PanelIt->sigma_SN = eigenC2MRP(PanelIt->dcm_SB * dcm_NB.transpose());
-        PanelIt->omega_SN_S = PanelIt->dcm_SB * (this->omegaLoc_BN_B + PanelIt->omega_SB_B);
+        const Eigen::MRPd sigma_SN = eigenC2MRP(PanelIt->dcm_SB * dcm_NB.transpose());
+        *PanelIt->sigma_SN = sigma_SN.coeffs();
+        *PanelIt->omega_SN_S = PanelIt->dcm_SB * (this->omegaLoc_BN_B + PanelIt->omega_SB_B);
 
         PanelIt->r_ScN_N = r_BN_N + dcm_NB * PanelIt->r_SB_B;
         PanelIt->v_ScN_N = v_BN_N + dcm_NB * (PanelIt->rPrime_SB_B + this->omegaLoc_BN_B.cross(PanelIt->r_SB_B));
+
+        *PanelIt->r_HN_N = r_BN_N + dcm_NB * PanelIt->r_HB_B;
+        *PanelIt->v_HN_N = v_BN_N + dcm_NB * (PanelIt->rPrime_HB_B + this->omegaLoc_BN_B.cross(PanelIt->r_HB_B));
     }
 
     return;
@@ -190,6 +202,24 @@ void NHingedRigidBodyStateEffector::registerStates(DynParamManager& states)
     this->thetaState->setState(thetaInitMatrix);
     this->thetaDotState = states.registerState((uint32_t) this->PanelVec.size(), 1, this->nameOfThetaDotState);
     this->thetaDotState->setState(thetaDotInitMatrix);
+
+    registerProperties(states);
+
+    return;
+}
+
+/*! This method registers the panel inertial properties with the dynamic parameter manager */
+void
+NHingedRigidBodyStateEffector::registerProperties(DynParamManager& states)
+{
+    Eigen::Vector3d stateInit = Eigen::Vector3d::Zero();
+    std::vector<HingedPanel>::iterator PanelIt;
+    for (PanelIt = this->PanelVec.begin(); PanelIt != this->PanelVec.end(); PanelIt++) {
+        PanelIt->r_HN_N = states.createProperty(PanelIt->nameOfInertialPositionProperty, stateInit);
+        PanelIt->v_HN_N = states.createProperty(PanelIt->nameOfInertialVelocityProperty, stateInit);
+        PanelIt->sigma_SN = states.createProperty(PanelIt->nameOfInertialAttitudeProperty, stateInit);
+        PanelIt->omega_SN_S = states.createProperty(PanelIt->nameOfInertialAngVelocityProperty, stateInit);
+    }
 
     return;
 }

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -208,7 +208,24 @@ void NHingedRigidBodyStateEffector::registerStates(DynParamManager& states)
     return;
 }
 
-/*! This method registers the panel inertial properties with the dynamic parameter manager */
+/*! This method attaches a dynamicEffector to one of the panels
+
+ @param newDynamicEffector the dynamic effector to be attached
+ @param segment the panel to attach to, counting outward from the hub starting at 1 */
+void
+NHingedRigidBodyStateEffector::addDynamicEffector(DynamicEffector* newDynamicEffector, int segment)
+{
+    if (segment <= 0 || segment > (int)this->PanelVec.size()) {
+        this->bskLogger.bskError("NHingedRigidBodyStateEffector: specifying attachment to a non-existent panel.");
+    }
+
+    HingedPanel& panel = this->PanelVec[(size_t)(segment - 1)];
+    panel.assignStateParamNames<DynamicEffector*>(newDynamicEffector);
+    panel.dynEffectors.push_back(newDynamicEffector);
+}
+
+/*! This method registers the panel inertial properties with the dynamic parameter manager and links
+ them into dependent dynamic effectors */
 void
 NHingedRigidBodyStateEffector::registerProperties(DynParamManager& states)
 {
@@ -219,6 +236,11 @@ NHingedRigidBodyStateEffector::registerProperties(DynParamManager& states)
         PanelIt->v_HN_N = states.createProperty(PanelIt->nameOfInertialVelocityProperty, stateInit);
         PanelIt->sigma_SN = states.createProperty(PanelIt->nameOfInertialAttitudeProperty, stateInit);
         PanelIt->omega_SN_S = states.createProperty(PanelIt->nameOfInertialAngVelocityProperty, stateInit);
+
+        std::vector<DynamicEffector*>::iterator dynIt;
+        for (dynIt = PanelIt->dynEffectors.begin(); dynIt != PanelIt->dynEffectors.end(); dynIt++) {
+            (*dynIt)->linkInProperties(states);
+        }
     }
 
     return;

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.cpp
@@ -41,9 +41,28 @@ NHingedRigidBodyStateEffector::NHingedRigidBodyStateEffector()
 
 uint64_t NHingedRigidBodyStateEffector::effectorID = 1;
 
-/*! This is the destructor, nothing to report here */
+/*! This is the destructor, releasing the per panel output messages */
 NHingedRigidBodyStateEffector::~NHingedRigidBodyStateEffector()
 {
+    for (size_t c = 0; c < this->nHingedRigidBodyOutMsgs.size(); c++) {
+        delete this->nHingedRigidBodyOutMsgs.at(c);
+        delete this->nHingedRigidBodyConfigLogOutMsgs.at(c);
+    }
+
+    return;
+}
+
+/*! This method appends a panel to the chain along with its output messages
+
+ @param NewPanel the panel to append to the chain
+ */
+void
+NHingedRigidBodyStateEffector::addHingedPanel(HingedPanel NewPanel)
+{
+    this->PanelVec.push_back(NewPanel);
+    this->nHingedRigidBodyOutMsgs.push_back(new Message<HingedRigidBodyMsgPayload>);
+    this->nHingedRigidBodyConfigLogOutMsgs.push_back(new Message<SCStatesMsgPayload>);
+
     return;
 }
 
@@ -51,8 +70,58 @@ NHingedRigidBodyStateEffector::~NHingedRigidBodyStateEffector()
 
  @param CurrentClock The current simulation time (used for time stamping)
  */
-void NHingedRigidBodyStateEffector::WriteOutputMessages(uint64_t CurrentClock [[maybe_unused]])
+void
+NHingedRigidBodyStateEffector::writeOutputStateMessages(uint64_t CurrentClock)
 {
+    this->computePanelInertialStates();
+
+    size_t panelIndex = 0;
+    std::vector<HingedPanel>::iterator PanelIt;
+    for (PanelIt = this->PanelVec.begin(); PanelIt != this->PanelVec.end(); PanelIt++) {
+        if (this->nHingedRigidBodyOutMsgs[panelIndex]->isLinked()) {
+            HingedRigidBodyMsgPayload panelBuffer = this->nHingedRigidBodyOutMsgs[panelIndex]->zeroMsgPayload;
+            panelBuffer.theta = PanelIt->theta;
+            panelBuffer.thetaDot = PanelIt->thetaDot;
+            this->nHingedRigidBodyOutMsgs[panelIndex]->write(&panelBuffer, this->moduleID, CurrentClock);
+        }
+
+        if (this->nHingedRigidBodyConfigLogOutMsgs[panelIndex]->isLinked()) {
+            SCStatesMsgPayload configLogMsg = this->nHingedRigidBodyConfigLogOutMsgs[panelIndex]->zeroMsgPayload;
+            // Note, logging the panel frame S is the body frame B of that object
+            eigenVector3d2CArray(PanelIt->r_ScN_N, configLogMsg.r_BN_N);
+            eigenVector3d2CArray(PanelIt->v_ScN_N, configLogMsg.v_BN_N);
+            eigenMRPd2CArray(PanelIt->sigma_SN, configLogMsg.sigma_BN);
+            eigenVector3d2CArray(PanelIt->omega_SN_S, configLogMsg.omega_BN_B);
+            this->nHingedRigidBodyConfigLogOutMsgs[panelIndex]->write(&configLogMsg, this->moduleID, CurrentClock);
+        }
+        panelIndex++;
+    }
+
+    return;
+}
+
+/*! This method computes the panel states relative to the inertial frame */
+void
+NHingedRigidBodyStateEffector::computePanelInertialStates()
+{
+    // - read live: the cached copy lags half a step at write time, unless a prescribed body set it
+    if (this->prescribedAttitudeProperty == nullptr) {
+        this->sigma_BN = Eigen::MRPd(this->hubSigmaState->getStateReference().data());
+    }
+    Eigen::MRPd sigmaLocal_BN = this->sigma_BN;
+    Eigen::Matrix3d dcm_NB = sigmaLocal_BN.toRotationMatrix();
+    Eigen::Vector3d r_BN_N = (Eigen::Vector3d)(*this->inertialPositionProperty);
+    Eigen::Vector3d v_BN_N = (Eigen::Vector3d)(*this->inertialVelocityProperty);
+
+    std::vector<HingedPanel>::iterator PanelIt;
+    for (PanelIt = this->PanelVec.begin(); PanelIt != this->PanelVec.end(); PanelIt++) {
+        PanelIt->sigma_SN = eigenC2MRP(PanelIt->dcm_SB * dcm_NB.transpose());
+        PanelIt->omega_SN_S = PanelIt->dcm_SB * (this->omegaLoc_BN_B + PanelIt->omega_SB_B);
+
+        PanelIt->r_ScN_N = r_BN_N + dcm_NB * PanelIt->r_SB_B;
+        PanelIt->v_ScN_N = v_BN_N + dcm_NB * (PanelIt->rPrime_SB_B + this->omegaLoc_BN_B.cross(PanelIt->r_SB_B));
+    }
+
     return;
 }
 
@@ -61,6 +130,12 @@ void NHingedRigidBodyStateEffector::linkInStates(DynParamManager& statesIn)
 {
     // - Get access to the hub states
     this->g_N = statesIn.getPropertyReference(this->propName_vehicleGravity);
+
+    this->inertialPositionProperty =
+      statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + this->propName_inertialPosition);
+    this->inertialVelocityProperty =
+      statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + this->propName_inertialVelocity);
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 
     return;
 }
@@ -157,6 +232,7 @@ void NHingedRigidBodyStateEffector::updateEffectorMassProps(double integTime [[m
         PanelIt->sHat2_B = PanelIt->dcm_SB.row(1);
         PanelIt->sHat3_B = PanelIt->dcm_SB.row(2);
 
+        PanelIt->r_HB_B = this->r_HB_B + sum_rH;
         PanelIt->r_SB_B = this->r_HB_B - PanelIt->d*PanelIt->sHat1_B + sum_rH;
         sum_rH += -2*PanelIt->d*PanelIt->sHat1_B;
 
@@ -165,6 +241,7 @@ void NHingedRigidBodyStateEffector::updateEffectorMassProps(double integTime [[m
 
         // - Find rPrime_SB_B
         sum_ThetaDot += PanelIt->thetaDot;
+        PanelIt->rPrime_HB_B = PanelIt->d * sum_rPrimeH;
         PanelIt->rPrime_SB_B = PanelIt->d*(sum_ThetaDot*PanelIt->sHat3_B + sum_rPrimeH);
         sum_rPrimeH += 2*PanelIt->sHat3_B*sum_ThetaDot;
 
@@ -231,7 +308,8 @@ void NHingedRigidBodyStateEffector::updateContributions(double integTime [[maybe
     Eigen::MRPd sigmaLocal_BN;
     Eigen::Matrix3d dcm_BN;
     Eigen::Matrix3d dcm_NB;
-    sigmaLocal_BN = sigma_BN;
+    this->sigma_BN = sigma_BN;
+    sigmaLocal_BN = this->sigma_BN;
     dcm_NB = sigmaLocal_BN.toRotationMatrix();
     dcm_BN = dcm_NB.transpose();
 
@@ -496,8 +574,9 @@ void NHingedRigidBodyStateEffector::updateEnergyMomContributions(double integTim
                                                                  double & rotEnergyContr, Eigen::Vector3d omega_BN_B)
 {
     // - Get the current omega state
+    this->omegaLoc_BN_B = omega_BN_B;
     Eigen::Vector3d omegaLocal_BN_B;
-    omegaLocal_BN_B = omega_BN_B;
+    omegaLocal_BN_B = this->omegaLoc_BN_B;
 
     Eigen::Vector3d omega_SN_B;
     Eigen::Matrix3d IPntS_B;
@@ -529,7 +608,7 @@ void NHingedRigidBodyStateEffector::updateEnergyMomContributions(double integTim
  */
 void NHingedRigidBodyStateEffector::UpdateState(uint64_t CurrentSimNanos)
 {
-    WriteOutputMessages(CurrentSimNanos);
+    this->writeOutputStateMessages(CurrentSimNanos);
 
     return;
 }

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -20,12 +20,13 @@
 #ifndef N_HINGED_RIGID_BODY_STATE_EFFECTOR_H
 #define N_HINGED_RIGID_BODY_STATE_EFFECTOR_H
 
-#include <Eigen/Dense>
-#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
+#include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
+#include <Eigen/Dense>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -73,6 +74,24 @@ struct HingedPanel {
     Eigen::MatrixXd* v_HN_N = nullptr;     //!< [m/s] inertial velocity vector of H relative to the inertial frame
     Eigen::MatrixXd* sigma_SN = nullptr;   //!< -- MRP attitude of panel frame S relative to the inertial frame
     Eigen::MatrixXd* omega_SN_S = nullptr; //!< [rad/s] inertial panel frame angular velocity vector
+
+    std::vector<DynamicEffector*> dynEffectors; //!< -- Vector of dynamic effectors attached to this panel
+    Eigen::Vector3d extForce_B;                 //!< [N] attached effector force on this panel in B frame components
+    Eigen::Vector3d extTorquePntH_B; //!< [N-m] attached effector torque on this panel about H in B frame components
+
+    /**
+     * @brief Assign this panel's state-engine property names to an attached effector.
+     * @tparam Type Pointer type for an effector that accepts inertial property names.
+     * @param effector Effector that receives the panel's inertial property names.
+     */
+    template<typename Type>
+    void assignStateParamNames(Type effector)
+    {
+        effector->setPropName_inertialPosition(this->nameOfInertialPositionProperty);
+        effector->setPropName_inertialVelocity(this->nameOfInertialVelocityProperty);
+        effector->setPropName_inertialAttitude(this->nameOfInertialAttitudeProperty);
+        effector->setPropName_inertialAngVelocity(this->nameOfInertialAngVelocityProperty);
+    };
 };
 
 /*! @brief NHingedRigidBodyStateEffector class */
@@ -115,6 +134,7 @@ public:
     void UpdateState(uint64_t CurrentSimNanos) override;
     void registerStates(DynParamManager& statesIn) override; //!< -- Method for registering the HRB states
     void registerProperties(DynParamManager& states) override; //!< -- Method for registering the panel properties
+    void addDynamicEffector(DynamicEffector* newDynamicEffector, int segment) override; //!< -- Attach an effector
     void linkInStates(DynParamManager& states) override;     //!< -- Method for getting access to other states
     void updateEffectorMassProps(double integTime) override; //!< -- Method for stateEffector to give mass contributions
     void updateContributions(double integTime,

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -26,6 +26,9 @@
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
+#include <cstdint>
+#include <string>
+#include <vector>
 
 
 
@@ -42,7 +45,6 @@ struct HingedPanel {
     double theta = 0.0;              //!< [rad] hinged rigid body angle
     double theta_0 = 0.0;            //!< [rad] hinged rigid body rest angle
     double thetaDot = 0.0;           //!< [rad/s] hinged rigid body angle rate
-    Eigen::Matrix3d dcm_SS_prev;     //!< -- DCM from previous S frame to current S frame
     Eigen::Matrix3d dcm_SB;          //!< -- DCM from body to S frame
     Eigen::Vector3d omega_BN_S;      //!< [rad/s] omega_BN in S frame components
     Eigen::Vector3d omega_SB_B;      //!< [rad/s] omega_SB in B frame components
@@ -69,22 +71,16 @@ public:
 
 private:
     double totalMass;                //!< [kg] Total mass of effector
-    StateData *thetaState;           //!< -- state manager of theta for hinged rigid body
-    StateData *thetaDotState;        //!< -- state manager of thetaDot for hinged rigid body
+    StateData* thetaState;           //!< -- state manager of theta for hinged rigid body
+    StateData* thetaDotState;        //!< -- state manager of thetaDot for hinged rigid body
     std::vector<HingedPanel> PanelVec; //!< -- vector containing all the info on the different panels
     Eigen::MatrixXd matrixADHRB;    //!< [-] term needed for back substitution
     Eigen::MatrixXd matrixEDHRB;    //!< [-] term needed for back substitution
     Eigen::MatrixX3d matrixFDHRB;   //!< [-] term needed for back substitution
     Eigen::MatrixX3d matrixGDHRB;   //!< [-] term needed for back substitution
-    Eigen::MatrixXd matrixHDHRB;    //!< [-] term needed for back substitution
-    Eigen::MatrixXd matrixKDHRB;    //!< [-] term needed for back substitution
-    Eigen::MatrixXd matrixLDHRB;    //!< [-] term needed for back substitution
-    Eigen::MatrixXd matrixMDHRB;    //!< [-] term needed for back substitution
     Eigen::VectorXd vectorVDHRB;    //!< [-] term needed for back substitution
-    Eigen::Vector3d aTheta;         //!< -- term needed for back substitution
-    Eigen::Vector3d bTheta;         //!< -- term needed for back substitution
     Eigen::Vector3d omegaLoc_BN_B;  //!< [rad/s] local copy of omegaBN
-    Eigen::MatrixXd *g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
+    Eigen::MatrixXd* g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
     static uint64_t effectorID;        //!< [] ID number of this panel
 
 public:
@@ -92,15 +88,23 @@ public:
     ~NHingedRigidBodyStateEffector();  //!< -- Destructor
     double HeaviFunc(double cond); //!< -- Heaviside function used for matrix contributions
     void WriteOutputMessages(uint64_t CurrentClock);
-	void UpdateState(uint64_t CurrentSimNanos);
-    void registerStates(DynParamManager& statesIn);  //!< -- Method for registering the HRB states
-    void linkInStates(DynParamManager& states);  //!< -- Method for getting access to other states
-    void updateEffectorMassProps(double integTime);  //!< -- Method for stateEffector to give mass contributions
-    void updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N);  //!< -- Back-sub contributions
-    void updateEnergyMomContributions(double integTime, Eigen::Vector3d & rotAngMomPntCContr_B,
-                                              double & rotEnergyContr, Eigen::Vector3d omega_BN_B);  //!< -- Energy and momentum calculations
-    void computeDerivatives(double integTime, Eigen::Vector3d rDDot_BN_N, Eigen::Vector3d omegaDot_BN_B, Eigen::MRPd sigma_BN);  //!< -- Method for each stateEffector to calculate derivatives
-    void readInputMessages();       //!< -- method to read input messages
+    void UpdateState(uint64_t CurrentSimNanos) override;
+    void registerStates(DynParamManager& statesIn) override; //!< -- Method for registering the HRB states
+    void linkInStates(DynParamManager& states) override;     //!< -- Method for getting access to other states
+    void updateEffectorMassProps(double integTime) override; //!< -- Method for stateEffector to give mass contributions
+    void updateContributions(double integTime,
+                             BackSubMatrices& backSubContr,
+                             Eigen::MRPd sigma_BN,
+                             Eigen::Vector3d omega_BN_B,
+                             Eigen::Vector3d g_N) override; //!< -- Back-sub contributions
+    void updateEnergyMomContributions(double integTime,
+                                      Eigen::Vector3d& rotAngMomPntCContr_B,
+                                      double& rotEnergyContr,
+                                      Eigen::Vector3d omega_BN_B) override; //!< -- Energy and momentum calculations
+    void computeDerivatives(double integTime,
+                            Eigen::Vector3d rDDot_BN_N,
+                            Eigen::Vector3d omegaDot_BN_B,
+                            Eigen::MRPd sigma_BN) override; //!< -- Method for computing the effector derivatives
 };
 
 

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -124,6 +124,7 @@ private:
     Eigen::MatrixXd* inertialVelocityProperty = nullptr; //!< [m/s] v_N velocity relative to system spice zeroBase
     Eigen::MatrixXd* g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
     std::string propertyNameIndex;  //!< -- effector identifier used to name the per panel properties
+    bool hasAttachedEffectors = false; //!< -- true once any panel carries a dynamic effector
     static uint64_t effectorID;        //!< [] ID number of this panel
 
 public:

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -30,7 +30,9 @@
 #include <string>
 #include <vector>
 
-
+#include "architecture/messaging/messaging.h"
+#include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
+#include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
 
 /*! Struct containing all the panel variables. All members are public by default so they can be changed by methods of
  the N_hingedRigidBodyStateEffector class. */
@@ -51,11 +53,18 @@ struct HingedPanel {
     Eigen::Vector3d sHat1_B;         //!< -- unit direction vector for the first axis of the S frame
     Eigen::Vector3d sHat2_B;         //!< -- unit direction vector for the second axis of the S frame
     Eigen::Vector3d sHat3_B;         //!< -- unit direction vector for the third axis of the S frame
+    Eigen::Vector3d r_HB_B;          //!< -- Vector pointing from B to this panel's hinge in B frame components
+    Eigen::Vector3d rPrime_HB_B;     //!< [m/s] Body time derivative of this panel's r_HB_B
     Eigen::Vector3d r_SB_B;          //!< -- Vector pointing from B to CoM of hinged rigid body in B frame components
     Eigen::Matrix3d rTilde_SB_B;     //!< -- Tilde matrix of rSB_B
     Eigen::Vector3d rPrime_SB_B;     //!< [m/s] Body time derivative of rSB_B
     Eigen::Matrix3d rPrimeTilde_SB_B;//!< -- Tilde matrix of rPrime_SB_B
     Eigen::Matrix3d ISPrimePntS_B;   //!< [kg-m^2/s] time body derivative IPntS in body frame components
+
+    Eigen::Vector3d r_ScN_N;    //!< [m] position vector of the panel CoM S relative to the inertial frame
+    Eigen::Vector3d v_ScN_N;    //!< [m/s] inertial velocity vector of S relative to the inertial frame
+    Eigen::MRPd sigma_SN;       //!< -- MRP attitude of panel frame S relative to the inertial frame
+    Eigen::Vector3d omega_SN_S; //!< [rad/s] inertial panel frame angular velocity vector
 };
 
 /*! @brief NHingedRigidBodyStateEffector class */
@@ -66,8 +75,10 @@ public:
     Eigen::Vector3d r_HB_B;          //!< [m] vector pointing from body frame origin to the first Hinge location
     Eigen::Matrix3d rTilde_HB_B;     //!< -- Tilde matrix of rHB_B
     Eigen::Matrix3d dcm_HB;          //!< -- DCM from body frame to hinge frame
-    void addHingedPanel(HingedPanel NewPanel) {PanelVec.push_back(NewPanel);} //!< class method
+    void addHingedPanel(HingedPanel NewPanel); //!< class method
     BSKLogger bskLogger;                      //!< -- BSK Logging
+    std::vector<Message<HingedRigidBodyMsgPayload>*> nHingedRigidBodyOutMsgs;   //!< -- panel state output messages
+    std::vector<Message<SCStatesMsgPayload>*> nHingedRigidBodyConfigLogOutMsgs; //!< -- panel config log messages
 
 private:
     double totalMass;                //!< [kg] Total mass of effector
@@ -80,6 +91,10 @@ private:
     Eigen::MatrixX3d matrixGDHRB;   //!< [-] term needed for back substitution
     Eigen::VectorXd vectorVDHRB;    //!< [-] term needed for back substitution
     Eigen::Vector3d omegaLoc_BN_B;  //!< [rad/s] local copy of omegaBN
+    Eigen::MRPd sigma_BN{0.0, 0.0, 0.0};       //!< -- Hub attitude relative to the inertial frame
+    StateData* hubSigmaState = nullptr;        //!< hub attitude state, read live for the published kinematics
+    Eigen::MatrixXd* inertialPositionProperty = nullptr; //!< [m] r_N position relative to system spice zeroBase
+    Eigen::MatrixXd* inertialVelocityProperty = nullptr; //!< [m/s] v_N velocity relative to system spice zeroBase
     Eigen::MatrixXd* g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
     static uint64_t effectorID;        //!< [] ID number of this panel
 
@@ -87,7 +102,7 @@ public:
     NHingedRigidBodyStateEffector();  //!< -- Contructor
     ~NHingedRigidBodyStateEffector();  //!< -- Destructor
     double HeaviFunc(double cond); //!< -- Heaviside function used for matrix contributions
-    void WriteOutputMessages(uint64_t CurrentClock);
+    void writeOutputStateMessages(uint64_t CurrentClock) override;
     void UpdateState(uint64_t CurrentSimNanos) override;
     void registerStates(DynParamManager& statesIn) override; //!< -- Method for registering the HRB states
     void linkInStates(DynParamManager& states) override;     //!< -- Method for getting access to other states
@@ -107,7 +122,8 @@ public:
                             Eigen::MRPd sigma_BN) override; //!< -- Method for computing the effector derivatives
 
 private:
-    void checkPanelUniformity(); //!< -- Method for rejecting a panel chain the EOMs cannot represent
+    void checkPanelUniformity();       //!< -- Method for rejecting a panel chain the EOMs cannot represent
+    void computePanelInertialStates(); //!< -- Method for computing the panel states relative to the inertial frame
 };
 
 

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -105,6 +105,9 @@ public:
                             Eigen::Vector3d rDDot_BN_N,
                             Eigen::Vector3d omegaDot_BN_B,
                             Eigen::MRPd sigma_BN) override; //!< -- Method for computing the effector derivatives
+
+private:
+    void checkPanelUniformity(); //!< -- Method for rejecting a panel chain the EOMs cannot represent
 };
 
 

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.h
@@ -63,8 +63,16 @@ struct HingedPanel {
 
     Eigen::Vector3d r_ScN_N;    //!< [m] position vector of the panel CoM S relative to the inertial frame
     Eigen::Vector3d v_ScN_N;    //!< [m/s] inertial velocity vector of S relative to the inertial frame
-    Eigen::MRPd sigma_SN;       //!< -- MRP attitude of panel frame S relative to the inertial frame
-    Eigen::Vector3d omega_SN_S; //!< [rad/s] inertial panel frame angular velocity vector
+
+    std::string nameOfInertialPositionProperty;    //!< -- identifier for the inertial position property
+    std::string nameOfInertialVelocityProperty;    //!< -- identifier for the inertial velocity property
+    std::string nameOfInertialAttitudeProperty;    //!< -- identifier for the inertial attitude property
+    std::string nameOfInertialAngVelocityProperty; //!< -- identifier for the inertial angular velocity property
+
+    Eigen::MatrixXd* r_HN_N = nullptr;     //!< [m] position vector of the panel hinge H relative to the inertial frame
+    Eigen::MatrixXd* v_HN_N = nullptr;     //!< [m/s] inertial velocity vector of H relative to the inertial frame
+    Eigen::MatrixXd* sigma_SN = nullptr;   //!< -- MRP attitude of panel frame S relative to the inertial frame
+    Eigen::MatrixXd* omega_SN_S = nullptr; //!< [rad/s] inertial panel frame angular velocity vector
 };
 
 /*! @brief NHingedRigidBodyStateEffector class */
@@ -96,6 +104,7 @@ private:
     Eigen::MatrixXd* inertialPositionProperty = nullptr; //!< [m] r_N position relative to system spice zeroBase
     Eigen::MatrixXd* inertialVelocityProperty = nullptr; //!< [m/s] v_N velocity relative to system spice zeroBase
     Eigen::MatrixXd* g_N;           //!< [m/s^2] Gravitational acceleration in N frame components
+    std::string propertyNameIndex;  //!< -- effector identifier used to name the per panel properties
     static uint64_t effectorID;        //!< [] ID number of this panel
 
 public:
@@ -105,6 +114,7 @@ public:
     void writeOutputStateMessages(uint64_t CurrentClock) override;
     void UpdateState(uint64_t CurrentSimNanos) override;
     void registerStates(DynParamManager& statesIn) override; //!< -- Method for registering the HRB states
+    void registerProperties(DynParamManager& states) override; //!< -- Method for registering the panel properties
     void linkInStates(DynParamManager& states) override;     //!< -- Method for getting access to other states
     void updateEffectorMassProps(double integTime) override; //!< -- Method for stateEffector to give mass contributions
     void updateContributions(double integTime,

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.i
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.i
@@ -31,7 +31,9 @@
 from Basilisk.architecture.swig_common_model import *
 %}
 %include "swig_eigen.i"
+%include "swig_conly_data.i"
 %include "std_string.i"
+%include "std_vector.i"
 %include "stdint.i"
 
 
@@ -39,6 +41,11 @@ from Basilisk.architecture.swig_common_model import *
 %include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.i"
 %include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 %include "nHingedRigidBodyStateEffector.h"
+
+%include "architecture/msgPayloadDefC/SCStatesMsgPayload.h"
+struct SCStatesMsg_C;
+%include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
+struct HingedRigidBodyMsg_C;
 
 %pythoncode %{
 import sys

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
@@ -14,13 +14,3 @@ how to run it, as well as testing.
 Message Connection Descriptions
 -------------------------------
 This state effector has no input or output messages.
-
-
-
-
-
-
-
-
-
-

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
@@ -22,4 +22,15 @@ how to run it, as well as testing.
 
 Message Connection Descriptions
 -------------------------------
-This state effector has no input or output messages.
+The following table lists all the module output messages. Each is a vector carrying one message per
+panel, ordered outward from the hub.
+
+.. bsk-module-io:: nHingedRigidBodyStateEffector
+    :caption: Module I/O Messages
+
+    output nHingedRigidBodyOutMsgs HingedRigidBodyMsgPayload
+        Output vector of messages containing the panel angle and angle rate.
+    output nHingedRigidBodyConfigLogOutMsgs SCStatesMsgPayload
+        Output vector of messages containing the panel inertial states. The position and velocity are
+        those of the panel center of mass, and the attitude and angular velocity are those of the
+        panel frame S.

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
@@ -9,6 +9,15 @@ The module
 contains further information on this module's function,
 how to run it, as well as testing.
 
+.. important::
+
+    The equations of motion are derived for a chain of identical panels. Every panel must carry the
+    same positive ``mass`` and the same hinge to center of mass distance ``d``, and each hinge sits
+    ``2d`` from the one before it. The panel inertia ``IPntS_S`` may differ from panel to panel.
+    Initialization rejects a chain that violates the mass or distance requirement. An uneven chain
+    is modeled with :ref:`dualHingedRigidBodyStateEffector` for two panels, or with
+    :ref:`spinningBodyNDOFStateEffector` for an arbitrary number.
+
 
 
 Message Connection Descriptions

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -81,7 +81,7 @@ FINE_TIMESTEP = 0.0005  # [s]
 @pytest.mark.parametrize("stateEffector, isParent", [
     ("hingedRigidBodies",             True),
     ("dualHingedRigidBodies",           True),
-    # ("nHingedRigidBodies",              True),
+    ("nHingedRigidBodies",            True),
     ("spinningBodiesOneDOF",          True),
     ("spinningBodiesTwoDOF",          True),
     ("spinningBodiesNDOF",            True),
@@ -405,6 +405,9 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     elif stateEffector == "hingedRigidBodies":
         stateEff, stateEffProps = setup_hingedRigidBodyStateEffector()
         segment = 1
+    elif stateEffector == "nHingedRigidBodies":
+        stateEff, stateEffProps = setup_nHingedRigidBodies()
+        segment = 2
     elif stateEffector == "linearTranslationBodiesOneDOF":
         stateEff, stateEffProps = setup_translatingBodiesOneDOF()
         segment = 1
@@ -469,11 +472,11 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     datLog = scObject.scStateOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, datLog)
 
-    # Log the effector's inertial properties
-    if segment == 1:
-        inertialPropLog = getattr(stateEff, f"{stateEffProps.inertialPropLogName}").recorder()
-    else:
+    # Log the effector's inertial properties, indexing the parents that publish one message per segment
+    if stateEffProps.inertialPropLogName.endswith("Msgs"):
         inertialPropLog = getattr(stateEff, f"{stateEffProps.inertialPropLogName}")[segment-1].recorder()
+    else:
+        inertialPropLog = getattr(stateEff, f"{stateEffProps.inertialPropLogName}").recorder()
     unitTestSim.AddModelToTask(unitTaskName, inertialPropLog)
 
     # Add energy and momentum variables to log
@@ -491,17 +494,21 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
         assert isChild, "FAILED: attached an incompatible dynamic effector without erroring"
 
     # Check that properties are being handed correctly from state effector to dynamic effector
-    if (stateEffector == "spinningBodiesNDOF" or stateEffector == "linearTranslationBodiesOneDOF"
-        or stateEffector == "linearTranslationBodiesNDOF"):
-        # newer effector classes keep their names private, so validate the name handed to the child
+    if stateEffector in ("spinningBodiesNDOF", "linearTranslationBodiesOneDOF",
+                         "linearTranslationBodiesNDOF", "nHingedRigidBodies"):
+        # newer effector classes keep their names out of reach, so validate the name handed to the child
         positionName = getModernStateEffInertialPropName(
-            scObject, segment, "Position", getDynEffInertialPropName(dynamicEffector, dynamicEff, "Position"))
+            scObject, stateEffector, segment, "Position",
+            getDynEffInertialPropName(dynamicEffector, dynamicEff, "Position"))
         velocityName = getModernStateEffInertialPropName(
-            scObject, segment, "Velocity", getDynEffInertialPropName(dynamicEffector, dynamicEff, "Velocity"))
+            scObject, stateEffector, segment, "Velocity",
+            getDynEffInertialPropName(dynamicEffector, dynamicEff, "Velocity"))
         attitudeName = getModernStateEffInertialPropName(
-            scObject, segment, "Attitude", getDynEffInertialPropName(dynamicEffector, dynamicEff, "Attitude"))
+            scObject, stateEffector, segment, "Attitude",
+            getDynEffInertialPropName(dynamicEffector, dynamicEff, "Attitude"))
         angvelocityName = getModernStateEffInertialPropName(
-            scObject, segment, "AngVelocity", getDynEffInertialPropName(dynamicEffector, dynamicEff, "AngVelocity"))
+            scObject, stateEffector, segment, "AngVelocity",
+            getDynEffInertialPropName(dynamicEffector, dynamicEff, "AngVelocity"))
     else:
         # older effector classes have public variable names that are simply checked directly
         positionName = getStateEffInertialPropName(segment, stateEff, "Position")
@@ -683,12 +690,14 @@ def getStateEffInertialPropName(segment, stateEff, propType):
     elif segment == 2:
         return getattr(stateEff, f"nameOfInertial{propType}Property2")
 
-def getModernStateEffInertialPropName(scObject, segment, propType, handedPropName):
+def getModernStateEffInertialPropName(scObject, stateEffector, segment, propType, handedPropName):
     # a generated name ends in a process-global counter, so validate the handed name instead of rebuilding it
-    if segment == 1:
-        pattern = "linearTranslationInertial" + propType + r"[0-9]+"
-    else:
+    if stateEffector == "nHingedRigidBodies":
+        pattern = "nHingedRigidBodyInertial" + propType + r"[0-9]+_" + str(segment)
+    elif stateEffector == "spinningBodiesNDOF":
         pattern = "spinningBodyInertial" + propType + r"[0-9]+_" + str(segment)
+    else:
+        pattern = "linearTranslationInertial" + propType + r"[0-9]+"
     try:
         scObject.dynManager.getPropertyReference(handedPropName)
     except BasiliskError:
@@ -1122,6 +1131,52 @@ def setup_dualHingedRigidBodies():
     stateEffProps.r_PB_B = r_H2B_B  # [m]
     stateEffProps.r_PcP_P = hingedBody.d2 * s1_hat
     stateEffProps.inertialPropLogName = "dualHingedRigidBodyConfigLogOutMsgs"
+
+    return(hingedBody, stateEffProps)
+
+def setup_nHingedRigidBodies():
+    hingedBody = nHingedRigidBodyStateEffector.NHingedRigidBodyStateEffector()
+
+    # Define properties of the panel chain, which the module requires to be identical panels
+    numberOfPanels = 3
+    panelMass = 100.0  # [kg]
+    panelHalfLength = 0.75  # [m]
+    thetaInit = [5 * macros.D2R, -2 * macros.D2R, 3 * macros.D2R]  # [rad]
+    thetaDotInit = [-1 * macros.D2R, 0.0, 0.5 * macros.D2R]  # [rad/s]
+    hingedBody.dcm_HB = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    hingedBody.r_HB_B = [[0.5], [-1.5], [-0.5]]  # [m]
+    for idx in range(numberOfPanels):
+        panel = nHingedRigidBodyStateEffector.HingedPanel()
+        panel.mass = panelMass  # [kg]
+        panel.d = panelHalfLength  # [m]
+        panel.k = 100.0  # [N*m/rad]
+        panel.c = 0.0  # [N*m*s/rad]
+        panel.IPntS_S = [[100.0, 0.0, 0.0], [0.0, 50.0, 0.0], [0.0, 0.0, 50.0]]  # [kg*m^2]
+        panel.thetaInit = thetaInit[idx]  # [rad]
+        panel.thetaDotInit = thetaDotInit[idx]  # [rad/s]
+        panel.theta_0 = 0.0  # [rad]
+        hingedBody.addHingedPanel(panel)
+    hingedBody.ModelTag = "HingedRigidBodyNDOF"
+
+    # Walk the chain to find each hinge, and the COM offset contribution to be divided by the hub mass
+    s1_hat = np.array([[-1.0], [0.0], [0.0]])
+    r_HB_B = np.array(hingedBody.r_HB_B)
+    hingeLocations = []
+    mr_ScB_B = 0.0
+    sumTheta = 0.0
+    for idx in range(numberOfPanels):
+        sumTheta += thetaInit[idx]
+        dcm_SB = rbk.euler2(sumTheta) @ np.array(hingedBody.dcm_HB)
+        hingeLocations.append(r_HB_B)
+        mr_ScB_B -= panelMass * (r_HB_B + np.transpose(dcm_SB) @ (panelHalfLength * s1_hat))
+        r_HB_B = r_HB_B + np.transpose(dcm_SB) @ (2 * panelHalfLength * s1_hat)
+
+    stateEffProps = stateEffectorProperties()
+    stateEffProps.totalMass = numberOfPanels * panelMass
+    stateEffProps.mr_PcB_B = mr_ScB_B
+    stateEffProps.r_PB_B = hingeLocations[1]  # [m] the panel the dynamic effector attaches to
+    stateEffProps.r_PcP_P = panelHalfLength * s1_hat
+    stateEffProps.inertialPropLogName = "nHingedRigidBodyConfigLogOutMsgs"
 
     return(hingedBody, stateEffProps)
 


### PR DESCRIPTION
* **Tickets addressed:** #1152
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Basilisk's effector branching architecture lets a dynamic effector attach to a state effector rather than to the hub. This work adds support for the N hinged rigid body as a parent, completing the hinged family after the single and dual hinged bodies. `addDynamicEffector` takes the panel index, hands that panel's property names to a child effector, and stores the child on that panel so its load reaches the correct row of the panel equations at every integrator substep. Each panel publishes the inertial position and velocity of its hinge point H rather than of its center of mass S, matching the other parents.

Whereas the other hinged bodies already published their panel states, this module had no output messages at all and computed nothing about where its panels sit relative to the inertial frame. It gains a panel state message and a panel configuration log message for each panel, along with the hinge kinematics the branching path needs.

The second commit also addresses a pre-existing attribute. The back-substitution matrices factor one panel mass and one hinge to center of mass distance out of the sums that run over the chain, so the equations of motion hold only for a chain of identical panels, but `HingedPanel` took both per panel and integrated a mixed chain without complaint. Checked against `dualHingedRigidBodyStateEffector` at matched geometry, an N=2 chain agrees to 1e-17 rad when the panels match and diverges by 2e-2 rad over two seconds when one mass differs. A chain of massless panels is accepted by that same relative comparison and then divides by the effector mass when locating its center of mass, which reaches the hub states as NaN with nothing logged. Initialization now rejects an uneven chain, a massless one, and an empty one. The restriction was inferable from the derivation, which drops the per-panel subscript on the panel mass partway through, and was stated nowhere. Generalizing the derivation would rewrite the A, F, G, and v terms along with the module PDF, so it was out of scope here.

Commits are ordered by concern: cleanup with no behavior change, the panel chain validation, then four commits of functional substance building from the panel properties to the equations of motion, then the module unit tests and the branching integrated test, the documentation table, and the release note snippet.

## Verification

`test_effectorBranching_integrated.py` gains the N hinged rigid body as a parent, with the child attached to the middle panel of a three panel chain so the load reaches the hub through one hinge inboard of it while another panel hangs outboard. That places a term in every row of the panel equations: the torque in the row of the panel carrying the child, the moment arm of its force in the row inboard of it, and nothing in the row outboard. The test asserts the change in rotational angular momentum about the system center of mass against the integrated external torque, the accumulated delta V against the integrated external force, and the change in rotational energy against the work the child does about that center of mass.

The energy check is the only one that reaches inside the parent's own equations of motion, since back substitution stays internally consistent even when one of its terms is wrong. Dampers are zeroed and the assertion is on convergence rather than on a fixed tolerance: halving the step must drop the residual to roughly a quarter. The N hinged rigid body converges at 0.250, matching every other parent, from a 1 ms residual of 1.9e-8 J.

`test_nHingedRigidBodyStateEffector.py` gains a comparison of both published message vectors against `dualHingedRigidBodyStateEffector` at matched geometry, on a hub carrying a non-identity attitude and nonzero rates so that every inertial transformation contributes, where both panels agree to 1e-16 in position, velocity, attitude, and angular velocity. It also gains a parametrized test that an uneven chain, a massless one, and an empty one are each rejected at initialization against their own error message, that a chain whose panels differ only in inertia still initializes, and that a dynamic effector attaches to the first and last panel of a chain but not to an index outside either end. The dynamics suite passes 834 tests with 91 skipped, and the documentation builds with no new warnings.

## Documentation

No existing documentation was invalidated. The module page gains the identical panel restriction, including the requirement that each panel mass be positive, and a message table, replacing the statement that the module has no input or output messages. The compatibility table in `bskPrinciples-11.rst` now marks the N hinged rigid body green for the thruster, constraint, faceted drag, and external force torque effectors. A release note snippet is added under `bskReleaseNotesSnippets/`, and the rejected chain is recorded in `bskKnownIssues.rst`.

## Future work

The N degree of freedom translating body, #1221, is the remaining state effector to be augmented for branching. Generalizing the N hinged rigid body equations of motion to a chain of dissimilar panels would remove the restriction this work only enforces.
