### PR TITLE
Remove build warning regarding antenna

### DIFF
--- a/.github/actions/docs/action.yml
+++ b/.github/actions/docs/action.yml
@@ -20,6 +20,11 @@ runs:
         else
           pip install -r requirements_doc.txt
         fi
+    - name: Install Node.js for documentation search tests
+      uses: actions/setup-node@v7
+      with:
+        node-version: '24'
+        package-manager-cache: false
     - name: Test documentation build integration
       shell: bash
       env:
@@ -32,6 +37,10 @@ runs:
           tests/test_generated_documentation_sync.py \
           tests/test_module_catalog.py \
           -m docsIntegration --error-for-skips --timeout=300 -v
+    - name: Test documentation search ranking
+      shell: bash
+      working-directory: src
+      run: pytest ../docs/tests/test_search_scorer.py --error-for-skips --timeout=300 -v
     - name: Generate doc artifacts
       shell: bash
       env:

--- a/conanfile.py
+++ b/conanfile.py
@@ -486,6 +486,12 @@ def create_conan_build_command(
         command.extend(["--no-remote", "-c", f"{OFFLINE_CONAN_CONF}=True"])
     if platform_name != "nt":
         command.extend(["-s", "compiler.cstd=gnu17"])
+        # Avoid Apple's linker alignment warning from cfitsio's common symbols.
+        # Track the flag in its package ID so cached binaries are rebuilt once.
+        command.extend([
+            "-c", 'cfitsio/*:tools.build:cflags=["-fno-common"]',
+            "-c", 'cfitsio/*:tools.info.package_id:confs=["tools.build:cflags"]',
+        ])
     if arguments.generator:
         command.extend(["-o", "&:generator=" + str(arguments.generator)])
 

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,10 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
+- GitHub issue 1542: macOS builds could emit a benign ``__common`` section alignment warning
+  when linking :ref:`simpleAntenna`. The Python build script now builds cfitsio with
+  ``-fno-common`` on non-Windows platforms and includes the flag in its Conan package ID
+  so existing cached binaries are rebuilt. This is fixed in the current version.
 - Incremental documentation builds now track transitive local includes, honor Sphinx Doxygen
   configuration overrides, and regenerate a project's XML after an interrupted cache update.
   Local headers remain tracked with ``SEARCH_INCLUDES=NO``, and environment-dependent Doxygen

--- a/docs/source/Support/bskReleaseNotesSnippets/1542-cfitsio-linker-alignment.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/1542-cfitsio-linker-alignment.rst
@@ -1,0 +1,1 @@
+- Fixed a benign macOS linker alignment warning when building :ref:`simpleAntenna` by compiling cfitsio with ``-fno-common`` and tracking the flag in its Conan package ID.

--- a/docs/tests/test_search_scorer.py
+++ b/docs/tests/test_search_scorer.py
@@ -1,0 +1,109 @@
+# ISC License
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""Check documentation search ranking with Node.js in the dedicated docs suite."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+SCORER = Path(__file__).resolve().parents[2] / "docs/source/_static/js/search-scorer.js"
+MODULE = "Documentation/fswAlgorithms/attControl/mrpPD"
+
+
+def rank(query, entries):
+    """Execute the real scorer, retaining result paths and numeric scores."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.fail(
+            "Documentation search tests require Node.js on PATH; install Node.js to run this suite.",
+            pytrace=False,
+        )
+    script = """
+const fs = require('node:fs');
+const vm = require('node:vm');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const context = {URLSearchParams, window: {location: {search: '?q=' + encodeURIComponent(input.query)}}};
+vm.createContext(context);
+vm.runInContext(fs.readFileSync(process.argv[1], 'utf8'), context);
+const scores = input.entries.map(item => [item[0], context.Scorer.score(item)]);
+scores.sort((a, b) => b[1] - a[1]);
+process.stdout.write(JSON.stringify(scores));
+"""
+    result = subprocess.run(
+        [node, "-e", script, str(SCORER)],
+        input=json.dumps({"query": query, "entries": entries}),
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def entry(path, title, score=15, anchor=""):
+    """Construct the six-field result format supported since Sphinx 7."""
+    return [path, title, anchor, None, score, path + ".rst"]
+
+
+@pytest.mark.parametrize("query", ["mrpPD", "MRPPD", " mrpPD "])
+def test_exact_module_outranks_related_pages(query):
+    """Put the exact module ahead of similarly named modules, tests, and indexes."""
+    results = rank(query, [
+        entry(MODULE + "/_UnitTest/test_mrpPD", "test_mrpPD", 26),
+        entry(MODULE + "/index", "mrpPD", 16),
+        entry(MODULE + "/mrpPD", "C Module: mrpPD", 5),
+        entry(MODULE + "Rust/mrpPDRust", "Rust Module: mrpPDRust", 20),
+        entry("examples/scenarioAttitudeFeedback", "scenarioAttitudeFeedback"),
+    ])
+    assert results[0][0] == MODULE + "/mrpPD"
+    assert results[-1][0] == MODULE + "/_UnitTest/test_mrpPD"
+
+
+def test_guides_and_examples_precede_internal_validation():
+    """General-topic searches retain test results but place user material first."""
+    results = rank("attitude control", [
+        entry(MODULE + "/_UnitTest/test_mrpPD", "test_mrpPD", 26),
+        entry("Learn/makingModules/rustModules", "Making Rust Modules", 5),
+        entry("examples/scenarioAttitudeFeedback", "scenarioAttitudeFeedback", 5),
+    ])
+    assert results[-1][0].endswith("test_mrpPD")
+    assert len(results) == 3
+
+
+@pytest.mark.parametrize("query", ["test_mrpPD", "mrpPD tests", "mrpPD validation"])
+def test_explicit_validation_queries_keep_test_priority(query):
+    """Do not bury validation documentation when the user explicitly seeks it."""
+    results = rank(query, [
+        entry(MODULE + "/_UnitTest/test_mrpPD", "test_mrpPD", 26),
+        entry("Learn/makingModules/rustModules", "Making Rust Modules", 5),
+    ])
+    assert results[0][0].endswith("test_mrpPD")
+
+
+def test_exact_api_query_keeps_symbol_priority():
+    """Specific function searches still prioritize their matching API entry."""
+    results = rank("Reset_mrpPD", [
+        entry(MODULE + "/mrpPD", "Reset_mrpPD", 26, "#reset-mrppd"),
+        entry(MODULE + "/mrpPD", "C Module: mrpPD", 5),
+    ])
+    assert results[0][1] == 106
+
+
+def test_legacy_folder_name_does_not_block_module_boost():
+    """Use the module page name rather than assuming it matches the directory."""
+    path = "Documentation/simulation/dynamics/RadiationPressure/radiationPressure"
+    assert rank("radiationPressure", [entry(path, "C++ Module: radiationPressure")])[0][1] == 127

--- a/src/tests/test_documentation_search.py
+++ b/src/tests/test_documentation_search.py
@@ -13,12 +13,10 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Check search ranking with Node when available; no browser or BSK build needed."""
+"""Check Sphinx integration for the documentation search scorer."""
 
 import ast
-import json
 from pathlib import Path
-import shutil
 import subprocess
 import sys
 
@@ -26,86 +24,6 @@ import pytest
 
 
 SCORER = Path(__file__).resolve().parents[2] / "docs/source/_static/js/search-scorer.js"
-MODULE = "Documentation/fswAlgorithms/attControl/mrpPD"
-
-
-def rank(query, entries):
-    """Execute the real scorer, retaining result paths and numeric scores."""
-    node = shutil.which("node")
-    if node is None:
-        pytest.skip("Search scorer checks require the optional Node.js runtime")
-    script = """
-const fs = require('node:fs');
-const vm = require('node:vm');
-const input = JSON.parse(fs.readFileSync(0, 'utf8'));
-const context = {URLSearchParams, window: {location: {search: '?q=' + encodeURIComponent(input.query)}}};
-vm.createContext(context);
-vm.runInContext(fs.readFileSync(process.argv[1], 'utf8'), context);
-const scores = input.entries.map(item => [item[0], context.Scorer.score(item)]);
-scores.sort((a, b) => b[1] - a[1]);
-process.stdout.write(JSON.stringify(scores));
-"""
-    result = subprocess.run(
-        [node, "-e", script, str(SCORER)],
-        input=json.dumps({"query": query, "entries": entries}),
-        capture_output=True, text=True, check=True,
-    )
-    return json.loads(result.stdout)
-
-
-def entry(path, title, score=15, anchor=""):
-    """Construct the six-field result format supported since Sphinx 7."""
-    return [path, title, anchor, None, score, path + ".rst"]
-
-
-@pytest.mark.parametrize("query", ["mrpPD", "MRPPD", " mrpPD "])
-def test_exact_module_outranks_related_pages(query):
-    """Put the exact module ahead of similarly named modules, tests, and indexes."""
-    results = rank(query, [
-        entry(MODULE + "/_UnitTest/test_mrpPD", "test_mrpPD", 26),
-        entry(MODULE + "/index", "mrpPD", 16),
-        entry(MODULE + "/mrpPD", "C Module: mrpPD", 5),
-        entry(MODULE + "Rust/mrpPDRust", "Rust Module: mrpPDRust", 20),
-        entry("examples/scenarioAttitudeFeedback", "scenarioAttitudeFeedback"),
-    ])
-    assert results[0][0] == MODULE + "/mrpPD"
-    assert results[-1][0] == MODULE + "/_UnitTest/test_mrpPD"
-
-
-def test_guides_and_examples_precede_internal_validation():
-    """General-topic searches retain test results but place user material first."""
-    results = rank("attitude control", [
-        entry(MODULE + "/_UnitTest/test_mrpPD", "test_mrpPD", 26),
-        entry("Learn/makingModules/rustModules", "Making Rust Modules", 5),
-        entry("examples/scenarioAttitudeFeedback", "scenarioAttitudeFeedback", 5),
-    ])
-    assert results[-1][0].endswith("test_mrpPD")
-    assert len(results) == 3
-
-
-@pytest.mark.parametrize("query", ["test_mrpPD", "mrpPD tests", "mrpPD validation"])
-def test_explicit_validation_queries_keep_test_priority(query):
-    """Do not bury validation documentation when the user explicitly seeks it."""
-    results = rank(query, [
-        entry(MODULE + "/_UnitTest/test_mrpPD", "test_mrpPD", 26),
-        entry("Learn/makingModules/rustModules", "Making Rust Modules", 5),
-    ])
-    assert results[0][0].endswith("test_mrpPD")
-
-
-def test_exact_api_query_keeps_symbol_priority():
-    """Specific function searches still prioritize their matching API entry."""
-    results = rank("Reset_mrpPD", [
-        entry(MODULE + "/mrpPD", "Reset_mrpPD", 26, "#reset-mrppd"),
-        entry(MODULE + "/mrpPD", "C Module: mrpPD", 5),
-    ])
-    assert results[0][1] == 106
-
-
-def test_legacy_folder_name_does_not_block_module_boost():
-    """Use the module page name rather than assuming it matches the directory."""
-    path = "Documentation/simulation/dynamics/RadiationPressure/radiationPressure"
-    assert rank("radiationPressure", [entry(path, "C++ Module: radiationPressure")])[0][1] == 127
 
 
 # Tool-dependent checks run in docs CI after its dependencies are installed.


### PR DESCRIPTION
* **Tickets addressed:** #1542
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Remove the macOS linker alignment warning when building `simpleAntenna` by compiling cfitsio with `-fno-common` on non-Windows platforms. Include the flag in cfitsio’s Conan package ID so existing cached binaries are rebuilt. Both settings are scoped to cfitsio.

A separate commit moves the nine Node.js documentation search-ranking checks outside default pytest collection. The shared GitHub docs action installs Node.js and explicitly runs these checks, failing on test failures or skips. This removes optional Node.js skips from regular desktop runs.

## Verification

- Confirmed a clean macOS build no longer emits the linker warning.
- Confirmed Conan rebuilds cfitsio while reusing other dependencies; common symbols in the cfitsio archive dropped from eight to zero.
- Passed 37 Conan regression tests and 16 antenna tests.
- Passed all nine relocated search-ranking checks and the existing Sphinx integration test.
- Verified default collection from both the repository root and `src` finds the same 6,250 tests, excluding the nine search-ranking checks.
- Passed pre-commit checks.

The search-test assertions are unchanged. Existing tests cover the build-configuration fix; no simulation behavior or expected results changed.

## Documentation

Added the release-note snippet and known-issue entry for the cfitsio linker warning. The updated RST entries rendered without warnings.

No documentation changes accompany the test-suite reorganization.

## Future work

None planned.