### PR TITLE
Add BSK usage web page

### DIFF
--- a/.github/scripts/collect_usage_metrics.py
+++ b/.github/scripts/collect_usage_metrics.py
@@ -23,11 +23,13 @@ import json
 import math
 import os
 import re
+import sys
 import time
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
+from http.client import HTTPException
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-from urllib.error import HTTPError, URLError
+from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -82,7 +84,9 @@ def _request_text(
             retryable = error.code == 429 or 500 <= error.code < 600
             if not retryable or attempt == REQUEST_ATTEMPTS - 1:
                 raise MetricsError(f"Request to {url} failed: HTTP {error.code}") from error
-        except (TimeoutError, URLError) as error:
+        except (HTTPException, OSError) as error:
+            # Body reads can raise these directly, without urllib wrapping
+            # them in URLError (which, like TimeoutError, is an OSError).
             if attempt == REQUEST_ATTEMPTS - 1:
                 raise MetricsError(f"Request to {url} failed: {error}") from error
 
@@ -103,16 +107,24 @@ def _request_json(url: str, *, token: Optional[str] = None) -> Any:
 
 
 def fetch_pypi_history(package_name: str) -> List[Dict[str, Any]]:
-    """Return daily downloads from ClickPy's copy of the public PyPI data."""
+    """Return daily counts excluding identifiable non-distribution files.
+
+    Older records without filenames are retained. An absent date remains
+    unknown because the source may have an ingestion gap.
+    """
     if not re.fullmatch(r"[A-Za-z0-9._-]+", package_name):
         raise MetricsError(f"Invalid PyPI package name: {package_name}")
 
     mirror_names = ", ".join(f"'{name}'" for name in PYPI_MIRROR_INSTALLERS)
     query = f"""
+        WITH (
+            filename = '' OR endsWith(filename, '.whl')
+            OR endsWith(filename, '.tar.gz') OR endsWith(filename, '.zip')
+        ) AS distribution_or_unknown
         SELECT
             date,
-            countIf(lower(installer) NOT IN ({mirror_names})) AS downloads,
-            countIf(lower(installer) = 'pip') AS pip_downloads
+            countIf(distribution_or_unknown AND lower(installer) NOT IN ({mirror_names})) AS downloads,
+            countIf(distribution_or_unknown AND lower(installer) = 'pip') AS pip_downloads
         FROM pypi.pypi
         WHERE project = {{package:String}}
         GROUP BY date
@@ -134,7 +146,7 @@ def fetch_pypi_history(package_name: str) -> List[Dict[str, Any]]:
             raw_row = json.loads(line)
             rows.append(
                 {
-                    "date": raw_row["date"],
+                    "date": date.fromisoformat(raw_row["date"]).isoformat(),
                     "pypi_downloads": int(raw_row["downloads"]),
                     "pypi_pip_downloads": int(raw_row["pip_downloads"]),
                 }
@@ -158,6 +170,8 @@ def fetch_github_metrics(repository: str, token: str) -> Dict[str, Any]:
     """Return current repository, clone, and release-asset metrics."""
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
         raise MetricsError(f"Invalid GitHub repository: {repository}")
+    if not token:
+        raise MetricsError("A GitHub token with repository Administration read permission is required")
 
     repository_data = _request_json(f"{GITHUB_API_URL}/repos/{repository}", token=token)
     clone_data = _request_json(
@@ -232,7 +246,7 @@ def load_history(path: Path) -> List[Dict[str, Any]]:
 def merge_history(
     existing_rows: Iterable[Dict[str, Any]],
     pypi_rows: Iterable[Dict[str, Any]],
-    github_metrics: Dict[str, Any],
+    github_metrics: Optional[Dict[str, Any]],
     snapshot_date: str,
 ) -> List[Dict[str, Any]]:
     """Merge overlapping source windows into one row per UTC date."""
@@ -246,16 +260,22 @@ def merge_history(
         row["pypi_downloads"] = source_row["pypi_downloads"]
         row["pypi_pip_downloads"] = source_row["pypi_pip_downloads"]
 
-    for source_row in github_metrics["clones"]:
-        row = rows_by_date.setdefault(source_row["date"], _empty_history_row(source_row["date"]))
-        row["github_clones"] = source_row["github_clones"]
-        row["github_unique_cloners"] = source_row["github_unique_cloners"]
+    if github_metrics is not None:
+        for source_row in github_metrics["clones"]:
+            row = rows_by_date.setdefault(source_row["date"], _empty_history_row(source_row["date"]))
+            row["github_clones"] = source_row["github_clones"]
+            row["github_unique_cloners"] = source_row["github_unique_cloners"]
 
-    snapshot_row = rows_by_date.setdefault(snapshot_date, _empty_history_row(snapshot_date))
-    snapshot_row["github_forks"] = github_metrics["forks"]
-    snapshot_row["github_release_asset_downloads"] = github_metrics[
-        "release_asset_downloads"
-    ]
+        snapshot_row = rows_by_date.setdefault(snapshot_date, _empty_history_row(snapshot_date))
+        snapshot_row["github_forks"] = github_metrics["forks"]
+        snapshot_row["github_release_asset_downloads"] = github_metrics["release_asset_downloads"]
+
+    if rows_by_date:
+        first_day = date.fromisoformat(min(rows_by_date))
+        last_day = date.fromisoformat(max(rows_by_date))
+        for offset in range((last_day - first_day).days + 1):
+            day = (first_day + timedelta(days=offset)).isoformat()
+            rows_by_date.setdefault(day, _empty_history_row(day))
     return [rows_by_date[date] for date in sorted(rows_by_date)]
 
 
@@ -285,36 +305,59 @@ def build_summary(
     rows: List[Dict[str, Any]],
     package_name: str,
     repository: str,
-    github_metrics: Dict[str, Any],
+    github_metrics: Optional[Dict[str, Any]],
     generated_at: str,
+    sources: Optional[Dict[str, Any]] = None,
+    previous_summary: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the machine-readable current summary."""
     clone_coverage = _coverage(rows, "github_clones")
     pypi_coverage = _coverage(rows, "pypi_downloads")
-    clone_dates = [item["date"] for item in github_metrics["clones"]]
+    previous_github = (previous_summary or {}).get("github", {})
+    clone_window = previous_github.get("current_clone_window", {
+        "start": None, "end": None, "clones": None, "unique_cloners": None,
+    })
+    if github_metrics is not None:
+        clone_dates = [item["date"] for item in github_metrics["clones"]]
+        clone_window = {
+            "start": min(clone_dates) if clone_dates else None,
+            "end": max(clone_dates) if clone_dates else None,
+            "clones": github_metrics["clone_window_count"],
+            "unique_cloners": github_metrics["clone_window_unique_cloners"],
+        }
+
+    def latest_value(field: str) -> Optional[int]:
+        return next((row[field] for row in reversed(rows) if row.get(field) is not None), None)
+
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": generated_at,
+        "collection_status": "partial" if any(
+            source["status"] == "error" for source in (sources or {}).values()
+        ) else "complete",
+        "sources": sources or {},
         "pypi": {
             "package": package_name,
+            "counting_policy": (
+                (previous_summary or {}).get("pypi", {}).get("counting_policy", "legacy_unfiltered")
+                if (sources or {}).get("pypi", {}).get("status") == "error"
+                else "distribution_files_or_unknown_filename"
+            ),
             "coverage": pypi_coverage,
             "downloads_excluding_known_mirrors": sum(
                 row["pypi_downloads"] or 0 for row in rows
-            ),
-            "pip_downloads": sum(row["pypi_pip_downloads"] or 0 for row in rows),
+            ) if pypi_coverage["start"] is not None else None,
+            "pip_downloads": sum(row["pypi_pip_downloads"] or 0 for row in rows)
+            if pypi_coverage["start"] is not None else None,
         },
         "github": {
             "repository": repository,
             "tracked_clone_coverage": clone_coverage,
-            "tracked_clones": sum(row["github_clones"] or 0 for row in rows),
-            "current_clone_window": {
-                "start": min(clone_dates) if clone_dates else None,
-                "end": max(clone_dates) if clone_dates else None,
-                "clones": github_metrics["clone_window_count"],
-                "unique_cloners": github_metrics["clone_window_unique_cloners"],
-            },
-            "forks": github_metrics["forks"],
-            "release_asset_downloads": github_metrics["release_asset_downloads"],
+            "tracked_clones": sum(row["github_clones"] or 0 for row in rows)
+            if clone_coverage["start"] is not None else None,
+            "current_clone_window": clone_window,
+            "forks": latest_value("github_forks"),
+            "release_asset_downloads": latest_value("github_release_asset_downloads"),
         },
     }
 
@@ -323,26 +366,26 @@ def _rolling_series(
     rows: List[Dict[str, Any]],
     field: str,
 ) -> List[Tuple[int, float]]:
-    """Return a trailing daily mean for one metric."""
+    """Return means only for seven consecutive observed days, including zeros."""
     window: List[Tuple[date, int]] = []
     points = []
     for row in rows:
         value = row.get(field)
         if value is None:
+            window = []
             continue
         current_date = date.fromisoformat(row["date"])
-        window = [
-            item
-            for item in window
-            if (current_date - item[0]).days < ROLLING_WINDOW_DAYS
-        ]
+        if window and (current_date - window[-1][0]).days != CONTIGUOUS_DAY_STEP:
+            window = []
         window.append((current_date, value))
-        points.append(
-            (
-                current_date.toordinal(),
-                sum(item[1] for item in window)/len(window),
+        window = window[-ROLLING_WINDOW_DAYS:]
+        if len(window) == ROLLING_WINDOW_DAYS:
+            points.append(
+                (
+                    current_date.toordinal(),
+                    sum(item[1] for item in window) / ROLLING_WINDOW_DAYS,
+                )
             )
-        )
     return points
 
 
@@ -377,6 +420,8 @@ def _series_path(
         if previous_day is None or day - previous_day > CONTIGUOUS_DAY_STEP:
             command = "M"
         commands.append(f"{command}{x_position:.1f},{y_position:.1f}")
+        if command == "M":
+            commands.append("l0,0")
         previous_day = day
     return " ".join(commands)
 
@@ -404,7 +449,7 @@ def _render_chart_panel(
             (
                 f'<text class="axis-text" x="{plot_left + plot_width/2}" '
                 f'y="{plot_top + plot_height/2}" text-anchor="middle">'
-                "No data collected yet</text>"
+                "No complete seven-day window available</text>"
             ),
         ]
 
@@ -507,18 +552,23 @@ def _render_chart_panel(
     return elements
 
 
-def render_usage_svg(rows: List[Dict[str, Any]], generated_at: str) -> str:
+def render_usage_svg(
+    rows: List[Dict[str, Any]],
+    generated_at: str,
+    sources: Optional[Dict[str, Any]] = None,
+) -> str:
     """Render the retained usage history as a self-contained SVG chart."""
     elements = [
         '<?xml version="1.0" encoding="UTF-8"?>',
         (
-            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" '
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 760" '
             'role="img" aria-labelledby="chart-title chart-description">'
         ),
         '<title id="chart-title">Basilisk package and repository usage</title>',
         (
             '<desc id="chart-description">Seven-day trailing means of daily PyPI '
-            'downloads and GitHub clone activity.</desc>'
+            'downloads and GitHub clone activity. Only complete windows of seven '
+            'observed days are shown.</desc>'
         ),
         """<style>
             .background { fill: #ffffff; }
@@ -560,7 +610,7 @@ def render_usage_svg(rows: List[Dict[str, Any]], generated_at: str) -> str:
                 .github-unique { stroke: #bc8cff; }
             }
         </style>""",
-        '<rect class="background" width="1000" height="700" />',
+        '<rect class="background" width="1000" height="760" />',
         '<text id="chart-title-text" class="chart-title" x="30" y="34">Basilisk usage</text>',
         (
             '<text class="chart-title chart-subtitle" x="970" y="32" '
@@ -574,7 +624,7 @@ def render_usage_svg(rows: List[Dict[str, Any]], generated_at: str) -> str:
                 ("pypi_downloads", "Non-mirror", "pypi-downloads"),
                 ("pypi_pip_downloads", "pip", "pip-downloads"),
             ],
-            "Daily PyPI artifact downloads — 7-day trailing mean",
+            "Daily PyPI download events — 7-day trailing mean",
             "Downloads/day",
             90.0,
         )
@@ -591,7 +641,19 @@ def render_usage_svg(rows: List[Dict[str, Any]], generated_at: str) -> str:
             425.0,
         )
     )
-    elements.append("</svg>")
+    elements.append(
+        '<text class="axis-text" x="30" y="723">'
+        'PyPI: known non-distribution files excluded after a successful refresh; '
+        'older unnamed files remain.</text>'
+    )
+    freshness = "; ".join(
+        f"{name}: {source['status']}; last success {source['last_success_at'] or 'never'}"
+        for name, source in (sources or {}).items()
+    )
+    elements.extend([
+        f'<text class="axis-text" x="30" y="745">{html.escape(freshness)}</text>',
+        "</svg>",
+    ])
     return "\n".join(elements) + "\n"
 
 
@@ -606,34 +668,52 @@ def render_readme(summary: Dict[str, Any]) -> str:
         f"{github['tracked_clone_coverage']['end']}"
     )
     clone_window_coverage = f"{clone_window['start']} through {clone_window['end']}"
