### PR TITLE
Add effector branching to the faceted SRP dynamic effector

### DIFF
--- a/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
+++ b/docs/source/Learn/bskPrinciples/bskPrinciples-11.rst
@@ -4,7 +4,7 @@ Advanced: Effector Module Branching
 ===================================
 
 Module branching in Basilisk enables the attachment of compatible dynamic effectors on state
-effectors as an alternative to attaching them directly to the hub. For example, a gimballed thruster
+effectors as an alternative to attaching them directly to the hub. For example, a gimbaled thruster
 can be modeled as a ``thrusterDynamicEffector`` attached to a ``spinningBodyTwoDOFStateEffector``,
 or a robotic docking arm can be modeled as a ``constraintDynamicEffector`` attached to a 7-DOF
 revolute ``spinningBodyNDOFStateEffector``. Multiple dynamic effectors can be attached to a state
@@ -16,239 +16,71 @@ be found in :ref:`effectorBranching`. Integrated testing of effector branching i
 
 Allowable Configurations
 ------------------------
-The currently supported configurations of state effectors compatible as "parent" effectors and
-dynamic effectors compatible as "child" effectors is summarized in the table below. Green shows
-currently supported configurations, yellow shows configurations expected to be supported in the
-future, and red shows configurations not planned to be supported. Additionally, blue shows the
-special case of prescribed effector branching explained in :ref:`prescribedMotionStateEffector`.
+Branching pairs a state effector acting as a parent with a dynamic effector acting as a child. The
+two sides are supported independently, so any parent listed below accepts any child listed below,
+and a parent accepts more than one child at a time.
 
-.. raw:: html
+State Effectors Supported as Parents
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    <style>
-      /* Responsive wrapper */
-      .table-wrapper {
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        margin: 1em 0;
-      }
+- :ref:`hingedRigidBodyStateEffector`
+- :ref:`dualHingedRigidBodyStateEffector`
+- :ref:`nHingedRigidBodyStateEffector`
+- :ref:`spinningBodyOneDOFStateEffector`
+- :ref:`spinningBodyTwoDOFStateEffector`
+- :ref:`spinningBodyNDOFStateEffector`
+- :ref:`linearTranslationOneDOFStateEffector`
+- :ref:`linearTranslationNDOFStateEffector`
 
-      /* Table base */
-      table.effector-compat {
-        border-collapse: collapse;
-        table-layout: fixed;              /* consistent sizing across browsers */
-        width: 100%;
-        text-align: center;
-        font-size: 0.9em;
-      }
+A parent with more than one degree of freedom additionally takes the segment its child attaches to,
+counting outward from the hub starting at 1.
 
-      /* Cells */
-      table.effector-compat th,
-      table.effector-compat td {
-        border: 1px solid #777;
-        padding: 6px 8px;
-      }
+:ref:`prescribedMotionStateEffector` is not in this list because it hosts state effectors rather
+than dynamic effectors, through the separate mechanism described under
+:ref:`prescribedMotionBranching` on its own page.
 
-      /* Header cells */
-      table.effector-compat thead th {
-        background-color: #e5e5e5;
-        color: #222;
-        font-weight: bold;
-      }
+Dynamic Effectors Supported as Children
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      /* Second column (row labels) */
-      table.effector-compat td.label {
-        background-color: #f5f5f5;
-        color: #222;
-        font-weight: bold;
-        white-space: normal;          /* allow wrapping */
-        overflow-wrap: anywhere;      /* wrap long words */
-        text-align: left;             /* readability */
-      }
+- :ref:`extForceTorque`
+- :ref:`thrusterDynamicEffector`
+- :ref:`constraintDynamicEffector`
+- :ref:`facetDragDynamicEffector`
+- :ref:`facetSRPDynamicEffector`
 
-      /* Rotated column headers (use inner wrapper, not the <th> itself) */
-      table.effector-compat th.rotate {
-        vertical-align: middle;
-        background-color: #d9d9d9;
-        padding: 0;                   /* inner span handles spacing */
-        height: 140px;                /* stable header height */
-        width: 38px;                  /* narrow columns for tall text */
-      }
-      @supports (writing-mode: vertical-rl) {
-        table.effector-compat th.rotate > .rotate-inner {
-          writing-mode: vertical-rl;
-          text-orientation: mixed;
-          transform: rotate(180deg);  /* bottom → top like original */
-          display: inline-block;
-          white-space: nowrap;
-          padding: 8px 4px;
-          line-height: 1.1;
-        }
-      }
-      @supports not (writing-mode: vertical-rl) {
-        table.effector-compat th.rotate > .rotate-inner {
-          display: inline-block;
-          transform: rotate(-90deg);
-          transform-origin: center;
-          white-space: nowrap;
-          padding: 8px 4px;
-          line-height: 1.1;
-        }
-      }
+A parent makes its inertial position, velocity, attitude, and angular velocity available in place
+of the hub's, and a child reads whichever of the four its model needs. Any geometry the user gives
+the child is then expressed relative to the parent's frame rather than the hub body frame.
 
-      /* FIRST COLUMN (vertical "Parent Effectors") — rotate-only, no writing-mode */
-      table.effector-compat td.vlabel {
-        position: relative;     /* anchor for absolute child */
-        padding: 0;
-        text-align: center;
-        overflow: hidden;       /* keep content inside the cell */
-      }
-      table.effector-compat td.vlabel .rotate-inner {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%) rotate(-90deg);  /* center + rotate */
-        transform-origin: center;
-        display: block;
-        white-space: nowrap;
-        line-height: 1;
-        padding: 6px 4px;
-        font-weight: bold;
-        color: #222;
-      }
-      @supports (writing-mode: vertical-rl) {
-        table.effector-compat td.vlabel .rotate-inner {
-          writing-mode: initial !important;
-          text-orientation: initial !important;
-        }
-      }
+Effectors Not Supported for Branching
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      /* Column widths via <colgroup> */
-      table.effector-compat col.col-vert  { width: 32px; }   /* first column */
-      table.effector-compat col.col-label { width: 280px; }  /* second column */
-      table.effector-compat col.col-data  { width: 32px; }   /* each data column */
+Every other effector attaches to the hub only.
 
