### PR TITLE
Enhance Rigid Body Motor Module

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/637-hinged-rigid-body-motor-gains.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/637-hinged-rigid-body-motor-gains.rst
@@ -1,1 +1,2 @@
 - Clarified that :ref:`hingedRigidBodyMotor` is an ideal PD torque controller, documented the meaning and units of its ``K`` and ``P`` gains, and distinguished them from passive joint stiffness and damping.
+- Added optional symmetric torque saturation to :ref:`hingedRigidBodyMotor` through the ``uMax`` parameter.

--- a/docs/source/Support/bskReleaseNotesSnippets/637-hinged-rigid-body-motor-gains.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/637-hinged-rigid-body-motor-gains.rst
@@ -1,2 +1,1 @@
-- Clarified that :ref:`hingedRigidBodyMotor` is an ideal PD torque controller, documented the meaning and units of its ``K`` and ``P`` gains, and distinguished them from passive joint stiffness and damping.
-- Added optional symmetric torque saturation to :ref:`hingedRigidBodyMotor` through the ``uMax`` parameter.
+- Improved :ref:`hingedRigidBodyMotor` documentation, gain and torque-limit configuration, parameter validation, and unit-test coverage.

--- a/docs/source/Support/bskReleaseNotesSnippets/637-hinged-rigid-body-motor-gains.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/637-hinged-rigid-body-motor-gains.rst
@@ -1,0 +1,1 @@
+- Clarified that :ref:`hingedRigidBodyMotor` is an ideal PD torque controller, documented the meaning and units of its ``K`` and ``P`` gains, and distinguished them from passive joint stiffness and damping.

--- a/examples/scenarioDeployingPanel.py
+++ b/examples/scenarioDeployingPanel.py
@@ -210,13 +210,13 @@ def run(show_plots):
     # motors
     motor1 = hingedRigidBodyMotor.HingedRigidBodyMotor()
     motor1.ModelTag = "hingedRigidBodyMotor"
-    motor1.K = 20  # proportional gain constant
-    motor1.P = 10  # derivative gain constant
+    motor1.K = 20  # [N m/rad] hinge-angle tracking gain
+    motor1.P = 10  # [N m s/rad] hinge-rate tracking gain
 
     motor2 = hingedRigidBodyMotor.HingedRigidBodyMotor()
     motor2.ModelTag = "hingedRigidBodyMotor2"
-    motor2.K = 20  # proportional gain constant
-    motor2.P = 10  # derivative gain constant
+    motor2.K = 20  # [N m/rad] hinge-angle tracking gain
+    motor2.P = 10  # [N m s/rad] hinge-rate tracking gain
 
     motor1.hingedBodyStateSensedInMsg.subscribeTo(panel1.hingedRigidBodyOutMsg)
     motor1.hingedBodyStateReferenceInMsg.subscribeTo(profiler1.hingedRigidBodyReferenceOutMsg)

--- a/src/simulation/dynamics/hingedRigidBodyMotor/_UnitTest/test_hingedRigidBodyMotor.py
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/_UnitTest/test_hingedRigidBodyMotor.py
@@ -1,12 +1,12 @@
-# 
+#
 #  ISC License
-# 
+#
 #  Copyright (c) 2022, Autonomous Vehicle Systems Lab, University of Colorado Boulder
-# 
+#
 #  Permission to use, copy, modify, and/or distribute this software for any
 #  purpose with or without fee is hereby granted, provided that the above
 #  copyright notice and this permission notice appear in all copies.
-# 
+#
 #  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
 #  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
 #  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -14,59 +14,62 @@
 #  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-# 