+
+    def count(value: Optional[int]) -> str:
+        return f"{value:,}" if value is not None else "unavailable"
+
     lines = [
         "# Basilisk usage metrics",
         "",
         f"Updated {summary['generated_at']}.",
+        f"Collection status: **{summary['collection_status']}**.",
+        "",
+        "| Source | Status | Last successful collection (UTC) | Latest error |",
+        "|---|---|---|---|",
+    ]
+    for name, source in summary["sources"].items():
+        error = (source["error"] or "none").replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| {name} | {source['status']} | {source['last_success_at'] or 'never'} | {error} |"
+        )
+    lines.extend([
+        "",
+        "Failed sources retain their previous observations; they are not new daily snapshots.",
+        "Collection time does not guarantee that the upstream dataset is current; see coverage dates.",
         "",
         "| Metric | Count | Coverage |",
         "|---|---:|---|",
         (
             "| PyPI downloads excluding known mirrors | "
-            f"{pypi['downloads_excluding_known_mirrors']:,} | {pypi_coverage} |"
+            f"{count(pypi['downloads_excluding_known_mirrors'])} | {pypi_coverage} |"
         ),
-        f"| PyPI downloads made by `pip` | {pypi['pip_downloads']:,} | {pypi_coverage} |",
+        f"| PyPI downloads made by `pip` | {count(pypi['pip_downloads'])} | {pypi_coverage} |",
         (
             "| GitHub clone events retained by this tracker | "
-            f"{github['tracked_clones']:,} | {tracked_clone_coverage} |"
+            f"{count(github['tracked_clones'])} | {tracked_clone_coverage} |"
         ),
         (
-            "| GitHub clones in the current API window | "
-            f"{clone_window['clones']:,} | {clone_window_coverage} |"
+            "| GitHub clones in the last successful API window | "
+            f"{count(clone_window['clones'])} | {clone_window_coverage} |"
         ),
         (
-            "| Unique GitHub cloners in the current API window | "
-            f"{clone_window['unique_cloners']:,} | {clone_window_coverage} |"
+            "| Unique GitHub cloners in the last successful API window | "
+            f"{count(clone_window['unique_cloners'])} | {clone_window_coverage} |"
         ),
-        f"| Current GitHub forks | {github['forks']:,} | snapshot |",
+        f"| Last observed GitHub forks | {count(github['forks'])} | snapshot |",
         (
             "| GitHub release-asset downloads | "
-            f"{github['release_asset_downloads']:,} | cumulative snapshot |"
+            f"{count(github['release_asset_downloads'])} | cumulative snapshot |"
         ),
         "",
         "![Daily Basilisk PyPI download and GitHub clone activity](usage.svg)",
@@ -647,6 +727,13 @@ def render_readme(summary: Dict[str, Any]) -> str:
         "  The `pip` count selects records whose installer is identified as `pip`.",
         "- The non-mirror count excludes `bandersnatch`, `z3c.pypimirror`, `Artifactory`,",
         "  and `devpi`, matching the known-mirror list documented by PyPI Stats.",
+        "- Counts exclude identified non-distribution files, including `.metadata` sidecars.",
+        "  Older records without filenames remain and may include metadata requests.",
+        "  PyPI changed its logging on 2026-08-24; historical counts are not fully comparable.",
+        f"  Retained PyPI counting policy: `{pypi['counting_policy']}`.",
+        "  A successful PyPI refresh applies the revised filter to returned historical dates.",
+        "- Plots require seven consecutive observed days. Explicit zeros count; absent dates",
+        "  remain unknown and break the plotted series. The latest reported day may be partial.",
         "- GitHub exposes clone traffic for only the latest 14 days. The tracker preserves",
         "  those daily counts; gaps longer than 14 days cannot be recovered.",
         "- Daily unique-cloner values cannot be summed into an all-time unique-user count.",
@@ -657,7 +744,7 @@ def render_readme(summary: Dict[str, Any]) -> str:
         "The data comes from the public PyPI dataset through",
         "[ClickPy](https://clickpy.clickhouse.com/) and from the",
         "[GitHub REST API](https://docs.github.com/en/rest/metrics/traffic).",
-    ]
+    ])
     return "\n".join(lines) + "\n"
 
 