-      /* Color palette */
-      table.effector-compat td.green  { background-color: #90ee90; }
-      table.effector-compat td.yellow { background-color: #fff59d; }
-      table.effector-compat td.red    { background-color: #ff9999; }
-      table.effector-compat td.blue   { background-color: #9ec5fe; }
+A state effector cannot act as a child of the branching described here. ``addDynamicEffector``
+accepts a dynamic effector, and a state effector contributes Backsubstitution matrices rather than a
+force and a torque, so the two do not interchange. This covers the spinning bodies, the translating
+bodies, the hinged rigid bodies, :ref:`linearSpringMassDamper`, :ref:`sphericalPendulum`,
+:ref:`reactionWheelStateEffector`, :ref:`vscmgStateEffector`, :ref:`thrusterStateEffector`, and
+:ref:`fuelTank`. The exception is :ref:`prescribedMotionStateEffector`, which hosts a subset of
+these as children through the mechanism described under :ref:`prescribedMotionBranching`.
 
-      /* Caption */
-      table.effector-compat caption {
-        caption-side: top;
-        text-align: left;
-        font-weight: bold;
-        margin-bottom: 0.5em;
-        font-size: 1.05em;
-      }
-    </style>
+The cannonball models, :ref:`dragDynamicEffector` and the cannonball option of
+:ref:`radiationPressure`, lump the whole vehicle into one sphere whose load acts on the hub, so they
+describe no component a segment could carry, and neither implements the child side.
 
-    <div class="table-wrapper">
-    <table class="effector-compat">
-      <caption>Effector Branching Compatibility</caption>
+:ref:`gravityEffector` is not a dynamic effector. It is a member of :ref:`spacecraft` whose field
+reaches the equations of motion as the gravitational acceleration handed to every state effector, so
+each branched body already carries its own weight. The vehicle level gravity gradient torque is
+covered separately by :ref:`GravityGradientEffector`, which reads the spacecraft inertia tensor
+about point B and therefore already tracks the configuration of every attached body.
 
-      <!-- IMPORTANT: <colgroup> must be AFTER caption, BEFORE thead -->
-      <colgroup>
-        <col class="col-vert">            <!-- 1st column: vertical label -->
-        <col class="col-label">           <!-- 2nd column: wider, wraps -->
-        <col class="col-data" span="16">  <!-- 16 child-effector columns -->
-      </colgroup>
+:ref:`MtbEffector` and :ref:`ExtPulsedTorque` are branchable in principle and are listed here only
+because no use case has called for them.
 
-      <thead>
-        <tr>
-          <th rowspan="2" colspan="2"></th>
-          <th colspan="16">Children Effectors</th>
-        </tr>
-        <tr>
-          <th class="rotate"><span class="rotate-inner">Thruster Dynamic Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Thruster State Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Constraint Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Faceted Drag Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">External Force Torque</span></th>
-          <th class="rotate"><span class="rotate-inner">SRP Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Fuel Tank Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Gravity Effector</span></th>
-          <th class="rotate"><span class="rotate-inner">Spinning Bodies</span></th>
-          <th class="rotate"><span class="rotate-inner">Translating Bodies</span></th>
-          <th class="rotate"><span class="rotate-inner">Hinged Rigid Bodies</span></th>
-          <th class="rotate"><span class="rotate-inner">Prescribed Bodies</span></th>
-          <th class="rotate"><span class="rotate-inner">Linear Spring Mass Damper</span></th>
-          <th class="rotate"><span class="rotate-inner">Spherical Pendulum</span></th>
-          <th class="rotate"><span class="rotate-inner">Reaction Wheel</span></th>
-          <th class="rotate"><span class="rotate-inner">VSCMG</span></th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td rowspan="9" class="label vlabel">
-            <span class="rotate-inner">Parent Effectors</span>
-          </td>
-          <td class="label">Spinning Bodies 1DOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Spinning Bodies 2DOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Spinning Bodies NDOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Hinged Rigid Bodies</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Dual Hinged Rigid Bodies</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">N Hinged Rigid Bodies</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Linear Translating Bodies 1DOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Linear Translating Bodies NDOF</td>
-          <td class="green"></td><td class="yellow"></td><td class="green"></td><td class="green"></td>
-          <td class="green"></td><td class="yellow"></td><td class="yellow"></td><td class="yellow"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-          <td class="red"></td><td class="red"></td><td class="red"></td><td class="red"></td>
-        </tr>
-        <tr>
-          <td class="label">Prescribed Motion</td>
-          <td class="blue"></td><td class="blue"></td><td class="blue"></td><td class="blue"></td>
-          <td class="blue"></td><td class="blue"></td><td class="blue"></td><td class="blue"></td>
-          <td class="blue"></td><td class="blue"></td><td class="blue"></td><td class="blue"></td>
-          <td class="blue"></td><td class="blue"></td><td class="blue"></td><td class="blue"></td>
-        </tr>
-      </tbody>
-    </table>
-    </div>
+:ref:`thrusterStateEffector` and :ref:`fuelTank` are the two worth revisiting if a mission calls for
+them, though either would first need the child side mechanism that a state effector does not have
+today.
 
 Setup
 -----
@@ -275,7 +107,7 @@ By default, effectors are attached to the hub using::
     scObject.addDynamicEffector(dynEff)
     scSim.AddModelToTask(simTaskName, dynEff)
 
-Dynamic effector's can instead be attached to a state effector as::
+Dynamic effectors can instead be attached to a state effector as::
 
     stateEff.addDynamicEffector(dynEff)
 
@@ -286,7 +118,7 @@ attach the dynamic effector to as::
     segment = 2
     stateEff.addDynamicEffector(dynEff, segment)
 
-Where segment is the integer number of the segement to be attached to, with 1 being the segment
+Where segment is the integer number of the segment to be attached to, with 1 being the segment
 attached to the hub, increasing outward from the hub. For example, spinningBodyOneDOFStateEffector
 will always attach to segment 1, attaching to the second to last segment of a 7DOF robotic arm would
 be segment 6. Note that in either case the dynamic effector is still added to the sim task.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -50,6 +50,16 @@ Version |release|
   panels, but the module accepted a per-panel mass and hinge to center of mass distance and
   integrated silently wrong dynamics when either varied along the chain. Initialization now rejects
   such a chain.
+- The :ref:`facetSRPDynamicEffector` indexed its articulation angles by facet while building the
+  list only from messages that had been written, so an incomplete read applied one facet's angle to
+  another. The facets now articulate only once every articulation message has been written.
+- The :ref:`facetSRPDynamicEffector` walked its facet geometry lists by the count given to
+  ``setNumFacets()`` rather than by the number of facets actually added, so a larger count read past
+  the end of every list and a smaller one silently dropped facets. Initialization now rejects a
+  mismatch.
+- :ref:`simIncludeThruster` defaulted the ``segment`` argument of ``addToSpacecraftSubcomponent()``
+  to 0, but attachment segments are numbered from 1, so every parent effector rejected the call
+  unless a segment was named. The default is now the segment attached to the hub.
 - The :ref:`linearTranslationNDOFStateEffector` and the :ref:`spinningBodyNDOFStateEffector` allocated
   a state and a configuration log output message for every body added to the chain and freed neither,
   so each effector leaked both for the life of the process. This is fixed in the current version.

--- a/docs/source/Support/bskReleaseNotesSnippets/1533-facet-srp-branching.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1533-facet-srp-branching.rst
@@ -1,0 +1,6 @@
+- Added support for :ref:`facetSRPDynamicEffector` to be attached to a branching state effector.
+- :ref:`facetSRPDynamicEffector` now rejects a facet count that does not match the facets added.
+- Fixed :ref:`facetSRPDynamicEffector` applying one facet's articulation angle to another when only some articulation messages had been written.
+- Fixed :ref:`simIncludeThruster` defaulting ``addToSpacecraftSubcomponent()`` to a segment that every parent effector rejects.
+- Documented the branching setup in each effector that supports it, which previously appeared only on the dynamic effector side.
+- Reorganized the effector branching compatibility table in :ref:`bskPrinciples-11` into lists of supported parents, supported children, and effectors not supported for branching.

--- a/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/HingedRigidBodies/hingedRigidBodyStateEffector.rst
@@ -103,3 +103,16 @@ This section is to outline the steps needed to setup a Hinged Rigid Body State E
 #. Add the module to the task list::
 
     unitTestSim.AddModelToTask(unitTaskName, panel1)
+
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by the panel rather than by the hub::
+
+    panel1.addDynamicEffector(childEffector)
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that panel's frame rather than the hub body frame. Both this effector
+and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/NHingedRigidBodies/nHingedRigidBodyStateEffector.rst
@@ -34,3 +34,19 @@ panel, ordered outward from the hub.
         Output vector of messages containing the panel inertial states. The position and velocity are
         those of the panel center of mass, and the attitude and angular velocity are those of the
         panel frame S.
+
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by one of the panels rather than by the hub::
+
+    panelEffector.addDynamicEffector(childEffector, segment)
+
+Here ``segment`` is the one-based panel number, counting outward from the hub, so ``1`` is the
+panel attached to the hub.
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that panel's frame rather than the hub body frame. Both this effector
+and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.rst
+++ b/src/simulation/dynamics/Thrusters/thrusterDynamicEffector/thrusterDynamicEffector.rst
@@ -38,3 +38,23 @@ provides information on what this message is used for.
 
 .. note::
   The dynamic behaviour of this module is governed by the variables inside :ref:`THRTimePair`, which determine the on and off-ramp characteristics. The default behaviour is to not have on and off-ramps active. The ``cutoffFrequency`` variable inside :ref:`THRSimConfig` has no impact on this module and is instead supposed to be used to determine the dynamic behaviour within :ref:`thrusterStateEffector`.
+
+
+Attaching to a State Effector
+-----------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so its load can be
+carried by an appendage instead of the hub. Attach it to the parent state effector rather than
+to the spacecraft::
+
+    stateEff.addDynamicEffector(thrusterSet, segment)
+
+A thruster set built with :ref:`simIncludeThruster` is attached through the factory instead::
+
+    thFactory.addToSpacecraftSubcomponent(thrModelTag, thrusterSet, stateEff, segment)
+
+The thrusters then fire from the parent segment's frame, using its inertial attitude and position in
+place of the hub's, so a gimbaled or deployed thruster follows its mount. The ``segment`` argument
+is omitted for a parent with a single degree of freedom.
+
+Both the parent and the child are still added to the task in the usual way, the same as when the
+child is attached to the hub.

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -48,23 +48,14 @@ from Basilisk.simulation import ( # state effectors
     linearTranslationOneDOFStateEffector,
     linearTranslationNDOFStateEffector,
     linearSpringMassDamper,
-    sphericalPendulum,
-    prescribedMotionStateEffector,
-    reactionWheelStateEffector,
-    vscmgStateEffector,
-    thrusterStateEffector,
-    fuelTank,
 )
 from Basilisk.simulation import ( # dynamic effectors
     extForceTorque,
     ExtPulsedTorque,
     thrusterDynamicEffector,
     constraintDynamicEffector,
-    dragDynamicEffector,
     facetDragDynamicEffector,
-    radiationPressure,
     facetSRPDynamicEffector,
-    MtbEffector,
 )
 from Basilisk.architecture import messaging
 
@@ -76,37 +67,28 @@ FINE_TIMESTEP = 0.0005  # [s]
 # uncomment this line if this test has an expected failure, adjust message as needed
 # @pytest.mark.xfail()
 
-# Note: effectors commented out as True are expected to be added in the future, effectors
-#       commented out as False are not expected to be added in the future
+# Note: an effector listed as False is one branching must reject. See bskPrinciples-11 for the
+#       full compatibility description.
 @pytest.mark.parametrize("stateEffector, isParent", [
     ("hingedRigidBodies",             True),
-    ("dualHingedRigidBodies",           True),
+    ("dualHingedRigidBodies",         True),
     ("nHingedRigidBodies",            True),
     ("spinningBodiesOneDOF",          True),
     ("spinningBodiesTwoDOF",          True),
     ("spinningBodiesNDOF",            True),
     ("linearTranslationBodiesOneDOF", True),
     ("linearTranslationBodiesNDOF",   True),
-    ("linearSpringMassDamper",          False),
-    # ("sphericalPendulum",               False),
-    # ("prescribedMotion",                False),
-    # ("reactionWheels",                  False),
-    # ("VSCMGs",                          False),
-    # ("thrusterStateEffector",           False),
-    # ("fuelTank",                        False),
+    ("linearSpringMassDamper",        False),
 ])
 @pytest.mark.parametrize("dynamicEffector, isChild", [
     ("extForceTorque",            True),
-    ("extPulseTorque",              False),
     ("thrusterDynamicEffector",   True),
     ("constraintEffectorOneHub",  True),
     ("constraintEffectorNoHubs",  True),
-    # ("dragEffector",                False),
     ("facetDragDynamicEffector",  True),
-    # ("radiationPressure",           False),
     ("facetSRPDynamicEffector",   True),
-    # ("MtbEffector",                 False),
     ("multiEffector",             True),
+    ("extPulseTorque",            False),
 ])
 
 def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamicEffector, isChild):

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -446,14 +446,15 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
     else:
         pytest.fail("ERROR: Effector branching integrated test using unrecognized dynamic effector input.")
 
-    # Add dynamic effector to state effector
+    # Add dynamic effector to state effector, omitting the segment where the parent defaults it
+    attachArgs = () if stateEffProps.defaultsSegment else (segment,)
     try:
         if dynamicEffector == "thrusterDynamicEffector": # if thruster, then use thruster factory
-            thFactory.addToSpacecraftSubcomponent("dynamicThruster", dynamicEff, stateEff, segment)
+            thFactory.addToSpacecraftSubcomponent("dynamicThruster", dynamicEff, stateEff, *attachArgs)
         elif dynamicEffector == "multiEffector": # if multiple effectors, loop over all to add
-            for dynEff in dynamicEff: stateEff.addDynamicEffector(dynEff, segment)
+            for dynEff in dynamicEff: stateEff.addDynamicEffector(dynEff, *attachArgs)
         else:
-            stateEff.addDynamicEffector(dynamicEff, segment)
+            stateEff.addDynamicEffector(dynamicEff, *attachArgs)
     except BasiliskError:
         # check if error was meant to happen
         assert not isParent, "FAILED: attempted attaching to a compatible state effector, but errored"
@@ -959,6 +960,7 @@ def setup_spinningBodiesOneDOF():
     stateEffProps.r_PB_B = spinningBody.r_SB_B
     stateEffProps.r_PcP_P = spinningBody.r_ScS_S
     stateEffProps.inertialPropLogName = "spinningBodyConfigLogOutMsg"
+    stateEffProps.defaultsSegment = True
 
     return(spinningBody, stateEffProps)
 
@@ -1097,6 +1099,7 @@ def setup_hingedRigidBodyStateEffector():
     stateEffProps.r_PB_B = hingedBody.r_HB_B
     stateEffProps.r_PcP_P = hingedBody.d * s1_hat
     stateEffProps.inertialPropLogName = "hingedRigidBodyConfigLogOutMsg"
+    stateEffProps.defaultsSegment = True
 
     return(hingedBody, stateEffProps)
 
@@ -1220,6 +1223,7 @@ def setup_translatingBodiesOneDOF():
     stateEffProps.r_PB_B = translatingBody.getR_F0B_B()  # [m]
     stateEffProps.r_PcP_P = translatingBody.getR_FcF_F()
     stateEffProps.inertialPropLogName = "translatingBodyConfigLogOutMsg"
+    stateEffProps.defaultsSegment = True
 
     return(translatingBody, stateEffProps)
 
@@ -1303,6 +1307,7 @@ class stateEffectorProperties:
     # to be used in checking equations of motion
     inertialPropLogName = "" # name of inertial property output log message
     r_PcP_P = [[0.0], [0.0], [0.0]] # individual COM for linkage that dynEff will be attached to
+    defaultsSegment = False # parent has one degree of freedom and defaults the attachment segment
 
 class facetDragProperties:
     # facet geometry and flow conditions, all expressed in the parent frame

--- a/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
+++ b/src/simulation/dynamics/_GeneralModuleFiles/_UnitTestDynamics/test_effectorBranching_integrated.py
@@ -104,7 +104,7 @@ FINE_TIMESTEP = 0.0005  # [s]
     # ("dragEffector",                False),
     ("facetDragDynamicEffector",  True),
     # ("radiationPressure",           False),
-    # ("facetSRPDynamicEffector",     False),
+    ("facetSRPDynamicEffector",   True),
     # ("MtbEffector",                 False),
     ("multiEffector",             True),
 ])
@@ -239,10 +239,13 @@ def test_effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dy
     :math:`i` segments. The sim 'truth' :math:`{}^{\mathcal{N}}\!\Delta v_{accum,C}` is logged from
     the spacecraft module.
 
-    For the :ref:`facetDragDynamicEffector` cases, the force and torque are also recomputed from
-    the parent segment's inertial attitude and velocity properties. The parent segment frames are
+    For the :ref:`facetDragDynamicEffector` and :ref:`facetSRPDynamicEffector` cases, the force
+    and torque are also recomputed from the parent segment's inertial properties, the attitude and
+    velocity for drag and the attitude and position for SRP. The parent segment frames are
     intentionally offset from the hub frame, so this comparison detects use of the hub kinematics
-    or an incorrect parent-to-inertial frame transformation.
+    or an incorrect parent-to-inertial frame transformation. The SRP case places the Sun close
+    enough that the parent's offset from the hub moves the load, which one astronomical unit
+    cannot, and checks the attitude and the position against the hub's one at a time.
     """
 
     coarseResidual = effectorBranchingIntegratedTest(show_plots, stateEffector, isParent,
@@ -434,6 +437,8 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
         dynamicEff, thFactory = setup_thrusterDynamicEffector()
     elif dynamicEffector == "facetDragDynamicEffector":
         dynamicEff, facetProps = setup_facetDragDynamicEffector()
+    elif dynamicEffector == "facetSRPDynamicEffector":
+        dynamicEff, srpProps = setup_facetSRPDynamicEffector()
     elif dynamicEffector == "constraintEffectorOneHub":
         dynamicEff, scObjectx = setup_constraintEffectorOneHub(scObject, stateEffProps)
         unitTestSim.AddModelToTask("unitTask", scObjectx)
@@ -563,6 +568,37 @@ def effectorBranchingIntegratedTest(show_plots, stateEffector, isParent, dynamic
             np.array(dynamicEff.torqueExternalPntB_B).flatten(), expectedTorque_P,
             rtol=0.0, atol=torque_accuracy,
             err_msg="FAILED: branched facet drag moment was not taken about the parent frame origin")
+
+    if dynamicEffector == "facetSRPDynamicEffector":
+        sigma_PN = np.array(scObject.dynManager.getPropertyReference(
+            dynamicEff.getPropName_inertialAttitude())).flatten()
+        r_PN_N = np.array(scObject.dynManager.getPropertyReference(
+            dynamicEff.getPropName_inertialPosition())).flatten()
+        expectedForce_P, expectedTorque_P = facetSRPLoad_P(srpProps, sigma_PN, r_PN_N)
+
+        sigma_BN = np.array(scObject.dynManager.getStateObject(
+            scObject.hub.nameOfHubSigma).getState()).flatten()
+        r_BN_N = np.array(scObject.dynManager.getStateObject(
+            scObject.hub.nameOfHubPosition).getState()).flatten()
+        hubSigmaForce_P, _ = facetSRPLoad_P(srpProps, sigma_BN, r_PN_N)
+        hubPosForce_P, _ = facetSRPLoad_P(srpProps, sigma_PN, r_BN_N)
+
+        # RKF45 takes its last stage at the step midpoint, so re-evaluate against the reads above
+        dynamicEff.computeForceTorque(0.0, 0.0)  # [s]
+        force_accuracy = 1e-12  # [N]
+        torque_accuracy = 1e-12  # [N*m]
+        assert not np.allclose(expectedForce_P, hubSigmaForce_P, rtol=0.0, atol=force_accuracy), (
+            "FAILED: this parent is not rotated enough from the hub to tell their attitudes apart")
+        assert not np.allclose(expectedForce_P, hubPosForce_P, rtol=0.0, atol=force_accuracy), (
+            "FAILED: this parent is not offset enough from the hub to tell their positions apart")
+        np.testing.assert_allclose(
+            np.array(dynamicEff.forceExternal_B).flatten(), expectedForce_P,
+            rtol=0.0, atol=force_accuracy,
+            err_msg="FAILED: branched SRP force was not built from the parent kinematics")
+        np.testing.assert_allclose(
+            np.array(dynamicEff.torqueExternalPntB_B).flatten(), expectedTorque_P,
+            rtol=0.0, atol=torque_accuracy,
+            err_msg="FAILED: branched SRP moment was not taken about the parent frame origin")
 
     # Continue to check state effector EOMs using pure force & torque
     if dynamicEffector != "extForceTorque":
@@ -801,6 +837,33 @@ def facetDragLoad_P(facetProps, sigma_PN, v_PN_N):
                             * speed**2 * vHat_P)
             force_P += facetForce_P
             torque_P += np.cross(facetProps.r_FP_P, facetForce_P)
+
+    return(force_P, torque_P)
+
+
+def facetSRPLoad_P(srpProps, sigma_PN, r_PN_N):
+    """Reference faceted SRP force and moment about the parent frame origin."""
+    SOLAR_RAD_FLUX = 1368.0  # [W/m^2] solar radiation flux at 1 AU, as the module defines it
+    SPEED_LIGHT = 299792458.0  # [m/s]
+    ASTRONOMICAL_UNIT = 149597870700.0  # [m]
+
+    dcm_PN = rbk.MRP2C(sigma_PN)
+    r_SP_P = dcm_PN @ (np.array(srpProps.r_SN_N) - np.array(r_PN_N))
+    sunDistance = np.linalg.norm(r_SP_P)
+    sHat = r_SP_P / sunDistance
+    pressure = (SOLAR_RAD_FLUX / SPEED_LIGHT) * (ASTRONOMICAL_UNIT / sunDistance)**2  # [N/m^2]
+
+    force_P = np.zeros(3)
+    torque_P = np.zeros(3)
+    for normal_P in srpProps.normals_P:
+        cosTheta = normal_P.dot(sHat)
+        projectedArea = srpProps.area * cosTheta
+        if projectedArea > 0.0:
+            facetForce_P = -pressure * projectedArea * (
+                (1 - srpProps.specularCoeff) * sHat
+                + 2 * (srpProps.diffuseCoeff / 3 + srpProps.specularCoeff * cosTheta) * normal_P)
+            force_P += facetForce_P
+            torque_P += np.cross(srpProps.r_CopP_P, facetForce_P)
 
     return(force_P, torque_P)
 
@@ -1278,6 +1341,33 @@ def setup_translatingBodiesNDOF():
 
     return(translatingBodyEffector, stateEffProps)
 
+def setup_facetSRPDynamicEffector():
+    facetSRP = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    facetSRP.ModelTag = "facetSRPDynamicEffector"
+
+    srpProps = facetSRPProperties()
+    srpProps.area = 10.0  # [m^2]
+    srpProps.diffuseCoeff = 0.2  # [-]
+    srpProps.specularCoeff = 0.6  # [-]
+    srpProps.r_CopP_P = np.array([0.0, 0.0, 0.3])  # [m] both faces share the panel centroid
+    srpProps.normals_P = [np.array([0.0, 0.0, 1.0]), np.array([0.0, 0.0, -1.0])]
+    # a Sun this close lets the parent's meter-scale offset from the hub show in the load
+    srpProps.r_SN_N = np.array([0.0, 1.0e9, 0.0])  # [m]
+
+    # facet geometry is expressed in the parent frame, not the hub body frame
+    facetSRP.setNumFacets(len(srpProps.normals_P))
+    for normal_P in srpProps.normals_P:
+        facetSRP.addFacet(srpProps.area, np.eye(3), normal_P, np.array([1.0, 0.0, 0.0]),
+                          srpProps.r_CopP_P, srpProps.diffuseCoeff, srpProps.specularCoeff)
+
+    sunMsgData = messaging.SpicePlanetStateMsgPayload()
+    sunMsgData.PositionVector = srpProps.r_SN_N
+    sunMsg = messaging.SpicePlanetStateMsg()
+    sunMsg.write(sunMsgData)
+    facetSRP.sunInMsg.subscribeTo(sunMsg)
+
+    return(facetSRP, srpProps)
+
 def setup_linearSpringMassDamper():
     linearSpring = linearSpringMassDamper.LinearSpringMassDamper()
     linearSpring.massInit = 50.0  # [kg]
@@ -1316,6 +1406,15 @@ class facetDragProperties:
     density = 0.0 # atmospheric density held fixed for the test
     r_FP_P = [0.0, 0.0, 0.0] # facet centroid relative to the parent frame origin
     normals_P = [] # outward facet normals
+
+class facetSRPProperties:
+    # facet geometry and optical properties, all expressed in the parent frame
+    area = 0.0 # [m^2] individual facet area
+    diffuseCoeff = 0.0 # individual facet diffuse reflection coefficient
+    specularCoeff = 0.0 # individual facet specular reflection coefficient
+    r_CopP_P = [0.0, 0.0, 0.0] # [m] facet center of pressure relative to the parent frame origin
+    normals_P = [] # outward facet normals
+    r_SN_N = [0.0, 0.0, 0.0] # [m] Sun inertial position held fixed for the test
 
 if __name__ == "__main__":
     effectorBranchingIntegratedTest(True, "hingedRigidBodies", True, "extForceTorque", True)

--- a/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.rst
+++ b/src/simulation/dynamics/constraintEffector/constraintDynamicEffector.rst
@@ -155,3 +155,20 @@ its optional status input and to update its filtered-force and filtered-torque o
 
 When the effector is scheduled, its ``Reset()`` repeats the gain validation and derivation.
 It does not clear the constraint filter history or change the parent attachments.
+
+Attaching to a State Effector
+-----------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`. A constraint needs two
+endpoints, and either or both of them may be a state effector rather than a hub::
+
+    stateEff.addDynamicEffector(constraintEffector, segment)
+    scObject2.addDynamicEffector(constraintEffector)
+
+The endpoint added first becomes body 1 of the constraint and the one added second becomes body 2,
+so ``r_P1B1_B1`` and ``r_P2B2_B2`` are each measured in the frame their own endpoint belongs to, the
+parent segment's frame for a state effector and the hub body frame for a spacecraft. Adding two
+state effectors connects two appendages directly, with no hub as an endpoint. The ``segment``
+argument is omitted for a parent with a single degree of freedom.
+
+Both the parent and the child are still added to the task in the usual way, the same as when the
+child is attached to the hub.

--- a/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.rst
+++ b/src/simulation/dynamics/dualHingedRigidBodies/dualHingedRigidBodyStateEffector.rst
@@ -75,3 +75,19 @@ This section is to outline the steps needed to setup a Hinged Rigid Body State E
 #. Add the module to the task list::
 
     unitTestSim.AddModelToTask(unitTaskName, panel1)
+
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by one of the panels rather than by the hub::
+
+    panel1.addDynamicEffector(childEffector, segment)
+
+Here ``segment`` is the one-based panel number, counting outward from the hub, so ``1`` is the
+panel attached to the hub.
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that panel's frame rather than the hub body frame. Both this effector
+and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/extForceTorque/extForceTorque.rst
+++ b/src/simulation/dynamics/extForceTorque/extForceTorque.rst
@@ -27,3 +27,20 @@ provides information on what this message is used for.
         commanded force input msg in B frame.
     input cmdForceInertialInMsg CmdForceInertialMsgPayload
         commanded force input msg in N frame.
+
+
+Attaching to a State Effector
+-----------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so its load can be
+carried by an appendage instead of the hub. Attach it to the parent state effector rather than
+to the spacecraft::
+
+    stateEff.addDynamicEffector(extFTObject, segment)
+
+This effector reads no kinematics of its own, so the body frame force and torque it is given are
+interpreted in the parent segment's frame and the torque is applied about that segment's frame
+origin. An inertial frame force is unaffected by the choice of parent. The ``segment`` argument is
+omitted for a parent with a single degree of freedom.
+
+Both the parent and the child are still added to the task in the usual way, the same as when the
+child is attached to the hub.

--- a/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.rst
+++ b/src/simulation/dynamics/facetDragEffector/facetDragDynamicEffector.rst
@@ -40,9 +40,7 @@ Attaching to a State Effector
 -----------------------------
 This effector supports the branching described in :ref:`bskPrinciples-11`, so a drag surface can
 be carried by an appendage instead of the hub. Attach it to the parent state effector rather than
-to the spacecraft:
-
-.. code-block:: python
+to the spacecraft::
 
     stateEff.addDynamicEffector(drag, segment)
 
@@ -50,7 +48,11 @@ The parent's inertial attitude and velocity then replace the hub's in the drag c
 panel that rotates or translates relative to the hub sees its own relative wind. Every facet normal
 and facet location passed to ``addFacet()`` is expressed in the parent segment's frame in that
 configuration, not in the hub body frame, and the resulting force and torque are returned about the
-parent frame origin.
+parent frame origin. The ``segment`` argument is omitted for a parent with a single degree of
+freedom.
+
+Both the parent and the child are still added to the task in the usual way, the same as when the
+child is attached to the hub.
 
 Input Message Timing
 ---------------------

--- a/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
@@ -39,7 +39,9 @@ from Basilisk.utilities import RigidBodyKinematics as rbk
 from Basilisk.utilities import orbitalMotion
 from Basilisk.simulation import facetSRPDynamicEffector
 from Basilisk.simulation import spacecraft
+from Basilisk.simulation import spinningBodyOneDOFStateEffector
 from Basilisk.architecture import messaging
+from Basilisk.architecture.bskLogging import BasiliskError
 
 # Vary the articulated facet initial angles and eclipse illumination factor
 @pytest.mark.parametrize("facetRotAngle1", [macros.D2R * -10.4, macros.D2R * 45.2, macros.D2R * 90.0, macros.D2R * 180.0])
@@ -305,6 +307,102 @@ def test_facetSRPDynamicEffector(show_plots, facetRotAngle1, facetRotAngle2, ecl
                                    srpTorque_BTruth[idx],
                                    atol=1e-12,
                                    verbose=True)
+
+@pytest.mark.parametrize("attachToParent", [False, True])
+@pytest.mark.parametrize("scheduleEffector", [True, False])
+@pytest.mark.parametrize("numFacets, numArticulatedFacets, numArticulationMsgs, shouldRaise", [
+    (2, 0, 0, False),
+    (2, 2, 2, False),
+    (3, 0, 0, True),
+    (1, 0, 0, True),
+    (2, 3, 3, True),
+    (2, 2, 1, True),
+])
+def test_facetSRPFacetCountValidation(numFacets, numArticulatedFacets, numArticulationMsgs, shouldRaise,
+                                      scheduleEffector, attachToParent):
+    """
+    Verify that initialization rejects a facet count that does not match the facets added.
+
+    The force loop walks the geometry lists by the declared facet count rather than by their own
+    size, so a count larger than the facets added indexes past the end of every list and a count
+    smaller silently drops the trailing facets. Neither raised, and the resulting load was wrong
+    without any indication. This is asserted as an error at initialization rather than as a
+    tolerance on a load, because the over-declared case is undefined behavior whose observed effect
+    is not stable. Two facets are always added, so the declared count is what varies.
+
+    **Test Parameters:**
+
+    - numFacets: [int]
+        facet count passed to ``setNumFacets``
+    - numArticulatedFacets: [int]
+        articulated facet count passed to ``setNumArticulatedFacets``
+    - numArticulationMsgs: [int]
+        number of articulation messages added by ``addArticulatedFacet``
+    - shouldRaise: [bool]
+        whether initialization must reject the configuration
+    - scheduleEffector: [bool]
+        whether the effector is added to the task in addition to the spacecraft
+    - attachToParent: [bool]
+        whether the effector attaches to a spinning body parent instead of the hub
+
+    The scheduling and attachment parameters matter because the checks must not depend on either.
+    Spacecraft initialization calls ``linkInStates()`` on a dynamic effector attached to the hub, a
+    branching parent calls ``linkInProperties()`` on a child attached to it, and neither calls
+    ``Reset()``, which runs only for a module added to a task.
+    """
+    scObject = spacecraft.Spacecraft()
+    scObject.ModelTag = "spacecraftBody"
+    scObject.hub.mHub = 750.0  # [kg]
+    scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+
+    srpEffector = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+    srpEffector.ModelTag = "srpEffector"
+    srpEffector.setNumFacets(numFacets)
+    srpEffector.setNumArticulatedFacets(numArticulatedFacets)
+
+    sunMsgData = messaging.SpicePlanetStateMsgPayload()
+    sunMsgData.PositionVector = [0.0, 149597870700.0, 0.0]  # [m]
+    srpEffector.sunInMsg.subscribeTo(messaging.SpicePlanetStateMsg().write(sunMsgData))
+
+    angleMsgData = messaging.HingedRigidBodyMsgPayload()
+    angleMsgData.theta = macros.D2R * 10.0  # [rad]
+    angleMsgs = []  # the effector only stores a subscriber, so the messages must outlive this scope
+    for _ in range(numArticulationMsgs):
+        angleMsgs.append(messaging.HingedRigidBodyMsg().write(angleMsgData))
+        srpEffector.addArticulatedFacet(angleMsgs[-1])
+
+    for _ in range(2):
+        srpEffector.addFacet(10.0,  # [m^2]
+                             np.identity(3),
+                             np.array([0.0, 1.0, 0.0]),
+                             np.array([1.0, 0.0, 0.0]),
+                             np.array([0.0, 0.0, 0.3]),  # [m]
+                             0.2,
+                             0.6)
+
+    unitTestSim = SimulationBaseClass.SimBaseClass()
+    unitTestSim.SetProgressBar(False)
+    unitTestSim.CreateNewProcess("TestProcess").addTask(
+        unitTestSim.CreateNewTask("unitTask", macros.sec2nano(0.01)))
+    if attachToParent:
+        parent = spinningBodyOneDOFStateEffector.SpinningBodyOneDOFStateEffector()
+        parent.ModelTag = "parent"
+        parent.sHat_S = [[1.0], [0.0], [0.0]]
+        scObject.addStateEffector(parent)
+        parent.addDynamicEffector(srpEffector)
+        unitTestSim.AddModelToTask("unitTask", parent)
+    else:
+        scObject.addDynamicEffector(srpEffector)
+    if scheduleEffector:
+        unitTestSim.AddModelToTask("unitTask", srpEffector)
+    unitTestSim.AddModelToTask("unitTask", scObject)
+
+    if shouldRaise:
+        with pytest.raises(BasiliskError, match="FacetSRPDynamicEffector"):
+            unitTestSim.InitializeSimulation()
+    else:
+        unitTestSim.InitializeSimulation()
+
 
 def computeFacetSRPForceTorque(index,
                                facetRotAngle1,

--- a/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/_UnitTest/test_unitFacetSRPDynamicEffector.py
@@ -404,6 +404,77 @@ def test_facetSRPFacetCountValidation(numFacets, numArticulatedFacets, numArticu
         unitTestSim.InitializeSimulation()
 
 
+def test_facetSRPPartialArticulationRead():
+    """
+    Verify that a partial articulation message read leaves every facet unarticulated.
+
+    The angle list is indexed by facet, so reading only some of the articulation messages once
+    shortened the list and shifted every remaining angle onto the wrong facet before running off
+    its end. Two articulated facets are declared and only the second message is written, carrying a
+    right angle that would swing whichever facet received it out of the sunlight. The resulting load
+    is compared against an otherwise identical effector that declares no articulation at all, which
+    the two must match because neither facet may articulate on an incomplete read.
+    """
+    def runCase(numArticulatedFacets, writeFirstMessage):
+        scObject = spacecraft.Spacecraft()
+        scObject.ModelTag = "spacecraftBody"
+        scObject.hub.mHub = 750.0  # [kg]
+        scObject.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+        scObject.hub.r_CN_NInit = [[7000.0e3], [0.0], [0.0]]  # [m]
+
+        srpEffector = facetSRPDynamicEffector.FacetSRPDynamicEffector()
+        srpEffector.ModelTag = "srpEffector"
+        srpEffector.setNumFacets(2)
+        srpEffector.setNumArticulatedFacets(numArticulatedFacets)
+
+        sunMsgData = messaging.SpicePlanetStateMsgPayload()
+        sunMsgData.PositionVector = [0.0, 149597870700.0, 0.0]  # [m]
+        srpEffector.sunInMsg.subscribeTo(messaging.SpicePlanetStateMsg().write(sunMsgData))
+
+        angleMsgData = messaging.HingedRigidBodyMsgPayload()
+        angleMsgData.theta = macros.D2R * 90.0  # [rad]
+        angleMsgs = []  # the effector only stores a subscriber, so the messages must outlive this scope
+        for index in range(numArticulatedFacets):
+            msg = messaging.HingedRigidBodyMsg()
+            if index > 0 or writeFirstMessage:
+                msg.write(angleMsgData)
+            angleMsgs.append(msg)
+            srpEffector.addArticulatedFacet(msg)
+
+        for _ in range(2):
+            srpEffector.addFacet(10.0,  # [m^2]
+                                 np.identity(3),
+                                 np.array([0.0, 1.0, 0.0]),
+                                 np.array([1.0, 0.0, 0.0]),
+                                 np.array([0.0, 0.0, 0.3]),  # [m]
+                                 0.2,
+                                 0.6)
+        scObject.addDynamicEffector(srpEffector)
+
+        unitTestSim = SimulationBaseClass.SimBaseClass()
+        unitTestSim.SetProgressBar(False)
+        unitTestSim.CreateNewProcess("TestProcess").addTask(
+            unitTestSim.CreateNewTask("unitTask", macros.sec2nano(0.01)))
+        unitTestSim.AddModelToTask("unitTask", srpEffector)
+        unitTestSim.AddModelToTask("unitTask", scObject)
+        unitTestSim.InitializeSimulation()
+        unitTestSim.ConfigureStopTime(macros.sec2nano(0.02))
+        unitTestSim.ExecuteSimulation()
+        srpEffector.computeForceTorque(0.0, 0.0)  # [s]
+        return np.array(srpEffector.forceExternal_B).flatten()
+
+    partialRead = runCase(2, False)
+    unarticulated = runCase(0, False)
+    fullRead = runCase(2, True)
+
+    accuracy = 1e-16  # [N]
+    assert not np.allclose(fullRead, unarticulated, rtol=0.0, atol=accuracy), (
+        "the articulation angle must change the load, or this test cannot detect a misassignment")
+    np.testing.assert_allclose(
+        partialRead, unarticulated, rtol=0.0, atol=accuracy,
+        err_msg="an incomplete articulation read articulated a facet from another facet's angle")
+
+
 def computeFacetSRPForceTorque(index,
                                facetRotAngle1,
                                facetRotAngle2,

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -31,11 +31,33 @@ const double solarRadFlux = 1368.0;  // [W/m^2] Solar radiation flux at 1 AU
  @param currentSimNanos [ns] Time the method is called
 */
 void FacetSRPDynamicEffector::Reset(uint64_t currentSimNanos [[maybe_unused]]) {
+    this->validateConfiguration();
+
+    // Default to full sunlight if no eclipse message is connected
+    this->sunVisibilityFactor.illuminationFactor = 1.0;
+}
+
+/*! This method runs every configuration check from each initialization path, since Reset() runs
+ only when the effector is also added to a task */
+void FacetSRPDynamicEffector::validateConfiguration() {
     if (!this->sunInMsg.isLinked()) {
         bskLogger.bskError("FacetSRPDynamicEffector.sunInMsg was not linked.");
     }
-    // Default to full sunlight if no eclipse message is connected
-    this->sunVisibilityFactor.illuminationFactor = 1.0;
+
+    // the force loop walks every geometry list by numFacets
+    if (this->numFacets != this->scGeometry.facetAreaList.size()) {
+        bskLogger.bskError("FacetSRPDynamicEffector: the facet count set by setNumFacets does not "
+                           "match the number of facets added by addFacet.");
+    }
+    if (this->numArticulatedFacets > this->numFacets) {
+        bskLogger.bskError("FacetSRPDynamicEffector: more articulated facets are declared than "
+                           "there are facets.");
+    }
+    if (this->articulatedFacetDataInMsgs.size() != this->numArticulatedFacets) {
+        bskLogger.bskError("FacetSRPDynamicEffector: the articulated facet count set by "
+                           "setNumArticulatedFacets does not match the number of articulation "
+                           "messages added by addArticulatedFacet.");
+    }
 }
 
 /*! This method populates the spacecraft facet geometry structure with user-input facet information.
@@ -82,6 +104,7 @@ void FacetSRPDynamicEffector::addArticulatedFacet(Message<HingedRigidBodyMsgPayl
 void FacetSRPDynamicEffector::linkInStates(DynParamManager& states) {
     this->hubSigma = states.getStateObject(this->stateNameOfSigma);
     this->hubPosition = states.getStateObject(this->stateNameOfPosition);
+    this->validateConfiguration();
 }
 
 /*! This method reads the Sun state input message. If time-varying facet articulations are considered,

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -127,21 +127,16 @@ void FacetSRPDynamicEffector::ReadMessages() {
     }
 
     // Read the facet articulation angle data
-    if (this->articulatedFacetDataInMsgs.size() == this->numArticulatedFacets) {
-        HingedRigidBodyMsgPayload facetAngleMsg;
-        this->facetArticulationAngleList.clear();
-        for (uint64_t i = 0; i < this->numArticulatedFacets; i++) {
-            if (this->articulatedFacetDataInMsgs[i].isLinked() && this->articulatedFacetDataInMsgs[i].isWritten()) {
-                    facetAngleMsg = this->articulatedFacetDataInMsgs[i]();
-                    this->facetArticulationAngleList.push_back(facetAngleMsg.theta);
-                    this->facetAngleMsgRead = true;
-                } else {
-                this->facetAngleMsgRead = false;
-            }
+    HingedRigidBodyMsgPayload facetAngleMsg;
+    this->facetArticulationAngleList.clear();
+    for (uint64_t i = 0; i < this->numArticulatedFacets; i++) {
+        if (this->articulatedFacetDataInMsgs[i].isLinked() && this->articulatedFacetDataInMsgs[i].isWritten()) {
+            facetAngleMsg = this->articulatedFacetDataInMsgs[i]();
+            this->facetArticulationAngleList.push_back(facetAngleMsg.theta);
         }
-    } else {
-        bskLogger.bskError("NUMBER OF ARTICULATED FACETS DOES NOT MATCH COUNTED VALUE.");
     }
+    // a partial read would shift the angles off their facets
+    this->facetAngleMsgRead = (this->facetArticulationAngleList.size() == this->numArticulatedFacets);
 }
 
 /*! This method computes the srp force and torque acting about the hub point B in B frame components.

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.cpp
@@ -97,6 +97,11 @@ void FacetSRPDynamicEffector::addArticulatedFacet(Message<HingedRigidBodyMsgPayl
     this->articulatedFacetDataInMsgs.push_back(tmpMsg->addSubscriber());
 }
 
+/*! This is the constructor, marking the effector as attachable to a state effector */
+FacetSRPDynamicEffector::FacetSRPDynamicEffector() {
+    this->isAttachableToStateEffector = true;
+}
+
 /*! This method gives the module access to the hub inertial attitude and position.
 
  @param states Dynamic parameter states
@@ -104,6 +109,16 @@ void FacetSRPDynamicEffector::addArticulatedFacet(Message<HingedRigidBodyMsgPayl
 void FacetSRPDynamicEffector::linkInStates(DynParamManager& states) {
     this->hubSigma = states.getStateObject(this->stateNameOfSigma);
     this->hubPosition = states.getStateObject(this->stateNameOfPosition);
+    this->validateConfiguration();
+}
+
+/*! This method gives the module access to its parent state effector's inertial properties.
+
+ @param properties Dynamic parameter properties
+*/
+void FacetSRPDynamicEffector::linkInProperties(DynParamManager& properties) {
+    this->inertialAttitudeProperty = properties.getPropertyReference(this->propName_inertialAttitude);
+    this->inertialPositionProperty = properties.getPropertyReference(this->propName_inertialPosition);
     this->validateConfiguration();
 }
 
@@ -139,7 +154,7 @@ void FacetSRPDynamicEffector::ReadMessages() {
     this->facetAngleMsgRead = (this->facetArticulationAngleList.size() == this->numArticulatedFacets);
 }
 
-/*! This method computes the srp force and torque acting about the hub point B in B frame components.
+/*! This method computes the srp force and torque acting about point B in B frame components.
 
  @param callTime [s] Time the method is called
  @param timeStep [s] Simulation time step
@@ -148,12 +163,17 @@ void FacetSRPDynamicEffector::computeForceTorque(double callTime [[maybe_unused]
     // Read the input messages
     ReadMessages();
 
-    // Compute dcm_BN
-    Eigen::MRPd sigma_BN(this->hubSigma->getState().data());
+    // the hub state names are assigned only when attached to the hub
+    Eigen::MRPd sigma_BN;
+    Eigen::Vector3d r_BN_N;
+    if (!this->stateNameOfSigma.empty()) {
+        sigma_BN = Eigen::MRPd(this->hubSigma->getState().data());
+        r_BN_N = this->hubPosition->getState();
+    } else {
+        sigma_BN = Eigen::MRPd(this->inertialAttitudeProperty->data());
+        r_BN_N = *this->inertialPositionProperty;
+    }
     Eigen::Matrix3d dcm_BN = sigma_BN.toRotationMatrix().transpose();
-
-    // Grab the current spacecraft inertial position
-    Eigen::Vector3d r_BN_N = this->hubPosition->getState();
 
     // Calculate the Sun unit direction vector relative to point B in B frame components
     Eigen::Vector3d r_SB_B = dcm_BN * (this->r_SN_N - r_BN_N);

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -70,6 +70,8 @@ public:
     ReadFunctor<EclipseMsgPayload> sunEclipseInMsg;                                      //!< (optional) Sun eclipse input message
 
 private:
+    void validateConfiguration();                                                        //!< Method to reject a facet configuration the force loop cannot walk
+
     std::vector<ReadFunctor<HingedRigidBodyMsgPayload>> articulatedFacetDataInMsgs;      //!< Articulated facet angle data input message
     std::vector<double> facetArticulationAngleList;                                      //!< [rad] Vector of facet rotation angles
     std::vector<Eigen::Vector3d> facetNHat_BList;                                        //!< Vector of facet normals expressed in B frame components

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.h
@@ -21,6 +21,7 @@
 #define FACET_SRP_DYNAMIC_EFFECTOR_H
 
 #include <Eigen/Dense>
+#include <cstdint>
 #include <vector>
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
@@ -44,12 +45,18 @@ typedef struct {
     std::vector<double> facetSpecularCoeffList;                       //!< Vector of facet spectral reflection optical coefficients
 }FacetedSRPSpacecraftGeometryData;
 
-/*! @brief Faceted Solar Radiation Pressure Dynamic Effector */
+/*! @brief Faceted Solar Radiation Pressure Dynamic Effector
+
+ The B frame quantities below are expressed in the frame this effector is attached to. That is the
+ hub body frame in the usual case, and the parent segment frame when this effector is attached to
+ a state effector through effector branching.
+*/
 class FacetSRPDynamicEffector final: public SysModel, public DynamicEffector {
 public:
-    FacetSRPDynamicEffector() = default;                                                 //!< Constructor
+    FacetSRPDynamicEffector();                                                           //!< Constructor
     ~FacetSRPDynamicEffector() = default;                                                //!< Destructor
     void linkInStates(DynParamManager& states) override;                                 //!< Method for giving the effector access to the hub states
+    void linkInProperties(DynParamManager& properties) override;                         //!< Method for giving the effector access to its parent state effector's properties
     void computeForceTorque(double callTime, double timeStep) override;                  //!< Method for computing the total SRP force and torque about point B
     void Reset(uint64_t currentSimNanos) override;                                       //!< Reset method
     void setNumFacets(const uint64_t numFacets);                                         //!< Setter method for the total number of spacecraft facets
@@ -80,6 +87,8 @@ private:
     Eigen::Vector3d r_SN_N;                                                              //!< [m] Sun inertial position vector
     StateData *hubPosition = nullptr;                                                    //!< [m] Hub inertial position vector
     StateData *hubSigma = nullptr;                                                       //!< Hub MRP inertial attitude
+    Eigen::MatrixXd *inertialPositionProperty = nullptr;                                 //!< [m] Parent frame inertial position vector
+    Eigen::MatrixXd *inertialAttitudeProperty = nullptr;                                 //!< Parent frame MRP inertial attitude
     bool facetAngleMsgRead = false;                                                      //!< Boolean variable signaling that the facet articulation messages are read
     uint64_t numFacets = 0;                                                              //!< Total number of spacecraft facets
     uint64_t numArticulatedFacets = 0;                                                   //!< Number of articulated facets

--- a/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.rst
+++ b/src/simulation/dynamics/facetSRPDynamicEffector/facetSRPDynamicEffector.rst
@@ -245,3 +245,29 @@ The following steps are required to set up the ``facetSRPDynamicEffector`` modul
 
 .. note::
     See the example script :ref:`scenarioSepMomentumManagement`, which illustrates how to set up a spacecraft with articulated panels for SRP calculation.
+
+
+Attaching to a State Effector
+-----------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so the facets can be
+carried by an appendage instead of the hub. Attach it to the parent state effector rather than to
+the spacecraft::
+
+    stateEff.addDynamicEffector(SRPEffector, segment)
+
+The parent's inertial attitude and position then replace the hub's, and the parent segment's frame
+replaces the hub body frame throughout ``addFacet()``. The facet normal and the center of pressure
+are expressed in that frame, and ``dcm_F0B`` orients the facet frame relative to it. The resulting
+force and torque are returned about the parent frame origin, which the parent carries into the hub
+equations of motion. The ``segment`` argument is omitted for a parent with a single degree of
+freedom.
+
+Attaching to a parent complements ``addArticulatedFacet()`` rather than replacing it. An articulated
+facet rotates its normal through a commanded angle, which is all a single axis solar array drive
+needs, but its center of pressure stays where ``addFacet()`` put it. Attach the effector to a parent
+instead when the facet's position moves relative to the hub, when the panel rides a translating body
+that has no articulation angle to supply, or when the panel sits on a gimbal or an arm that one
+angle about one axis cannot describe.
+
+Both the parent and the child are still added to the task in the usual way, the same as when the
+child is attached to the hub.

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesNDOF/linearTranslationNDOFStateEffector.rst
@@ -142,17 +142,15 @@ This section is to outline the steps needed to setup a Translating Body State Ef
 
 Hosting a Dynamic Effector
 --------------------------
-This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible dynamic
-effector can be carried by one of the translating bodies rather than by the hub::
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by one of the translating bodies rather than by the hub::
 
     translatingBodyEffector.addDynamicEffector(childEffector, segment)
 
-Here ``segment`` is the one-based body number, counting outward from the hub, so ``1`` is the body
-attached to the hub. The child then reads that body's inertial position, velocity, attitude, and
-angular velocity in place of the hub's, and any geometry given to the child is expressed in that
-body's frame rather than the hub body frame.
+Here ``segment`` is the one-based translating body number, counting outward from the hub, so ``1``
+is the translating body attached to the hub.
 
-Both this effector and the child are still added to the task in the usual way::
-
-    scSim.AddModelToTask(taskName, translatingBodyEffector)
-    scSim.AddModelToTask(taskName, childEffector)
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that translating body's frame rather than the hub body frame. Both this
+effector and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.rst
+++ b/src/simulation/dynamics/linearTranslationalBodies/linearTranslationBodiesOneDOF/linearTranslationOneDOFStateEffector.rst
@@ -113,3 +113,16 @@ This section is to outline the steps needed to setup a Translating Body State Ef
 #. Add the module to the task list::
 
     unitTestSim.AddModelToTask(unitTaskName, translatingBody)
+
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by the translating body rather than by the hub::
+
+    translatingBody.addDynamicEffector(childEffector)
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that translating body's frame rather than the hub body frame. Both this
+effector and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
+++ b/src/simulation/dynamics/prescribedMotion/prescribedMotionStateEffector.rst
@@ -61,6 +61,8 @@ motion is provided in the following journal paper
     Leah Kiner, Hanspeter Schaub, and Cody Allard
     Journal of Aerospace Information Systems 2025 22:8, 703-715
 
+.. _prescribedMotionBranching:
+
 Branching Capability
 ^^^^^^^^^^^^^^^^^^^^
 An additional feature of this module is the ability to attach other state effectors to the prescribed motion component.

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.rst
@@ -123,3 +123,18 @@ and reference inputs and to update its output messages through ``UpdateState()``
 When the effector is scheduled, its ``Reset()`` repeats the chain validation.
 ``Reset()`` does not reset the integrated angle or angle-rate states; those states receive their configured
 initial values when they are registered with the spacecraft dynamics.
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by one of the spinning bodies rather than by the hub::
+
+    spinningBodyEffector.addDynamicEffector(childEffector, segment)
+
+Here ``segment`` is the one-based spinning body number, counting outward from the hub, so ``1`` is the
+spinning body attached to the hub.
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that spinning body's frame rather than the hub body frame. Both this
+effector and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
@@ -124,3 +124,15 @@ and reference inputs and to update its output messages through ``UpdateState()``
 When the effector is scheduled, its ``Reset()`` repeats the same validation and
 normalization.  ``Reset()`` does not reset the integrated angle or angle-rate states; those states receive their
 configured initial values when they are registered with the spacecraft dynamics.
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by the spinning body rather than by the hub::
+
+    spinningBody.addDynamicEffector(childEffector)
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that spinning body's frame rather than the hub body frame. Both this
+effector and the child are still added to the task in the usual way.

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.rst
@@ -143,3 +143,18 @@ and reference inputs and to update its output messages through ``UpdateState()``
 When the effector is scheduled, its ``Reset()`` repeats the same validation and
 normalization.  ``Reset()`` does not reset the integrated angles or angle-rate states; those states receive their
 configured initial values when they are registered with the spacecraft dynamics.
+
+Hosting a Dynamic Effector
+--------------------------
+This effector supports the branching described in :ref:`bskPrinciples-11`, so a compatible
+dynamic effector can be carried by one of the spinning bodies rather than by the hub::
+
+    spinningBodyEffector.addDynamicEffector(childEffector, segment)
+
+Here ``segment`` is the one-based spinning body number, counting outward from the hub, so ``1`` is the
+spinning body attached to the hub.
+
+This effector then makes its inertial position, velocity, attitude, and angular velocity available
+in place of the hub's, and the child reads whichever of the four its model needs. Any geometry given
+to the child is expressed in that spinning body's frame rather than the hub body frame. Both this
+effector and the child are still added to the task in the usual way.

--- a/src/utilities/simIncludeThruster.py
+++ b/src/utilities/simIncludeThruster.py
@@ -236,7 +236,7 @@ class thrusterFactory(object):
 
         return
 
-    def addToSpacecraftSubcomponent(self, modelTag, thEffector, baseEffector, segment=0, r_PcP_P=None):
+    def addToSpacecraftSubcomponent(self, modelTag, thEffector, baseEffector, segment=1, r_PcP_P=None):
         """
             This function is for adding a thruster cluster to intermediate bodies
 
@@ -246,9 +246,15 @@ class thrusterFactory(object):
                 module model tag string
             thEffector: thrusterEffector
                 thruster effector handle
-            baseEffector: intermediate body to be attached to, see table for compatibility guide
-            segment: if subcomponent is multi-body, designate which integer segment
-            default segment to base segment
+            baseEffector: stateEffector
+                intermediate body to be attached to, see :ref:`bskPrinciples-11` for the state
+                effectors that can host one
+            segment: int
+                one-based segment of a multi-body base effector, counting outward from the hub and
+                defaulting to the segment attached to the hub
+            r_PcP_P: list
+                [m] parent body center of mass relative to the parent body frame origin, in parent
+                frame components, left unset when the two points coincide
         """
 
         thEffector.ModelTag = modelTag


### PR DESCRIPTION
* **Tickets addressed:** #1533
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
`facetSRPDynamicEffector` attached to the hub only, so its facet geometry was fixed in the hub body frame and its loads were built from the hub attitude and position. `addArticulatedFacet()` rotates a facet normal through a commanded angle but leaves the center of pressure where `addFacet()` put it, so a panel whose position moves relative to the hub, a panel on a translating body, and a panel on a multiple degree of freedom gimbal or arm could not be represented. This work attaches the effector to a branching state effector following the pattern of #1289 for drag: `linkInProperties()` collects the parent's inertial attitude and position, and `computeForceTorque()` selects between those and the hub states on whether the hub state names were assigned. Facet geometry is then expressed in the parent segment's frame, and the load is returned about the parent frame origin.

Two defects in the module surfaced while writing the tests and are fixed first. The force loop walked the geometry lists by the count given to `setNumFacets()` rather than by their own size, so a larger count read past the end of every list and a smaller one silently dropped facets. The articulation angle list was built only from the messages that had been written, so an incomplete read applied one facet's angle to another. The thruster factory's `addToSpacecraftSubcomponent()` also defaulted its segment to 0, which every parent rejects, so the argument was mandatory in practice.

This is the last effector-side branching item planned, so the compatibility table in `bskPrinciples-11` is replaced with lists of supported parents, supported children, and effectors not supported for branching, with the reason each unsupported effector is unsupported, and every branching enabled effector page gains a section on hosting or attaching.

The commits are ordered by concern: the two module fixes, the branching change, the thruster factory default, the integrated test coverage, the SRP module page, the principles page, the per effector pages, and the release notes.

## Verification
Two unit tests are added to `test_unitFacetSRPDynamicEffector.py`. The first asserts that initialization rejects a facet count, an articulated facet count, or an articulation message count that does not match what was added. It runs with and without the effector on a task, and attached either to the hub or to a spinning body parent, since the checks must not depend on `Reset()` or on which of `linkInStates()` and `linkInProperties()` reaches them. The second writes only one of two articulation messages and asserts that the load matches an unarticulated effector, which the old code fails by articulating the first facet from the second facet's angle.

The faceted SRP effector joins `test_effectorBranching_integrated.py` as a child of every parent, with the Sun placed one million kilometers off track in a stand-alone message. At one astronomical unit the parent's meter-scale offset from the hub moves the force by less than the tolerance, whereas a Sun this close moves it well clear of it. The force and torque are recomputed from the parent's attitude and position properties, and the load is asserted to differ from one built with the hub attitude and from one built with the hub position, one at a time, so the case fails if the effector reads either from the hub. The commented entries for effectors that do not branch are dropped, since the principles page now carries that taxonomy.

Locally, the SRP unit suite, the thruster dynamic effector suite, the branching integrated test, and the SEP momentum management scenario pass, and a clean Sphinx build reports no warning on any touched page.

## Documentation
Reviewers should check `bskPrinciples-11.rst`, which replaces the compatibility table, the new section at the end of `facetSRPDynamicEffector.rst`, which states that the parent segment's frame replaces the hub frame throughout `addFacet()` and when to attach rather than articulate, and the hosting and attaching sections added to each branching enabled effector page. The known issues file gains entries for the two module fixes and the thruster factory default, and the release note snippet is `1533-facet-srp-branching.rst`.

## Future work
The last step in this effector branching saga is to push the branch for #1393 that adds scenarios for effector branching. These should be some of the most compelling examples to the community, and also accompanies a journal paper on this added functionality.