-# 
+#
+#
 
 import pytest
 from Basilisk.architecture import messaging
 from Basilisk.simulation import hingedRigidBodyMotor
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
-from Basilisk.utilities import unitTestSupport
 
 
-@pytest.mark.parametrize("accuracy", [1e-12])
-@pytest.mark.parametrize("K", [5,10])
-@pytest.mark.parametrize("P", [1,2])
-@pytest.mark.parametrize("sensedTheta, sensedThetaDot, refTheta, refThetaDot", [
-    (1,.1,1.2,.2),
-    (1,.1,.8,-.1)
-])
-def test_hingedRigidBodyMotor(show_plots, K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, accuracy):
+# K [N m/rad], P [N m s/rad], angles [rad], rates [rad/s], uMax [N m], and expected torque [N m].
+@pytest.mark.parametrize(
+    "K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, uMax, expectedTorque",
+    [
+        pytest.param(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, None, 1.1, id="unlimited-positive"),
+        pytest.param(5.0, 1.0, 1.0, 0.1, 0.8, -0.1, None, -1.2, id="unlimited-negative"),
+        pytest.param(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, 2.0, 1.1, id="limited-in-range"),
+        pytest.param(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, 0.5, 0.5, id="limited-positive"),
+        pytest.param(5.0, 1.0, 1.0, 0.1, 0.8, -0.1, 0.5, -0.5, id="limited-negative"),
+        pytest.param(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, 0.0, 0.0, id="zero-limit"),
+    ],
+)
+def test_hingedRigidBodyMotor(
+    K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, uMax, expectedTorque
+):
     r"""
     **Validation Test Description**
 
-    This test checks if the output motor torque matches what is expected from the PD control law for the given reference and sensed hinged rigid body state.
+    Verify that the module output matches the PD control law with torque saturation disabled and with a configured
+    symmetric torque limit.  The cases exercise positive and negative saturation, a command inside the limit, and a
+    zero limit.
 
-    **Test Parameters**
+    **Test Parameter Discussion**
 
-    Args:
-        K (double): Proportional gain value.
-        P (double): Derivative gain value.
-        sensedTheta (double): sensed theta value.
-        sensedThetaDot (double): sensed thetaDot value.
-        refTheta (double): reference theta value.
-        refThetaDot (double): reference thetaDot value.
-        accuracy (double): unit text accuracy
+    ``K`` and ``P`` are positive controller gains.  The sensed and reference hinge states produce both signs of raw
+    torque command.  ``uMax`` is either left at its negative default, set above or below the raw command magnitude, or
+    set to zero.
 
     **Description of Variables Being Tested**
-    
-    K and P are varied (note both must be set to positive values). The sensed hinged rigid body state is held constant while the reference is also varied to check positive and negative deltas.
 
+    The first element of ``motorTorqueOutMsg.motorTorque`` is compared with the independently evaluated and clamped
+    controller torque.
     """
-    [testResults, testMessage] = hingedRigidBodyMotorTestFunction(show_plots, K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, accuracy)
-    assert testResults < 1, testMessage
+    actualTorque = run_motor_case(
+        K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, uMax
+    )
+    assert actualTorque == pytest.approx(expectedTorque, rel=1e-12)
 
 
-def hingedRigidBodyMotorTestFunction(show_plots, K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, accuracy):
-    """Test method"""
-    testFailCount = 0
-    testMessages = []
+def run_motor_case(K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, uMax):
+    """Run one controller configuration and return its torque output."""
     unitTaskName = "unitTask"
     unitProcessName = "TestProcess"
 
     unitTestSim = SimulationBaseClass.SimBaseClass()
-    testProcessRate = macros.sec2nano(0.5)
+    testProcessRate = macros.sec2nano(0.5)  # [ns]
     testProc = unitTestSim.CreateNewProcess(unitProcessName)
     testProc.addTask(unitTestSim.CreateNewTask(unitTaskName, testProcessRate))
 
@@ -89,33 +92,23 @@ def hingedRigidBodyMotorTestFunction(show_plots, K, P, sensedTheta, sensedThetaD
     # subscribe input messages to module
     module.hingedBodyStateSensedInMsg.subscribeTo(hingedBodyStateSensedInMsg)
     module.hingedBodyStateReferenceInMsg.subscribeTo(hingedBodyStateReferenceInMsg)
-    
+
     module.K = K
     module.P = P
+    if uMax is not None:
+        module.uMax = uMax
 
     # setup output message recorder objects
     dataLog = module.motorTorqueOutMsg.recorder()
     unitTestSim.AddModelToTask(unitTaskName, dataLog)
 
     unitTestSim.InitializeSimulation()
-    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))
+    unitTestSim.ConfigureStopTime(macros.sec2nano(1.0))  # [ns]
     unitTestSim.ExecuteSimulation()
 
