### PR TITLE
Augment NDOF Linear Translating Bodies for Branching Dynamics

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
@@ -234,8 +234,8 @@ special case of prescribed effector branching explained in :ref:`prescribedMotio
         </tr>
         <tr>
           <td class="label">Linear Translating Bodies NDOF</td>
-          <td class="yellow"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="yellow"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
+          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
+          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
           <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
         </tr>

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -18,6 +18,9 @@ Version |release| (July 7, 2026)
   panels, but the module accepted a per-panel mass and hinge to center of mass distance and
   integrated silently wrong dynamics when either varied along the chain. Initialization now rejects
   such a chain.
+- The :ref:`linearTranslationNDOFStateEffector` and the :ref:`spinningBodyNDOFStateEffector` allocated
+  a state and a configuration log output message for every body added to the chain and freed neither,
+  so each effector leaked both for the life of the process. This is fixed in the current version.
 - Every state effector acting as a parent published the inertial state of its attachment frame once
   per task step from its own ``UpdateState()``. A child effector therefore evaluated its loads against
   kinematics a full task step old. These are now refreshed within the integration.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -21,6 +21,9 @@ Version |release| (July 7, 2026)
 - The :ref:`linearTranslationNDOFStateEffector` and the :ref:`spinningBodyNDOFStateEffector` allocated
   a state and a configuration log output message for every body added to the chain and freed neither,
   so each effector leaked both for the life of the process. This is fixed in the current version.
+- The :ref:`linearTranslationNDOFStateEffector` built its translating body configuration log from a
+  hub attitude cached at the previous integrator substep, so the logged body attitude lagged the hub
+  attitude even though the body does not rotate relative to the hub. This is fixed in the current version.
 - The :ref:`linearTranslationNDOFStateEffector` accepted a chain whose joint mass matrix is singular,
   most simply one whose outermost body was left at its default zero mass, and inverting it filled the
   spacecraft state with NaN. It also took an invalid rotation matrix or inertia tensor at face value

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -21,6 +21,10 @@ Version |release| (July 7, 2026)
 - The :ref:`linearTranslationNDOFStateEffector` and the :ref:`spinningBodyNDOFStateEffector` allocated
   a state and a configuration log output message for every body added to the chain and freed neither,
   so each effector leaked both for the life of the process. This is fixed in the current version.
+- The :ref:`linearTranslationNDOFStateEffector` accepted a chain whose joint mass matrix is singular,
+  most simply one whose outermost body was left at its default zero mass, and inverting it filled the
+  spacecraft state with NaN. It also took an invalid rotation matrix or inertia tensor at face value
+  and integrated silently wrong dynamics. Initialization now rejects all of these, and an empty chain.
 - Every state effector acting as a parent published the inertial state of its attachment frame once
   per task step from its own ``UpdateState()``. A child effector therefore evaluated its loads against
   kinematics a full task step old. These are now refreshed within the integration.

--- a/docs/source/Support/bskReleaseNotesSnippets/1221-ndof-translating-body-branching.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1221-ndof-translating-body-branching.rst
@@ -1,0 +1,6 @@
+- Added support for :ref:`linearTranslationNDOFStateEffector` to be the parent for dynamic effectors.
+- :ref:`linearTranslationNDOFStateEffector` now rejects a chain whose joint mass matrix is singular, an empty chain, and an invalid rotation matrix or inertia tensor.
+- :ref:`linearTranslationOneDOFStateEffector` now rejects an invalid rotation matrix or inertia tensor, matching the spinning body effectors.
+- Fixed the :ref:`linearTranslationNDOFStateEffector` translating body configuration log, which reported an attitude lagging the hub by an integrator substep.
+- :ref:`linearTranslationNDOFStateEffector` now accepts a zero body mass, which its massless joint setup documented but the setter rejected.
+- Fixed a memory leak of the per body output messages in :ref:`linearTranslationNDOFStateEffector` and :ref:`spinningBodyNDOFStateEffector`.

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -86,7 +86,7 @@ FINE_TIMESTEP = 0.0005  # [s]
     ("spinningBodiesTwoDOF",          True),
     ("spinningBodiesNDOF",            True),
     ("linearTranslationBodiesOneDOF", True),
-    # ("linearTranslationBodiesNDOF",     True),
+    ("linearTranslationBodiesNDOF",   True),
     ("linearSpringMassDamper",          False),
     # ("sphericalPendulum",               False),
     # ("prescribedMotion",                False),
@@ -264,6 +264,7 @@ def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dy
     "spinningBodiesTwoDOF",
     "spinningBodiesNDOF",
     "linearTranslationBodiesOneDOF",
+    "linearTranslationBodiesNDOF",
 ])
 def test_parentPublishesCurrentVelocityToChild(stateEffector):
     r"""
@@ -324,6 +325,7 @@ def test_parentPublishesCurrentVelocityToChild(stateEffector):
         "spinningBodiesTwoDOF": setup_spinningBodiesTwoDOF,
         "spinningBodiesNDOF": setup_spinningBodiesNDOF,
         "linearTranslationBodiesOneDOF": setup_translatingBodiesOneDOF,
+        "linearTranslationBodiesNDOF": setup_translatingBodiesNDOF,
     }
     stateEff, stateEffProps = setupByName[stateEffector]()
     weldParentSegmentToHub(stateEffector, stateEff)
@@ -411,6 +413,9 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     elif stateEffector == "linearTranslationBodiesOneDOF":
         stateEff, stateEffProps = setup_translatingBodiesOneDOF()
         segment = 1
+    elif stateEffector == "linearTranslationBodiesNDOF":
+        stateEff, stateEffProps = setup_translatingBodiesNDOF()
+        segment = 2
     elif stateEffector == "linearSpringMassDamper":
         stateEff, stateEffProps = setup_linearSpringMassDamper()
         segment = 1
@@ -696,6 +701,8 @@ def getModernStateEffInertialPropName(scObject, stateEffector, segment, propType
         pattern = "nHingedRigidBodyInertial" + propType + r"[0-9]+_" + str(segment)
     elif stateEffector == "spinningBodiesNDOF":
         pattern = "spinningBodyInertial" + propType + r"[0-9]+_" + str(segment)
+    elif stateEffector == "linearTranslationBodiesNDOF":
+        pattern = "linearTranslationInertial" + propType + r"[0-9]+_" + str(segment)
     else:
         pattern = "linearTranslationInertial" + propType + r"[0-9]+"
     try:
@@ -811,6 +818,9 @@ def weldParentSegmentToHub(stateEffector, stateEff):
     elif stateEffector == "linearTranslationBodiesOneDOF":
         stateEff.setRhoDotInit(0.0)  # [m/s]
         numberOfDegreesOfFreedom = 1
+    elif stateEffector == "linearTranslationBodiesNDOF":
+        numberOfDegreesOfFreedom = len(stateEff.translatingBodyOutMsgs)
+        stateEff.getTranslatingBody(0).setRhoDotInit(0.0)  # [m/s]
     else:
         pytest.fail("Weld requested for a state effector that exposes no lock.")
 
@@ -1212,6 +1222,57 @@ def setup_translatingBodiesOneDOF():
     stateEffProps.inertialPropLogName = "translatingBodyConfigLogOutMsg"
 
     return(translatingBody, stateEffProps)
+
+def setup_translatingBodiesNDOF():
+    translatingBodyEffector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
+
+    # Define properties of the chain, whose first body is rotated away from the hub frame
+    numberOfBodies = 3
+    bodyMass = 20.0  # [kg]
+    rhoInit = [1.0, 0.5, -0.25]  # [m]
+    rhoDotInit = [0.05, -0.02, 0.03]  # [m/s]
+    fHat_P = np.array([[3.0 / 5.0], [4.0 / 5.0], [0.0]])
+    r_FcF_F = np.array([[-1.0], [1.0], [0.0]])  # [m]
+    r_F0P_P = np.array([[-1.0], [1.0], [0.0]])  # [m]
+    dcm_F0B = np.array([[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]])
+
+    for idx in range(numberOfBodies):
+        body = linearTranslationNDOFStateEffector.TranslatingBody()
+        body.setMass(bodyMass)
+        body.setK(100.0)  # [N/m]
+        body.setC(0.0)  # [N*s/m]
+        body.setRhoInit(rhoInit[idx])
+        body.setRhoDotInit(rhoDotInit[idx])
+        body.setFHat_P(fHat_P)
+        body.setR_FcF_F(r_FcF_F)
+        body.setR_F0P_P(r_F0P_P)
+        body.setIPntFc_F([[50.0, 0.0, 0.0],  # [kg*m^2]
+                          [0.0, 80.0, 0.0],
+                          [0.0, 0.0, 60.0]])
+        body.setDCM_FP(dcm_F0B if idx == 0 else np.eye(3))
+        translatingBodyEffector.addTranslatingBody(body)
+    translatingBodyEffector.ModelTag = "linearTranslationNDOF"
+
+    # Walk the chain to find each frame origin, and the COM offset contribution to be divided by
+    # the hub mass. Each body's axis and offset are stated in its parent's frame.
+    dcm_FB = np.eye(3)
+    r_FB_B = np.zeros((3, 1))
+    frameOrigins = []
+    mr_FcB_B = np.zeros((3, 1))
+    for idx in range(numberOfBodies):
+        r_FB_B = r_FB_B + dcm_FB.transpose() @ (r_F0P_P + rhoInit[idx] * fHat_P)
+        dcm_FB = (dcm_F0B if idx == 0 else np.eye(3)) @ dcm_FB
+        frameOrigins.append(r_FB_B)
+        mr_FcB_B -= bodyMass * (r_FB_B + dcm_FB.transpose() @ r_FcF_F)
+
+    stateEffProps = stateEffectorProperties()
+    stateEffProps.totalMass = numberOfBodies * bodyMass
+    stateEffProps.mr_PcB_B = mr_FcB_B
+    stateEffProps.r_PB_B = frameOrigins[1]  # [m] the body the dynamic effector attaches to
+    stateEffProps.r_PcP_P = r_FcF_F
+    stateEffProps.inertialPropLogName = "translatingBodyConfigLogOutMsgs"
+
+    return(translatingBodyEffector, stateEffProps)
 
 def setup_linearSpringMassDamper():
     linearSpring = linearSpringMassDamper.LinearSpringMassDamper()

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
@@ -225,20 +225,31 @@ def test_translatingBodyDynamicEffectorSegmentBounds(segment, shouldRaise):
         effector.addDynamicEffector(child, segment)
 
 
-# axis and mass [kg] of each body in the chain, outward from the hub. A body given no mass keeps the
-# zero default, since the setter rejects a non-positive mass, and is given a zero inertia to match.
+def test_translatingBodyMassSetterBoundary():
+    """Verify that the mass setter accepts zero and rejects a negative mass."""
+    body = linearTranslationNDOFStateEffector.TranslatingBody()
+    body.setMass(1.0)  # [kg]
+    body.setMass(0.0)  # [kg]
+    assert body.getMass() == 0.0
+
+    with pytest.raises(BasiliskError, match="greater than or equal to 0"):
+        body.setMass(-1.0)  # [kg]
+
+
+# Axis and mass [kg] of each body in the chain, outward from the hub. A massless body is given zero
+# mass and zero inertia explicitly.
 X_AXIS = [[1.0], [0.0], [0.0]]
 Y_AXIS = [[0.0], [1.0], [0.0]]
 Z_AXIS = [[0.0], [0.0], [1.0]]
 XY_AXIS = [[1.0], [1.0], [0.0]]
 VALIDATION_CHAINS = {
     'Valid': [(20.0, X_AXIS), (15.0, Y_AXIS)],
-    'MasslessJoint': [(None, X_AXIS), (20.0, Y_AXIS)],
-    'MasslessChain': [(None, X_AXIS), (None, Y_AXIS), (20.0, Z_AXIS)],
-    'MasslessOutermost': [(20.0, X_AXIS), (None, Y_AXIS)],
-    'CollinearMassless': [(None, X_AXIS), (20.0, X_AXIS)],
+    'MasslessJoint': [(0.0, X_AXIS), (20.0, Y_AXIS)],
+    'MasslessChain': [(0.0, X_AXIS), (0.0, Y_AXIS), (20.0, Z_AXIS)],
+    'MasslessOutermost': [(20.0, X_AXIS), (0.0, Y_AXIS)],
+    'CollinearMassless': [(0.0, X_AXIS), (20.0, X_AXIS)],
     # pairwise independent axes that collectively span only two dimensions
-    'CoplanarMassless': [(None, X_AXIS), (None, Y_AXIS), (20.0, XY_AXIS)],
+    'CoplanarMassless': [(0.0, X_AXIS), (0.0, Y_AXIS), (20.0, XY_AXIS)],
     'NoBodies': [],
     'SkewedDCM': [(20.0, X_AXIS), (15.0, Y_AXIS)],
     'AsymmetricInertia': [(20.0, X_AXIS), (15.0, Y_AXIS)],
@@ -306,9 +317,8 @@ def test_translatingBodyConfigurationValidation(chain, shouldRaise, scheduleEffe
     effector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
     for mass, fHat_P in VALIDATION_CHAINS[chain]:
         body = linearTranslationNDOFStateEffector.TranslatingBody()
-        if mass is not None:
-            body.setMass(mass)  # [kg]
-        else:
+        body.setMass(mass)  # [kg]
+        if mass == 0.0:
             body.setIPntFc_F([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])  # [kg*m^2]
         if chain == 'SkewedDCM':
             body.setDCM_FP([[1.0, 0.1, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
@@ -42,6 +42,18 @@ from Basilisk.utilities import (
 )
 from Basilisk.simulation import spacecraft, linearTranslationNDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
+from Basilisk.architecture.bskLogging import BasiliskError
+
+
+def randomValidInertia():
+    r"""Generate a random diagonal inertia tensor that is physically realizable."""
+    secondMoments = np.random.uniform(2.5, 50.0, 3)  # [kg m^2]
+    principalInertias = np.array([
+        secondMoments[1] + secondMoments[2],
+        secondMoments[0] + secondMoments[2],
+        secondMoments[0] + secondMoments[1]
+    ])  # [kg m^2]
+    return np.diag(principalInertias)
 
 
 # uncomment this line is this test is to be skipped in the global unit test run, adjust message as needed
@@ -81,6 +93,136 @@ def test_translatingBody(show_plots, function):
 
     testFunction(show_plots)
 
+# axis and mass [kg] of each body in the chain, outward from the hub. A body given no mass keeps the
+# zero default, since the setter rejects a non-positive mass, and is given a zero inertia to match.
+X_AXIS = [[1.0], [0.0], [0.0]]
+Y_AXIS = [[0.0], [1.0], [0.0]]
+Z_AXIS = [[0.0], [0.0], [1.0]]
+XY_AXIS = [[1.0], [1.0], [0.0]]
+VALIDATION_CHAINS = {
+    'Valid': [(20.0, X_AXIS), (15.0, Y_AXIS)],
+    'MasslessJoint': [(None, X_AXIS), (20.0, Y_AXIS)],
+    'MasslessChain': [(None, X_AXIS), (None, Y_AXIS), (20.0, Z_AXIS)],
+    'MasslessOutermost': [(20.0, X_AXIS), (None, Y_AXIS)],
+    'CollinearMassless': [(None, X_AXIS), (20.0, X_AXIS)],
+    # pairwise independent axes that collectively span only two dimensions
+    'CoplanarMassless': [(None, X_AXIS), (None, Y_AXIS), (20.0, XY_AXIS)],
+    'NoBodies': [],
+    'SkewedDCM': [(20.0, X_AXIS), (15.0, Y_AXIS)],
+    'AsymmetricInertia': [(20.0, X_AXIS), (15.0, Y_AXIS)],
+    'TriangleInertia': [(20.0, X_AXIS), (15.0, Y_AXIS)],
+}
+
+
+@pytest.mark.parametrize("scheduleEffector", [True, False])
+@pytest.mark.parametrize("chain, shouldRaise", [
+    ('Valid', False),
+    ('MasslessJoint', False),
+    ('MasslessChain', False),
+    ('MasslessOutermost', True),
+    ('CollinearMassless', True),
+    ('CoplanarMassless', True),
+    ('NoBodies', True),
+    ('SkewedDCM', True),
+    ('AsymmetricInertia', True),
+    ('TriangleInertia', True),
+])
+def test_translatingBodyConfigurationValidation(chain, shouldRaise, scheduleEffector):
+    """
+    Verify that initialization rejects a chain the equations of motion cannot represent, and that a
+    massless body used to build a multiple degree of freedom joint is not one of them.
+
+    The joint mass matrix sums the masses outboard of each axis. A body may be left massless so that
+    several single axis bodies compose one multi-axis joint, but the matrix is singular whenever some
+    nonzero combination of axis rates leaves every body carrying mass at rest. That covers a massless
+    outermost body and a massless body sharing its axis with the body outboard of it, and it is a
+    collective condition rather than a pairwise one: massless stages along x and y followed by a
+    massive stage along x + y have pairwise independent axes yet span only two dimensions, so they
+    are rejected as well.
+    Inverting a singular matrix fills the spacecraft state with NaN rather than raising, which is why
+    this is asserted as an error at initialization instead of as a tolerance on a trajectory. The
+    axes are fixed in their parents and a translating body does not rotate, so the matrix never
+    changes during the integration. The rotation matrix and inertia tensor checks match those the
+    spinning body effectors already apply, including skipping the inertia check for a massless body,
+    whose inertia tensor is legitimately zero.
+
+    An accepted chain is integrated as well, because initializing without error would not show that
+    a massless body carries the correct dynamics. Every damper is zero, so the rotational energy and
+    the rotational angular momentum about the vehicle center of mass must both be conserved.
+
+    **Test Parameters:**
+
+    - chain: [string]
+        translating body configuration to initialize
+    - shouldRaise: [bool]
+        whether initialization must reject the configuration
+    - scheduleEffector: [bool]
+        whether the effector is added to the task in addition to the spacecraft
+
+    The scheduling parameter matters because the checks must not depend on it. Spacecraft
+    initialization calls ``registerStates()`` on every attached state effector but never calls
+    ``Reset()``, which runs only for a module added to a task. The module user guide adds the
+    effector to the spacecraft alone, so validation reached from ``Reset()`` would miss the
+    documented setup and let a singular chain integrate to NaN.
+    """
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+    scObject.hub.omega_BN_BInit = [[0.1], [-0.2], [0.3]]  # [rad/s]
+
+    effector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
+    for mass, fHat_P in VALIDATION_CHAINS[chain]:
+        body = linearTranslationNDOFStateEffector.TranslatingBody()
+        if mass is not None:
+            body.setMass(mass)  # [kg]
+        else:
+            body.setIPntFc_F([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])  # [kg*m^2]
+        if chain == 'SkewedDCM':
+            body.setDCM_FP([[1.0, 0.1, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        if chain == 'AsymmetricInertia':
+            body.setIPntFc_F([[50.0, 3.0, 0.0], [0.0, 80.0, 0.0], [0.0, 0.0, 60.0]])  # [kg*m^2]
+        if chain == 'TriangleInertia':
+            # positive definite, but the principal moments violate the triangle inequality
+            body.setIPntFc_F([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 90.0]])  # [kg*m^2]
+        body.setR_FcF_F([[0.5], [0.2], [-0.3]])  # [m]
+        body.setR_F0P_P([[1.0], [0.5], [0.25]])  # [m]
+        body.setFHat_P(fHat_P)
+        body.setRhoInit(0.1)  # [m]
+        body.setRhoDotInit(0.05)  # [m/s]
+        body.setK(10.0)  # [N/m]
+        effector.addTranslatingBody(body)
+    scObject.addStateEffector(effector)
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.SetProgressBar(False)
+    unitTestSim.CreateNewProcess("TestProcess").addTask(
+        unitTestSim.CreateNewTask("unitTask", macros.sec2nano(0.001)))
+    if scheduleEffector:
+        unitTestSim.AddModelToTask("unitTask", effector)
+    unitTestSim.AddModelToTask("unitTask", scObject)
+    conservationLog = scObject.logger(["totRotEnergy", "totRotAngMomPntC_N"])
+    unitTestSim.AddModelToTask("unitTask", conservationLog)
+
+    if shouldRaise:
+        with pytest.raises(BasiliskError):
+            unitTestSim.InitializeSimulation()
+        return
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+    unitTestSim.ExecuteSimulation()
+
+    accuracy = 1e-10
+    rotEnergy = np.array(conservationLog.totRotEnergy)
+    rotAngMom = np.array(conservationLog.totRotAngMomPntC_N)
+    np.testing.assert_allclose(rotEnergy, rotEnergy[0], rtol=accuracy,
+                               err_msg="Rotational energy is not constant.")
+    np.testing.assert_allclose(rotAngMom, np.broadcast_to(rotAngMom[0], rotAngMom.shape),
+                               rtol=accuracy,
+                               err_msg="Rotational angular momentum is not constant.")
+
+
 def translatingBodyNoInput(show_plots):
     r"""
     This test does not use any input messages or lock flags, so the links are free to move.
@@ -106,9 +248,7 @@ def translatingBodyNoInput(show_plots):
     # define properties
     translatingBody1 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody1.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody1.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                 [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                 [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody1.setIPntFc_F(randomValidInertia())
     translatingBody1.setDCM_FP([[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]])
     translatingBody1.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                 [np.random.uniform(-1.0, 1.0)],
@@ -124,9 +264,7 @@ def translatingBodyNoInput(show_plots):
 
     translatingBody2 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody2.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody2.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody2.setIPntFc_F(randomValidInertia())
     translatingBody2.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody2.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -142,9 +280,7 @@ def translatingBodyNoInput(show_plots):
 
     translatingBody3 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody3.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody3.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody3.setIPntFc_F(randomValidInertia())
     translatingBody3.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody3.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -160,9 +296,7 @@ def translatingBodyNoInput(show_plots):
 
     translatingBody4 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody4.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody4.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody4.setIPntFc_F(randomValidInertia())
     translatingBody4.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody4.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -348,9 +482,7 @@ def translatingBodyLockAxis(show_plots):
     # define properties
     translatingBody1 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody1.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody1.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody1.setIPntFc_F(randomValidInertia())
     translatingBody1.setDCM_FP([[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]])
     translatingBody1.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -366,9 +498,7 @@ def translatingBodyLockAxis(show_plots):
 
     translatingBody2 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody2.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody2.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody2.setIPntFc_F(randomValidInertia())
     translatingBody2.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody2.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -384,9 +514,7 @@ def translatingBodyLockAxis(show_plots):
 
     translatingBody3 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody3.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody3.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody3.setIPntFc_F(randomValidInertia())
     translatingBody3.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody3.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -402,9 +530,7 @@ def translatingBodyLockAxis(show_plots):
 
     translatingBody4 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody4.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody4.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody4.setIPntFc_F(randomValidInertia())
     translatingBody4.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody4.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -597,9 +723,7 @@ def translatingBodyCommandedForce(show_plots):
     # define properties
     translatingBody1 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody1.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody1.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody1.setIPntFc_F(randomValidInertia())
     translatingBody1.setDCM_FP([[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]])
     translatingBody1.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -615,9 +739,7 @@ def translatingBodyCommandedForce(show_plots):
 
     translatingBody2 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody2.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody2.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody2.setIPntFc_F(randomValidInertia())
     translatingBody2.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody2.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -633,9 +755,7 @@ def translatingBodyCommandedForce(show_plots):
 
     translatingBody3 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody3.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody3.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody3.setIPntFc_F(randomValidInertia())
     translatingBody3.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody3.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],
@@ -651,9 +771,7 @@ def translatingBodyCommandedForce(show_plots):
 
     translatingBody4 = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody4.setMass(np.random.uniform(5.0, 50.0))
-    translatingBody4.setIPntFc_F([[np.random.uniform(5.0, 100.0), 0.0, 0.0],
-                                  [0.0, np.random.uniform(5.0, 100.0), 0.0],
-                                  [0.0, 0.0, np.random.uniform(5.0, 100.0)]])
+    translatingBody4.setIPntFc_F(randomValidInertia())
     translatingBody4.setDCM_FP([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
     translatingBody4.setR_FcF_F([[np.random.uniform(-1.0, 1.0)],
                                  [np.random.uniform(-1.0, 1.0)],

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
@@ -41,7 +41,7 @@ from Basilisk.utilities import (
     macros,
 )
 from Basilisk.simulation import spacecraft, linearTranslationNDOFStateEffector, gravityEffector
-from Basilisk.simulation import linearTranslationOneDOFStateEffector
+from Basilisk.simulation import linearTranslationOneDOFStateEffector, extForceTorque
 from Basilisk.architecture import messaging
 from Basilisk.architecture.bskLogging import BasiliskError
 
@@ -194,6 +194,35 @@ def test_translatingBodyOutputMessagesMatchOneDOF():
         np.testing.assert_allclose(getattr(nDofConfig, field), getattr(oneDofConfig, field),
                                    rtol=accuracy, atol=accuracy,
                                    err_msg=field + " does not match the one-DOF effector.")
+
+
+@pytest.mark.parametrize("segment, shouldRaise", [(1, False), (3, False), (0, True), (4, True)])
+def test_translatingBodyDynamicEffectorSegmentBounds(segment, shouldRaise):
+    """
+    Verify that dynamic effectors can attach only to existing translating bodies.
+
+    A three-body chain accepts its first and last body numbers and rejects the adjacent values
+    outside the valid one-based range.
+
+    **Test Parameters:**
+
+    - segment: [int]
+        one-based body number supplied to ``addDynamicEffector``
+    - shouldRaise: [bool]
+        whether the body number is outside the valid range
+    """
+    effector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
+    for _ in range(3):
+        body = linearTranslationNDOFStateEffector.TranslatingBody()
+        body.setMass(20.0)  # [kg]
+        effector.addTranslatingBody(body)
+
+    child = extForceTorque.ExtForceTorque()
+    if shouldRaise:
+        with pytest.raises(BasiliskError, match="non-existent translating body"):
+            effector.addDynamicEffector(child, segment)
+    else:
+        effector.addDynamicEffector(child, segment)
 
 
 # axis and mass [kg] of each body in the chain, outward from the hub. A body given no mass keeps the

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
@@ -41,6 +41,7 @@ from Basilisk.utilities import (
     macros,
 )
 from Basilisk.simulation import spacecraft, linearTranslationNDOFStateEffector, gravityEffector
+from Basilisk.simulation import linearTranslationOneDOFStateEffector
 from Basilisk.architecture import messaging
 from Basilisk.architecture.bskLogging import BasiliskError
 
@@ -92,6 +93,108 @@ def test_translatingBody(show_plots, function):
         raise ValueError(f"Function '{function}' not found in global scope")
 
     testFunction(show_plots)
+
+def test_translatingBodyOutputMessagesMatchOneDOF():
+    """
+    Verify both output-message vectors against the equivalent one-DOF model.
+
+    A single-body N-DOF effector and a one-DOF effector are given identical geometry, mass
+    properties, and initial states on their own spacecraft in one simulation. The hub starts with a
+    non-identity attitude and nonzero translational and angular velocity so that every inertial
+    transformation contributes. The displacement, displacement rate, inertial position, inertial
+    velocity, attitude, and angular velocity are compared at every step.
+    """
+    timeStep = 0.01  # [s]
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.SetProgressBar(False)
+    testProc = unitTestSim.CreateNewProcess("TestProcess")
+    testProc.addTask(unitTestSim.CreateNewTask("unitTask", macros.sec2nano(timeStep)))
+
+    mass = 20.0  # [kg]
+    k = 100.0  # [N/m]
+    rhoInit = 0.4  # [m]
+    rhoDotInit = 0.05  # [m/s]
+    fHat = [[3.0 / 5.0], [4.0 / 5.0], [0.0]]
+    r_FcF_F = [[-1.0], [1.0], [0.5]]  # [m]
+    r_F0B_B = [[-1.0], [1.0], [0.0]]  # [m]
+    IPntFc_F = [[50.0, 0.0, 0.0], [0.0, 80.0, 0.0], [0.0, 0.0, 60.0]]  # [kg*m^2]
+    dcm_FB = [[0.0, -1.0, 0.0], [0.0, 0.0, -1.0], [1.0, 0.0, 0.0]]
+
+    nDofEffector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
+    nDofEffector.ModelTag = "translatingBodyNDOF"
+    body = linearTranslationNDOFStateEffector.TranslatingBody()
+    body.setMass(mass)
+    body.setK(k)
+    body.setC(0.0)  # [N*s/m]
+    body.setRhoInit(rhoInit)
+    body.setRhoDotInit(rhoDotInit)
+    body.setFHat_P(fHat)
+    body.setR_FcF_F(r_FcF_F)
+    body.setR_F0P_P(r_F0B_B)
+    body.setIPntFc_F(IPntFc_F)
+    body.setDCM_FP(dcm_FB)
+    nDofEffector.addTranslatingBody(body)
+
+    oneDofEffector = linearTranslationOneDOFStateEffector.LinearTranslationOneDOFStateEffector()
+    oneDofEffector.ModelTag = "translatingBodyOneDOF"
+    oneDofEffector.setMass(mass)
+    oneDofEffector.setK(k)
+    oneDofEffector.setC(0.0)  # [N*s/m]
+    oneDofEffector.setRhoInit(rhoInit)
+    oneDofEffector.setRhoDotInit(rhoDotInit)
+    oneDofEffector.setFHat_B(fHat)
+    oneDofEffector.setR_FcF_F(r_FcF_F)
+    oneDofEffector.setR_F0B_B(r_F0B_B)
+    oneDofEffector.setIPntFc_F(IPntFc_F)
+    oneDofEffector.setDCM_FB(dcm_FB)
+
+    recorders = []
+    for effector in (nDofEffector, oneDofEffector):
+        scObject = spacecraft.Spacecraft()
+        scObject.ModelTag = "spacecraft" + effector.ModelTag
+        scObject.hub.mHub = 750.0  # [kg]
+        scObject.hub.r_BcB_B = [[0.0], [0.0], [1.0]]  # [m]
+        scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+        scObject.hub.r_CN_NInit = [[-4020338.690396649], [7490566.741852513], [5248299.211589362]]  # [m]
+        scObject.hub.v_CN_NInit = [[-5199.77710904224], [-3436.681645356935], [1041.576797498721]]  # [m/s]
+        scObject.hub.sigma_BNInit = [[0.1], [0.2], [-0.3]]
+        scObject.hub.omega_BN_BInit = [[0.5], [-0.4], [0.6]]  # [rad/s]
+
+        earthGravBody = gravityEffector.GravBodyData()
+        earthGravBody.planetName = "earth_planet_data"
+        earthGravBody.mu = 0.3986004415E+15  # [m^3/s^2]
+        earthGravBody.isCentralBody = True
+        scObject.gravField.gravBodies = spacecraft.GravBodyVector([earthGravBody])
+
+        scObject.addStateEffector(effector)
+        unitTestSim.AddModelToTask("unitTask", effector)
+        unitTestSim.AddModelToTask("unitTask", scObject)
+
+    for outMsg, configMsg in ((nDofEffector.translatingBodyOutMsgs[0],
+                               nDofEffector.translatingBodyConfigLogOutMsgs[0]),
+                              (oneDofEffector.translatingBodyOutMsg,
+                               oneDofEffector.translatingBodyConfigLogOutMsg)):
+        stateRec = outMsg.recorder()
+        configRec = configMsg.recorder()
+        unitTestSim.AddModelToTask("unitTask", stateRec)
+        unitTestSim.AddModelToTask("unitTask", configRec)
+        recorders.append((stateRec, configRec))
+
+    unitTestSim.InitializeSimulation()
+    unitTestSim.ConfigureStopTime(macros.sec2nano(10 * timeStep))
+    unitTestSim.ExecuteSimulation()
+
+    (nDofState, nDofConfig), (oneDofState, oneDofConfig) = recorders
+    accuracy = 1e-10
+    np.testing.assert_allclose(nDofState.rho, oneDofState.rho, rtol=accuracy,
+                               err_msg="Displacement does not match the one-DOF effector.")
+    np.testing.assert_allclose(nDofState.rhoDot, oneDofState.rhoDot, rtol=accuracy,
+                               err_msg="Displacement rate does not match the one-DOF effector.")
+    for field in ("r_BN_N", "v_BN_N", "sigma_BN", "omega_BN_B"):
+        np.testing.assert_allclose(getattr(nDofConfig, field), getattr(oneDofConfig, field),
+                                   rtol=accuracy, atol=accuracy,
+                                   err_msg=field + " does not match the one-DOF effector.")
+
 
 # axis and mass [kg] of each body in the chain, outward from the hub. A body given no mass keeps the
 # zero default, since the setter rejects a non-positive mass, and is given a zero inertia to match.

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/_UnitTest/test_linearTranslationNDOFStateEffector.py
@@ -285,9 +285,10 @@ def test_translatingBodyConfigurationValidation(chain, shouldRaise, scheduleEffe
     Inverting a singular matrix fills the spacecraft state with NaN rather than raising, which is why
     this is asserted as an error at initialization instead of as a tolerance on a trajectory. The
     axes are fixed in their parents and a translating body does not rotate, so the matrix never
-    changes during the integration. The rotation matrix and inertia tensor checks match those the
-    spinning body effectors already apply, including skipping the inertia check for a massless body,
-    whose inertia tensor is legitimately zero.
+    changes during the integration. The singular cases also verify that the error reports this
+    collective condition rather than a more restrictive axis-independence rule. The rotation matrix
+    and inertia tensor checks match those the spinning body effectors already apply, including
+    skipping the inertia check for a massless body, whose inertia tensor is legitimately zero.
 
     An accepted chain is integrated as well, because initializing without error would not show that
     a massless body carries the correct dynamics. Every damper is zero, so the rotational energy and
@@ -347,8 +348,10 @@ def test_translatingBodyConfigurationValidation(chain, shouldRaise, scheduleEffe
     unitTestSim.AddModelToTask("unitTask", conservationLog)
 
     if shouldRaise:
-        with pytest.raises(BasiliskError):
+        with pytest.raises(BasiliskError) as error:
             unitTestSim.InitializeSimulation()
+        if chain in ('MasslessOutermost', 'CollinearMassless', 'CoplanarMassless'):
+            assert "nonzero combination of joint rates leaves every mass-bearing body stationary" in str(error.value)
         return
 
     unitTestSim.InitializeSimulation()

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -286,6 +286,24 @@ void LinearTranslationNDOFStateEffector::registerStates(DynParamManager& states)
     this->validateConfiguration();
 }
 
+/*! This method attaches a dynamicEffector to one of the translating bodies
+
+ @param newDynamicEffector the dynamic effector to be attached
+ @param segment the translating body to attach to, counting outward from the hub starting at 1 */
+void
+LinearTranslationNDOFStateEffector::addDynamicEffector(DynamicEffector* newDynamicEffector, int segment)
+{
+    if (segment <= 0 || segment > this->N) {
+        bskLogger.bskError("LinearTranslationNDOFStateEffector: specifying attachment to a "
+                           "non-existent translating body.");
+        return;
+    }
+
+    auto& translatingBody = this->translatingBodyVec[static_cast<size_t>(segment - 1)];
+    translatingBody->assignStateParamNames<DynamicEffector*>(newDynamicEffector);
+    translatingBody->dynEffectors.push_back(newDynamicEffector);
+}
+
 /*! This method registers each translating body's inertial properties with the dynamic parameter
  manager and links them into dependent dynamic effectors
 
@@ -300,6 +318,10 @@ LinearTranslationNDOFStateEffector::registerProperties(DynParamManager& states)
         translatingBody->sigma_FN = states.createProperty(translatingBody->nameOfInertialAttitudeProperty, stateInit);
         translatingBody->omega_FN_F =
           states.createProperty(translatingBody->nameOfInertialAngVelocityProperty, stateInit);
+
+        for (auto& dynEffector : translatingBody->dynEffectors) {
+            dynEffector->linkInProperties(states);
+        }
     }
 }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -39,9 +39,13 @@ LinearTranslationNDOFStateEffector::LinearTranslationNDOFStateEffector()
 
 uint64_t LinearTranslationNDOFStateEffector::effectorID = 1;
 
-/*! This is the destructor, nothing to report here */
+/*! This is the destructor, releasing the per body output messages */
 LinearTranslationNDOFStateEffector::~LinearTranslationNDOFStateEffector()
 {
+    for (size_t c = 0; c < this->translatingBodyOutMsgs.size(); c++) {
+        delete this->translatingBodyOutMsgs.at(c);
+        delete this->translatingBodyConfigLogOutMsgs.at(c);
+    }
 }
 
 void TranslatingBody::setMass(double mass) {

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -260,8 +260,8 @@ LinearTranslationNDOFStateEffector::checkJointMassMatrix()
     this->computeMRho(MRho);
     if (Eigen::FullPivLU<Eigen::MatrixXd>(MRho).rank() < this->N) {
         bskLogger.bskError("LinearTranslationNDOFStateEffector: the translating body masses and axes leave the joint "
-                           "mass matrix singular. The outermost body must carry mass, and a massless body's axis must "
-                           "be independent of the axes outboard of it.");
+                           "mass matrix singular because at least one nonzero combination of joint rates leaves every "
+                           "mass-bearing body stationary.");
     }
 }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -34,6 +34,8 @@ LinearTranslationNDOFStateEffector::LinearTranslationNDOFStateEffector()
 
     this->nameOfRhoState = "translatingBodyRho" + std::to_string(LinearTranslationNDOFStateEffector::effectorID);
     this->nameOfRhoDotState = "translatingBodyRhoDot" + std::to_string(LinearTranslationNDOFStateEffector::effectorID);
+    // preserves the effectorID for bodies added later
+    this->propertyNameIndex = std::to_string(LinearTranslationNDOFStateEffector::effectorID);
     LinearTranslationNDOFStateEffector::effectorID++;
 }
 
@@ -102,6 +104,12 @@ void LinearTranslationNDOFStateEffector::addTranslatingBody(const std::shared_pt
     this->ARho.conservativeResize(this->ARho.rows()+1, 3);
     this->BRho.conservativeResize(this->BRho.rows()+1, 3);
     this->CRho.conservativeResize(this->CRho.rows()+1);
+
+    const std::string bodySuffix = this->propertyNameIndex + "_" + std::to_string(this->N);
+    newBody->nameOfInertialPositionProperty = "linearTranslationInertialPosition" + bodySuffix;
+    newBody->nameOfInertialVelocityProperty = "linearTranslationInertialVelocity" + bodySuffix;
+    newBody->nameOfInertialAttitudeProperty = "linearTranslationInertialAttitude" + bodySuffix;
+    newBody->nameOfInertialAngVelocityProperty = "linearTranslationInertialAngVelocity" + bodySuffix;
 }
 
 /*! This method is used to get a translating body. */
@@ -171,8 +179,8 @@ void LinearTranslationNDOFStateEffector::writeOutputStateMessages(uint64_t Curre
             // Logging the F frame is the body frame B of that object
             eigenVector3d2CArray(translatingBody->r_FcN_N, configLogMsg.r_BN_N);
             eigenVector3d2CArray(translatingBody->v_FcN_N, configLogMsg.v_BN_N);
-            eigenMRPd2CArray(translatingBody->sigma_FN, configLogMsg.sigma_BN);
-            eigenVector3d2CArray(translatingBody->omega_FN_F, configLogMsg.omega_BN_B);
+            eigenMatrixXd2CArray(*translatingBody->sigma_FN, configLogMsg.sigma_BN);
+            eigenMatrixXd2CArray(*translatingBody->omega_FN_F, configLogMsg.omega_BN_B);
             this->translatingBodyConfigLogOutMsgs[i]->write(&configLogMsg, this->moduleID, CurrentClock);
         }
 
@@ -274,7 +282,25 @@ void LinearTranslationNDOFStateEffector::registerStates(DynParamManager& states)
     this->rhoState->setState(RhoInitMatrix);
     this->rhoDotState->setState(RhoDotInitMatrix);
 
+    this->registerProperties(states);
     this->validateConfiguration();
+}
+
+/*! This method registers each translating body's inertial properties with the dynamic parameter
+ manager and links them into dependent dynamic effectors
+
+ @param states the dynamic parameter manager holding the published properties */
+void
+LinearTranslationNDOFStateEffector::registerProperties(DynParamManager& states)
+{
+    const Eigen::Vector3d stateInit = Eigen::Vector3d::Zero();
+    for (auto& translatingBody : this->translatingBodyVec) {
+        translatingBody->r_FN_N = states.createProperty(translatingBody->nameOfInertialPositionProperty, stateInit);
+        translatingBody->v_FN_N = states.createProperty(translatingBody->nameOfInertialVelocityProperty, stateInit);
+        translatingBody->sigma_FN = states.createProperty(translatingBody->nameOfInertialAttitudeProperty, stateInit);
+        translatingBody->omega_FN_F =
+          states.createProperty(translatingBody->nameOfInertialAngVelocityProperty, stateInit);
+    }
 }
 
 /*! This method allows the TB state effector to provide its contributions to the mass props and mass prop rates of the
@@ -554,13 +580,18 @@ void LinearTranslationNDOFStateEffector::computeTranslatingBodyInertialStates()
     for(auto& translatingBody: this->translatingBodyVec) {
         // Compute the rotational properties, noting that F does not rotate relative to B
         const Eigen::Matrix3d dcm_FN = translatingBody->dcm_FB * this->dcm_BN;
-        translatingBody->sigma_FN = eigenC2MRP(dcm_FN);
-        translatingBody->omega_FN_F = translatingBody->dcm_FB * this->omega_BN_B;
+        *translatingBody->sigma_FN = eigenC2MRP(dcm_FN).coeffs();
+        *translatingBody->omega_FN_F = translatingBody->dcm_FB * this->omega_BN_B;
 
-        // Compute the translation properties of the center of mass Fc
+        // Compute the translation properties of the center of mass Fc and of the frame origin F
         translatingBody->rDot_FcB_B = translatingBody->rPrime_FcB_B + this->omega_BN_B.cross(translatingBody->r_FcB_B);
         translatingBody->r_FcN_N = r_BN_N + this->dcm_BN.transpose() * translatingBody->r_FcB_B;
         translatingBody->v_FcN_N = v_BN_N + this->dcm_BN.transpose() * translatingBody->rDot_FcB_B;
+
+        *translatingBody->r_FN_N = r_BN_N + this->dcm_BN.transpose() * translatingBody->r_FB_B;
+        *translatingBody->v_FN_N =
+          v_BN_N +
+          this->dcm_BN.transpose() * (translatingBody->rPrime_FB_B + this->omega_BN_B.cross(translatingBody->r_FB_B));
     }
 }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -192,6 +192,7 @@ void LinearTranslationNDOFStateEffector::linkInStates(DynParamManager& statesIn)
 {
     this->inertialPositionProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + "r_BN_N");
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + "v_BN_N");
+    this->hubSigmaState = statesIn.getStateObject(this->nameOfSpacecraftAttachedTo + this->stateNameOfSigma);
 }
 
 /*! This method runs every configuration check. Spacecraft initialization always reaches it through
@@ -524,19 +525,16 @@ void LinearTranslationNDOFStateEffector::updateEnergyMomContributions(double int
     rotEnergyContr = 0.0;
 
     for(auto& translatingBody: this->translatingBodyVec) {
-        // Update omega_FN_B
-        translatingBody->omega_FN_B = this->omega_BN_B;
-
-        // Compute rDot_FcB_B
+        // Compute rDot_FcB_B, noting that the F frame shares the hub angular velocity
         translatingBody->rDot_FcB_B = translatingBody->rPrime_FcB_B
                                       + this->omega_BN_B.cross(translatingBody->r_FcB_B);
 
         // Find rotational angular momentum contribution from hub
-        rotAngMomPntCContr_B += translatingBody->IPntFc_B * translatingBody->omega_FN_B
+        rotAngMomPntCContr_B += translatingBody->IPntFc_B * this->omega_BN_B
                                 + translatingBody->mass * translatingBody->r_FcB_B.cross(translatingBody->rDot_FcB_B);
 
         // Find rotational energy contribution from the hub
-        rotEnergyContr += 1.0 / 2.0 * translatingBody->omega_FN_B.dot(translatingBody->IPntFc_B * translatingBody->omega_FN_B)
+        rotEnergyContr += 1.0 / 2.0 * this->omega_BN_B.dot(translatingBody->IPntFc_B * this->omega_BN_B)
                         + 1.0 / 2.0 * translatingBody->mass * translatingBody->rDot_FcB_B.dot(translatingBody->rDot_FcB_B)
                         + 1.0 / 2.0 * translatingBody->k * (translatingBody->rho - translatingBody->rhoRef) *
                         (translatingBody->rho - translatingBody->rhoRef);
@@ -546,16 +544,23 @@ void LinearTranslationNDOFStateEffector::updateEnergyMomContributions(double int
 /*! This method computes the translating body states relative to the inertial frame */
 void LinearTranslationNDOFStateEffector::computeTranslatingBodyInertialStates()
 {
-    for(auto& translatingBody: this->translatingBodyVec) {
-        // Compute the rotational properties
-        Eigen::Matrix3d dcm_FN;
-        dcm_FN = translatingBody->dcm_FB * this->dcm_BN;
-        translatingBody->sigma_FN = eigenC2MRP(dcm_FN);
-        translatingBody->omega_FN_F = translatingBody->dcm_FB * translatingBody->omega_FN_B;
+    // - read live: the cached copy lags an integrator substep at write time
+    const Eigen::MRPd sigmaHub_BN(this->hubSigmaState->getStateReference().data());
+    this->dcm_BN = sigmaHub_BN.toRotationMatrix().transpose();
 
-        // Compute the translation properties
-        translatingBody->r_FcN_N = (Eigen::Vector3d)*this->inertialPositionProperty + this->dcm_BN.transpose() * translatingBody->r_FcB_B;
-        translatingBody->v_FcN_N = (Eigen::Vector3d)*this->inertialVelocityProperty + this->dcm_BN.transpose() * translatingBody->rDot_FcB_B;
+    const Eigen::Vector3d r_BN_N = (Eigen::Vector3d)*this->inertialPositionProperty;
+    const Eigen::Vector3d v_BN_N = (Eigen::Vector3d)*this->inertialVelocityProperty;
+
+    for(auto& translatingBody: this->translatingBodyVec) {
+        // Compute the rotational properties, noting that F does not rotate relative to B
+        const Eigen::Matrix3d dcm_FN = translatingBody->dcm_FB * this->dcm_BN;
+        translatingBody->sigma_FN = eigenC2MRP(dcm_FN);
+        translatingBody->omega_FN_F = translatingBody->dcm_FB * this->omega_BN_B;
+
+        // Compute the translation properties of the center of mass Fc
+        translatingBody->rDot_FcB_B = translatingBody->rPrime_FcB_B + this->omega_BN_B.cross(translatingBody->r_FcB_B);
+        translatingBody->r_FcN_N = r_BN_N + this->dcm_BN.transpose() * translatingBody->r_FcB_B;
+        translatingBody->v_FcN_N = v_BN_N + this->dcm_BN.transpose() * translatingBody->rDot_FcB_B;
     }
 }
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -85,7 +85,7 @@ void LinearTranslationNDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unu
             translatingBody->fHat_P.normalize();
         }
         else {
-            bskLogger.bskError("Norm of fHat must be greater than 0. sHat may not have been set by the user.");
+            bskLogger.bskError("Norm of fHat must be greater than 0. fHat may not have been set by the user.");
         }
     }
 }

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -49,10 +49,10 @@ LinearTranslationNDOFStateEffector::~LinearTranslationNDOFStateEffector()
 }
 
 void TranslatingBody::setMass(double mass) {
-    if (mass > 0.0)
+    if (mass >= 0.0)
         this->mass = mass;
     else {
-        this->bskLogger.bskError("Mass must be greater than 0.");
+        this->bskLogger.bskError("Mass must be greater than or equal to 0.");
     }
 }
 
@@ -84,14 +84,7 @@ void TranslatingBody::setC(double c) {
 /*! This method is used to reset the module. */
 void LinearTranslationNDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]])
 {
-    for(auto& translatingBody: this->translatingBodyVec) {
-        if (translatingBody->fHat_P.norm() > 0.0) {
-            translatingBody->fHat_P.normalize();
-        }
-        else {
-            bskLogger.bskError("Norm of fHat must be greater than 0. fHat may not have been set by the user.");
-        }
-    }
+    this->validateConfiguration();
 }
 
 /*! This method is used to add a translating body. */
@@ -201,6 +194,68 @@ void LinearTranslationNDOFStateEffector::linkInStates(DynParamManager& statesIn)
     this->inertialVelocityProperty = statesIn.getPropertyReference(this->nameOfSpacecraftAttachedTo + "v_BN_N");
 }
 
+/*! This method runs every configuration check. Spacecraft initialization always reaches it through
+ registerStates(), whereas Reset() runs only when the effector is also added to a task */
+void
+LinearTranslationNDOFStateEffector::validateConfiguration()
+{
+    for (auto& translatingBody : this->translatingBodyVec) {
+        if (translatingBody->fHat_P.norm() > 0.0) {
+            translatingBody->fHat_P.normalize();
+        }
+        else {
+            bskLogger.bskError("Norm of fHat must be greater than 0. fHat may not have been set by the user.");
+        }
+    }
+
+    this->checkBodyConfiguration();
+    this->checkJointMassMatrix();
+}
+
+/*! This method checks each translating body's user set frame and inertia */
+void
+LinearTranslationNDOFStateEffector::checkBodyConfiguration()
+{
+    if (this->translatingBodyVec.empty()) {
+        bskLogger.bskError("LinearTranslationNDOFStateEffector: at least one translating body is required.");
+        return;
+    }
+
+    for (const auto& translatingBody : this->translatingBodyVec) {
+        if (!eigenIsRotationMatrix(translatingBody->dcm_FP)) {
+            bskLogger.bskError(
+              "LinearTranslationNDOFStateEffector: a translating body's dcm_FP is not a valid rotation matrix; it must "
+              "be orthogonal and right-handed. It may not have been set properly by the user.");
+        }
+        // a massless body legitimately carries a zero inertia tensor, so only check when its mass > 0
+        if (translatingBody->mass > 0.0 && !eigenIsValidInertiaMatrix(translatingBody->IPntFc_F)) {
+            bskLogger.bskError("LinearTranslationNDOFStateEffector: a translating body's IPntFc_F is not a valid "
+                               "inertia tensor. It may not have been set properly by the user.");
+        }
+    }
+}
+
+/*! This method checks that the joint mass matrix the equations of motion invert is not singular */
+void
+LinearTranslationNDOFStateEffector::checkJointMassMatrix()
+{
+    // the axes are fixed in their parents and a translating body does not rotate, so the matrix
+    // never changes during the integration and the equations of motion can build it here
+    Eigen::Matrix3d dcm_FB = Eigen::Matrix3d::Identity();
+    for (auto& translatingBody : this->translatingBodyVec) {
+        translatingBody->fHat_B = dcm_FB.transpose() * translatingBody->fHat_P;
+        dcm_FB = translatingBody->dcm_FP * dcm_FB;
+    }
+
+    Eigen::MatrixXd MRho = Eigen::MatrixXd::Zero(this->N, this->N);
+    this->computeMRho(MRho);
+    if (Eigen::FullPivLU<Eigen::MatrixXd>(MRho).rank() < this->N) {
+        bskLogger.bskError("LinearTranslationNDOFStateEffector: the translating body masses and axes leave the joint "
+                           "mass matrix singular. The outermost body must carry mass, and a massless body's axis must "
+                           "be independent of the axes outboard of it.");
+    }
+}
+
 /*! This method allows the TB state effector to register its states: rho and rhoDot with the dynamic parameter manager */
 void LinearTranslationNDOFStateEffector::registerStates(DynParamManager& states)
 {
@@ -217,6 +272,8 @@ void LinearTranslationNDOFStateEffector::registerStates(DynParamManager& states)
     }
     this->rhoState->setState(RhoInitMatrix);
     this->rhoDotState->setState(RhoDotInitMatrix);
+
+    this->validateConfiguration();
 }
 
 /*! This method allows the TB state effector to provide its contributions to the mass props and mass prop rates of the

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.cpp
@@ -412,7 +412,7 @@ void LinearTranslationNDOFStateEffector::updateEffectorMassProps(double integTim
 
 /*! This method allows the TB state effector to give its contributions to the matrices needed for the back-sub
  method */
-void LinearTranslationNDOFStateEffector::updateContributions(double integTime [[maybe_unused]], BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
+void LinearTranslationNDOFStateEffector::updateContributions(double integTime, BackSubMatrices & backSubContr, Eigen::MRPd sigma_BN, Eigen::Vector3d omega_BN_B, Eigen::Vector3d g_N)
 {
     // Find the DCM from N to B frames
     this->sigma_BN = sigma_BN;
@@ -423,6 +423,18 @@ void LinearTranslationNDOFStateEffector::updateContributions(double integTime [[
     Eigen::MatrixX3d ARhoStar = Eigen::MatrixX3d::Zero(this->N, 3);
     Eigen::MatrixX3d BRhoStar = Eigen::MatrixX3d::Zero(this->N, 3);
     Eigen::VectorXd CRhoStar = Eigen::VectorXd::Zero(this->N);
+
+    bool hasAttachedEffectors = false;
+    for (const auto& translatingBody : this->translatingBodyVec) {
+        if (!translatingBody->dynEffectors.empty()) {
+            hasAttachedEffectors = true;
+            break;
+        }
+    }
+    if (hasAttachedEffectors) {
+        this->computeTranslatingBodyInertialStates();
+    }
+    this->computeDependentEffectors(backSubContr, integTime);
 
     this->computeMRho(MRho);
     this->computeARhoStar(ARhoStar);
@@ -435,6 +447,30 @@ void LinearTranslationNDOFStateEffector::updateContributions(double integTime [[
     this->CRho = MRhoInv * CRhoStar;
 
     this->computeBackSubContributions(backSubContr);
+}
+
+/*! This method collects the loads from any attached dynamic effectors and applies them to the hub
+
+ @param backSubContr the Backsubstitution contributions this effector adds to the hub
+ @param integTime the integration time the attached effectors evaluate their loads at */
+void
+LinearTranslationNDOFStateEffector::computeDependentEffectors(BackSubMatrices& backSubContr, double integTime)
+{
+    for (auto& translatingBody : this->translatingBodyVec) {
+        translatingBody->extForce_B.setZero();
+        translatingBody->extTorquePntF_B.setZero();
+        for (auto& dynEffector : translatingBody->dynEffectors) {
+            dynEffector->computeForceTorque(integTime, double(0.0));
+            // a child's "_B" loads are already in this body's F frame, so only "_N" is rotated
+            translatingBody->extForce_B += translatingBody->dcm_FB.transpose() * dynEffector->forceExternal_B +
+                                           this->dcm_BN * dynEffector->forceExternal_N;
+            translatingBody->extTorquePntF_B += translatingBody->dcm_FB.transpose() * dynEffector->torqueExternalPntB_B;
+        }
+
+        backSubContr.vecTrans += translatingBody->extForce_B;
+        backSubContr.vecRot +=
+          translatingBody->extTorquePntF_B + translatingBody->r_FB_B.cross(translatingBody->extForce_B);
+    }
 }
 
 /*! This method compute MRho for back-sub */
@@ -513,8 +549,10 @@ void LinearTranslationNDOFStateEffector::computeCRhoStar(Eigen::VectorXd& CRhoSt
             Eigen::Vector3d rPrime_FciB_B = this->translatingBodyVec[iIndex]->rPrime_FcB_B;
 
             F_g = this->translatingBodyVec[iIndex]->mass * g_B;
+            // a torque does no work through a prismatic joint, so only the force reaches this equation
             CRhoStar(n, 0) += this->translatingBodyVec[nIndex]->fHat_B.transpose()
-                * (F_g - this->translatingBodyVec[iIndex]->mass *
+                * (F_g + this->translatingBodyVec[iIndex]->extForce_B
+                       - this->translatingBodyVec[iIndex]->mass *
                               (this->omega_BN_B.cross(this->omega_BN_B.cross(r_FciB_B))
                                + 2 * this->omega_BN_B.cross(rPrime_FciB_B)));
         }

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -125,8 +125,15 @@ private:
     // Inertial properties
     Eigen::Vector3d r_FcN_N = Eigen::Vector3d::Zero();      //!< [m] position vector of translating body's center of mass Fc relative to the inertial frame origin N
     Eigen::Vector3d v_FcN_N = Eigen::Vector3d::Zero();      //!< [m/s] inertial velocity vector of Fc relative to inertial frame
-    Eigen::MRPd sigma_FN{0.0, 0.0, 0.0};                    //!< -- MRP attitude of frame F relative to inertial frame
-    Eigen::Vector3d omega_FN_F = Eigen::Vector3d::Zero();   //!< [rad/s] inertial translating body frame angular velocity vector
+    Eigen::MatrixXd* r_FN_N = nullptr;      //!< [m] position vector of the translating frame F origin relative to the inertial frame origin N
+    Eigen::MatrixXd* v_FN_N = nullptr;      //!< [m/s] inertial velocity vector of F relative to inertial frame
+    Eigen::MatrixXd* sigma_FN = nullptr;    //!< -- MRP attitude of frame F relative to inertial frame
+    Eigen::MatrixXd* omega_FN_F = nullptr;  //!< [rad/s] inertial translating body frame angular velocity vector
+
+    std::string nameOfInertialPositionProperty;    //!< -- identifier for the inertial position property
+    std::string nameOfInertialVelocityProperty;    //!< -- identifier for the inertial velocity property
+    std::string nameOfInertialAttitudeProperty;    //!< -- identifier for the inertial attitude property
+    std::string nameOfInertialAngVelocityProperty; //!< -- identifier for the inertial angular velocity property
 
     BSKLogger bskLogger;
 };
@@ -180,6 +187,7 @@ private:
     StateData* hubSigmaState = nullptr; //!< hub attitude state, read live for the published kinematics
     std::string nameOfRhoState;        //!< -- identifier for the rho state data container
     std::string nameOfRhoDotState;     //!< -- identifier for the rhoDot state data container
+    std::string propertyNameIndex;     //!< -- effector identifier used to name the per body properties
 
     // module functions
     void Reset(uint64_t CurrentClock) final;
@@ -187,6 +195,7 @@ private:
     void writeOutputStateMessages(uint64_t CurrentClock) final;
     void UpdateState(uint64_t CurrentSimNanos) final;
     void registerStates(DynParamManager& statesIn) final;
+    void registerProperties(DynParamManager& states) final;
     void linkInStates(DynParamManager& states) final;
     void updateContributions(double integTime,
                              BackSubMatrices& backSubContr,

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -115,7 +115,6 @@ private:
     Eigen::Vector3d rPrime_FP_B = Eigen::Vector3d::Zero();  //!< [m/s] body frame time derivative of r_FP_B
     Eigen::Vector3d rPrime_FF0_B = Eigen::Vector3d::Zero(); //!< [m/s] body frame time derivative of r_FF0_B
     Eigen::Vector3d rDot_FcB_B = Eigen::Vector3d::Zero();   //!< [m/s] inertial frame time derivative of r_FcB_B
-    Eigen::Vector3d omega_FN_B = Eigen::Vector3d::Zero();   //!< [rad/s] angular velocity of the F frame wrt the N frame in B frame components
 
     // Matrix quantities
     Eigen::Matrix3d dcm_FB = Eigen::Matrix3d::Identity();      //!< -- DCM from body frame to F frame
@@ -178,6 +177,7 @@ private:
     Eigen::MatrixXd* inertialVelocityProperty = nullptr;    //!< [m] v_N inertial velocity relative to system spice zeroBase/refBase
     StateData* rhoState = nullptr;
     StateData* rhoDotState = nullptr;
+    StateData* hubSigmaState = nullptr; //!< hub attitude state, read live for the published kinematics
     std::string nameOfRhoState;        //!< -- identifier for the rho state data container
     std::string nameOfRhoDotState;     //!< -- identifier for the rhoDot state data container
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -20,12 +20,17 @@
 #ifndef LINEAR_TRANSLATION_N_DOF_STATE_EFFECTOR_H
 #define LINEAR_TRANSLATION_N_DOF_STATE_EFFECTOR_H
 
-#include <Eigen/Dense>
-#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
-#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/utilities/avsEigenMRP.h"
 #include "architecture/utilities/bskLogging.h"
+#include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
+#include <Eigen/Dense>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "architecture/msgPayloadDefC/ArrayMotorForceMsgPayload.h"
 #include "architecture/msgPayloadDefC/ArrayEffectorLockMsgPayload.h"
@@ -135,6 +140,21 @@ private:
     std::string nameOfInertialAttitudeProperty;    //!< -- identifier for the inertial attitude property
     std::string nameOfInertialAngVelocityProperty; //!< -- identifier for the inertial angular velocity property
 
+    std::vector<DynamicEffector*> dynEffectors;    //!< -- vector of dynamic effectors attached to this body
+
+    /**
+     * @brief Assign this body's state-engine property names to an attached effector.
+     * @tparam Type Pointer type for an effector that accepts inertial property names.
+     * @param effector Effector that receives the body's inertial property names.
+     */
+    template <typename Type>
+    void assignStateParamNames(Type effector) {
+        effector->setPropName_inertialPosition(this->nameOfInertialPositionProperty);
+        effector->setPropName_inertialVelocity(this->nameOfInertialVelocityProperty);
+        effector->setPropName_inertialAttitude(this->nameOfInertialAttitudeProperty);
+        effector->setPropName_inertialAngVelocity(this->nameOfInertialAngVelocityProperty);
+    }
+
     BSKLogger bskLogger;
 };
 
@@ -196,6 +216,7 @@ private:
     void UpdateState(uint64_t CurrentSimNanos) final;
     void registerStates(DynParamManager& statesIn) final;
     void registerProperties(DynParamManager& states) final;
+    void addDynamicEffector(DynamicEffector* newDynamicEffector, int segment) final;
     void linkInStates(DynParamManager& states) final;
     void updateContributions(double integTime,
                              BackSubMatrices& backSubContr,

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -141,6 +141,8 @@ private:
     std::string nameOfInertialAngVelocityProperty; //!< -- identifier for the inertial angular velocity property
 
     std::vector<DynamicEffector*> dynEffectors;    //!< -- vector of dynamic effectors attached to this body
+    Eigen::Vector3d extForce_B = Eigen::Vector3d::Zero();      //!< [N] attached effector force on this body in B frame components
+    Eigen::Vector3d extTorquePntF_B = Eigen::Vector3d::Zero(); //!< [N-m] attached effector torque on this body about F in B frame components
 
     /**
      * @brief Assign this body's state-engine property names to an attached effector.
@@ -223,6 +225,7 @@ private:
                              Eigen::MRPd sigma_BN,
                              Eigen::Vector3d omega_BN_B,
                              Eigen::Vector3d g_N) final;
+    void computeDependentEffectors(BackSubMatrices& backSubContr, double integTime);
     void computeMRho(Eigen::MatrixXd& MRho);
     void computeARhoStar(Eigen::MatrixX3d& ARhoStar);
     void computeBRhoStar(Eigen::MatrixX3d& BRhoStar);

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -208,6 +208,9 @@ private:
                                       double& rotEnergyContr,
                                       Eigen::Vector3d omega_BN_B) final;
     void prependSpacecraftNameToStates() final;
+    void validateConfiguration();
+    void checkBodyConfiguration();
+    void checkJointMassMatrix();
     void computeTranslatingBodyInertialStates();
 };
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.h
@@ -93,7 +93,7 @@ private:
     bool isAxisLocked = false;     //!< -- lock flag
     Eigen::Matrix3d IPntFc_F = Eigen::Matrix3d::Identity();   //!< [kg-m^2] Inertia of body about point Fc in F frame components
     Eigen::Vector3d r_FcF_F = Eigen::Vector3d::Zero();        //!< [m] vector pointing from translating frame F origin to point Fc (center of mass of arm) in F frame components
-    Eigen::Vector3d r_F0P_P = Eigen::Vector3d::Zero();        //!< [m] vector pointing from parent origin to translating frame F origin in F frame components
+    Eigen::Vector3d r_F0P_P = Eigen::Vector3d::Zero();        //!< [m] vector pointing from parent origin to translating frame F0 origin in parent frame components
     Eigen::Vector3d fHat_P{1.0, 0.0, 0.0};           //!< -- translating axis in parent frame components.
     Eigen::Matrix3d dcm_FP = Eigen::Matrix3d::Identity();     //!< -- DCM from parent frame to current F frame
 
@@ -102,34 +102,32 @@ private:
     double rhoDot = 0.0;           //!< [m/s] translating body velocity of F frame wrt F0 frame
 
     // Vector quantities
-    Eigen::Vector3d r_FF0_B;            //!< [m] vector pointing from translating frame F to translating frame F0 (magnitude rho)
-    Eigen::Vector3d r_F0P_B;            //!< [m] vector pointing from parent translating frame P to translating frame F0
-    Eigen::Vector3d fHat_B;             //!< -- translating axis in B frame components.
-    Eigen::Vector3d r_FcF_B;            //!< [m] vector pointing from translating frame F origin to point Fc (center of mass of arm) in B frame components
-    Eigen::Vector3d r_FB_B;             //!< [m] vector pointing from body frame B origin to F frame in B frame components
-    Eigen::Vector3d r_FcB_B;            //!< [m] vector pointing from body frame B origin to Fc in B frame components
-    Eigen::Vector3d r_FP_B;             //!< [m] vector from parent frame to current F frame in B frame componentes
-    Eigen::Vector3d r_FP_P;             //!< [m] vector from parent frame to current F frame in parent frame components
-    Eigen::Vector3d rPrime_FB_B;        //!< [m/s] body frame time derivative of r_FB_B
-    Eigen::Vector3d rPrime_FcF_B;       //!< [m/s] body frame time derivative of r_FcF_B
-    Eigen::Vector3d rPrime_FcB_B;       //!< [m/s] body frame time derivative of r_FcB_B
-    Eigen::Vector3d rPrime_FP_B;        //!< [m/s] body frame time derivative of r_FP_B
-    Eigen::Vector3d rPrime_FF0_B;       //!< [m/s] body frame time derivative of r_FF0_B
-    Eigen::Vector3d rDot_FcB_B;         //!< [m/s] inertial frame time derivative of r_FcB_B
-    Eigen::Vector3d omega_FN_B;         //!< [rad/s] angular velocity of the F frame wrt the N frame in B frame components
+    Eigen::Vector3d r_FF0_B = Eigen::Vector3d::Zero();      //!< [m] vector pointing from translating frame F0 to translating frame F (magnitude rho)
+    Eigen::Vector3d r_F0P_B = Eigen::Vector3d::Zero();      //!< [m] vector pointing from parent translating frame P to translating frame F0
+    Eigen::Vector3d fHat_B = Eigen::Vector3d::Zero();       //!< -- translating axis in B frame components.
+    Eigen::Vector3d r_FcF_B = Eigen::Vector3d::Zero();      //!< [m] vector pointing from translating frame F origin to point Fc (center of mass of arm) in B frame components
+    Eigen::Vector3d r_FB_B = Eigen::Vector3d::Zero();       //!< [m] vector pointing from body frame B origin to F frame in B frame components
+    Eigen::Vector3d r_FcB_B = Eigen::Vector3d::Zero();      //!< [m] vector pointing from body frame B origin to Fc in B frame components
+    Eigen::Vector3d r_FP_B = Eigen::Vector3d::Zero();       //!< [m] vector from parent frame to current F frame in B frame components
+    Eigen::Vector3d rPrime_FB_B = Eigen::Vector3d::Zero();  //!< [m/s] body frame time derivative of r_FB_B
+    Eigen::Vector3d rPrime_FcF_B = Eigen::Vector3d::Zero(); //!< [m/s] body frame time derivative of r_FcF_B
+    Eigen::Vector3d rPrime_FcB_B = Eigen::Vector3d::Zero(); //!< [m/s] body frame time derivative of r_FcB_B
+    Eigen::Vector3d rPrime_FP_B = Eigen::Vector3d::Zero();  //!< [m/s] body frame time derivative of r_FP_B
+    Eigen::Vector3d rPrime_FF0_B = Eigen::Vector3d::Zero(); //!< [m/s] body frame time derivative of r_FF0_B
+    Eigen::Vector3d rDot_FcB_B = Eigen::Vector3d::Zero();   //!< [m/s] inertial frame time derivative of r_FcB_B
+    Eigen::Vector3d omega_FN_B = Eigen::Vector3d::Zero();   //!< [rad/s] angular velocity of the F frame wrt the N frame in B frame components
 
     // Matrix quantities
-    Eigen::Matrix3d dcm_FB;            //!< -- DCM from body frame to F frame
-    Eigen::Matrix3d IPntFc_B;          //!< [kg-m^2] Inertia of body about point Fc in B frame components
-    Eigen::Matrix3d IPrimePntFc_B;     //!< [kg-m^2/s] body frame time derivative of IPntFc_B
-    Eigen::Matrix3d rTilde_FcB_B;      //!< [m] tilde matrix of r_FcB_B
-    Eigen::Matrix3d omegaTilde_FB_B;   //!< [rad/s] tilde matrix of omega_FB_B
+    Eigen::Matrix3d dcm_FB = Eigen::Matrix3d::Identity();      //!< -- DCM from body frame to F frame
+    Eigen::Matrix3d IPntFc_B = Eigen::Matrix3d::Zero();        //!< [kg-m^2] Inertia of body about point Fc in B frame components
+    Eigen::Matrix3d IPrimePntFc_B = Eigen::Matrix3d::Zero();   //!< [kg-m^2/s] body frame time derivative of IPntFc_B
+    Eigen::Matrix3d rTilde_FcB_B = Eigen::Matrix3d::Zero();    //!< [m] tilde matrix of r_FcB_B
 
     // Inertial properties
-    Eigen::Vector3d r_FcN_N;            //!< [m] position vector of translating body's center of mass Fc relative to the inertial frame origin N
-    Eigen::Vector3d v_FcN_N;            //!< [m/s] inertial velocity vector of Fc relative to inertial frame
-    Eigen::MRPd sigma_FN;               //!< -- MRP attitude of frame S relative to inertial frame
-    Eigen::Vector3d omega_FN_F;         //!< [rad/s] inertial translating body frame angular velocity vector
+    Eigen::Vector3d r_FcN_N = Eigen::Vector3d::Zero();      //!< [m] position vector of translating body's center of mass Fc relative to the inertial frame origin N
+    Eigen::Vector3d v_FcN_N = Eigen::Vector3d::Zero();      //!< [m/s] inertial velocity vector of Fc relative to inertial frame
+    Eigen::MRPd sigma_FN{0.0, 0.0, 0.0};                    //!< -- MRP attitude of frame F relative to inertial frame
+    Eigen::Vector3d omega_FN_F = Eigen::Vector3d::Zero();   //!< [rad/s] inertial translating body frame angular velocity vector
 
     BSKLogger bskLogger;
 };
@@ -171,17 +169,17 @@ private:
     Eigen::VectorXd CRho;     //!< -- scalar term for back substitution
 
     // Hub properties
-    Eigen::Vector3d omega_BN_B;   //!< [rad/s] angular velocity of the B frame wrt the N frame in B frame components
-    Eigen::MRPd sigma_BN;         //!< -- body frame attitude wrt to the N frame in MRPs
-    Eigen::Matrix3d dcm_BN;       //!< -- DCM from inertial frame to body frame
+    Eigen::Vector3d omega_BN_B = Eigen::Vector3d::Zero();  //!< [rad/s] angular velocity of the B frame wrt the N frame in B frame components
+    Eigen::MRPd sigma_BN{0.0, 0.0, 0.0};                   //!< -- body frame attitude wrt to the N frame in MRPs
+    Eigen::Matrix3d dcm_BN = Eigen::Matrix3d::Identity();  //!< -- DCM from inertial frame to body frame
 
     // States
     Eigen::MatrixXd* inertialPositionProperty = nullptr;    //!< [m] r_N inertial position relative to system spice zeroBase/refBase
     Eigen::MatrixXd* inertialVelocityProperty = nullptr;    //!< [m] v_N inertial velocity relative to system spice zeroBase/refBase
     StateData* rhoState = nullptr;
     StateData* rhoDotState = nullptr;
-    std::string nameOfRhoState;        //!< -- identifier for the theta state data container
-    std::string nameOfRhoDotState;     //!< -- identifier for the thetaDot state data container
+    std::string nameOfRhoState;        //!< -- identifier for the rho state data container
+    std::string nameOfRhoDotState;     //!< -- identifier for the rhoDot state data container
 
     // module functions
     void Reset(uint64_t CurrentClock) final;

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
@@ -139,3 +139,20 @@ This section is to outline the steps needed to setup a Translating Body State Ef
     scObject.addStateEffector(translatingBodyEffector)
 
    See :ref:`spacecraft` documentation on how to set up a spacecraft object.
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible dynamic
+effector can be carried by one of the translating bodies rather than by the hub::
+
+    translatingBodyEffector.addDynamicEffector(childEffector, segment)
+
+Here ``segment`` is the one-based body number, counting outward from the hub, so ``1`` is the body
+attached to the hub. The child then reads that body's inertial position, velocity, attitude, and
+angular velocity in place of the hub's, and any geometry given to the child is expressed in that
+body's frame rather than the hub body frame.
+
+Both this effector and the child are still added to the task in the usual way::
+
+    scSim.AddModelToTask(taskName, translatingBodyEffector)
+    scSim.AddModelToTask(taskName, childEffector)

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
@@ -2,7 +2,15 @@
 Executive Summary
 -----------------
 
-The N-DoF linear translation body class is an instantiation of the state effector abstract class with :math:`N` degrees of freedom. The integrated test is validating the interaction between the linear translation body module and the rigid body hub that it is attached to. In this case, a 4-DoF linear translation body has an inertia tensor and is attached to the hub by four single-degree-of-freedom axes. Each spinning axis is fixed in the parent's body frame and the effector is rigid, which means that its center of mass location does not move in the :math:`F` frame. An optional motor force can be applied on the spinning axis, and the user can also lock the axis through a command. Moreover, the user can input a displacement reference that the effector will track through a spring and damper.
+The N-DoF linear translation body class is an instantiation of the state effector abstract class
+with :math:`N` degrees of freedom. The integrated test is validating the interaction between the
+linear translation body module and the rigid body hub that it is attached to. In this case, a 4-DoF
+linear translation body has an inertia tensor and is attached to the hub by four
+single-degree-of-freedom axes. Each translating axis is fixed in the parent's body frame and each
+body is rigid, which means that its center of mass location does not move in the :math:`F` frame. An
+optional motor force can be applied on each translating axis, and the user can also lock an axis
+through a command. Moreover, the user can input a displacement reference that the effector will
+track through a spring and damper.
 
 
 Message Connection Descriptions
@@ -12,16 +20,18 @@ The following table lists all the module input and output messages.  The module 
 .. bsk-module-io:: linearTranslationNDOFStateEffector
     :caption: Module I/O Messages
 
-    output translatingBodyOutMsg LinearTranslationRigidBodyMsgPayload
-        Output message containing the linear translation body state displacement and displacement rate.
+    output translatingBodyOutMsgs LinearTranslationRigidBodyMsgPayload
+        Output vector of messages containing the linear translation body state displacement and displacement rate.
     input motorForceInMsg ArrayMotorForceMsgPayload
-        (Optional) Input message of the motor force value.
+        (Optional) Input message of the motor force value for every axis.
     input motorLockInMsg ArrayEffectorLockMsgPayload
-        (Optional) Input message for locking the axis.
-    input translatingBodyRefInMsg LinearTranslationRigidBodyMsgPayload
-        (Optional) Input message for prescribing the displacement and displacement rate.
-    output translatingBodyConfigLogOutMsg SCStatesMsgPayload
-        Output message containing the translating body inertial position and attitude states.
+        (Optional) Input message for locking each axis.
+    input translatingBodyRefInMsgs LinearTranslationRigidBodyMsgPayload
+        (Optional) Input vector of messages for prescribing the displacement and displacement rate.
+    output translatingBodyConfigLogOutMsgs SCStatesMsgPayload
+        Output vector of messages containing the translating body inertial states. The position and
+        velocity are those of the body center of mass, and the attitude and angular velocity are
+        those of the body frame F.
 
 
 Detailed Module Description
@@ -42,17 +52,17 @@ User Guide
 ----------
 This section is to outline the steps needed to setup a Translating Body State Effector in Python using Basilisk.
 
-#. Import the linearTranslatingBodyNDOFStateEffector class::
+#. Import the linearTranslationNDOFStateEffector class::
 
-    from Basilisk.simulation import linearTranslatingBodyNDOFStateEffector
+    from Basilisk.simulation import linearTranslationNDOFStateEffector
 
 #. Create an instantiation of a Translating body::
 
-    translatingBodyEffector = linearTranslatingBodyNDOFStateEffector.linearTranslatingBodyNDOFStateEffector()
+    translatingBodyEffector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
 
-#. For each degree of freedom, create and set the properties of a translating body::
+#. For each degree of freedom, create and set the properties of a translating body.  The mass must be positive::
 
-    translatingBody = linearTranslationNDOFStateEffector.translatingBody()
+    translatingBody = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody.setMass(50.0)
     translatingBody.setIPntFc_F([[100.0, 0.0, 0.0],
                                  [0.0, 80.0, 0.0],
@@ -79,36 +89,36 @@ This section is to outline the steps needed to setup a Translating Body State Ef
     translatingBody.setK(100.0)
     translatingBody.setC(0.0)
 
-#. (Optional) Define a unique name for each state.  If you have multiple translating bodies, they each must have a unique name.  If these names are not specified, then the default names are used which are incremented by the effector number::
+#. (Optional) Define a unique name for each state.  If you have multiple effectors, they each must have a unique name.  If these names are not specified, then the default names are used which are incremented by the effector number::
 
-    translatingBody.nameOfRhoState = "translatingBodyRho"
-    translatingBody.nameOfRhoDotState = "translatingBodyRhoDot"
+    translatingBodyEffector.setNameOfRhoState("translatingBodyRho")
+    translatingBodyEffector.setNameOfRhoDotState("translatingBodyRhoDot")
 
-#. (Optional) Connect a command force message::
+#. (Optional) Connect a command force message, which carries one force per degree of freedom::
 
     cmdArray = messaging.ArrayMotorForceMsgPayload()
-    cmdArray.motorForce = [cmdForce]  # [Nm]
+    cmdArray.motorForce = [cmdForce]  # [N]
     cmdMsg = messaging.ArrayMotorForceMsg().write(cmdArray)
-    translatingBody.motorForceInMsg.subscribeTo(cmdMsg)
+    translatingBodyEffector.motorForceInMsg.subscribeTo(cmdMsg)
 
-#. (Optional) Connect an axis-locking message (0 means the axis is free to move and 1 locks the axis)::
+#. (Optional) Connect an axis-locking message, which carries one flag per degree of freedom (0 means the axis is free to move and 1 locks the axis)::
 
     lockArray = messaging.ArrayEffectorLockMsgPayload()
     lockArray.effectorLockFlag = [1]
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
-    translatingBody.motorLockInMsg.subscribeTo(lockMsg)
+    translatingBodyEffector.motorLockInMsg.subscribeTo(lockMsg)
 
-#. (Optional) Connect a displacement and displacement rate reference message::
+#. (Optional) Connect a displacement and displacement rate reference message to any degree of freedom::
 
     translationRef = messaging.LinearTranslationRigidBodyMsgPayload()
     translationRef.rho = 0.2
     translationRef.rhoDot = 0.0
     translationRefMsg = messaging.LinearTranslationRigidBodyMsg().write(translationRef)
-    translatingBody.translatingBodyRefInMsg.subscribeTo(translationRefMsg)
+    translatingBodyEffector.translatingBodyRefInMsgs[0].subscribeTo(translationRefMsg)
 
-#. The linear states of the body are created using an output message ``translatingBodyOutMsg``.
+#. The linear states of each body are created using the output message vector ``translatingBodyOutMsgs``.
 
-#. The translating body config log state output message is ``translatingBodyConfigLogOutMsg``.
+#. The translating body config log state output message vector is ``translatingBodyConfigLogOutMsgs``.
 
 #. Add the effector to your spacecraft::
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
@@ -12,6 +12,10 @@ optional motor force can be applied on each translating axis, and the user can a
 through a command. Moreover, the user can input a displacement reference that the effector will
 track through a spring and damper.
 
+Nominally, each degree of freedom corresponds to an additional rigid body link. However, by setting
+the mass and the inertia of a body to 0, several single axis bodies can compose one multiple degree
+of freedom joint instead.
+
 
 Message Connection Descriptions
 -------------------------------
@@ -60,7 +64,7 @@ This section is to outline the steps needed to setup a Translating Body State Ef
 
     translatingBodyEffector = linearTranslationNDOFStateEffector.LinearTranslationNDOFStateEffector()
 
-#. For each degree of freedom, create and set the properties of a translating body.  The mass must be positive::
+#. For each degree of freedom, create and set the properties of a translating body.  A body may carry zero mass and zero inertia, subject to the condition in the note below::
 
     translatingBody = linearTranslationNDOFStateEffector.TranslatingBody()
     translatingBody.setMass(50.0)
@@ -88,6 +92,16 @@ This section is to outline the steps needed to setup a Translating Body State Ef
 
     translatingBody.setK(100.0)
     translatingBody.setC(0.0)
+
+   .. note::
+
+       Initialization rejects a chain whose joint mass matrix is singular, which happens exactly
+       when some nonzero combination of joint rates leaves every body carrying mass stationary. A
+       massless outermost body and a massless body sharing its axis with the body outboard of it are
+       the simplest cases, but the condition is collective rather than pairwise. Massless stages
+       along :math:`\hat{x}` and :math:`\hat{y}` followed by a massive stage along
+       :math:`\hat{x} + \hat{y}` have pairwise independent axes and are still rejected, because the
+       three axes span only two dimensions.
 
 #. (Optional) Define a unique name for each state.  If you have multiple effectors, they each must have a unique name.  If these names are not specified, then the default names are used which are incremented by the effector number::
 

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/_UnitTest/test_linearTranslationOneDOFStateEffector.py
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/_UnitTest/test_linearTranslationOneDOFStateEffector.py
@@ -39,6 +39,7 @@ from Basilisk.utilities import (
 )
 from Basilisk.simulation import spacecraft, linearTranslationOneDOFStateEffector, gravityEffector
 from Basilisk.architecture import messaging
+from Basilisk.architecture.bskLogging import BasiliskError
 
 
 # uncomment this line if this test is to be skipped in the global unit test run, adjust message as needed
@@ -86,6 +87,84 @@ def test_translatingBody(show_plots, function):
         func(show_plots, 0.5)
     else:
         func(show_plots)
+
+
+@pytest.mark.parametrize("scheduleEffector", [True, False])
+@pytest.mark.parametrize("configuration, shouldRaise", [
+    ('Valid', False),
+    ('SkewedDCM', True),
+    ('MirroredDCM', True),
+    ('AsymmetricInertia', True),
+    ('NegativeInertia', True),
+    ('TriangleInertia', True),
+])
+def test_translatingBodyConfigurationValidation(configuration, shouldRaise, scheduleEffector):
+    """
+    Verify that initialization rejects a translating body whose frame or inertia is not physical.
+
+    The frame orientation and the inertia tensor enter the mass properties directly, through
+    ``dcm_FB.transpose() * IPntFc_F * dcm_FB`` and ``dcm_FB.transpose() * r_FcF_F``, so a matrix that
+    is merely close to a rotation or to an inertia tensor produces wrong dynamics rather than an
+    error. These are the checks the spinning body effectors already apply, asserted here on five ways
+    of getting them wrong: a non-orthogonal frame, a left-handed frame, a non-symmetric inertia, one
+    that is not positive definite, and one whose principal moments violate the triangle inequality.
+
+    **Test Parameters:**
+
+    - configuration: [string]
+        translating body configuration to initialize
+    - shouldRaise: [bool]
+        whether initialization must reject the configuration
+    - scheduleEffector: [bool]
+        whether the effector is added to the task in addition to the spacecraft
+
+    The scheduling parameter matters because the checks must not depend on it. Spacecraft
+    initialization calls ``registerStates()`` on every attached state effector but never calls
+    ``Reset()``, which runs only for a module added to a task.
+    """
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+
+    effector = linearTranslationOneDOFStateEffector.LinearTranslationOneDOFStateEffector()
+    effector.setMass(20.0)  # [kg]
+    effector.setFHat_B([[1.0], [0.0], [0.0]])
+    effector.setR_F0B_B([[1.0], [0.5], [0.25]])  # [m]
+
+    dcm_FB = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    if configuration == 'SkewedDCM':
+        dcm_FB = [[1.0, 0.1, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    elif configuration == 'MirroredDCM':
+        # orthogonal but left-handed, so it reflects rather than rotates
+        dcm_FB = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]]
+    effector.setDCM_FB(dcm_FB)
+
+    IPntFc_F = [[50.0, 0.0, 0.0], [0.0, 80.0, 0.0], [0.0, 0.0, 60.0]]  # [kg*m^2]
+    if configuration == 'AsymmetricInertia':
+        IPntFc_F = [[50.0, 3.0, 0.0], [0.0, 80.0, 0.0], [0.0, 0.0, 60.0]]  # [kg*m^2]
+    elif configuration == 'NegativeInertia':
+        # symmetric, but a negative principal moment leaves it indefinite
+        IPntFc_F = [[50.0, 0.0, 0.0], [0.0, 80.0, 0.0], [0.0, 0.0, -10.0]]  # [kg*m^2]
+    elif configuration == 'TriangleInertia':
+        # positive definite, but the principal moments violate the triangle inequality
+        IPntFc_F = [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 90.0]]  # [kg*m^2]
+    effector.setIPntFc_F(IPntFc_F)
+    scObject.addStateEffector(effector)
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.SetProgressBar(False)
+    unitTestSim.CreateNewProcess("TestProcess").addTask(
+        unitTestSim.CreateNewTask("unitTask", macros.sec2nano(0.001)))
+    if scheduleEffector:
+        unitTestSim.AddModelToTask("unitTask", effector)
+    unitTestSim.AddModelToTask("unitTask", scObject)
+
+    if shouldRaise:
+        with pytest.raises(BasiliskError):
+            unitTestSim.InitializeSimulation()
+    else:
+        unitTestSim.InitializeSimulation()
 
 
 # rho ref and cmd force are zero, no lock flag

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.cpp
@@ -44,6 +44,23 @@ LinearTranslationOneDOFStateEffector::~LinearTranslationOneDOFStateEffector()
 }
 
 void LinearTranslationOneDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]]) {
+    this->validateConfiguration();
+}
+
+/*! This method runs every configuration check. Spacecraft initialization always reaches it through
+ registerStates(), whereas Reset() runs only when the effector is also added to a task */
+void LinearTranslationOneDOFStateEffector::validateConfiguration() {
+    if (!eigenIsRotationMatrix(this->dcm_FB)) {
+        this->bskLogger.bskError("LinearTranslationOneDOFStateEffector: dcm_FB is not a valid rotation "
+                                 "matrix; it must be orthogonal and right-handed. It may not have been "
+                                 "set properly by the user.");
+    }
+
+    // the mass is strictly positive here, so unlike a spinning body there is no massless case to skip
+    if (!eigenIsValidInertiaMatrix(this->IPntFc_F)) {
+        this->bskLogger.bskError("LinearTranslationOneDOFStateEffector: IPntFc_F is not a valid inertia "
+                                 "tensor. It may not have been set properly by the user.");
+    }
 }
 
 void LinearTranslationOneDOFStateEffector::setMass(double mass) {
@@ -114,6 +131,7 @@ void LinearTranslationOneDOFStateEffector::registerStates(DynParamManager& state
     this->rhoDotState->setState(rhoDotInitMatrix);
 
     registerProperties(states);
+    this->validateConfiguration();
 }
 
 /*! This method attaches a dynamicEffector

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.h
@@ -147,6 +147,7 @@ private:
     Eigen::MatrixXd* omega_FN_F = nullptr;                        //!< [rad/s] inertial translating body frame angular velocity vector
 
     void Reset(uint64_t CurrentClock) override;
+    void validateConfiguration();  //!< Method to reject a configuration the equations of motion cannot represent
 	void registerStates(DynParamManager& states) override;
 	void linkInStates(DynParamManager& states) override;
     void registerProperties(DynParamManager& states) override;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -41,6 +41,10 @@ uint64_t SpinningBodyNDOFStateEffector::effectorID = 1;
 
 SpinningBodyNDOFStateEffector::~SpinningBodyNDOFStateEffector()
 {
+    for (size_t c = 0; c < this->spinningBodyOutMsgs.size(); c++) {
+        delete this->spinningBodyOutMsgs.at(c);
+        delete this->spinningBodyConfigLogOutMsgs.at(c);
+    }
 }
 
 void SpinningBodyNDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]])


### PR DESCRIPTION
* **Tickets addressed:** #1221
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Basilisk's effector branching architecture lets a dynamic effector attach to a state effector rather than to the hub. This work adds support for the NDOF translating body as a parent. `addDynamicEffector` takes the body number, counting outward from the hub starting at 1, hands that body's property names to a child effector, and stores the child on that body so its load reaches the correct row of the translating body equations at every integrator substep. Each body publishes the inertial position and velocity of its frame origin F rather than of its center of mass Fc, matching the other parents.

Four pre-existing defects surfaced along the way. Both spinning and translating NDOF effectors allocated a state message and a configuration log message for every body added to the chain and freed neither, so each leaked both for the life of the process. The translating body configuration log built its attitude from a hub attitude cached at the previous integrator substep, which left the logged body attitude lagging the hub even though a translating body does not rotate relative to the hub. The module also inverted a joint mass matrix without checking it, so a chain whose outermost body was left at its default zero mass filled the spacecraft state with NaN, and an empty chain divided the effector center of mass by a zero total to reach the same end. Neither translating body module validated the frame orientation or the inertia tensor the way the spinning bodies already do, so a matrix merely close to a rotation or to an inertia tensor produced wrong dynamics rather than an error.

A translating body may still be left massless, carrying a zero mass and a zero inertia, so that several single axis bodies compose one multiple degree of freedom joint. The joint mass matrix is singular only when some nonzero combination of axis rates leaves every body carrying mass at rest, which covers both a massless outermost body and a massless body sharing its axis with the body outboard of it. Initialization rejects those two cases and accepts the useful one. The inertia check is skipped for a massless body, whose inertia tensor is legitimately zero, matching what the spinning bodies already do.

Commits are ordered by concern: cleanup with no behavior change, the message leak, the two configuration validation commits, the hub attitude read, then three commits of branching substance building from the published body properties through the attachment method to the equations of motion, then the branching integrated test, the documentation table, and the release note snippet. Most commits carry the unit test that pins them rather than collecting the tests into one commit, so a change and its test can be read together. The equations of motion commit is the exception, since the branching integrated test is what covers it.

## Verification

`test_effectorBranching_integrated.py` gains the N degree of freedom translating body as a parent, with the child attached to the middle body of a three body chain so the load reaches the two axes inboard of it and not the one outboard. The test asserts the change in rotational angular momentum about the system center of mass against the integrated external torque, the accumulated delta V against the integrated external force, and the change in rotational energy against the work the child does about that center of mass.

The energy check is the only one that reaches inside the parent's own equations of motion, since Backsubstitution stays internally consistent even when one of its terms is wrong. Dampers are zeroed and the assertion is on convergence rather than on a fixed tolerance: halving the step must drop the residual to roughly a quarter. The translating body converges at 0.250, matching every other parent.

`test_linearTranslationNDOFStateEffector.py` gains a comparison of both published message vectors against `linearTranslationOneDOFStateEffector` at matched geometry, on a hub carrying a non-identity attitude and nonzero rates so that every inertial transformation contributes. The two agree to 1e-10 in displacement, displacement rate, position, velocity, attitude, and angular velocity, where before the hub attitude fix they did not. A parametrized test then covers the chains initialization must reject, namely a massless outermost body, a massless body collinear with the body outboard of it, an empty chain, a skewed rotation matrix, and two unphysical inertia tensors. The same test integrates the chains it accepts, including two that use a massless body to build a multi-axis joint, and requires rotational energy and angular momentum to hold constant across the run. A third test attaches a dynamic effector to the first and last body of a chain and rejects an index outside either end. `test_linearTranslationOneDOFStateEffector.py` gains the matching frame and inertia cases, including a left-handed frame and a negative principal moment.

## Documentation

No existing documentation was invalidated. The module page named both message vectors and the Python class in their singular one-DOF forms, which is corrected, and it gains the massless body idiom along with the restriction on where a massless body may sit in the chain. The compatibility table in `bskPrinciples-11.rst` now marks the N degree of freedom translating body green for the thruster, constraint, faceted drag, and external force torque effectors, which leaves every state effector that supports branching marked the same way. A release note snippet is added under `bskReleaseNotesSnippets/`, and the leaked messages, the stale attitude, and the rejected chain are recorded in `bskKnownIssues.rst`.

Reviewers should check the module page, the compatibility table, and the known issues entries, which together carry the massless body rule that the code enforces only at initialization.

## Future work

With every state effector now able to act as a parent, the remaining branching work is on the child side. The thruster state effector, the SRP effector, the fuel tank effector, and the gravity effector are marked in `bskPrinciples-11.rst` as candidates to be supported. However, the SRP effector is the only one expected to be enabled, and more specifically the face SPR effector.

Separately, `TranslatingBody` defaults its inertia tensor to the identity rather than to zero, so a body left massless carries 1 kg m^2 about each axis until the user zeroes the inertia as well. The spinning bodies share that default. Changing it would alter the mass properties of existing scripts, so it was left out of scope here and documented instead.
