### PR TITLE
Make nightly BSK wheel building less overly restrictive

### DIFF
--- a/.github/scripts/build_optional_bsk_wheel.py
+++ b/.github/scripts/build_optional_bsk_wheel.py
@@ -306,16 +306,38 @@ def normalize_compatible_version_field(
     differences.append(f"{path}: {base_version!r} versus {component_version!r}")
 
 
-def normalize_compatible_diagnostic_versions(
+def normalize_nonsemantic_diagnostic_field(
+    base_values: dict[str, object],
+    component_values: dict[str, object],
+    field: str,
+    path: str,
+    differences: list[str],
+) -> None:
+    """Normalize one diagnostic-only string and record its difference."""
+    base_value = base_values.get(field)
+    component_value = component_values.get(field)
+    if base_value == component_value:
+        return
+    if not isinstance(base_value, str) or not isinstance(component_value, str):
+        return
+
+    base_values[field] = "compatible-diagnostic-value"
+    component_values[field] = "compatible-diagnostic-value"
+    differences.append(f"{path}: {base_value!r} versus {component_value!r}")
+
+
+def normalize_compatible_diagnostics(
     base_build_info: dict[str, object],
     component_build_info: dict[str, object],
 ) -> list[str]:
-    """Normalize compatible patch/build differences in diagnostic versions.
+    """Normalize compatible differences in build diagnostics.
 
     Optional wheel inputs are built by independent GitHub runners. During a
     runner-image rollout, those machines can carry different patch releases of
-    otherwise compatible compilers and build tools. ABI-relevant metadata is
-    still compared exactly by :func:`validate_build_feature_metadata`.
+    otherwise compatible compilers and build tools. Compiler launchers only
+    wrap compiler invocation and can differ when optional caching is unavailable.
+    All other build metadata remains exact, and compiled ABI metadata is
+    validated separately by :func:`validate_build_abi_metadata`.
     """
     differences: list[str] = []
     base_diagnostics = base_build_info.get("diagnostics")
@@ -345,6 +367,13 @@ def normalize_compatible_diagnostic_versions(
                     f"diagnostics.compilers.{compiler_name}.{field}",
                     differences,
                 )
+            normalize_nonsemantic_diagnostic_field(
+                base_compiler,
+                component_compiler,
+                "launcher",
+                f"diagnostics.compilers.{compiler_name}.launcher",
+                differences,
+            )
 
     base_tools = base_diagnostics.get("tools")
     component_tools = component_diagnostics.get("tools")
@@ -361,15 +390,15 @@ def normalize_compatible_diagnostic_versions(
     return differences
 
 
-def warn_compatible_diagnostic_versions(differences: list[str]) -> None:
-    """Report compatible compiler and build-tool version differences."""
+def warn_compatible_build_metadata(differences: list[str]) -> None:
+    """Report compatible build-metadata differences."""
     if not differences:
         return
 
     details = "\n  ".join(differences)
     print(
-        "warning: base and component wheels use compatible patch/build "
-        "versions from independent runners:\n"
+        "warning: base and component wheels have compatible build-metadata "
+        "differences from independent runners:\n"
         f"  {details}",
         file=sys.stderr,
     )
@@ -518,7 +547,7 @@ def validate_build_feature_metadata(
     component_archive: zipfile.ZipFile,
     component: OptionalComponent,
 ) -> list[str]:
-    """Validate feature metadata and return compatible diagnostic revisions."""
+    """Validate feature metadata and return compatible diagnostic differences."""
     base_build_info = parse_build_info_data(base_archive.read(BUILD_INFO_DATA_PATH))
     component_build_info = parse_build_info_data(
         component_archive.read(BUILD_INFO_DATA_PATH)
@@ -552,7 +581,7 @@ def validate_build_feature_metadata(
         **component_features,
         component.build_feature: base_enabled,
     }
-    version_differences = normalize_compatible_diagnostic_versions(
+    diagnostic_differences = normalize_compatible_diagnostics(
         normalized_base_info,
         normalized_component_info,
     )
@@ -561,7 +590,7 @@ def validate_build_feature_metadata(
             f"{BUILD_INFO_DATA_PATH} differs between the base and component builds "
             f"beyond the expected {component.build_feature!r} feature value."
         )
-    return version_differences
+    return diagnostic_differences
 
 
 def validate_common_payloads(
@@ -578,7 +607,7 @@ def validate_common_payloads(
         raise ValueError(
             f"Both wheel build inputs must contain {BUILD_INFO_DATA_PATH}."
         )
-    version_differences = validate_build_feature_metadata(
+    compatible_differences = validate_build_feature_metadata(
         base_archive,
         component_archive,
         component,
@@ -591,10 +620,10 @@ def validate_common_payloads(
             "either input provides it."
         )
     if base_has_abi_data:
-        version_differences.extend(
+        compatible_differences.extend(
             validate_build_abi_metadata(base_archive, component_archive)
         )
-    warn_compatible_diagnostic_versions(version_differences)
+    warn_compatible_build_metadata(compatible_differences)
 
     changed = []
     for name in sorted(base_payload & component_payload):

--- a/docs/source/Support/bskReleaseNotesSnippets/nightly-wheel-sccache-metadata.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/nightly-wheel-sccache-metadata.rst
@@ -1,0 +1,1 @@
+- Allow optional-wheel packaging to continue when independently built inputs differ only in compiler-cache launcher diagnostics.

--- a/src/tests/test_optionalWheelBuilder.py
+++ b/src/tests/test_optionalWheelBuilder.py
@@ -76,13 +76,27 @@ def _buildInfoData(opNavEnabled, *, schemaVersion=4, diagnostics=None):
     return f"buildInfoData = {buildInfo!r}\n".encode("utf-8")
 
 
-def _windowsBuildDiagnostics(msvcVersion, rustVersion, cargoVersion):
+def _windowsBuildDiagnostics(
+    msvcVersion,
+    rustVersion,
+    cargoVersion,
+    compilerLauncher="",
+):
     return {
         "target": {"system": "Windows", "processor": "AMD64"},
         "build": {"configuration": "Release", "generator": "Ninja"},
         "compilers": {
-            "c": {"id": "MSVC", "version": msvcVersion},
-            "cxx": {"id": "MSVC", "version": msvcVersion, "standard": "17"},
+            "c": {
+                "id": "MSVC",
+                "version": msvcVersion,
+                "launcher": compilerLauncher,
+            },
+            "cxx": {
+                "id": "MSVC",
+                "version": msvcVersion,
+                "launcher": compilerLauncher,
+                "standard": "17",
+            },
             "rust": {
                 "id": "rustc",
                 "version": rustVersion,
@@ -187,7 +201,7 @@ def test_patch_build_tool_version_differences_warn(capsys):
             )
 
     warning = capsys.readouterr().err
-    assert "compatible patch/build versions" in warning
+    assert "compatible build-metadata differences" in warning
     assert "19.51.36252.0" in warning
     assert "19.51.36248.0" in warning
     assert "1.97.1" in warning
@@ -221,7 +235,7 @@ def test_patch_abi_compiler_version_differences_warn(capsys):
             )
 
     warning = capsys.readouterr().err
-    assert "compatible patch/build versions" in warning
+    assert "compatible build-metadata differences" in warning
     assert "195136252" in warning
     assert "195136248" in warning
     assert "patchVersion: 0 versus 1" in warning
@@ -256,6 +270,40 @@ def test_abi_layout_difference_fails():
                     payload,
                     component,
                 )
+
+
+def test_compiler_launcher_differences_warn(capsys):
+    """Compiler-cache availability differs without changing compatibility."""
+    payload = {WHEEL_BUILDER.BUILD_INFO_DATA_PATH}
+    component = WHEEL_BUILDER.COMPONENTS["opnav"]
+    baseData = _buildInfoData(
+        False,
+        diagnostics=_windowsBuildDiagnostics("19.51.1", "1.97.1", "1.97.1"),
+    )
+    componentData = _buildInfoData(
+        True,
+        diagnostics=_windowsBuildDiagnostics(
+            "19.51.1",
+            "1.97.1",
+            "1.97.1",
+            compilerLauncher="sccache",
+        ),
+    )
+
+    with _buildInfoArchive(baseData) as baseArchive:
+        with _buildInfoArchive(componentData) as componentArchive:
+            WHEEL_BUILDER.validate_common_payloads(
+                baseArchive,
+                componentArchive,
+                payload,
+                payload,
+                component,
+            )
+
+    warning = capsys.readouterr().err
+    assert "compatible build-metadata differences" in warning
+    assert "diagnostics.compilers.c.launcher: '' versus 'sccache'" in warning
+    assert "diagnostics.compilers.cxx.launcher: '' versus 'sccache'" in warning
 
 
 def test_build_tool_minor_version_difference_fails():


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Retains strict compatibility validation between independently built core and optional-component wheels while treating compiler-launcher differences as non-semantic build diagnostics.

Differences such as direct compiler invocation versus `sccache` now produce a warning instead of failing optional-wheel packaging. Missing, malformed, ABI-relevant, and otherwise unexpected metadata differences remain fatal.

The commits are organized by validation behavior, regression coverage, and release-note documentation.

## Verification

- Ran `.venv/bin/pytest -q src/tests/test_optionalWheelBuilder.py src/tests/test_buildInfo.py`: 25 tests passed.
- Added regression coverage for asymmetric `sccache` availability.
- Replayed the core and opNav wheel artifacts from the failed Linux nightly run. Packaging completed successfully while reporting the expected C and C++ launcher warnings.
- Confirmed `git diff --check` passes.

## Documentation

Added a release-note snippet describing the optional-wheel packaging behavior change. No public API or user documentation was invalidated.

## Future work

None currently. Additional diagnostic fields should only be relaxed if they are demonstrated to be non-semantic and covered by regression tests.