-    # pull module data and make sure it is correct
-    trueTorque = -K*(sensedTheta-refTheta)-P*(sensedThetaDot-refThetaDot)
-    torqueEqualTest = unitTestSupport.isDoubleEqualRelative(trueTorque, dataLog.motorTorque[-1][0], accuracy)
-    if not torqueEqualTest:
-        testFailCount += 1;
-        testMessages.append("Failed motor torque.")
-    if testFailCount == 0:
-        print("PASSED: " + module.ModelTag)
-    else:
-        print(testMessages)
-
-    return [testFailCount, "".join(testMessages)]
+    return dataLog.motorTorque[-1][0]
 
 
 if __name__ == "__main__":
-    test_hingedRigidBodyMotor(False, 5, 1, 1, .1, 1.2, .2, 1e-12) # first test case above
-
-
+    torque = run_motor_case(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, 0.5)
+    assert torque == pytest.approx(0.5, rel=1e-12)

--- a/src/simulation/dynamics/hingedRigidBodyMotor/_UnitTest/test_hingedRigidBodyMotor.py
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/_UnitTest/test_hingedRigidBodyMotor.py
@@ -17,8 +17,11 @@
 #
 #
 
+import math
+
 import pytest
 from Basilisk.architecture import messaging
+from Basilisk.architecture.bskLogging import BasiliskError
 from Basilisk.simulation import hingedRigidBodyMotor
 from Basilisk.utilities import SimulationBaseClass
 from Basilisk.utilities import macros
@@ -34,6 +37,9 @@ from Basilisk.utilities import macros
         pytest.param(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, 0.5, 0.5, id="limited-positive"),
         pytest.param(5.0, 1.0, 1.0, 0.1, 0.8, -0.1, 0.5, -0.5, id="limited-negative"),
         pytest.param(5.0, 1.0, 1.0, 0.1, 1.2, 0.2, 0.0, 0.0, id="zero-limit"),