@@ -671,9 +758,50 @@ def collect_metrics(
     output_directory.mkdir(parents=True, exist_ok=True)
     history_path = output_directory / "metrics.csv"
     existing_rows = load_history(history_path)
-    pypi_rows = fetch_pypi_history(package_name)
-    github_metrics = fetch_github_metrics(repository, github_token)
+    summary_path = output_directory / "summary.json"
+    previous_summary = {}
+    if summary_path.exists():
+        try:
+            previous_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            if not isinstance(previous_summary, dict) or previous_summary.get("schema_version") not in (1, 2):
+                raise ValueError("Unknown summary schema")
+            for name in ("pypi", "github"):
+                if not isinstance(previous_summary.get(name), dict):
+                    raise ValueError(f"Missing {name} summary")
+            if previous_summary["pypi"].get("package") != package_name or previous_summary["github"].get(
+                "repository"
+            ) != repository:
+                raise ValueError("History belongs to a different package or repository")
+        except (ValueError, TypeError) as error:
+            raise MetricsError(f"Invalid previous summary in {summary_path}: {error}") from error
+
+    errors = {}
+    github_metrics = None
+    pypi_rows = []
+    try:
+        github_metrics = fetch_github_metrics(repository, github_token)
+    except MetricsError as error:
+        errors["github"] = str(error)
+    try:
+        pypi_rows = fetch_pypi_history(package_name)
+    except MetricsError as error:
+        errors["pypi"] = str(error)
+    if len(errors) == 2:
+        raise MetricsError("No sources collected: " + "; ".join(f"{name}: {error}" for name, error in errors.items()))
+
     generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    sources = {}
+    for name in ("pypi", "github"):
+        previous_source = previous_summary.get("sources", {}).get(name, {})
+        last_success = previous_source.get("last_success_at")
+        if previous_summary.get("schema_version") == 1:
+            last_success = previous_summary.get("generated_at")
+        sources[name] = {
+            "status": "error" if name in errors else "ok",
+            "last_attempt_at": generated_at,
+            "last_success_at": last_success if name in errors else generated_at,
+            "error": errors.get(name),
+        }
     snapshot_date = generated_at[:10]
     rows = merge_history(existing_rows, pypi_rows, github_metrics, snapshot_date)
     summary = build_summary(
@@ -682,10 +810,12 @@ def collect_metrics(
         repository,
         github_metrics,
         generated_at,
+        sources,
+        previous_summary,
     )
 
     write_history(history_path, rows)
-    (output_directory / "summary.json").write_text(
+    summary_path.write_text(
         json.dumps(summary, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
@@ -694,7 +824,7 @@ def collect_metrics(
         encoding="utf-8",
     )
     (output_directory / "usage.svg").write_text(
-        render_usage_svg(rows, generated_at),
+        render_usage_svg(rows, generated_at, sources),
         encoding="utf-8",
     )
     return summary
@@ -708,12 +838,7 @@ def main() -> None:
     parser.add_argument("--github-token-env", default="BSK_TRAFFIC_TOKEN")
     args = parser.parse_args()
 
-    github_token = os.environ.get(args.github_token_env)
-    if not github_token:
-        raise SystemExit(
-            f"Environment variable {args.github_token_env} must contain a GitHub "
-            "token with repository Administration read permission"
-        )
+    github_token = os.environ.get(args.github_token_env, "")
 
     try:
         summary = collect_metrics(
@@ -726,6 +851,8 @@ def main() -> None:
         raise SystemExit(str(error)) from error
 
     print(json.dumps(summary, indent=2, sort_keys=True))
+    if summary["collection_status"] == "partial":
+        print("Wrote artifacts with partial source data; inspect summary.json for errors.", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/collect_usage_metrics.py
+++ b/.github/scripts/collect_usage_metrics.py
@@ -1,0 +1,732 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""Collect durable PyPI and GitHub usage metrics for Basilisk."""
+
+import argparse
+import csv
+import html
+import json
+import math
+import os
+import re
+import time
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+CLICKPY_URL = "https://sql-clickhouse.clickhouse.com/"
+GITHUB_API_URL = "https://api.github.com"
+REQUEST_TIMEOUT_SECONDS = 120  # [s]
+RETRY_DELAY_SECONDS = 5  # [s]
+REQUEST_ATTEMPTS = 3
+ROLLING_WINDOW_DAYS = 7  # [day]
+CONTIGUOUS_DAY_STEP = 1  # [day]
+CSV_FIELDS = (
+    "date",
+    "pypi_downloads",
+    "pypi_pip_downloads",
+    "github_clones",
+    "github_unique_cloners",
+    "github_forks",
+    "github_release_asset_downloads",
+)
+PYPI_MIRROR_INSTALLERS = (
+    "bandersnatch",
+    "z3c.pypimirror",
+    "artifactory",
+    "devpi",
+)
+
+
+class MetricsError(RuntimeError):
+    """Report a failure to retrieve or validate usage metrics."""
+
+
+def _request_text(
+    url: str,
+    *,
+    data: Optional[bytes] = None,
+    headers: Optional[Dict[str, str]] = None,
+) -> str:
+    request_headers = {
+        "Accept": "application/json",
+        "User-Agent": "basilisk-usage-metrics/1",
+    }
+    if headers:
+        request_headers.update(headers)
+
+    for attempt in range(REQUEST_ATTEMPTS):
+        request = Request(url, data=data, headers=request_headers)
+        try:
+            with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+                return response.read().decode("utf-8")
+        except HTTPError as error:
+            retryable = error.code == 429 or 500 <= error.code < 600
+            if not retryable or attempt == REQUEST_ATTEMPTS - 1:
+                raise MetricsError(f"Request to {url} failed: HTTP {error.code}") from error
+        except (TimeoutError, URLError) as error:
+            if attempt == REQUEST_ATTEMPTS - 1:
+                raise MetricsError(f"Request to {url} failed: {error}") from error
+
+        time.sleep(RETRY_DELAY_SECONDS*(attempt+1))
+
+    raise MetricsError(f"Request to {url} failed")
+
+
+def _request_json(url: str, *, token: Optional[str] = None) -> Any:
+    headers = {"X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = _request_text(url, headers=headers)
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError as error:
+        raise MetricsError(f"Request to {url} returned invalid JSON") from error
+
+
+def fetch_pypi_history(package_name: str) -> List[Dict[str, Any]]:
+    """Return daily downloads from ClickPy's copy of the public PyPI data."""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", package_name):
+        raise MetricsError(f"Invalid PyPI package name: {package_name}")
+
+    mirror_names = ", ".join(f"'{name}'" for name in PYPI_MIRROR_INSTALLERS)
+    query = f"""
+        SELECT
+            date,
+            countIf(lower(installer) NOT IN ({mirror_names})) AS downloads,
+            countIf(lower(installer) = 'pip') AS pip_downloads
+        FROM pypi.pypi
+        WHERE project = {{package:String}}
+        GROUP BY date
+        ORDER BY date
+        FORMAT JSONEachRow
+    """
+    query_parameters = urlencode({"user": "demo", "param_package": package_name})
+    response = _request_text(
+        f"{CLICKPY_URL}?{query_parameters}",
+        data=query.encode("utf-8"),
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+    )
+
+    rows = []
+    try:
+        for line in response.splitlines():
+            if not line.strip():
+                continue
+            raw_row = json.loads(line)
+            rows.append(
+                {
+                    "date": raw_row["date"],
+                    "pypi_downloads": int(raw_row["downloads"]),
+                    "pypi_pip_downloads": int(raw_row["pip_downloads"]),
+                }
+            )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise MetricsError("ClickPy returned an unexpected response") from error
+
+    if not rows:
+        raise MetricsError(f"ClickPy returned no data for {package_name}")
+    return rows
+
+
+def _github_url(repository: str, endpoint: str, **query: Any) -> str:
+    url = f"{GITHUB_API_URL}/repos/{repository}/{endpoint}"
+    if query:
+        url = f"{url}?{urlencode(query)}"
+    return url
+
+
+def fetch_github_metrics(repository: str, token: str) -> Dict[str, Any]:
+    """Return current repository, clone, and release-asset metrics."""
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise MetricsError(f"Invalid GitHub repository: {repository}")
+
+    repository_data = _request_json(f"{GITHUB_API_URL}/repos/{repository}", token=token)
+    clone_data = _request_json(
+        _github_url(repository, "traffic/clones", per="day"),
+        token=token,
+    )
+
+    release_asset_downloads = 0
+    page = 1
+    while True:
+        releases = _request_json(
+            _github_url(repository, "releases", per_page=100, page=page),
+            token=token,
+        )
+        if not isinstance(releases, list):
+            raise MetricsError("GitHub returned an unexpected releases response")
+        try:
+            for release in releases:
+                for asset in release.get("assets", []):
+                    release_asset_downloads += int(asset["download_count"])
+        except (AttributeError, KeyError, TypeError, ValueError) as error:
+            raise MetricsError("GitHub returned an unexpected release asset") from error
+        if len(releases) < 100:
+            break
+        page += 1
+
+    try:
+        clones = [
+            {
+                "date": item["timestamp"][:10],
+                "github_clones": int(item["count"]),
+                "github_unique_cloners": int(item["uniques"]),
+            }
+            for item in clone_data["clones"]
+        ]
+        return {
+            "clones": clones,
+            "clone_window_count": int(clone_data["count"]),
+            "clone_window_unique_cloners": int(clone_data["uniques"]),
+            "forks": int(repository_data["forks_count"]),
+            "release_asset_downloads": release_asset_downloads,
+        }
+    except (KeyError, TypeError, ValueError) as error:
+        raise MetricsError("GitHub returned an unexpected metrics response") from error
+
+
+def _empty_history_row(date: str) -> Dict[str, Any]:
+    row = {field: None for field in CSV_FIELDS}
+    row["date"] = date
+    return row
+
+
+def load_history(path: Path) -> List[Dict[str, Any]]:
+    """Load the previously collected CSV history, if present."""
+    if not path.exists():
+        return []
+
+    rows = []
+    with path.open(newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        if tuple(reader.fieldnames or ()) != CSV_FIELDS:
+            raise MetricsError(f"Unexpected columns in {path}")
+        for raw_row in reader:
+            row = _empty_history_row(raw_row["date"])
+            for field in CSV_FIELDS[1:]:
+                value = raw_row[field]
+                row[field] = int(value) if value else None
+            rows.append(row)
+    return rows
+
+
+def merge_history(
+    existing_rows: Iterable[Dict[str, Any]],
+    pypi_rows: Iterable[Dict[str, Any]],
+    github_metrics: Dict[str, Any],
+    snapshot_date: str,
+) -> List[Dict[str, Any]]:
+    """Merge overlapping source windows into one row per UTC date."""
+    rows_by_date = {
+        row["date"]: _empty_history_row(row["date"]) | dict(row)
+        for row in existing_rows
+    }
+
+    for source_row in pypi_rows:
+        row = rows_by_date.setdefault(source_row["date"], _empty_history_row(source_row["date"]))
+        row["pypi_downloads"] = source_row["pypi_downloads"]
+        row["pypi_pip_downloads"] = source_row["pypi_pip_downloads"]
+
+    for source_row in github_metrics["clones"]:
+        row = rows_by_date.setdefault(source_row["date"], _empty_history_row(source_row["date"]))
+        row["github_clones"] = source_row["github_clones"]
+        row["github_unique_cloners"] = source_row["github_unique_cloners"]
+
+    snapshot_row = rows_by_date.setdefault(snapshot_date, _empty_history_row(snapshot_date))
+    snapshot_row["github_forks"] = github_metrics["forks"]
+    snapshot_row["github_release_asset_downloads"] = github_metrics[
+        "release_asset_downloads"
+    ]
+    return [rows_by_date[date] for date in sorted(rows_by_date)]
+
+
+def write_history(path: Path, rows: Iterable[Dict[str, Any]]) -> None:
+    """Write history in a stable CSV format."""
+    with path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=CSV_FIELDS, lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    field: "" if row.get(field) is None else row[field]
+                    for field in CSV_FIELDS
+                }
+            )
+
+
+def _coverage(rows: List[Dict[str, Any]], field: str) -> Dict[str, Optional[str]]:
+    dates = [row["date"] for row in rows if row.get(field) is not None]
+    return {
+        "start": min(dates) if dates else None,
+        "end": max(dates) if dates else None,
+    }
+
+
+def build_summary(
+    rows: List[Dict[str, Any]],
+    package_name: str,
+    repository: str,
+    github_metrics: Dict[str, Any],
+    generated_at: str,
+) -> Dict[str, Any]:
+    """Build the machine-readable current summary."""
+    clone_coverage = _coverage(rows, "github_clones")
+    pypi_coverage = _coverage(rows, "pypi_downloads")
+    clone_dates = [item["date"] for item in github_metrics["clones"]]
+    return {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "pypi": {
+            "package": package_name,
+            "coverage": pypi_coverage,
+            "downloads_excluding_known_mirrors": sum(
+                row["pypi_downloads"] or 0 for row in rows
+            ),
+            "pip_downloads": sum(row["pypi_pip_downloads"] or 0 for row in rows),
+        },
+        "github": {
+            "repository": repository,
+            "tracked_clone_coverage": clone_coverage,
+            "tracked_clones": sum(row["github_clones"] or 0 for row in rows),
+            "current_clone_window": {
+                "start": min(clone_dates) if clone_dates else None,
+                "end": max(clone_dates) if clone_dates else None,
+                "clones": github_metrics["clone_window_count"],
+                "unique_cloners": github_metrics["clone_window_unique_cloners"],
+            },
+            "forks": github_metrics["forks"],
+            "release_asset_downloads": github_metrics["release_asset_downloads"],
+        },
+    }
+
+
+def _rolling_series(
+    rows: List[Dict[str, Any]],
+    field: str,
+) -> List[Tuple[int, float]]:
+    """Return a trailing daily mean for one metric."""
+    window: List[Tuple[date, int]] = []
+    points = []
+    for row in rows:
+        value = row.get(field)
+        if value is None:
+            continue
+        current_date = date.fromisoformat(row["date"])
+        window = [
+            item
+            for item in window
+            if (current_date - item[0]).days < ROLLING_WINDOW_DAYS
+        ]
+        window.append((current_date, value))
+        points.append(
+            (
+                current_date.toordinal(),
+                sum(item[1] for item in window)/len(window),
+            )
+        )
+    return points
+
+
+def _nice_ceiling(maximum: float) -> float:
+    """Round a positive chart maximum to a readable upper bound."""
+    if maximum <= 0:
+        return 1.0
+    magnitude = 10**math.floor(math.log10(maximum))
+    normalized = maximum/magnitude
+    for multiplier in (1, 2, 5, 10):
+        if normalized <= multiplier:
+            return multiplier*magnitude
+    return 10*magnitude
+
+
+def _series_path(
+    points: List[Tuple[int, float]],
+    x_minimum: int,
+    x_maximum: int,
+    y_maximum: float,
+    plot_bounds: Tuple[float, float, float, float],
+) -> str:
+    """Convert dated values to an SVG path while retaining data gaps."""
+    left, top, width, height = plot_bounds
+    x_span = max(x_maximum - x_minimum, 1)
+    commands = []
+    previous_day = None
+    for day, value in points:
+        x_position = left + width*(day - x_minimum)/x_span
+        y_position = top + height*(1 - value/y_maximum)
+        command = "L"
+        if previous_day is None or day - previous_day > CONTIGUOUS_DAY_STEP:
+            command = "M"
+        commands.append(f"{command}{x_position:.1f},{y_position:.1f}")
+        previous_day = day
+    return " ".join(commands)
+
+
+def _render_chart_panel(
+    rows: List[Dict[str, Any]],
+    series: List[Tuple[str, str, str]],
+    title: str,
+    y_axis_title: str,
+    plot_top: float,
+) -> List[str]:
+    """Render one Cartesian SVG panel."""
+    plot_left = 90.0
+    plot_width = 875.0
+    plot_height = 225.0
+    plot_bounds = (plot_left, plot_top, plot_width, plot_height)
+    series_points = {
+        field: _rolling_series(rows, field)
+        for field, _, _ in series
+    }
+    all_points = [point for points in series_points.values() for point in points]
+    if not all_points:
+        return [
+            f'<text class="panel-title" x="{plot_left}" y="{plot_top - 24}">{title}</text>',
+            (
+                f'<text class="axis-text" x="{plot_left + plot_width/2}" '
+                f'y="{plot_top + plot_height/2}" text-anchor="middle">'
+                "No data collected yet</text>"
+            ),
+        ]
+
+    x_minimum = min(point[0] for point in all_points)
+    x_maximum = max(point[0] for point in all_points)
+    y_maximum = _nice_ceiling(max(point[1] for point in all_points))
+    elements = [
+        f'<text class="panel-title" x="{plot_left}" y="{plot_top - 24}">{title}</text>',
+        (
+            f'<rect class="chart-frame" x="{plot_left}" y="{plot_top}" '
+            f'width="{plot_width}" height="{plot_height}" />'
+        ),
+    ]
+
+    tick_count = 4
+    for tick_index in range(tick_count + 1):
+        tick_value = y_maximum*tick_index/tick_count
+        y_position = plot_top + plot_height*(1 - tick_index/tick_count)
+        elements.extend(
+            [
+                (
+                    f'<line class="grid-line" x1="{plot_left}" y1="{y_position:.1f}" '
+                    f'x2="{plot_left + plot_width}" y2="{y_position:.1f}" />'
+                ),
+                (
+                    f'<text class="axis-text" x="{plot_left - 10}" y="{y_position + 4:.1f}" '
+                    f'text-anchor="end">{tick_value:,.0f}</text>'
+                ),
+            ]
+        )
+
+    x_tick_count = 5
+    x_span = max(x_maximum - x_minimum, 1)
+    x_tick_days = sorted(
+        {
+            round(x_minimum + x_span*tick_index/(x_tick_count - 1))
+            for tick_index in range(x_tick_count)
+        }
+    )
+    for tick_day in x_tick_days:
+        x_position = plot_left + plot_width*(tick_day - x_minimum)/x_span
+        tick_label = date.fromordinal(tick_day).isoformat()
+        elements.extend(
+            [
+                (
+                    f'<line class="axis-tick" x1="{x_position:.1f}" '
+                    f'y1="{plot_top + plot_height}" x2="{x_position:.1f}" '
+                    f'y2="{plot_top + plot_height + 6}" />'
+                ),
+                (
+                    f'<text class="axis-text" x="{x_position:.1f}" '
+                    f'y="{plot_top + plot_height + 23}" '
+                    f'text-anchor="middle">{tick_label}</text>'
+                ),
+            ]
+        )
+
+    elements.extend(
+        [
+            (
+                f'<text class="axis-title" x="{plot_left + plot_width/2}" '
+                f'y="{plot_top + plot_height + 45}" text-anchor="middle">UTC date</text>'
+            ),
+            (
+                f'<text class="axis-title" x="22" '
+                f'y="{plot_top + plot_height/2}" text-anchor="middle" '
+                f'transform="rotate(-90 22 {plot_top + plot_height/2})">'
+                f'{y_axis_title}</text>'
+            ),
+        ]
+    )
+
+    legend_x = plot_left + plot_width - 385
+    legend_y = plot_top - 29
+    for series_index, (field, label, css_class) in enumerate(series):
+        item_x = legend_x + 190*series_index
+        path_data = _series_path(
+            series_points[field],
+            x_minimum,
+            x_maximum,
+            y_maximum,
+            plot_bounds,
+        )
+        elements.extend(
+            [
+                (
+                    f'<line class="legend-line {css_class}" x1="{item_x}" '
+                    f'y1="{legend_y}" x2="{item_x + 28}" y2="{legend_y}" />'
+                ),
+                (
+                    f'<text class="legend-text" x="{item_x + 36}" '
+                    f'y="{legend_y + 4}">{label}</text>'
+                ),
+                (
+                    f'<path class="data-line {css_class}" '
+                    f'd="{path_data}" />'
+                ),
+            ]
+        )
+    return elements
+
+
+def render_usage_svg(rows: List[Dict[str, Any]], generated_at: str) -> str:
+    """Render the retained usage history as a self-contained SVG chart."""
+    elements = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" '
+            'role="img" aria-labelledby="chart-title chart-description">'
+        ),
+        '<title id="chart-title">Basilisk package and repository usage</title>',
+        (
+            '<desc id="chart-description">Seven-day trailing means of daily PyPI '
+            'downloads and GitHub clone activity.</desc>'
+        ),
+        """<style>
+            .background { fill: #ffffff; }
+            .chart-frame { fill: none; stroke: #8c959f; stroke-width: 1; }
+            .grid-line { stroke: #d8dee4; stroke-width: 1; }
+            .axis-tick { stroke: #57606a; stroke-width: 1; }
+            .chart-title, .panel-title, .axis-title, .axis-text, .legend-text {
+                fill: #24292f;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            }
+            .chart-title { font-size: 22px; font-weight: 600; }
+            .chart-subtitle { fill: #57606a; font-size: 12px; }
+            .panel-title { font-size: 16px; font-weight: 600; }
+            .axis-title { font-size: 12px; font-weight: 600; }
+            .axis-text, .legend-text { font-size: 11px; }
+            .data-line, .legend-line {
+                fill: none;
+                stroke-linejoin: round;
+                stroke-linecap: round;
+                stroke-width: 2.5;
+                vector-effect: non-scaling-stroke;
+            }
+            .pypi-downloads { stroke: #0969da; }
+            .pip-downloads { stroke: #bf8700; }
+            .github-clones { stroke: #1a7f37; }
+            .github-unique { stroke: #8250df; }
+            @media (prefers-color-scheme: dark) {
+                .background { fill: #0d1117; }
+                .chart-frame { stroke: #6e7681; }
+                .grid-line { stroke: #30363d; }
+                .axis-tick { stroke: #8b949e; }
+                .chart-title, .panel-title, .axis-title, .axis-text, .legend-text {
+                    fill: #e6edf3;
+                }
+                .chart-subtitle { fill: #8b949e; }
+                .pypi-downloads { stroke: #58a6ff; }
+                .pip-downloads { stroke: #d29922; }
+                .github-clones { stroke: #3fb950; }
+                .github-unique { stroke: #bc8cff; }
+            }
+        </style>""",
+        '<rect class="background" width="1000" height="700" />',
+        '<text id="chart-title-text" class="chart-title" x="30" y="34">Basilisk usage</text>',
+        (
+            '<text class="chart-title chart-subtitle" x="970" y="32" '
+            f'text-anchor="end">Updated {html.escape(generated_at)}</text>'
+        ),
+    ]
+    elements.extend(
+        _render_chart_panel(
+            rows,
+            [
+                ("pypi_downloads", "Non-mirror", "pypi-downloads"),
+                ("pypi_pip_downloads", "pip", "pip-downloads"),
+            ],
+            "Daily PyPI artifact downloads — 7-day trailing mean",
+            "Downloads/day",
+            90.0,
+        )
+    )
+    elements.extend(
+        _render_chart_panel(
+            rows,
+            [
+                ("github_clones", "Clones", "github-clones"),
+                ("github_unique_cloners", "Unique cloners", "github-unique"),
+            ],
+            "Daily GitHub clone activity — 7-day trailing mean",
+            "Events/day",
+            425.0,
+        )
+    )
+    elements.append("</svg>")
+    return "\n".join(elements) + "\n"
+
+
+def render_readme(summary: Dict[str, Any]) -> str:
+    """Render a human-readable landing page for the metrics branch."""
+    pypi = summary["pypi"]
+    github = summary["github"]
+    clone_window = github["current_clone_window"]
+    pypi_coverage = f"{pypi['coverage']['start']} through {pypi['coverage']['end']}"
+    tracked_clone_coverage = (
+        f"{github['tracked_clone_coverage']['start']} through "
+        f"{github['tracked_clone_coverage']['end']}"
+    )
+    clone_window_coverage = f"{clone_window['start']} through {clone_window['end']}"
+    lines = [
+        "# Basilisk usage metrics",
+        "",
+        f"Updated {summary['generated_at']}.",
+        "",
+        "| Metric | Count | Coverage |",
+        "|---|---:|---|",
+        (
+            "| PyPI downloads excluding known mirrors | "
+            f"{pypi['downloads_excluding_known_mirrors']:,} | {pypi_coverage} |"
+        ),
+        f"| PyPI downloads made by `pip` | {pypi['pip_downloads']:,} | {pypi_coverage} |",
+        (
+            "| GitHub clone events retained by this tracker | "
+            f"{github['tracked_clones']:,} | {tracked_clone_coverage} |"
+        ),
+        (
+            "| GitHub clones in the current API window | "
+            f"{clone_window['clones']:,} | {clone_window_coverage} |"
+        ),
+        (
+            "| Unique GitHub cloners in the current API window | "
+            f"{clone_window['unique_cloners']:,} | {clone_window_coverage} |"
+        ),
+        f"| Current GitHub forks | {github['forks']:,} | snapshot |",
+        (
+            "| GitHub release-asset downloads | "
+            f"{github['release_asset_downloads']:,} | cumulative snapshot |"
+        ),
+        "",
+        "![Daily Basilisk PyPI download and GitHub clone activity](usage.svg)",
+        "",
+        "`metrics.csv` contains the daily history and `summary.json` contains the latest",
+        "machine-readable totals. `usage.svg` contains the plotted seven-day trends.",
+        "",
+        "## Interpretation",
+        "",
+        "- PyPI counts are file-download events, not verified installations or unique users.",
+        "  The `pip` count selects records whose installer is identified as `pip`.",
+        "- The non-mirror count excludes `bandersnatch`, `z3c.pypimirror`, `Artifactory`,",
+        "  and `devpi`, matching the known-mirror list documented by PyPI Stats.",
+        "- GitHub exposes clone traffic for only the latest 14 days. The tracker preserves",
+        "  those daily counts; gaps longer than 14 days cannot be recovered.",
+        "- Daily unique-cloner values cannot be summed into an all-time unique-user count.",
+        "- Forks are currently existing forks, not a lifetime count of every fork ever made.",
+        "- Release downloads cover uploaded release assets only. GitHub provides no download",
+        "  count for its automatically generated source ZIP and tar archives.",
+        "",
+        "The data comes from the public PyPI dataset through",
+        "[ClickPy](https://clickpy.clickhouse.com/) and from the",
+        "[GitHub REST API](https://docs.github.com/en/rest/metrics/traffic).",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def collect_metrics(
+    output_directory: Path,
+    package_name: str,
+    repository: str,
+    github_token: str,
+) -> Dict[str, Any]:
+    """Collect, merge, and write all usage-metric artifacts."""
+    output_directory.mkdir(parents=True, exist_ok=True)
+    history_path = output_directory / "metrics.csv"
+    existing_rows = load_history(history_path)
+    pypi_rows = fetch_pypi_history(package_name)
+    github_metrics = fetch_github_metrics(repository, github_token)
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    snapshot_date = generated_at[:10]
+    rows = merge_history(existing_rows, pypi_rows, github_metrics, snapshot_date)
+    summary = build_summary(
+        rows,
+        package_name,
+        repository,
+        github_metrics,
+        generated_at,
+    )
+
+    write_history(history_path, rows)
+    (output_directory / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_directory / "README.md").write_text(
+        render_readme(summary),
+        encoding="utf-8",
+    )
+    (output_directory / "usage.svg").write_text(
+        render_usage_svg(rows, generated_at),
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--package", default="bsk")
+    parser.add_argument("--repository", default="AVSLab/basilisk")
+    parser.add_argument("--github-token-env", default="BSK_TRAFFIC_TOKEN")
+    args = parser.parse_args()
+
+    github_token = os.environ.get(args.github_token_env)
+    if not github_token:
+        raise SystemExit(
+            f"Environment variable {args.github_token_env} must contain a GitHub "
+            "token with repository Administration read permission"
+        )
+
+    try:
+        summary = collect_metrics(
+            args.output_dir,
+            args.package,
+            args.repository,
+            github_token,
+        )
+    except MetricsError as error:
+        raise SystemExit(str(error)) from error
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/restore_usage_metrics.sh
+++ b/.github/scripts/restore_usage_metrics.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -euo pipefail
+metrics_directory="$1"
+metrics_branch="${2:-usage-metrics}"
+mkdir -p "${metrics_directory}"
+
+# Only a successful lookup with no matching ref establishes a first run.
+# Network/authentication failures must stop publication of shortened history.
+remote_ref="$(git ls-remote --heads origin "refs/heads/${metrics_branch}")"
+if [[ -z "${remote_ref}" ]]; then
+    if git show-ref --verify --quiet "refs/remotes/origin/${metrics_branch}"; then
+        echo "Metrics branch disappeared after checkout; refusing to discard history." >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+git fetch origin "${metrics_branch}:refs/remotes/origin/${metrics_branch}"
+git show "origin/${metrics_branch}:metrics.csv" > "${metrics_directory}/metrics.csv"
+git show "origin/${metrics_branch}:summary.json" > "${metrics_directory}/summary.json"

--- a/.github/scripts/tests/test_collect_usage_metrics.py
+++ b/.github/scripts/tests/test_collect_usage_metrics.py
@@ -1,0 +1,218 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""Unit tests for the Basilisk usage-metrics collector."""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "collect_usage_metrics.py"
+SPEC = importlib.util.spec_from_file_location("collect_usage_metrics", SCRIPT_PATH)
+METRICS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(METRICS)
+
+
+def _github_metrics():
+    return {
+        "clones": [
+            {
+                "date": "2026-09-02",
+                "github_clones": 12,
+                "github_unique_cloners": 5,
+            },
+            {
+                "date": "2026-09-03",
+                "github_clones": 20,
+                "github_unique_cloners": 7,
+            },
+        ],
+        "clone_window_count": 32,
+        "clone_window_unique_cloners": 10,
+        "forks": 133,
+        "release_asset_downloads": 4,
+    }
+
+
+class UsageMetricsTest(unittest.TestCase):
+    def test_merge_history_preserves_and_updates_overlapping_data(self):
+        """An API overlap updates known dates without discarding older counts."""
+        existing_rows = [
+            {
+                **METRICS._empty_history_row("2026-09-01"),
+                "github_clones": 8,
+                "github_unique_cloners": 4,
+            },
+            {
+                **METRICS._empty_history_row("2026-09-02"),
+                "github_clones": 1,
+                "github_unique_cloners": 1,
+            },
+        ]
+        pypi_rows = [
+            {
+                "date": "2026-09-02",
+                "pypi_downloads": 40,
+                "pypi_pip_downloads": 25,
+            },
+            {
+                "date": "2026-09-03",
+                "pypi_downloads": 50,
+                "pypi_pip_downloads": 30,
+            },
+        ]
+
+        rows = METRICS.merge_history(
+            existing_rows,
+            pypi_rows,
+            _github_metrics(),
+            "2026-09-03",
+        )
+
+        self.assertEqual(
+            [row["date"] for row in rows],
+            [
+                "2026-09-01",
+                "2026-09-02",
+                "2026-09-03",
+            ],
+        )
+        self.assertEqual(rows[0]["github_clones"], 8)
+        self.assertEqual(rows[1]["github_clones"], 12)
+        self.assertEqual(rows[2]["github_forks"], 133)
+        self.assertEqual(rows[2]["github_release_asset_downloads"], 4)
+
+    def test_summary_does_not_sum_daily_unique_cloners(self):
+        """The summary uses GitHub's window-level unique-cloner value."""
+        rows = METRICS.merge_history(
+            [],
+            [
+                {
+                    "date": "2026-09-03",
+                    "pypi_downloads": 50,
+                    "pypi_pip_downloads": 30,
+                }
+            ],
+            _github_metrics(),
+            "2026-09-03",
+        )
+
+        summary = METRICS.build_summary(
+            rows,
+            "bsk",
+            "AVSLab/basilisk",
+            _github_metrics(),
+            "2026-09-04T00:00:00+00:00",
+        )
+
+        self.assertEqual(summary["github"]["tracked_clones"], 32)
+        self.assertEqual(
+            summary["github"]["current_clone_window"]["unique_cloners"],
+            10,
+        )
+        self.assertNotIn("unique_cloners", summary["github"])
+
+    def test_csv_history_round_trip_preserves_missing_values(self):
+        """Blank cells remain missing when CSV history is reloaded."""
+        rows = [
+            {
+                **METRICS._empty_history_row("2026-09-03"),
+                "pypi_downloads": 50,
+                "pypi_pip_downloads": 30,
+            }
+        ]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = Path(temporary_directory) / "metrics.csv"
+            METRICS.write_history(path, rows)
+            loaded_rows = METRICS.load_history(path)
+
+        self.assertEqual(loaded_rows, rows)
+
+    def test_generated_readme_explains_metric_limitations(self):
+        """The generated landing page distinguishes downloads from installs."""
+        rows = METRICS.merge_history(
+            [],
+            [
+                {
+                    "date": "2026-09-03",
+                    "pypi_downloads": 50,
+                    "pypi_pip_downloads": 30,
+                }
+            ],
+            _github_metrics(),
+            "2026-09-03",
+        )
+        summary = METRICS.build_summary(
+            rows,
+            "bsk",
+            "AVSLab/basilisk",
+            _github_metrics(),
+            "2026-09-04T00:00:00+00:00",
+        )
+
+        readme = METRICS.render_readme(summary)
+
+        self.assertIn("file-download events, not verified installations", readme)
+        self.assertIn("latest 14 days", readme)
+        self.assertIn("automatically generated source ZIP", readme)
+
+    def test_summary_is_json_serializable(self):
+        """The generated summary contains only stable JSON-compatible values."""
+        rows = METRICS.merge_history(
+            [],
+            [],
+            _github_metrics(),
+            "2026-09-03",
+        )
+        summary = METRICS.build_summary(
+            rows,
+            "bsk",
+            "AVSLab/basilisk",
+            _github_metrics(),
+            "2026-09-04T00:00:00+00:00",
+        )
+
+        self.assertEqual(json.loads(json.dumps(summary)), summary)
+
+    def test_usage_svg_contains_accessible_labeled_series(self):
+        """The generated chart identifies its content and plotted series."""
+        rows = METRICS.merge_history(
+            [],
+            [
+                {
+                    "date": "2026-09-03",
+                    "pypi_downloads": 50,
+                    "pypi_pip_downloads": 30,
+                }
+            ],
+            _github_metrics(),
+            "2026-09-03",
+        )
+
+        svg = METRICS.render_usage_svg(rows, "2026-09-04T00:00:00+00:00")
+
+        self.assertIn('role="img"', svg)
+        self.assertIn('<title id="chart-title">', svg)
+        self.assertIn("7-day trailing mean", svg)
+        self.assertIn('class="data-line pypi-downloads"', svg)
+        self.assertIn('class="data-line github-clones"', svg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_collect_usage_metrics.py
+++ b/.github/scripts/tests/test_collect_usage_metrics.py
@@ -18,9 +18,20 @@
 
 import importlib.util
 import json
+import os
+import shutil
+import sqlite3
+import subprocess
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
+from datetime import date, datetime, timezone
+from http.client import HTTPResponse, IncompleteRead, RemoteDisconnected
+from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "collect_usage_metrics.py"
@@ -48,6 +59,67 @@ def _github_metrics():
         "forks": 133,
         "release_asset_downloads": 4,
     }
+
+
+def _http_response(body, *, declared_length=None):
+    """Parse an in-memory HTTP response, optionally with a truncated body."""
+    length = len(body) if declared_length is None else declared_length
+    wire_data = f"HTTP/1.1 200 OK\r\nContent-Length: {length}\r\n\r\n".encode("ascii") + body
+    socket = SimpleNamespace(makefile=lambda mode: BytesIO(wire_data))
+    response = HTTPResponse(socket)
+    response.begin()
+    return response
+
+
+class HttpRequestTest(unittest.TestCase):
+    def test_truncated_response_retries_and_can_recover(self):
+        """An incomplete body is discarded and a later complete response is used."""
+        responses = [_http_response(b"{", declared_length=2), _http_response(b"{}")]
+        with patch.object(METRICS, "urlopen", side_effect=responses) as request, \
+                patch.object(METRICS.time, "sleep") as sleep:
+            self.assertEqual(METRICS._request_text("https://example.invalid/metrics"), "{}")
+        self.assertEqual(request.call_count, 2)
+        sleep.assert_called_once_with(METRICS.RETRY_DELAY_SECONDS)
+
+    def test_truncated_responses_exhaust_retries_as_metrics_error(self):
+        """Real HTTP body truncation becomes a source error after all retries."""
+        responses = [_http_response(b"{", declared_length=2) for _ in range(METRICS.REQUEST_ATTEMPTS)]
+        with patch.object(METRICS, "urlopen", side_effect=responses) as request, \
+                patch.object(METRICS.time, "sleep") as sleep:
+            with self.assertRaises(METRICS.MetricsError) as raised:
+                METRICS._request_text("https://example.invalid/metrics")
+        self.assertIsInstance(raised.exception.__cause__, IncompleteRead)
+        self.assertEqual(request.call_count, METRICS.REQUEST_ATTEMPTS)
+        self.assertEqual(
+            [call.args[0] for call in sleep.call_args_list],
+            [METRICS.RETRY_DELAY_SECONDS*(attempt+1) for attempt in range(METRICS.REQUEST_ATTEMPTS-1)],
+        )
+
+    def test_response_read_errors_are_retried_and_normalized(self):
+        """Socket and HTTP read failures use the same bounded retry path."""
+        for error in (ConnectionResetError("reset"), TimeoutError("timed out"),
+                      OSError("read failed"), URLError("unreachable"), RemoteDisconnected("disconnected")):
+            with self.subTest(error=type(error).__name__):
+                responses = [_http_response(b"{}") for _ in range(METRICS.REQUEST_ATTEMPTS)]
+                with patch.object(METRICS, "urlopen", side_effect=responses) as request, \
+                        patch.object(HTTPResponse, "read", side_effect=error), \
+                        patch.object(METRICS.time, "sleep") as sleep:
+                    with self.assertRaises(METRICS.MetricsError) as raised:
+                        METRICS._request_text("https://example.invalid/metrics")
+                self.assertIs(raised.exception.__cause__, error)
+                self.assertEqual(request.call_count, METRICS.REQUEST_ATTEMPTS)
+                self.assertEqual(sleep.call_count, METRICS.REQUEST_ATTEMPTS-1)
+
+    def test_non_retryable_http_status_still_fails_immediately(self):
+        """HTTP status handling takes precedence over the generic I/O handler."""
+        error = HTTPError("https://example.invalid/metrics", 403, "Forbidden", {}, BytesIO())
+        self.addCleanup(error.close)
+        with patch.object(METRICS, "urlopen", side_effect=error) as request, \
+                patch.object(METRICS.time, "sleep") as sleep:
+            with self.assertRaisesRegex(METRICS.MetricsError, "HTTP 403"):
+                METRICS._request_text("https://example.invalid/metrics")
+        request.assert_called_once()
+        sleep.assert_not_called()
 
 
 class UsageMetricsTest(unittest.TestCase):
@@ -192,18 +264,11 @@ class UsageMetricsTest(unittest.TestCase):
 
     def test_usage_svg_contains_accessible_labeled_series(self):
         """The generated chart identifies its content and plotted series."""
-        rows = METRICS.merge_history(
-            [],
-            [
-                {
-                    "date": "2026-09-03",
-                    "pypi_downloads": 50,
-                    "pypi_pip_downloads": 30,
-                }
-            ],
-            _github_metrics(),
-            "2026-09-03",
-        )
+        rows = [
+            {"date": f"2026-09-{day:02d}", "pypi_downloads": 50,
+             "pypi_pip_downloads": 30, "github_clones": 12, "github_unique_cloners": 5}
+            for day in range(1, 9)
+        ]
 
         svg = METRICS.render_usage_svg(rows, "2026-09-04T00:00:00+00:00")
 
@@ -212,6 +277,343 @@ class UsageMetricsTest(unittest.TestCase):
         self.assertIn("7-day trailing mean", svg)
         self.assertIn('class="data-line pypi-downloads"', svg)
         self.assertIn('class="data-line github-clones"', svg)
+        ET.fromstring(svg)
+
+    def test_rolling_average_counts_explicit_zero_days(self):
+        """Seven known days include zero counts in the denominator."""
+        rows = [
+            {"date": f"2026-09-{day:02d}", "pypi_downloads": 70 if day in (1, 7) else 0}
+            for day in range(1, 8)
+        ]
+        self.assertEqual(METRICS._rolling_series(rows, "pypi_downloads"), [
+            (date(2026, 9, 7).toordinal(), 20.0)
+        ])
+
+    def test_rolling_average_requires_a_complete_window(self):
+        """Both absent dates and explicitly unknown values break the window."""
+        complete = [
+            {"date": f"2026-09-{day:02d}", "pypi_downloads": day}
+            for day in range(1, 16)
+        ]
+        for missing in (True, False):
+            with self.subTest(absent=missing):
+                rows = [dict(row) for row in complete]
+                if missing:
+                    del rows[7]
+                else:
+                    rows[7]["pypi_downloads"] = None
+                self.assertEqual(METRICS._rolling_series(rows, "pypi_downloads"), [
+                    (date(2026, 9, 7).toordinal(), 4.0),
+                    (date(2026, 9, 15).toordinal(), 12.0),
+                ])
+
+    def test_sparse_history_remains_unknown_in_csv_and_chart(self):
+        """An absent source date is retained as blank and never averaged as zero."""
+        rows = METRICS.merge_history([], [
+            {"date": "2026-09-01", "pypi_downloads": 70, "pypi_pip_downloads": 40},
+            {"date": "2026-09-07", "pypi_downloads": 70, "pypi_pip_downloads": 40},
+        ], None, "2026-09-07")
+        self.assertEqual(len(rows), 7)
+        self.assertIsNone(rows[1]["pypi_downloads"])
+        self.assertEqual(METRICS._rolling_series(rows, "pypi_downloads"), [])
+        self.assertIn("No complete seven-day window", METRICS.render_usage_svg(rows, "test"))
+
+    def test_pypi_query_filters_known_files_and_retains_unknown_filenames(self):
+        """Evaluate the actual SQL predicate against distribution and metadata fixtures."""
+        class CountIf:
+            def __init__(self):
+                self.total = 0
+
+            def step(self, value):
+                self.total += bool(value)
+
+            def finalize(self):
+                return self.total
+
+        with sqlite3.connect(":memory:") as connection:
+            self.addCleanup(connection.close)
+            connection.row_factory = sqlite3.Row
+            connection.create_function("endsWith", 2, lambda value, suffix: value.endswith(suffix))
+            connection.create_aggregate("countIf", 1, CountIf)
+            connection.execute("CREATE TABLE pypi (date TEXT, project TEXT, installer TEXT, filename TEXT)")
+            connection.executemany("INSERT INTO pypi VALUES (?, ?, ?, ?)", [
+                ("2026-09-01", "bsk", "pip", filename)
+                for filename in ("bsk.whl", "bsk.tar.gz", "bsk.zip", "", "bsk.whl.metadata", "bsk.whl.asc")
+            ] + [
+                ("2026-09-01", "bsk", "uv", "bsk.whl"),
+                ("2026-09-01", "bsk", "bandersnatch", "bsk.whl"),
+                ("2026-09-01", "another-package", "pip", "other.whl"),
+                ("2026-09-02", "bsk", "pip", "bsk.whl.metadata"),
+            ])
+
+            def query_source(url, *, data, headers):
+                # Translate only ClickHouse's expression-alias WITH syntax and
+                # wire formatting; execute its filtering/counting expressions.
+                prefix, select = data.decode().split("SELECT", 1)
+                expression = prefix.strip()[len("WITH "):].rsplit(" AS ", 1)[0]
+                sql = f"WITH annotated AS (SELECT *, {expression} AS distribution_or_unknown FROM pypi) SELECT {select}"
+                sql = sql.replace("FROM pypi.pypi", "FROM annotated")
+                sql = sql.replace("{package:String}", "?").replace("FORMAT JSONEachRow", "")
+                return "\n".join(json.dumps(dict(row)) for row in connection.execute(sql, ("bsk",)))
+
+            with patch.object(METRICS, "_request_text", side_effect=query_source):
+                rows = METRICS.fetch_pypi_history("bsk")
+
+        self.assertEqual(rows, [
+            {"date": "2026-09-01", "pypi_downloads": 5, "pypi_pip_downloads": 4},
+            {"date": "2026-09-02", "pypi_downloads": 0, "pypi_pip_downloads": 0},
+        ])
+
+
+class SourceFailureTest(unittest.TestCase):
+    def setUp(self):
+        """Seed retained artifacts from a successful collection."""
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.output = Path(temporary.name)
+        self.today = "2026-09-04"
+        self.yesterday = "2026-09-03"
+        clock = patch.object(METRICS, "datetime")
+        self.addCleanup(clock.stop)
+        clock.start().now.return_value = datetime(2026, 9, 4, tzinfo=timezone.utc)
+        self.old_time = self.yesterday + "T00:00:00+00:00"
+        self.pypi_rows = [{"date": self.today, "pypi_downloads": 40, "pypi_pip_downloads": 20}]
+        self.github = _github_metrics()
+        self.github["clones"] = [{"date": self.today, "github_clones": 32, "github_unique_cloners": 10}]
+        self.old_rows = [{
+            **METRICS._empty_history_row(self.yesterday),
+            "pypi_downloads": 100, "pypi_pip_downloads": 50,
+            "github_clones": 99, "github_unique_cloners": 20,
+            "github_forks": 120, "github_release_asset_downloads": 2,
+        }]
+        METRICS.write_history(self.output / "metrics.csv", self.old_rows)
+        sources = {name: {"status": "ok", "last_attempt_at": self.old_time,
+                          "last_success_at": self.old_time, "error": None}
+                   for name in ("pypi", "github")}
+        self.previous = METRICS.build_summary(
+            self.old_rows, "bsk", "AVSLab/basilisk", self.github, self.old_time, sources,
+        )
+        (self.output / "summary.json").write_text(json.dumps(self.previous), encoding="utf-8")
+
+    def collect(self, *, pypi_error=None, github_error=None, output=None):
+        with patch.object(METRICS, "fetch_pypi_history", return_value=self.pypi_rows,
+                          side_effect=pypi_error) as pypi, \
+                patch.object(METRICS, "fetch_github_metrics", return_value=self.github,
+                             side_effect=github_error) as github:
+            summary = METRICS.collect_metrics(output or self.output, "bsk", "AVSLab/basilisk", "fixture")
+            pypi.assert_called_once()
+            github.assert_called_once()
+            return summary
+
+    def test_pypi_failure_still_retains_github_and_marks_pypi_stale(self):
+        """A PyPI outage publishes new clones without relabeling old PyPI observations."""
+        summary = self.collect(pypi_error=METRICS.MetricsError("ClickPy unavailable"))
+        self.assertEqual(summary["collection_status"], "partial")
+        self.assertEqual(summary["github"]["tracked_clones"], 131)
+        self.assertEqual(summary["pypi"]["downloads_excluding_known_mirrors"], 100)
+        self.assertEqual(summary["sources"]["pypi"]["last_success_at"], self.old_time)
+        self.assertEqual(summary["sources"]["github"]["last_success_at"], summary["generated_at"])
+        self.assertIsNone(METRICS.load_history(self.output / "metrics.csv")[-1]["pypi_downloads"])
+        self.assertIn("ClickPy unavailable", (self.output / "README.md").read_text())
+        self.assertIn("pypi: error", (self.output / "usage.svg").read_text())
+
+    def test_github_failure_preserves_window_without_fabricating_a_snapshot(self):
+        """Old GitHub totals and unique-window data remain explicitly stale."""
+        summary = self.collect(github_error=METRICS.MetricsError("GitHub unavailable"))
+        self.assertEqual(summary["pypi"]["downloads_excluding_known_mirrors"], 140)
+        self.assertEqual(summary["github"]["forks"], 120)
+        self.assertEqual(summary["github"]["current_clone_window"], self.previous["github"]["current_clone_window"])
+        self.assertEqual(summary["sources"]["github"]["last_success_at"], self.old_time)
+        latest = METRICS.load_history(self.output / "metrics.csv")[-1]
+        self.assertIsNone(latest["github_forks"])
+        self.assertIsNone(latest["github_clones"])
+
+    def test_truncated_pypi_response_still_retains_github(self):
+        """A body-read failure saves new GitHub data and retains stale PyPI history."""
+        responses = [_http_response(b"{", declared_length=2) for _ in range(METRICS.REQUEST_ATTEMPTS)]
+        with patch.object(METRICS, "fetch_github_metrics", return_value=self.github) as github, \
+                patch.object(METRICS, "urlopen", side_effect=responses) as request, \
+                patch.object(METRICS.time, "sleep"):
+            summary = METRICS.collect_metrics(self.output, "bsk", "AVSLab/basilisk", "fixture")
+        github.assert_called_once()
+        self.assertEqual(request.call_count, METRICS.REQUEST_ATTEMPTS)
+        self.assertEqual(summary["collection_status"], "partial")
+        self.assertEqual(summary["sources"]["pypi"]["status"], "error")
+        self.assertEqual(summary["sources"]["pypi"]["last_success_at"], self.old_time)
+        self.assertEqual(summary["sources"]["github"]["status"], "ok")
+        rows = METRICS.load_history(self.output / "metrics.csv")
+        self.assertEqual(rows[0], self.old_rows[0])
+        self.assertEqual(rows[-1]["github_clones"], 32)
+        self.assertIsNone(rows[-1]["pypi_downloads"])
+        self.assertEqual(json.loads((self.output / "summary.json").read_text()), summary)
+        self.assertIn("IncompleteRead", (self.output / "README.md").read_text())
+        self.assertIn("pypi: error", (self.output / "usage.svg").read_text())
+
+    def test_truncated_github_response_still_collects_pypi(self):
+        """An earlier GitHub body-read failure does not skip PyPI collection."""
+        responses = [_http_response(b"{", declared_length=2) for _ in range(METRICS.REQUEST_ATTEMPTS)]
+        with patch.object(METRICS, "fetch_pypi_history", return_value=self.pypi_rows) as pypi, \
+                patch.object(METRICS, "urlopen", side_effect=responses) as request, \
+                patch.object(METRICS.time, "sleep"):
+            summary = METRICS.collect_metrics(self.output, "bsk", "AVSLab/basilisk", "fixture")
+        pypi.assert_called_once()
+        self.assertEqual(request.call_count, METRICS.REQUEST_ATTEMPTS)
+        self.assertEqual(summary["collection_status"], "partial")
+        self.assertEqual(summary["sources"]["github"]["status"], "error")
+        self.assertEqual(summary["sources"]["github"]["last_success_at"], self.old_time)
+        self.assertEqual(summary["sources"]["pypi"]["status"], "ok")
+        rows = METRICS.load_history(self.output / "metrics.csv")
+        self.assertEqual(rows[0], self.old_rows[0])
+        self.assertEqual(rows[-1]["pypi_downloads"], 40)
+        self.assertIsNone(rows[-1]["github_clones"])
+
+    def test_first_partial_collection_reports_unknown_counts_not_zero(self):
+        """An unavailable source without retained history is represented by nulls."""
+        for failed_source in ("pypi", "github"):
+            with self.subTest(source=failed_source):
+                output = self.output / failed_source
+                summary = self.collect(output=output, **{
+                    failed_source + "_error": METRICS.MetricsError("unavailable")
+                })
+                self.assertIsNone(summary["sources"][failed_source]["last_success_at"])
+                if failed_source == "pypi":
+                    self.assertIsNone(summary["pypi"]["downloads_excluding_known_mirrors"])
+                else:
+                    self.assertIsNone(summary["github"]["forks"])
+                    self.assertIsNone(summary["github"]["current_clone_window"]["unique_cloners"])
+                self.assertIn("unavailable", (output / "README.md").read_text())
+                ET.fromstring((output / "usage.svg").read_text())
+
+    def test_both_failed_sources_leave_existing_artifacts_unchanged(self):
+        """A total outage attempts both sources and does not overwrite history."""
+        before = {path.name: path.read_bytes() for path in self.output.iterdir()}
+        with patch.object(METRICS, "fetch_pypi_history", side_effect=METRICS.MetricsError("offline")) as pypi, \
+                patch.object(METRICS, "fetch_github_metrics", side_effect=METRICS.MetricsError("offline")) as github:
+            with self.assertRaisesRegex(METRICS.MetricsError, "No sources collected"):
+                METRICS.collect_metrics(self.output, "bsk", "AVSLab/basilisk", "fixture")
+            pypi.assert_called_once()
+            github.assert_called_once()
+        self.assertEqual(before, {path.name: path.read_bytes() for path in self.output.iterdir()})
+
+    def test_missing_github_token_still_collects_pypi(self):
+        """A missing secret is reported per source without preventing PyPI collection."""
+        with patch.object(METRICS, "fetch_pypi_history", return_value=self.pypi_rows), \
+                patch.object(METRICS, "_request_json") as github_request:
+            summary = METRICS.collect_metrics(self.output, "bsk", "AVSLab/basilisk", "")
+        github_request.assert_not_called()
+        self.assertEqual(summary["sources"]["pypi"]["status"], "ok")
+        self.assertEqual(summary["sources"]["github"]["status"], "error")
+        self.assertIn("token", summary["sources"]["github"]["error"])
+
+    def test_recovery_refreshes_counts_and_clears_errors(self):
+        """A recovered source replaces overlapping counts and becomes current again."""
+        self.collect(pypi_error=METRICS.MetricsError("offline"))
+        self.pypi_rows.append({"date": self.yesterday, "pypi_downloads": 80, "pypi_pip_downloads": 30})
+        summary = self.collect()
+        self.assertEqual(summary["collection_status"], "complete")
+        self.assertEqual(summary["pypi"]["downloads_excluding_known_mirrors"], 120)
+        self.assertIsNone(summary["sources"]["pypi"]["error"])
+        rows = METRICS.load_history(self.output / "metrics.csv")
+        self.assertEqual(len(rows), 2)
+
+    def test_legacy_summary_retains_original_freshness_and_counting_policy(self):
+        """Schema-one history is not misrepresented as a successful filtered refresh."""
+        legacy = dict(self.previous, schema_version=1)
+        del legacy["sources"]
+        del legacy["pypi"]["counting_policy"]
+        (self.output / "summary.json").write_text(json.dumps(legacy), encoding="utf-8")
+        summary = self.collect(pypi_error=METRICS.MetricsError("offline"))
+        self.assertEqual(summary["sources"]["pypi"]["last_success_at"], self.old_time)
+        self.assertEqual(summary["pypi"]["counting_policy"], "legacy_unfiltered")
+
+
+@unittest.skipUnless(os.name != "nt" and shutil.which("bash") and shutil.which("git"),
+                     "The workflow restore script runs on POSIX GitHub runners")
+class RestoreHistoryTest(unittest.TestCase):
+    def setUp(self):
+        """Create an isolated bare remote and a checkout with fetched references."""
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.remote = self.root / "remote.git"
+        self.checkout = self.root / "checkout"
+        # Hooks may inherit GIT_INDEX_FILE or GIT_DIR from the developer's
+        # checkout. Do not let the fixture commands touch that repository.
+        self.env = {
+            **{key: value for key, value in os.environ.items() if not key.startswith("GIT_")},
+            "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_AUTHOR_NAME": "Test", "GIT_AUTHOR_EMAIL": "test@example.invalid",
+            "GIT_COMMITTER_NAME": "Test", "GIT_COMMITTER_EMAIL": "test@example.invalid",
+        }
+        self.git("init", "--bare", str(self.remote), cwd=self.root)
+        self.seed_branch("develop", {"README.md": "fixture"})
+        self.git("clone", "--branch", "develop", str(self.remote), str(self.checkout), cwd=self.root)
+        self.output = self.root / "output"
+        self.script = SCRIPT_PATH.with_name("restore_usage_metrics.sh")
+
+    def git(self, *args, cwd=None, data=None):
+        return subprocess.run(["git", *args], cwd=cwd or self.remote, env=self.env,
+                              input=data, text=True, capture_output=True, check=True).stdout.strip()
+
+    def seed_branch(self, branch, files):
+        entries = []
+        for name, content in sorted(files.items()):
+            blob = self.git("hash-object", "-w", "--stdin", data=content)
+            entries.append(f"100644 blob {blob}\t{name}\n")
+        tree = self.git("mktree", data="".join(entries))
+        commit = self.git("commit-tree", tree, "-m", "Fixture")
+        self.git("update-ref", "refs/heads/" + branch, commit)
+        return commit
+
+    def restore(self, failed_command=None):
+        fault = ""
+        if failed_command:
+            fault = f'git() {{ if [[ "$1" == {failed_command} ]]; then return 128; fi; command git "$@"; }}\n'
+        return subprocess.run(["bash", "-c", fault + 'source "$1" "$2"', "restore",
+                               str(self.script), str(self.output)], cwd=self.checkout,
+                              env=self.env, text=True, capture_output=True)
+
+    def test_first_run_requires_a_successful_remote_lookup(self):
+        """A confirmed absent branch allows collection; a lookup failure does not."""
+        self.assertEqual(self.restore().returncode, 0)
+        self.assertFalse((self.output / "metrics.csv").exists())
+        self.assertNotEqual(self.restore("ls-remote").returncode, 0)
+
+    def test_existing_history_and_freshness_are_restored(self):
+        """The CSV and summary are restored byte for byte from the metrics branch."""
+        files = {"metrics.csv": "old history\n", "summary.json": '{"generated_at":"old"}\n'}
+        self.seed_branch("usage-metrics", files)
+        result = self.restore()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for name, content in files.items():
+            self.assertEqual((self.output / name).read_text(), content)
+
+    def test_failed_fetch_stops_even_with_an_existing_remote_reference(self):
+        """The reviewed history-loss scenario fails before collection can proceed."""
+        commit = self.seed_branch("usage-metrics", {"metrics.csv": "old", "summary.json": "{}"})
+        self.git("fetch", "origin", cwd=self.checkout)
+        self.assertNotEqual(self.restore("fetch").returncode, 0)
+        self.assertFalse((self.output / "metrics.csv").exists())
+        self.assertEqual(self.git("rev-parse", "refs/heads/usage-metrics"), commit)
+
+    def test_missing_history_file_stops_restoration(self):
+        """An existing metrics branch must contain both durable artifacts."""
+        for missing in ("metrics.csv", "summary.json"):
+            with self.subTest(missing=missing):
+                self.seed_branch("usage-metrics", {
+                    name: "fixture" for name in ("metrics.csv", "summary.json") if name != missing
+                })
+                # Ensure subsequent fixtures do not cause a non-fast-forward
+                # fetch failure before the missing-file check is exercised.
+                self.git("fetch", "--force", "origin", cwd=self.checkout)
+                self.assertNotEqual(self.restore().returncode, 0)
+
+    def test_disappearing_remote_branch_does_not_discard_known_history(self):
+        """A branch removed after checkout cannot be mistaken for initial setup."""
+        self.seed_branch("usage-metrics", {"metrics.csv": "old", "summary.json": "{}"})
+        self.git("fetch", "origin", cwd=self.checkout)
+        self.git("update-ref", "-d", "refs/heads/usage-metrics")
+        self.assertNotEqual(self.restore().returncode, 0)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/usage-metrics.yml
+++ b/.github/workflows/usage-metrics.yml
@@ -38,16 +38,9 @@ jobs:
           -p 'test_collect_usage_metrics.py'
 
       - name: Restore existing history
-        shell: bash
-        run: |
-          set -euo pipefail
-          metrics_directory="${RUNNER_TEMP}/usage-metrics-data"
-          mkdir -p "${metrics_directory}"
-          if git fetch origin "${METRICS_BRANCH}:refs/remotes/origin/${METRICS_BRANCH}"; then
-            if git cat-file -e "origin/${METRICS_BRANCH}:metrics.csv"; then
-              git show "origin/${METRICS_BRANCH}:metrics.csv" > "${metrics_directory}/metrics.csv"
-            fi
-          fi
+        run: >-
+          bash .github/scripts/restore_usage_metrics.sh
+          "${RUNNER_TEMP}/usage-metrics-data" "${METRICS_BRANCH}"
 
       - name: Collect metrics
         env:
@@ -86,3 +79,19 @@ jobs:
 
           git commit -m "Update usage metrics"
           git push origin "HEAD:${METRICS_BRANCH}"
+
+      # Publish available observations before reporting a partial failure so
+      # a PyPI outage cannot prevent retention of GitHub's short-lived data.
+      - name: Report collection status
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["RUNNER_TEMP"]) / "usage-metrics-data" / "summary.json"
+          summary = json.loads(path.read_text(encoding="utf-8"))
+          failed = [name for name, source in summary["sources"].items() if source["status"] == "error"]
+          if failed:
+              raise SystemExit("Available metrics were published, but collection failed for: " + ", ".join(failed))
+          PY

--- a/.github/workflows/usage-metrics.yml
+++ b/.github/workflows/usage-metrics.yml
@@ -1,0 +1,88 @@
+name: Collect Usage Metrics
+
+on:
+  schedule:
+    # Run daily after the public PyPI datasets normally finish updating.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: usage-metrics
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Collect PyPI and GitHub metrics
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10  # [min]
+    env:
+      METRICS_BRANCH: usage-metrics
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Test collector
+        run: >-
+          python -m unittest discover
+          -s .github/scripts/tests
+          -p 'test_collect_usage_metrics.py'
+
+      - name: Restore existing history
+        shell: bash
+        run: |
+          set -euo pipefail
+          metrics_directory="${RUNNER_TEMP}/usage-metrics-data"
+          mkdir -p "${metrics_directory}"
+          if git fetch origin "${METRICS_BRANCH}:refs/remotes/origin/${METRICS_BRANCH}"; then
+            if git cat-file -e "origin/${METRICS_BRANCH}:metrics.csv"; then
+              git show "origin/${METRICS_BRANCH}:metrics.csv" > "${metrics_directory}/metrics.csv"
+            fi
+          fi
+
+      - name: Collect metrics
+        env:
+          BSK_TRAFFIC_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN }}
+        run: >-
+          python .github/scripts/collect_usage_metrics.py
+          --output-dir "${RUNNER_TEMP}/usage-metrics-data"
+          --package bsk
+          --repository "${GITHUB_REPOSITORY}"
+
+      - name: Publish durable history
+        shell: bash
+        run: |
+          set -euo pipefail
+          metrics_directory="${RUNNER_TEMP}/usage-metrics-data"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git show-ref --verify --quiet "refs/remotes/origin/${METRICS_BRANCH}"; then
+            git switch --force-create "${METRICS_BRANCH}" "origin/${METRICS_BRANCH}"
+          else
+            git switch --orphan "${METRICS_BRANCH}"
+          fi
+
+          install -m 0644 "${metrics_directory}/metrics.csv" metrics.csv
+          install -m 0644 "${metrics_directory}/summary.json" summary.json
+          install -m 0644 "${metrics_directory}/README.md" README.md
+          install -m 0644 "${metrics_directory}/usage.svg" usage.svg
+          touch .nojekyll
+          git add -- .nojekyll README.md metrics.csv summary.json usage.svg
+
+          if git diff --cached --quiet; then
+            echo "Usage metrics did not change."
+            exit 0
+          fi
+
+          git commit -m "Update usage metrics"
+          git push origin "HEAD:${METRICS_BRANCH}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,11 @@ repos:
           entry: python src/utilities/preCommitTools/checkCommitMessage.py
           language: python
           stages: [commit-msg]
+      -   id: usage-metrics-tests
+          name: Test usage metrics collector
+          entry: >-
+            python -m unittest discover -s .github/scripts/tests
+            -p test_collect_usage_metrics.py
+          language: python
+          files: '^\.github/(scripts|workflows/usage-metrics\.yml)'
+          pass_filenames: false

--- a/docs/source/Support/Developer.rst
+++ b/docs/source/Support/Developer.rst
@@ -17,6 +17,7 @@ The following support files help with writing Basilisk modules.
    Developer/bskModuleCheckoutList
    Developer/UnderstandingBasilisk
    Developer/performanceBenchmarks
+   Developer/usageMetrics
    Developer/addSupportData
    Developer/bskReleaseGuide
    Developer/bskSdkReleaseGuide

--- a/docs/source/Support/Developer/CodingGuidlines.rst
+++ b/docs/source/Support/Developer/CodingGuidlines.rst
@@ -218,7 +218,13 @@ C/C++ Exceptions
 Python Exceptions
 -----------------
 
--  Variables are to be lower camelCase. This is done to maintain consistency across the C/C++ and Python code bases which are interfaced via SWIG.
+-  General-purpose Python implementation and tooling names are to follow
+   PEP 8. This includes using ``under_scored`` names for functions, methods,
+   local variables, and parameters.
+-  Public BSK module attributes, message variables, mathematical quantities,
+   and names shared across C/C++ and Python interfaces are to retain the
+   established Basilisk naming conventions. This includes lower ``camelCase``
+   where applicable and the frame and attitude notation described above.
 -  Inline comments are accepted so long as they are kept brief.
 -  Binary operator spaces will be adhered to as specified in PEP 8, however, not for math symbols operations. E.g. no spaces are included around \*, /, +, -, etc
 

--- a/docs/source/Support/Developer/usageMetrics.rst
+++ b/docs/source/Support/Developer/usageMetrics.rst
@@ -1,0 +1,121 @@
+.. _usageMetrics:
+
+Usage Metrics
+=============
+
+Basilisk collects daily PyPI and GitHub usage metrics with the
+``Collect Usage Metrics`` GitHub Actions workflow. The workflow writes durable
+history to the orphan ``usage-metrics`` branch so routine snapshots do not add
+commits to ``develop`` or trigger the normal build workflow.
+
+Usage Plot
+----------
+
+The metrics workflow regenerates the following plot after every successful
+collection. The documentation references the image on the ``usage-metrics``
+branch, so readers see the latest published data without waiting for another
+documentation build. The plotted lines show seven-day trailing means; exact
+daily values remain available in ``metrics.csv``.
+
+.. image:: https://raw.githubusercontent.com/AVSLab/basilisk/usage-metrics/usage.svg
+   :alt: Daily Basilisk PyPI download and GitHub clone activity
+   :width: 100%
+   :target: https://github.com/AVSLab/basilisk/tree/usage-metrics
+
+Collected Metrics
+-----------------
+
+The branch contains the following generated files:
+
+``metrics.csv``
+    One row per UTC date. It contains PyPI download events, downloads made by
+    ``pip``, GitHub clone events and daily unique cloners, and snapshots of the
+    current fork and release-asset download counts.
+
+``summary.json``
+    Machine-readable current totals, source coverage dates, and the latest
+    GitHub clone window.
+
+``README.md``
+    A human-readable summary and the interpretation caveats for each metric.
+
+``usage.svg``
+    A light- and dark-theme plot of the seven-day trailing means for PyPI
+    downloads and GitHub clone activity.
+
+PyPI history is read from the public PyPI data replicated by
+`ClickPy <https://clickpy.clickhouse.com/>`__. The non-mirror count excludes
+``bandersnatch``, ``z3c.pypimirror``, ``Artifactory``, and ``devpi``, matching
+the `PyPI Stats known-mirror list <https://pypistats.org/faqs>`__. The separate
+``pip`` count selects records whose installer is identified as ``pip``.
+
+GitHub Configuration
+--------------------
+
+GitHub exposes clone traffic only to repository collaborators and retains only
+the latest 14 days. The workflow reads the existing ``BOT_ACCESS_TOKEN``
+Actions secret. That token must be either:
+
+- a fine-grained token with read-only repository Administration permission; or
+- a classic token with sufficient access to read the repository traffic API.
+
+See the `GitHub repository traffic API
+<https://docs.github.com/en/rest/metrics/traffic>`__ for the current permission
+requirements. The token is used only for API reads. The workflow's scoped
+``GITHUB_TOKEN`` publishes the generated files, so repository Actions settings
+must permit workflows to write repository contents.
+
+After the workflow reaches the default branch, run it once manually to seed the
+``usage-metrics`` branch. The daily schedule then merges GitHub's overlapping
+14-day windows, which preserves clone counts beyond GitHub's retention period.
+
+Retrieving the Data
+-------------------
+
+The ``usage-metrics`` branch becomes available after the first successful
+workflow run. Because the Basilisk repository is public, anyone can read the
+generated data; no GitHub token or repository membership is required.
+
+The branch and its rendered summary can be viewed at
+`github.com/AVSLab/basilisk/tree/usage-metrics
+<https://github.com/AVSLab/basilisk/tree/usage-metrics>`__. The individual data
+files can be downloaded directly:
+
+.. code-block:: bash
+
+   curl --fail --location --remote-name \
+     https://raw.githubusercontent.com/AVSLab/basilisk/usage-metrics/metrics.csv
+   curl --fail --location --remote-name \
+     https://raw.githubusercontent.com/AVSLab/basilisk/usage-metrics/summary.json
+   curl --fail --location --remote-name \
+     https://raw.githubusercontent.com/AVSLab/basilisk/usage-metrics/usage.svg
+
+To inspect or copy the files without switching the current checkout away from
+its source branch, fetch the metrics branch as a remote-tracking branch:
+
+.. code-block:: bash
+
+   git fetch origin usage-metrics:refs/remotes/origin/usage-metrics
+   git show origin/usage-metrics:metrics.csv
+   git show origin/usage-metrics:summary.json
+
+To obtain the generated files together with the complete daily commit history,
+clone only the orphan branch into a separate directory:
+
+.. code-block:: bash
+
+   git clone --branch usage-metrics --single-branch \
+     https://github.com/AVSLab/basilisk.git basilisk-usage-metrics
+
+Interpretation Limits
+---------------------
+
+PyPI supplies file-download events, not successful installations or unique
+users. Repeated installs, continuous integration, caches, mirrors, and other
+installers affect the counts.
+
+GitHub's window-level unique-cloner count must not be added across windows or
+dates because the same user can occur more than once. The fork count represents
+currently existing forks, not every fork ever created. Release-asset downloads
+include only files explicitly uploaded to a release; GitHub does not publish a
+download count for automatically generated source ZIP and tar archives.

--- a/docs/source/Support/Developer/usageMetrics.rst
+++ b/docs/source/Support/Developer/usageMetrics.rst
@@ -17,6 +17,12 @@ branch, so readers see the latest published data without waiting for another
 documentation build. The plotted lines show seven-day trailing means; exact
 daily values remain available in ``metrics.csv``.
 
+A plotted mean requires seven consecutive observed UTC dates. Explicit zero
+counts are included, but missing dates are unknown and break the series until
+another complete window is available. In particular, ClickPy's lack of records
+for a date does not establish zero downloads: it may reflect an ingestion gap.
+The latest reported day's count may still be partial.
+
 .. image:: https://raw.githubusercontent.com/AVSLab/basilisk/usage-metrics/usage.svg
    :alt: Daily Basilisk PyPI download and GitHub clone activity
    :width: 100%
@@ -34,7 +40,8 @@ The branch contains the following generated files:
 
 ``summary.json``
     Machine-readable current totals, source coverage dates, and the latest
-    GitHub clone window.
+    successfully retrieved GitHub clone window. Schema version 2 also records
+    each source's status, last attempt, last successful collection, and error.
 
 ``README.md``
     A human-readable summary and the interpretation caveats for each metric.
@@ -48,6 +55,42 @@ PyPI history is read from the public PyPI data replicated by
 ``bandersnatch``, ``z3c.pypimirror``, ``Artifactory``, and ``devpi``, matching
 the `PyPI Stats known-mirror list <https://pypistats.org/faqs>`__. The separate
 ``pip`` count selects records whose installer is identified as ``pip``.
+
+Both PyPI counts exclude records with a known filename that does not end in
+``.whl``, ``.tar.gz``, or ``.zip``. This removes identifiable metadata sidecars
+and signatures. Older records without filenames are retained because they
+cannot be reliably classified. A successful collection refreshes returned
+historical dates with this filter; totals can decrease after the first refresh.
+
+Missing CSV values are blank rather than zero. If a source has never been
+collected successfully, its unavailable summary counts are JSON ``null``.
+
+Source Failures and Freshness
+------------------------------
+
+The collector retrieves PyPI and GitHub data independently. When one source
+fails, it publishes the available observations and retains the other source's
+earlier data. It does not copy old fork or release counts into a new daily
+snapshot. The last successful GitHub API window is retained as a whole, including
+its unique-cloner count; it is never reconstructed by adding daily unique counts.
+
+In ``summary.json``, ``collection_status`` is ``complete`` or ``partial``.
+Each entry under ``sources`` contains ``status`` (``ok`` or ``error``),
+``last_attempt_at``, ``last_success_at``, and ``error``. The README and plot also
+show source freshness. ``generated_at`` is the artifact generation time, not
+the freshness of every source. Even a successful API request may return delayed
+data, so check the source coverage dates as well.
+
+After publishing a partial collection, the workflow reports a failed run so
+maintainers can investigate. If both sources fail, it leaves published artifacts
+unchanged and fails without publishing. A remote lookup, fetch, or history
+restore failure also stops publication. Only a successful remote lookup that
+confirms the metrics branch is absent permits an initial collection.
+
+The workflow restores both ``metrics.csv`` and ``summary.json``. Version 1
+summaries are accepted and upgraded; if PyPI is unavailable during that upgrade,
+``pypi.counting_policy`` remains ``legacy_unfiltered`` until a successful refresh.
+Normal filtered collections use ``distribution_files_or_unknown_filename``.
 
 GitHub Configuration
 --------------------
@@ -113,6 +156,13 @@ Interpretation Limits
 PyPI supplies file-download events, not successful installations or unique
 users. Repeated installs, continuous integration, caches, mirrors, and other
 installers affect the counts.
+
+PyPI changed its download logging on August 24, 2026, to exclude metadata
+requests, leaving older source records unchanged. Although the collector removes
+identifiable non-distribution files, older entries without filenames may still
+include these requests. Historical totals and trends are therefore not fully
+comparable across this change. See `PyPI's explanation of the counting change
+<https://blog.pypi.org/posts/2026-08-31-download-counts/>`__.
 
 GitHub's window-level unique-cloner count must not be added across windows or
 dates because the same user can occur more than once. The fork count represents

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -8,8 +8,8 @@ Basilisk Known Issues
 
     The use of ``cMsgCInterfacePy`` is deprecated.  Use ``messaging`` instead.
 
-Version |release| (July 7, 2026)
---------------------------------
+Version |release|
+-----------------
 - Incremental documentation builds now track transitive local includes, honor Sphinx Doxygen
   configuration overrides, and regenerate a project's XML after an interrupted cache update.
   Local headers remain tracked with ``SEARCH_INCLUDES=NO``, and environment-dependent Doxygen
@@ -24,6 +24,15 @@ Version |release| (July 7, 2026)
   Projects using ``CITE_BIB_FILES`` also bypass reuse so bibliography edits cannot leave stale citations.
   Parallel Sphinx builds now retain XML dependency records from all workers, preventing stale API
   pages after header edits. Older saved Sphinx environments are reread once to restore those records.
+- GitHub issue 1538: PyPI changed its download logging on August 24, 2026, to exclude
+  metadata requests. The :ref:`usageMetrics` collector filters identifiable
+  non-distribution files, but older source records without filenames cannot be
+  classified reliably. Historical download trends remain only partially comparable
+  across this upstream change.
+- GitHub issue 1538: Interrupted HTTP response reads could stop usage-metrics
+  collection before saving data from the healthy source. The collector now retries
+  these failures and, if retries are exhausted, saves available observations while
+  marking the failed source's retained data as stale.
 - GitHub issue 1459: ``RetentionPolicy.addVariableLog()`` still called the removed
   ``SimBaseClass.AddVariableForLogging()`` and ``GetLogVariableData()`` methods, causing every
   Monte Carlo variable-retention request to fail with ``AttributeError``. Variable retention now

--- a/docs/source/Support/bskReleaseNotesSnippets/usage-metrics-tracking.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/usage-metrics-tracking.rst
@@ -1,0 +1,1 @@
+- Added daily PyPI and GitHub usage-metrics collection with durable CSV history, a generated summary, and a live documentation plot sourced from the ``usage-metrics`` branch.

--- a/docs/source/Support/bskReleaseNotesSnippets/usage-metrics-tracking.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/usage-metrics-tracking.rst
@@ -1,1 +1,3 @@
 - Added daily PyPI and GitHub usage-metrics collection with durable CSV history, a generated summary, and a live documentation plot sourced from the ``usage-metrics`` branch.
+- Protected retained usage history against restore failures, preserved independent source observations during outages with explicit freshness reporting, filtered identifiable non-distribution PyPI requests, and required complete seven-day windows for usage plots.
+- Retried interrupted usage-metrics HTTP response reads and preserved healthy-source data when those retries are exhausted.


### PR DESCRIPTION
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

This PR adds automated collection and publication of Basilisk usage metrics.

The collector retrieves:

- Daily PyPI download events excluding known mirrors.
- The subset of PyPI downloads whose installer is identified as `pip`.
- Daily GitHub clone events and unique cloners.
- Current GitHub fork counts.
- Cumulative GitHub release-asset downloads.

Generated history is stored on an orphan `usage-metrics` branch, keeping routine data updates out of `develop`. Each run restores the existing CSV, refreshes overlapping source data, and publishes:

- `metrics.csv`
- `summary.json`
- `README.md`
- `usage.svg`

The SVG shows seven-day trailing means for PyPI downloads and GitHub clone activity. The documentation references the SVG directly from the metrics branch so the displayed plot can update without rebuilding the documentation.

The commits are organized for review as follows:

1. Add the collector, history-merging logic, output generation, and unit tests.
2. Add the daily GitHub Actions workflow and orphan-branch publication.
3. Add the documentation, generated usage plot, and release-note snippet.

Reviewing by commit is recommended because these commits separate the collection logic, automation, and user-facing documentation.

## Verification

Six unit tests were added for the collector. They verify:

- Overlapping data updates without discarding older history.
- Correct handling of GitHub window-level unique-cloner counts.
- CSV round-trip behavior for missing values.
- Metric limitations in the generated README.
- JSON serialization of the generated summary.
- Accessibility metadata and labeled series in the generated SVG.

The tests passed with Python 3.14, matching the GitHub Actions environment, and with macOS system Python 3.9.

The following additional checks passed:

- Pre-commit checks for all modified files.
- `git diff --check`.
- Codespell.
- A warning-as-error Sphinx build of `Support/Developer/usageMetrics`.
- XML validation and visual inspection of the generated SVG.

A live, read-only collection was also run against the `bsk` PyPI project and `AVSLab/basilisk`. It successfully queried ClickPy and the GitHub API and generated all four expected output files.

The GitHub-hosted publication step has not yet been run because `workflow_dispatch` is only available after the workflow reaches the default branch. The first post-merge run will validate the repository secret, Actions write permission, and creation of the orphan branch.

No existing tests were removed or re-baselined.

## Documentation

A new `usageMetrics.rst` page documents:

- Which metrics are collected.
- The distinction between non-mirror PyPI downloads and downloads attributed to `pip`.
- The limitations of treating download events as installations.
- GitHub clone retention and unique-cloner semantics.
- Required token and workflow permissions.
- How the orphan branch retains daily history.
- How anyone can view, download, fetch, or separately clone the published data.
- How the live usage plot is incorporated into the Basilisk documentation.

The page was added to the developer documentation index. A release-note snippet was also added.

Reviewers should check the metric definitions and interpretation caveats carefully. In particular, PyPI reports artifact downloads rather than verified installations, and GitHub does not provide download counts for automatically generated source ZIP and tar archives.

The embedded plot will not resolve until the first successful workflow run creates the public `usage-metrics` branch.

## Future work

After this PR reaches the default branch:

1. Verify that `BOT_ACCESS_TOKEN` can read repository traffic statistics.
2. Verify that Actions is permitted to write repository contents.
3. Manually run `Collect Usage Metrics` to seed the `usage-metrics` branch.
4. Confirm that the published CSV, JSON, README, and SVG are publicly accessible.
5. Run the workflow a second time to verify that overlapping dates are updated without duplication.
6. Monitor subsequent scheduled runs to confirm that GitHub clone history is retained beyond GitHub's 14-day API window.