+        pytest.param(0.0, 1.0, 1.0, 0.1, 1.2, 0.2, None, 0.1, id="rate-only"),
+        pytest.param(5.0, 0.0, 1.0, 0.1, 1.2, 0.2, None, 1.0, id="proportional-only"),
+        pytest.param(0.0, 0.0, 1.0, 0.1, 1.2, 0.2, None, 0.0, id="zero-gains"),
     ],
 )
 def test_hingedRigidBodyMotor(
@@ -48,9 +54,9 @@ def test_hingedRigidBodyMotor(
 
     **Test Parameter Discussion**
 
-    ``K`` and ``P`` are positive controller gains.  The sensed and reference hinge states produce both signs of raw
-    torque command.  ``uMax`` is either left at its negative default, set above or below the raw command magnitude, or
-    set to zero.
+    ``K`` and ``P`` are nonnegative controller gains, including proportional-only, rate-only, and zero-gain cases.  The
+    sensed and reference hinge states produce both signs of raw torque command.  ``uMax`` is either left at its negative
+    default, set above or below the raw command magnitude, or set to zero.
 
     **Description of Variables Being Tested**
 
@@ -61,6 +67,56 @@ def test_hingedRigidBodyMotor(
         K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, uMax
     )
     assert actualTorque == pytest.approx(expectedTorque, rel=1e-12)
+
+
+# K [N m/rad] and P [N m s/rad].
+@pytest.mark.parametrize(
+    "K, P",
+    [
+        pytest.param(-1.0, 1.0, id="negative-K"),
+        pytest.param(1.0, -1.0, id="negative-P"),
+        pytest.param(math.nan, 1.0, id="nan-K"),
+        pytest.param(1.0, math.nan, id="nan-P"),
+        pytest.param(math.inf, 1.0, id="infinite-K"),
+        pytest.param(1.0, math.inf, id="infinite-P"),
+    ],
+)
+def test_hingedRigidBodyMotor_rejects_invalid_gains(K, P):
+    """Verify that ``Reset()`` rejects negative and non-finite controller gains."""
+    module = make_reset_ready_module()
+    module.K = K
+    module.P = P
+
+    with pytest.raises(BasiliskError, match="K and P must be set to finite, non-negative values"):
+        module.Reset(0)  # [ns]
+
+
+# uMax [N m].
+@pytest.mark.parametrize(
+    "uMax",
+    [
+        pytest.param(math.nan, id="nan-uMax"),
+        pytest.param(math.inf, id="positive-infinite-uMax"),
+        pytest.param(-math.inf, id="negative-infinite-uMax"),
+    ],
+)
+def test_hingedRigidBodyMotor_rejects_nonfinite_torque_limit(uMax):
+    """Verify that ``Reset()`` rejects a non-finite motor-torque limit."""
+    module = make_reset_ready_module()
+    module.uMax = uMax
+
+    with pytest.raises(BasiliskError, match="uMax must be set to a finite value"):
+        module.Reset(0)  # [ns]
+
+
+def make_reset_ready_module():
+    """Return a module with both required input messages connected."""
+    module = hingedRigidBodyMotor.HingedRigidBodyMotor()
+    sensedMsg = messaging.HingedRigidBodyMsg().write(messaging.HingedRigidBodyMsgPayload())
+    referenceMsg = messaging.HingedRigidBodyMsg().write(messaging.HingedRigidBodyMsgPayload())
+    module.hingedBodyStateSensedInMsg.subscribeTo(sensedMsg)
+    module.hingedBodyStateReferenceInMsg.subscribeTo(referenceMsg)
+    return module
 
 
 def run_motor_case(K, P, sensedTheta, sensedThetaDot, refTheta, refThetaDot, uMax):

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
@@ -19,7 +19,9 @@
 
 
 #include "simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h"
+
 #include <algorithm>
+#include <cmath>
 
 /** @brief Constructs a hinged rigid body motor controller with torque saturation disabled. */
 HingedRigidBodyMotor::HingedRigidBodyMotor()
@@ -46,8 +48,11 @@ void HingedRigidBodyMotor::Reset(uint64_t CurrentSimNanos [[maybe_unused]])
     if (!this->hingedBodyStateReferenceInMsg.isLinked()) {
         bskLogger.bskError("HingedRigidBodyMotor.hingedBodyStateReferenceInMsg was not linked.");
     }
-    if (this->K <= 0.0 || this->P <= 0.0) {
-        bskLogger.bskError("HingedRigidBodyMotor K and P must be set to positive values.");
+    if (!std::isfinite(this->K) || !std::isfinite(this->P) || this->K < 0.0 || this->P < 0.0) {
+        bskLogger.bskError("HingedRigidBodyMotor K and P must be set to finite, non-negative values.");
+    }
+    if (!std::isfinite(this->uMax)) {
+        bskLogger.bskError("HingedRigidBodyMotor uMax must be set to a finite value.");
     }
 
 }

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.cpp
@@ -19,15 +19,14 @@
 
 
 #include "simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h"
-#include <iostream>
+#include <algorithm>
 
-/*! This is the constructor for the module class.  It sets default variable
-    values and initializes the various parts of the model */
+/** @brief Constructs a hinged rigid body motor controller with torque saturation disabled. */
 HingedRigidBodyMotor::HingedRigidBodyMotor()
 {
-    //! zero values will lead to zero outputs
-    this->K = 0.0;
-    this->P = 0.0;
+    this->K = 0.0;  // [N m/rad]
+    this->P = 0.0;  // [N m s/rad]
+    this->uMax = -1.0;  // [N m] negative values disable torque saturation
 }
 
 /*! Module Destructor */
@@ -35,9 +34,9 @@ HingedRigidBodyMotor::~HingedRigidBodyMotor()
 {
 }
 
-/*! This method is used to reset the module and checks that required input messages are connect.
-
-*/
+/** @brief Checks that required input messages and controller gains are configured.
+ * @param CurrentSimNanos [ns] Current simulation time; unused during reset.
+ */
 void HingedRigidBodyMotor::Reset(uint64_t CurrentSimNanos [[maybe_unused]])
 {
     //! check that required input messages are connected
@@ -54,17 +53,17 @@ void HingedRigidBodyMotor::Reset(uint64_t CurrentSimNanos [[maybe_unused]])
 }
 
 
-/*! This is the main method that gets called every time the module is updated.  It calculates a motor torque on a hinged rigid body using a simple PD control law.
-
-*/
+/** @brief Calculates and limits the commanded hinge torque.
+ * @param CurrentSimNanos [ns] Current simulation time.
+ */
 void HingedRigidBodyMotor::UpdateState(uint64_t CurrentSimNanos)
 {
     //! local variables
-    double sensedTheta;
-    double sensedThetaDot;
-    double refTheta;
-    double refThetaDot;
-    double torque;
+    double sensedTheta;  // [rad]
+    double sensedThetaDot;  // [rad/s]
+    double refTheta;  // [rad]
+    double refThetaDot;  // [rad/s]
+    double torque;  // [N m]
 
     HingedRigidBodyMsgPayload hingedBodyStateSensedInMsgBuffer;  //!< local copy of message buffer for reference
     HingedRigidBodyMsgPayload hingedBodyStateReferenceInMsgBuffer;  //!< local copy of message buffer for measurement
@@ -84,7 +83,10 @@ void HingedRigidBodyMotor::UpdateState(uint64_t CurrentSimNanos)
     refThetaDot = hingedBodyStateReferenceInMsgBuffer.thetaDot;
 
     //! calculate motor torque
-    torque = -1 * this->K * (sensedTheta - refTheta) - this->P * (sensedThetaDot - refThetaDot);
+    torque = this->K * (refTheta - sensedTheta) + this->P * (refThetaDot - sensedThetaDot);
+    if (this->uMax >= 0.0) {
+        torque = std::clamp(torque, -this->uMax, this->uMax);
+    }
     motorTorqueOutMsgBuffer.motorTorque[0] = torque;
 
     //! write to the output messages

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h
@@ -27,8 +27,10 @@
 #include "architecture/utilities/bskLogging.h"
 #include "architecture/messaging/messaging.h"
 
-/*! @brief Calculates a motor torque to drive a hinged panel to a reference angle state. A sensed and reference hinged rigid body angle
-           drives a simple PD control law.
+/** @brief Computes an ideal commanded hinge torque using a PD tracking law.
+ *
+ * The module uses sensed and reference hinge angles and angular rates to calculate a torque command.  It is an ideal
+ * controller and does not model electromechanical motor dynamics or actuator limits.
  */
 class HingedRigidBodyMotor: public SysModel {
 public:
@@ -39,9 +41,9 @@ public:
     void UpdateState(uint64_t CurrentSimNanos);
 
 public:
-    
-    double K;  //!< gain on theta
-    double P; //!< gain on theta dot
+
+    double K;  //!< [N m/rad] proportional gain on hinge-angle tracking error
+    double P;  //!< [N m s/rad] derivative gain on hinge-rate tracking error
 
     ReadFunctor<HingedRigidBodyMsgPayload> hingedBodyStateSensedInMsg;  //!< sensed rigid body state (theta, theta dot)
     ReadFunctor<HingedRigidBodyMsgPayload> hingedBodyStateReferenceInMsg;  //!< reference hinged rigid body state (theta, theta dot)

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h
@@ -21,6 +21,8 @@
 #ifndef HINGEDRIGIDBODYMOTOR_H
 #define HINGEDRIGIDBODYMOTOR_H
 
+#include <cstdint>
+
 #include "architecture/_GeneralModuleFiles/sys_model.h"
 #include "architecture/msgPayloadDefC/HingedRigidBodyMsgPayload.h"
 #include "architecture/msgPayloadDefC/ArrayMotorTorqueMsgPayload.h"
@@ -30,7 +32,7 @@
 /** @brief Computes an ideal commanded hinge torque using a PD tracking law.
  *
  * The module uses sensed and reference hinge angles and angular rates to calculate a torque command.  It is an ideal
- * controller and does not model electromechanical motor dynamics or actuator limits.
+ * controller with optional symmetric torque saturation; it does not model electromechanical motor dynamics.
  */
 class HingedRigidBodyMotor: public SysModel {
 public:
@@ -44,6 +46,7 @@ public:
 
     double K;  //!< [N m/rad] proportional gain on hinge-angle tracking error
     double P;  //!< [N m s/rad] derivative gain on hinge-rate tracking error
+    double uMax;  //!< [N m] maximum torque magnitude; a negative value disables saturation
 
     ReadFunctor<HingedRigidBodyMsgPayload> hingedBodyStateSensedInMsg;  //!< sensed rigid body state (theta, theta dot)
     ReadFunctor<HingedRigidBodyMsgPayload> hingedBodyStateReferenceInMsg;  //!< reference hinged rigid body state (theta, theta dot)

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.h
@@ -44,9 +44,9 @@ public:
 
 public:
 
-    double K;  //!< [N m/rad] proportional gain on hinge-angle tracking error
-    double P;  //!< [N m s/rad] derivative gain on hinge-rate tracking error
-    double uMax;  //!< [N m] maximum torque magnitude; a negative value disables saturation
+    double K;  //!< [N m/rad] finite, nonnegative proportional gain on hinge-angle tracking error
+    double P;  //!< [N m s/rad] finite, nonnegative derivative gain on hinge-rate tracking error
+    double uMax;  //!< [N m] finite maximum torque magnitude; a negative value disables saturation
 
     ReadFunctor<HingedRigidBodyMsgPayload> hingedBodyStateSensedInMsg;  //!< sensed rigid body state (theta, theta dot)
     ReadFunctor<HingedRigidBodyMsgPayload> hingedBodyStateReferenceInMsg;  //!< reference hinged rigid body state (theta, theta dot)

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.rst
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.rst
@@ -58,6 +58,9 @@ where
       - N m s/rad
       - Derivative gain on hinge-rate tracking error.  The name ``P`` is retained for API compatibility; it is the
         derivative gain commonly denoted by :math:`K_d` in PD-controller notation.
+    * - :math:`u_{\max}`
+      - N m
+      - Optional symmetric torque magnitude limit configured through ``uMax``.
 
 Thus, positive :math:`K` and :math:`P` produce a restoring torque that reduces the reference-tracking error.  Both gains
 must currently be assigned strictly positive values before the simulation initializes.  The constructor initializes
@@ -92,10 +95,19 @@ gains across the intended configurations and simulation time steps.
 Module Assumptions and Limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The commanded torque is ideal and unsaturated.  This module does not model motor current, voltage, speed-torque curves,
-gearboxes, backlash, actuator dynamics, torque or rate limits, or thermal effects.  Large gains can therefore command
-unrealistic torques and can make the simulated dynamics numerically stiff.  Model those effects separately when they
-are important to the analysis.
+The optional ``uMax`` parameter applies a symmetric limit to the ideal controller output after evaluating the PD control
+law:
+
+.. math::
+
+    u_{\mathrm{out}} = \operatorname{clamp}(u, -u_{\max}, u_{\max}).
+
+Set ``uMax`` to the nonnegative maximum torque magnitude in N m.  A negative value disables saturation; the default is
+``uMax = -1.0`` N m.  In particular, ``uMax = 0`` commands zero torque.
+
+The limit does not model motor current, voltage, speed-torque curves, gearboxes, backlash, actuator dynamics, asymmetric
+torque limits, rate limits, or thermal effects.  Large gains can still make the simulated dynamics numerically stiff.
+Model those effects separately when they are important to the analysis.
 
 User Guide
 ----------
@@ -121,3 +133,4 @@ A sample setup is done using:
 
     testModule.K = 1.0  # [N m/rad] hinge-angle tracking gain
     testModule.P = 1.0  # [N m s/rad] hinge-rate tracking gain
+    testModule.uMax = 0.5  # [N m] optional symmetric torque limit

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.rst
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.rst
@@ -62,9 +62,10 @@ where
       - N m
       - Optional symmetric torque magnitude limit configured through ``uMax``.
 
-Thus, positive :math:`K` and :math:`P` produce a restoring torque that reduces the reference-tracking error.  Both gains
-must currently be assigned strictly positive values before the simulation initializes.  The constructor initializes
-them to zero, but ``Reset()`` reports an error if either value remains zero or is negative.
+The gains must be finite and nonnegative.  Positive :math:`K` and :math:`P` produce a restoring torque that reduces the
+reference-tracking error.  Set ``K = 0`` to disable angle feedback for a rate-only controller, or set ``P = 0`` to
+disable rate feedback for a proportional-only controller.  Setting both gains to zero commands zero torque.  ``Reset()``
+reports an error if either gain is negative or non-finite.
 
 Relationship to State-Effector Stiffness and Damping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -102,8 +103,9 @@ law:
 
     u_{\mathrm{out}} = \operatorname{clamp}(u, -u_{\max}, u_{\max}).
 
-Set ``uMax`` to the nonnegative maximum torque magnitude in N m.  A negative value disables saturation; the default is
-``uMax = -1.0`` N m.  In particular, ``uMax = 0`` commands zero torque.
+Set ``uMax`` to a finite value in N m.  A nonnegative value specifies the maximum torque magnitude, while a negative
+value disables saturation; the default is ``uMax = -1.0`` N m.  In particular, ``uMax = 0`` commands zero torque.
+``Reset()`` reports an error if ``uMax`` is non-finite.
 
 The limit does not model motor current, voltage, speed-torque curves, gearboxes, backlash, actuator dynamics, asymmetric
 torque limits, rate limits, or thermal effects.  Large gains can still make the simulated dynamics numerically stiff.

--- a/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.rst
+++ b/src/simulation/dynamics/hingedRigidBodyMotor/hingedRigidBodyMotor.rst
@@ -1,6 +1,8 @@
 Executive Summary
 -----------------
-Calculates a motor torque given a sensed and reference hinged rigid body state using a simple PD control law.
+This module implements an ideal proportional-derivative (PD) hinge controller.  It calculates a commanded hinge torque
+from sensed and reference hinge angles and angular rates.  Despite the module name, it does not model the electrical or
+mechanical dynamics of a physical motor.
 
 Message Connection Descriptions
 -------------------------------
@@ -22,12 +24,78 @@ provides information on what this message is used for.
 Detailed Model Description
 --------------------------
 
-This module takes in a reference angle and angle rate, as well as a sensed angle and angle rate, and calculates the motor torque according to:
+Control Law and Gain Definitions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The controller calculates the commanded hinge torque according to
 
 .. math::
-    u = -K(\theta_s-\theta_r)-P(\dot{\theta}_s-\dot{\theta}_r)
 
-K and P are the constant gains. Both should be set to positive values.
+    u = K(\theta_r-\theta_s) + P(\dot{\theta}_r-\dot{\theta}_s),
+
+where
+
+.. list-table::
+    :widths: 15 20 65
+    :header-rows: 1
+
+    * - Symbol
+      - Units
+      - Meaning
+    * - :math:`u`
+      - N m
+      - Commanded torque applied to the hinge.
+    * - :math:`\theta_r`, :math:`\theta_s`
+      - rad
+      - Reference and sensed hinge angles, respectively.
+    * - :math:`\dot{\theta}_r`, :math:`\dot{\theta}_s`
+      - rad/s
+      - Reference and sensed hinge angular rates, respectively.
+    * - :math:`K`
+      - N m/rad
+      - Proportional gain on hinge-angle tracking error.
+    * - :math:`P`
+      - N m s/rad
+      - Derivative gain on hinge-rate tracking error.  The name ``P`` is retained for API compatibility; it is the
+        derivative gain commonly denoted by :math:`K_d` in PD-controller notation.
+
+Thus, positive :math:`K` and :math:`P` produce a restoring torque that reduces the reference-tracking error.  Both gains
+must currently be assigned strictly positive values before the simulation initializes.  The constructor initializes
+them to zero, but ``Reset()`` reports an error if either value remains zero or is negative.
+
+Relationship to State-Effector Stiffness and Damping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The motor gains should not be confused with the ``k`` and ``c`` parameters of
+:ref:`spinningBodyOneDOFStateEffector` or :ref:`hingedRigidBodyStateEffector`.  The state-effector parameters represent
+passive physical joint stiffness and damping.  In contrast, ``K`` and ``P`` define active feedback torque commanded by
+this module.  If both are enabled, their torques act together in the coupled dynamics model.  Set the state-effector
+``k`` and ``c`` parameters to zero for an ideal torque-driven hinge without passive compliance, or give them nonzero
+values only when physical joint stiffness and damping are intentionally part of the model.
+
+Gain Selection
+~~~~~~~~~~~~~~
+
+For an isolated hinge with equivalent rotational inertia :math:`J_{\mathrm{eq}}`, a useful initial gain estimate follows
+from the standard second-order response:
+
+.. math::
+
+    K = J_{\mathrm{eq}}\omega_n^2, \qquad
+    P = 2\zeta J_{\mathrm{eq}}\omega_n,
+
+where :math:`J_{\mathrm{eq}}` is the equivalent hinge inertia in kg m^2, :math:`\omega_n` is the desired natural
+frequency in rad/s, and :math:`\zeta` is the desired dimensionless damping ratio.  In a coupled spacecraft and appendage
+system, :math:`J_{\mathrm{eq}}` is configuration dependent, so these relations are only a starting point.  Validate the
+gains across the intended configurations and simulation time steps.
+
+Module Assumptions and Limitations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The commanded torque is ideal and unsaturated.  This module does not model motor current, voltage, speed-torque curves,
+gearboxes, backlash, actuator dynamics, torque or rate limits, or thermal effects.  Large gains can therefore command
+unrealistic torques and can make the simulated dynamics numerically stiff.  Model those effects separately when they
+are important to the analysis.
 
 User Guide
 ----------
@@ -42,7 +110,7 @@ The interface module is created in python using:
 .. code-block:: python
     :linenos:
 
-    testModule = hingedRigidBodyMotor.hingedRigidBodyMotor()
+    testModule = hingedRigidBodyMotor.HingedRigidBodyMotor()
     testModule.ModelTag = "hingedRigidBodyMotor"
 
 
@@ -51,7 +119,5 @@ A sample setup is done using:
 .. code-block:: python
     :linenos:
 
-    testModule.K = 1 # proportional gain constant
-    testModule.P = 1 # derivative gain constant
-
-If :math:`K` and :math:`P` are not set, they default to 0.
+    testModule.K = 1.0  # [N m/rad] hinge-angle tracking gain
+    testModule.P = 1.0  # [N m s/rad] hinge-rate tracking gain


### PR DESCRIPTION
**Tickets addressed:** Closes #637 
**Review:** By commit
**Merge strategy:** Merge (no squash)

## Description

This PR enhances `hingedRigidBodyMotor` through three independently reviewable commits:

1. Clarifies that the module implements an ideal PD torque controller, documents the physical meaning and units of the proportional gain `K` and derivative gain `P`, and distinguishes these controller gains from passive joint stiffness and damping.
2. Adds optional symmetric motor-torque saturation through the `uMax` parameter. A negative value disables saturation, zero prevents torque output, and a positive value limits the commanded torque to `[-uMax, uMax]`.
3. Allows `K` or `P` to be zero, supporting proportional-only and rate-only control, while strengthening configuration validation to reject negative or non-finite gains and non-finite torque limits.

## Verification

The existing `hingedRigidBodyMotor` unit test was expanded to cover:

- Positive and negative unsaturated torque commands.
- Disabled torque saturation.
- Commands within the configured torque limit.
- Positive and negative torque saturation.
- A zero torque limit.
- Rate-only control with `K = 0`.
- Proportional-only control with `P = 0`.
- Zero output with `K = P = 0`.
- Rejection of negative `K` and `P` values during `Reset()`.
- Rejection of non-finite `K`, `P`, and `uMax` values during `Reset()`.

No test results were re-baselined.

The final branch was validated with:

- The `hingedRigidBodyMotor` build target.
- The focused module unit tests: **18 passed**.
- `scenarioDeployingPanel`: **1 passed**.
- The full Sphinx HTML documentation build with warnings treated as errors.
- Repository pre-commit checks.
- `git diff --check`.

## Documentation

The `hingedRigidBodyMotor` module documentation was updated to describe:

- The controller equation and sign convention.
- The meaning, units, and validation requirements of `K`, `P`, and `uMax`.
- The distinction between active motor control gains and passive state-effector stiffness and damping.
- Torque-saturation behavior.
- Proportional-only, rate-only, and zero-gain configurations.
- Gain and torque-limit validation performed during `Reset()`.

The corresponding C++ API comments and release-note snippet were also updated. Reviewers should check the rendered `hingedRigidBodyMotor` module page and the release-note entry for accuracy and completeness.

## Future work

Gearbox modeling and contact physics, including hard panel rotation limits, are outside the scope of this PR. Panel-stop contact dynamics should be modeled with Basilisk's MuJoCo dynamics engine rather than the Back-Substitution Method dynamics engine.
