### PR TITLE
Allow RW mass properties to be added with balanced and simple jitter reaction wheels

### DIFF
--- a/docs/source/Support/bskReleaseNotesSnippets/600-reaction-wheel-mass-accounting.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/600-reaction-wheel-mass-accounting.rst
@@ -1,1 +1,3 @@
 - Documented the existing hub and wheel mass-property accounting for all three :ref:`reactionWheelStateEffector` models, including center-of-mass and parallel-axis contributions and guidance for switching models without double-counting (issue 600).
+- Added the opt-in ``includeWheelMassProperties`` setting to :ref:`reactionWheelStateEffector` for automatic mass, center-of-mass, inertia, energy, and momentum accounting of balanced and simple-jitter wheels with axisymmetric inertia. The default preserves existing hub accounting (issue 600).
+- Added initialization checks for finite, positive spin inertia in every wheel model and for valid mass, transverse inertia, and imbalance inputs in fully coupled wheels, independently of the mass-accounting option.

--- a/docs/source/Support/bskReleaseNotesSnippets/600-reaction-wheel-mass-accounting.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/600-reaction-wheel-mass-accounting.rst
@@ -1,0 +1,1 @@
+- Documented the existing hub and wheel mass-property accounting for all three :ref:`reactionWheelStateEffector` models, including center-of-mass and parallel-axis contributions and guidance for switching models without double-counting (issue 600).

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelMassProperties.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelMassProperties.py
@@ -1,0 +1,279 @@
+# ISC License
+#
+# Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""Validate optional wheel mass accounting against fully coupled and lumped-hub models."""
+
+import numpy as np
+import pytest
+
+from Basilisk.architecture import messaging
+from Basilisk.architecture.bskLogging import BasiliskError
+from Basilisk.simulation import reactionWheelStateEffector, spacecraft
+from Basilisk.utilities import SimulationBaseClass, macros, simIncludeRW
+
+
+BALANCED = reactionWheelStateEffector.BalancedWheels
+SIMPLE = reactionWheelStateEffector.JitterSimple
+COUPLED = reactionWheelStateEffector.JitterFullyCoupled
+
+
+def _parallel_axis(position):
+    """Return the parallel-axis tensor per unit mass for a body-frame displacement."""
+    return np.dot(position, position) * np.eye(3) - np.outer(position, position)
+
+
+def _make_simulation(models, include=None, lump_into_hub=False, driven=False):
+    """Configure offset, nonparallel wheels on a translating and rotating free spacecraft."""
+    sim = SimulationBaseClass.SimBaseClass()
+    process = sim.CreateNewProcess("process")
+    step = 0.002  # [s]
+    process.addTask(sim.CreateNewTask("task", macros.sec2nano(step)))
+    sc = spacecraft.Spacecraft()
+    sc.ModelTag = "spacecraft"
+    hub_mass = 80.0  # [kg]
+    hub_center = np.array([0.2, -0.1, 0.3])  # [m]
+    hub_inertia = np.diag([20.0, 25.0, 30.0])  # [kg*m^2]
+    sc.hub.r_CN_NInit = [1.0, 2.0, -3.0]  # [m]
+    sc.hub.v_CN_NInit = [0.2, 0.3, -0.1]  # [m/s]
+    sc.hub.sigma_BNInit = [0.1, -0.2, 0.05]  # [-]
+    sc.hub.omega_BN_BInit = [0.12, -0.08, 0.2]  # [rad/s]
+
+    factory = simIncludeRW.rwFactory()
+    axes = [[1.0, 2.0, -1.0], [-2.0, 1.0, 3.0], [2.0, -3.0, 1.0]]  # [-]
+    positions = [[0.7, -0.4, 0.2], [-0.3, 0.8, 0.5], [0.2, 0.1, -0.6]]  # [m]
+    masses = [2.0, 3.0, 4.0]  # [kg]
+    spin_inertias = [0.2, 0.3, 0.4]  # [kg*m^2]
+    transverse_inertias = [0.15, 0.23, 0.31]  # [kg*m^2]
+    speeds = [2.0, -3.0, 4.0]  # [rad/s]
+    first_moment = hub_mass * hub_center
+    inertia_at_origin = hub_inertia + hub_mass * _parallel_axis(hub_center)
+    expected_mass = hub_mass
+    expected_first_moment = first_moment.copy()
+    expected_inertia = inertia_at_origin.copy()
+    for i, model in enumerate(models):
+        wheel = factory.create(
+            "custom", axes[i], Js=spin_inertias[i], rWB_B=positions[i], RWModel=model,
+            useMaxTorque=False, useMinTorque=False, useRWfriction=False,
+        )
+        wheel.mass = masses[i]
+        wheel.Jt = transverse_inertias[i]
+        wheel.Jg = transverse_inertias[i]
+        wheel.Omega = speeds[i]
+        wheel.U_s = 0.0  # [kg*m]
+        wheel.U_d = 0.0  # [kg*m^2]
+        # Transform principal inertias using the factory's independent orthonormal wheel triad.
+        frame = np.column_stack([np.array(axis).reshape(3) for axis in
+                                 (wheel.gsHat_B, wheel.w2Hat0_B, wheel.w3Hat0_B)])
+        tensor = frame @ np.diag([wheel.Js, wheel.Jt, wheel.Jg]) @ frame.T
+        position = np.array(positions[i])
+        translated_tensor = tensor + wheel.mass * _parallel_axis(position)
+        if include or lump_into_hub or model == COUPLED:
+            expected_mass += wheel.mass
+            expected_first_moment += wheel.mass * position
+            expected_inertia += translated_tensor
+        if lump_into_hub and model != COUPLED:
+            hub_mass += wheel.mass
+            first_moment += wheel.mass * position
+            inertia_at_origin += translated_tensor
+
+    hub_center = first_moment / hub_mass
+    sc.hub.mHub = hub_mass
+    sc.hub.r_BcB_B = hub_center.tolist()
+    sc.hub.IHubPntBc_B = (inertia_at_origin - hub_mass * _parallel_axis(hub_center)).tolist()
+    wheels = reactionWheelStateEffector.ReactionWheelStateEffector()
+    assert wheels.includeWheelMassProperties is False
+    if include is not None:
+        wheels.includeWheelMassProperties = include
+    factory.addToSpacecraft("wheels", wheels, sc)
+    torques = [0.03, -0.02, 0.01] if driven else [0.0, 0.0, 0.0]  # [N*m]
+    command = messaging.ArrayMotorTorqueMsg().write(messaging.ArrayMotorTorqueMsgPayload(motorTorque=torques))
+    wheels.rwMotorCmdInMsg.subscribeTo(command)
+    sim.AddModelToTask("task", wheels, 2)
+    sim.AddModelToTask("task", sc, 1)
+    state = sc.scStateOutMsg.recorder()
+    mass = sc.scMassOutMsg.recorder()
+    speed = wheels.rwSpeedOutMsg.recorder()
+    conserved = sc.logger(["totRotEnergy", "totOrbEnergy", "totRotAngMomPntC_N", "totOrbAngMomPntN_N"])
+    for recorder in (state, mass, speed, conserved):
+        sim.AddModelToTask("task", recorder)
+    expected = (expected_mass, expected_first_moment / expected_mass, expected_inertia)
+    return sim, sc, wheels, factory, command, state, mass, speed, conserved, expected
+
+
+def _run(models, include=None, lump_into_hub=False, driven=False):
+    """Run the configured system and return histories and independent mass-property expectations."""
+    objects = _make_simulation(models, include, lump_into_hub, driven)
+    sim, sc, wheels, factory, command, state, mass, speed, conserved, expected = objects
+    sim.InitializeSimulation()
+    duration = 3.0  # [s]
+    sim.ConfigureStopTime(macros.sec2nano(duration))
+    sim.ExecuteSimulation()
+    histories = {
+        "position": state.r_BN_N,
+        "velocity": state.v_BN_N,
+        "attitude": state.sigma_BN,
+        "rate": state.omega_BN_B,
+        "speeds": speed.wheelSpeeds[:, :len(models)],
+        "mass": mass.massSC,
+        "center": mass.c_B,
+        "inertia": mass.ISC_PntB_B,
+        "rot_energy": conserved.totRotEnergy,
+        "orb_energy": conserved.totOrbEnergy,
+        "rot_momentum": conserved.totRotAngMomPntC_N,
+        "orb_momentum": conserved.totOrbAngMomPntN_N,
+    }
+    for name, truth in zip(("mass", "center", "inertia"), expected):
+        np.testing.assert_allclose(histories[name] - truth, 0.0, atol=2.0e-13,
+                                   err_msg=f"Incorrect {name} accounting")
+    np.testing.assert_allclose(wheels.effProps.rEffPrime_CB_B, 0.0, atol=1.0e-14)  # [m/s]
+    np.testing.assert_allclose(wheels.effProps.IEffPrimePntB_B, 0.0, atol=1.0e-14)  # [kg*m^2/s]
+    return histories
+
+
+@pytest.mark.parametrize("models", [[BALANCED] * 3, [SIMPLE] * 3, [BALANCED, SIMPLE, COUPLED]],
+                         ids=["balanced", "simple", "mixed"])
+@pytest.mark.parametrize("driven", [False, True], ids=["free", "motor_torque"])
+def test_mass_properties_match_fully_coupled(models, driven):
+    """Compare mass properties and trajectories to zero-imbalance fully coupled and lumped-hub systems.
+
+    Offset wheel locations and a nonzero hub center exercise parallel-axis and first-moment terms.
+    Free motion must conserve energy and momentum; internal motor torque must conserve momentum.
+    The mixed case verifies that the option never double-counts fully coupled wheel properties.
+    """
+    automatic = _run(models, include=True, driven=driven)
+    coupled = _run([COUPLED] * 3, include=True, driven=driven)
+    legacy = _run(models, lump_into_hub=True, driven=driven)
+    for name, history in automatic.items():
+        for reference in (coupled, legacy):
+            np.testing.assert_allclose(history, reference[name], rtol=2.0e-11, atol=2.0e-12, err_msg=name)
+    for name in ("rot_momentum", "orb_momentum", "orb_energy"):
+        np.testing.assert_allclose(automatic[name] - automatic[name][0], 0.0, atol=2.0e-11, err_msg=name)
+    if not driven:
+        np.testing.assert_allclose(automatic["rot_energy"], automatic["rot_energy"][0], rtol=2.0e-12)
+    else:
+        assert np.max(np.abs(automatic["speeds"][-1] - automatic["speeds"][0])) > 0.05  # [rad/s]
+
+
+@pytest.mark.parametrize("model", [BALANCED, SIMPLE, COUPLED])
+def test_default_mass_accounting_is_preserved(model):
+    """Verify the unset option matches explicit false and fully coupled accounting is unconditional."""
+    default = _run([model] * 3)
+    disabled = _run([model] * 3, include=False)
+    for name in default:
+        np.testing.assert_array_equal(default[name], disabled[name])
+    if model == COUPLED:
+        enabled = _run([model] * 3, include=True)
+        for name in default:
+            np.testing.assert_array_equal(default[name], enabled[name])
+
+
+@pytest.mark.parametrize("field,value,expected_error", [
+    ("mass", 0.0, "positive wheel mass"),  # [kg]
+    ("mass", float("nan"), "positive wheel mass"),  # [kg]
+    ("Js", -0.1, "positive Js"),  # [kg*m^2]
+    ("Jt", float("inf"), "positive wheel mass"),  # [kg*m^2]
+    ("Jg", 0.16, "axisymmetric wheel inertia"),  # [kg*m^2]
+    ("Js", 0.4, "axisymmetric wheel inertia"),  # [kg*m^2]
+    ("gsHat_B", [2.0, 0.0, 0.0], "unit spin axis"),  # [-]
+    ("rWB_B", [float("nan"), 0.0, 0.0], "finite wheel position"),  # [m]
+])
+@pytest.mark.parametrize("validation_path", ["attachment", "reset"])
+def test_automatic_mass_properties_validate_configuration(field, value, expected_error, validation_path):
+    """Reject invalid opt-in geometry during state registration even without task scheduling."""
+    objects = _make_simulation([BALANCED] * 3, include=True)
+    sim, sc, wheels, factory = objects[:4]
+    setattr(factory.rwList["RW1"], field, value)
+    with pytest.raises(BasiliskError, match=expected_error):
+        if validation_path == "attachment":
+            wheels.registerStates(sc.dynManager)
+        else:
+            wheels.Reset(0)
+
+
+@pytest.mark.parametrize("field,value,expected_error", [
+    ("mass", 0.0, "positive wheel mass"),  # [kg]
+    ("mass", -1.0, "positive wheel mass"),  # [kg]
+    ("mass", float("nan"), "positive wheel mass"),  # [kg]
+    ("mass", float("inf"), "positive wheel mass"),  # [kg]
+    ("Jt", 0.0, "positive wheel mass"),  # [kg*m^2]
+    ("Jg", -0.1, "positive wheel mass"),  # [kg*m^2]
+    ("Jg", float("nan"), "positive wheel mass"),  # [kg*m^2]
+    ("U_s", float("inf"), "finite U_s and U_d"),  # [kg*m]
+    ("U_d", float("nan"), "finite U_s and U_d"),  # [kg*m^2]
+    ("U_d", 0.3, "positive definite"),  # [kg*m^2]
+    ("U_d", -0.3, "positive definite"),  # [kg*m^2]
+    ("gsHat_B", [2.0, 0.0, 0.0], "unit spin axis"),  # [-]
+    ("rWB_B", [float("nan"), 0.0, 0.0], "finite wheel position"),  # [m]
+])
+@pytest.mark.parametrize("validation_path", ["attachment", "reset"])
+def test_fully_coupled_mass_properties_validate_configuration(field, value, expected_error, validation_path):
+    """Validate coupled wheel inputs before division or inertia use, with the new option left disabled."""
+    objects = _make_simulation([COUPLED] * 3)
+    sim, sc, wheels, factory = objects[:4]
+    setattr(factory.rwList["RW1"], field, value)
+    with pytest.raises(BasiliskError, match=expected_error):
+        if validation_path == "attachment":
+            wheels.registerStates(sc.dynManager)
+        else:
+            wheels.Reset(0)
+
+
+@pytest.mark.parametrize("model", [BALANCED, SIMPLE, COUPLED])
+@pytest.mark.parametrize("spin_inertia", [0.0, -0.1, float("nan"), float("inf")])  # [kg*m^2]
+def test_all_models_require_valid_spin_inertia(model, spin_inertia):
+    """Spin inertia is consumed by every model even when constant wheel mass properties are in the hub."""
+    objects = _make_simulation([model] * 3)
+    sim, sc, wheels, factory = objects[:4]
+    factory.rwList["RW1"].Js = spin_inertia
+    with pytest.raises(BasiliskError, match="positive Js"):
+        wheels.registerStates(sc.dynManager)
+
+
+@pytest.mark.parametrize("model", [BALANCED, SIMPLE])
+def test_legacy_simplified_models_do_not_require_unused_mass_properties(model):
+    """Legacy wheel configurations can omit the constant mass and transverse inertia kept in the hub."""
+    objects = _make_simulation([model] * 3)
+    sim, sc, wheels, factory = objects[:4]
+    for wheel in factory.rwList.values():
+        wheel.mass = 0.0  # [kg] unused in legacy simplified accounting
+        wheel.Jt = 0.0  # [kg*m^2] unused in legacy simplified accounting
+        wheel.Jg = 0.0  # [kg*m^2] unused in legacy simplified accounting
+    sim.InitializeSimulation()
+
+
+def test_fully_coupled_dynamic_imbalance_conserves_energy_and_momentum():
+    """Verify free-motion conservation with equal transverse moments and a nonzero product of inertia."""
+    objects = _make_simulation([COUPLED] * 3)
+    sim, sc, wheels, factory = objects[:4]
+    conserved = objects[8]
+    wheel = factory.rwList["RW1"]
+    wheel.Jg = wheel.Jt
+    wheel.U_d = 0.01  # [kg*m^2]
+    sim.InitializeSimulation()
+    assert wheel.J13 == pytest.approx(0.01)  # [kg*m^2]
+
+    duration = 3.0  # [s]
+    sim.ConfigureStopTime(macros.sec2nano(duration))
+    sim.ExecuteSimulation()
+
+    for energy in (conserved.totRotEnergy, conserved.totOrbEnergy):
+        np.testing.assert_allclose(energy, energy[0], rtol=2.0e-12, atol=0.0)
+    for momentum in (conserved.totRotAngMomPntC_N, conserved.totOrbAngMomPntN_N):
+        np.testing.assert_allclose(momentum - momentum[0], 0.0, atol=2.0e-11)  # [kg*m^2/s]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_initialization.py
+++ b/src/simulation/dynamics/reactionWheels/_UnitTest/test_reactionWheelStateEffector_initialization.py
@@ -48,7 +48,7 @@ def test_fully_coupled_wheel_initializes_without_task_scheduling():
     )
     wheel.mass = 2.0  # [kg]
     wheel.U_s = 0.6  # [kg*m]
-    wheel.U_d = 0.4  # [kg*m^2]
+    wheel.U_d = 0.004  # [kg*m^2] keep the rotor inertia positive definite
 
     wheel_effector = reactionWheelStateEffector.ReactionWheelStateEffector()
     wheel_factory.addToSpacecraft("reactionWheels", wheel_effector, spacecraft_model)
@@ -59,4 +59,4 @@ def test_fully_coupled_wheel_initializes_without_task_scheduling():
     sim.InitializeSimulation()
 
     assert wheel.d == pytest.approx(0.3)  # [m]
-    assert wheel.J13 == pytest.approx(0.4)  # [kg*m^2]
+    assert wheel.J13 == pytest.approx(0.004)  # [kg*m^2]

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.cpp
@@ -20,6 +20,9 @@
 
 #include "reactionWheelStateEffector.h"
 
+#include <algorithm>
+#include <cmath>
+
 ReactionWheelStateEffector::ReactionWheelStateEffector()
 {
 	CallCounts = 0;
@@ -67,8 +70,44 @@ void ReactionWheelStateEffector::linkInStates(DynParamManager& states)
  */
 void ReactionWheelStateEffector::initializeWheelConfiguration(RWConfigPayload& rw)
 {
+    const bool simplifiedModel = rw.RWModel == BalancedWheels || rw.RWModel == JitterSimple;
+    const bool contributesMass = rw.RWModel == JitterFullyCoupled
+                                 || (this->includeWheelMassProperties && simplifiedModel);
+    const double relativeTolerance = 1.0e-12;  // [-]
+    if (!std::isfinite(rw.Js) || rw.Js <= 0.0) {
+        this->bskLogger.bskError("ReactionWheelStateEffector: all wheel models require finite, positive Js.");
+    }
+    if (contributesMass) {
+        if (!std::isfinite(rw.mass) || rw.mass <= 0.0
+            || !std::isfinite(rw.Jt) || rw.Jt <= 0.0 || !std::isfinite(rw.Jg) || rw.Jg <= 0.0) {
+            this->bskLogger.bskError("ReactionWheelStateEffector: models contributing mass properties require "
+                                    "finite, positive wheel mass, Jt, and Jg.");
+        }
+        if (simplifiedModel && (std::abs(rw.Jt - rw.Jg) > relativeTolerance * std::max(rw.Jt, rw.Jg)
+                                || rw.Js > 2.0 * rw.Jt * (1.0 + relativeTolerance))) {
+            this->bskLogger.bskError("ReactionWheelStateEffector: includeWheelMassProperties requires "
+                                    "axisymmetric wheel inertia with Jt = Jg and Js <= 2*Jt.");
+        }
+        if (!rw.rWB_B.allFinite() || !rw.gsHat_B.allFinite()
+            || std::abs(rw.gsHat_B.squaredNorm() - 1.0) > relativeTolerance) {
+            this->bskLogger.bskError("ReactionWheelStateEffector: models contributing mass properties require "
+                                    "a finite wheel position and unit spin axis.");
+        }
+    }
     if (rw.RWModel == JitterFullyCoupled) {
+        if (!std::isfinite(rw.U_s) || !std::isfinite(rw.U_d)) {
+            this->bskLogger.bskError("ReactionWheelStateEffector: fully coupled wheels require finite U_s and U_d.");
+        }
+        // With positive diagonal inertias, this condition makes the full tensor (J13 = U_d) positive definite.
+        // Compare square roots instead of inertia products to avoid overflow.
+        if (std::abs(rw.U_d) / std::sqrt(rw.Js) >= std::sqrt(rw.Jg)) {
+            this->bskLogger.bskError("ReactionWheelStateEffector: fully coupled wheel inertia must be positive "
+                                    "definite, requiring U_d^2 < Js*Jg.");
+        }
         rw.d = rw.U_s / rw.mass;
+        if (!std::isfinite(rw.d)) {
+            this->bskLogger.bskError("ReactionWheelStateEffector: fully coupled wheel offset U_s/mass must be finite.");
+        }
         rw.J13 = rw.U_d;
     }
 }
@@ -186,6 +225,17 @@ void ReactionWheelStateEffector::updateEffectorMassProps(double integTime [[mayb
 			rw.w3Hat_B = dcm_BW.col(2);
 			thetaCount++;
 		}
+        if (this->includeWheelMassProperties && (rw.RWModel == BalancedWheels || rw.RWModel == JitterSimple)) {
+            // The simplified models use the nominal, axisymmetric wheel geometry for constant mass properties.
+            rw.IRWPntWc_B = rw.Jt * Eigen::Matrix3d::Identity()
+                           + (rw.Js - rw.Jt) * rw.gsHat_B * rw.gsHat_B.transpose();
+            rw.rWcB_B = rw.rWB_B;
+            rw.rTildeWcB_B = eigenTilde(rw.rWcB_B);
+            this->effProps.mEff += rw.mass;
+            this->effProps.rEff_CB_B += rw.mass * rw.rWcB_B;
+            this->effProps.IEffPntB_B += rw.IRWPntWc_B
+                                       + rw.mass * rw.rTildeWcB_B * rw.rTildeWcB_B.transpose();
+        }
 	}
 
     // - Need to divide out the total mass of the reaction wheels from rCB_B and rPrimeCB_B
@@ -398,6 +448,13 @@ void ReactionWheelStateEffector::updateEnergyMomContributions(double integTime [
 		if (rw.RWModel == BalancedWheels || rw.RWModel == JitterSimple) {
 			rotAngMomPntCContr_B += rw.Js*rw.gsHat_B*rw.Omega;
             rotEnergyContr += 1.0/2.0*rw.Js*rw.Omega*rw.Omega + rw.Js*rw.Omega*rw.gsHat_B.dot(omegaLoc_BN_B);
+            if (this->includeWheelMassProperties) {
+                const Eigen::Vector3d wheelVelocity_B = omegaLoc_BN_B.cross(rw.rWcB_B);
+                rotAngMomPntCContr_B += rw.IRWPntWc_B * omegaLoc_BN_B
+                                       + rw.mass * rw.rWcB_B.cross(wheelVelocity_B);
+                rotEnergyContr += 0.5 * omegaLoc_BN_B.dot(rw.IRWPntWc_B * omegaLoc_BN_B)
+                                  + 0.5 * rw.mass * wheelVelocity_B.squaredNorm();
+            }
 		} else if (rw.RWModel == JitterFullyCoupled) {
 			Eigen::Vector3d omega_WN_B = omegaLoc_BN_B + rw.Omega*rw.gsHat_B;
 			Eigen::Vector3d r_WcB_B = rw.rWcB_B;

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.h
@@ -21,8 +21,15 @@
 #ifndef REACTIONWHEELSTATEEFFECTOR_H
 #define REACTIONWHEELSTATEEFFECTOR_H
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
 #include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
+#include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicObject.h"
 #include <Eigen/Dense>
@@ -64,6 +71,15 @@ public:
 	void ConfigureRWRequests(double CurrentTime);
 
 public:
+
+    /*! @brief Include constant mass properties for balanced and simple-jitter wheels.
+     * @note Defaults to false, preserving the convention that these properties are included in the hub.
+     * Set before simulation initialization and leave unchanged during a run. When true, exclude these
+     * wheel properties from the hub and provide positive mass and axisymmetric inertia (Jt = Jg).
+     * Fully coupled jitter wheels always contribute their own mass properties, regardless of this option.
+     */
+    bool includeWheelMassProperties = false;
+
 	std::vector<std::shared_ptr<RWConfigPayload>> ReactionWheelData;          //!< RW information
 
 	ReadFunctor<ArrayMotorTorqueMsgPayload> rwMotorCmdInMsg;    //!< RW motor torque array cmd input message

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
@@ -14,11 +14,11 @@ how to run it, as well as testing.
 Module Assumptions and Limitations
 ----------------------------------
 
-The wheel model determines how mass properties are accounted for. A balanced wheel has constant
-mass properties, but these properties are not automatically added to the spacecraft by the balanced
-model. The same convention applies to the simple-jitter model.
+The wheel model and ``includeWheelMassProperties`` option determine how mass properties are accounted
+for. The option defaults to ``False`` to preserve existing simulations: balanced and simple-jitter
+wheels then require their constant mass properties to be included in the hub.
 
-.. list-table:: Wheel mass-property accounting
+.. list-table:: Default wheel mass-property accounting (``includeWheelMassProperties = False``)
     :header-rows: 1
     :widths: 20 40 40
 
@@ -37,11 +37,15 @@ model. The same convention applies to the simple-jitter model.
         time derivatives, including imbalance effects.
       - Exclude the mass properties already represented by this wheel effector from the hub.
 
-Setting a nonzero ``mass`` on a ``BalancedWheels`` or ``JitterSimple`` wheel does not increase the
+With the default option, setting a nonzero ``mass`` on a ``BalancedWheels`` or ``JitterSimple`` wheel does not increase the
 spacecraft mass. Likewise, setting ``rWB_B``, ``Jt``, or ``Jg`` does not add the wheel's constant
 center-of-mass or inertia contribution in these two models. The spin-axis inertia ``Js`` is still
 used in wheel acceleration, spacecraft rotational coupling, angular momentum, and energy; it must
 be configured even when the wheel's constant inertia is included in the hub.
+
+With ``includeWheelMassProperties = True``, balanced and simple-jitter wheels instead contribute
+their nominal mass, center-of-mass offset, and axisymmetric inertia through the effector. The option
+does not change the accounting for fully coupled wheels, which always contribute their own properties.
 
 See :ref:`reactionWheelMassAccounting` for the hub inputs and model-switching guidance.
 
@@ -74,7 +78,7 @@ or when using unlimited torque with small spacecraft inertia.
 Configuring Hub and Wheel Mass Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For ``BalancedWheels`` and ``JitterSimple``, configure the hub to include the wheels as if they were
+By default, for ``BalancedWheels`` and ``JitterSimple``, configure the hub to include the wheels as if they were
 locked relative to the body. The effector separately models their relative spin. Update all three
 hub inputs consistently:
 
@@ -120,12 +124,80 @@ Check the selected factory's mass and inertia definitions when partitioning the 
 
 .. warning::
 
-    Count each wheel's mass properties exactly once. If the hub inputs already describe the assembled
+    Count each wheel's mass properties exactly once. With the default option, if the hub inputs already describe the assembled
     spacecraft with balanced or simple-jitter wheels, do not add those wheels again. When switching
     to ``JitterFullyCoupled``, remove the mass properties represented by those wheels from the hub
     and recompute its center of mass and inertia about that center. When switching back, include them
     again. Changing ``RWModel`` does not adjust the hub inputs automatically. For mixed wheel models,
     apply this convention to each wheel individually.
+
+Automatic Inclusion of Wheel Mass Properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To let the effector account for the constant properties of its balanced and simple-jitter wheels,
+set the option before ``InitializeSimulation()``:
+
+.. code-block:: python
+
+    rwStateEffector = reactionWheelStateEffector.ReactionWheelStateEffector()
+    rwStateEffector.includeWheelMassProperties = True
+    rwFactory.addToSpacecraft("ReactionWheels", rwStateEffector, scObject)
+
+Configure ``scObject.hub`` with only the remaining rigid structure, excluding the mass properties
+represented by these wheels. The option applies to all balanced and simple-jitter wheels in this
+effector. For mixed wheel models, fully coupled wheels still contribute exactly once. Leave the
+option unchanged during a simulation run.
+
+For each balanced or simple-jitter wheel, the effector uses ``mass``, ``rWB_B``, ``gsHat_B``, ``Js``,
+and ``Jt`` to compute the nominal mass properties. Its constant inertia is the axisymmetric tensor
+given above, shifted from ``rWB_B`` to :math:`B` using the parallel-axis theorem. The effector also
+includes the corresponding rigid-body kinetic energy and angular momentum, in addition to the
+existing relative-spin terms. The derivatives of these constant mass properties are zero.
+
+This option requires finite, positive ``mass``, ``Js``, ``Jt``, and ``Jg``, with ``Jt = Jg`` and
+``Js <= 2*Jt`` for a physically valid axisymmetric inertia. The inertia comparisons allow a relative
+tolerance of :math:`10^{-12}`. ``rWB_B`` must be finite, and ``gsHat_B`` must be a finite unit vector
+(squared norm within :math:`10^{-12}` of unity). Invalid configurations raise ``BSK_ERROR`` during
+state registration or ``Reset()``. The axisymmetry restriction applies to balanced and simple-jitter
+wheels when the option is enabled.
+
+The option does not turn a simplified wheel model into a fully coupled imbalance model. Balanced
+wheels continue to ignore imbalance parameters; simple-jitter wheels retain their existing applied
+imbalance forces and torques, while their mass properties use nominal centered geometry. Use
+``JitterFullyCoupled`` when the moving center of mass and coupled imbalance dynamics are needed.
+
+When enabling the option on an existing simulation, remove the wheels' constant mass properties from
+the hub and recompute its center of mass and inertia about that center. When disabling it, add the
+balanced and simple-jitter wheel properties back into the hub. With the option enabled, switching
+between balanced wheels and fully coupled wheels with zero imbalance and axisymmetric inertia does
+not require repartitioning the hub mass properties.
+
+Configuration Validation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every wheel model requires finite, positive ``Js``, since it is used in the spin dynamics regardless
+of the mass-accounting option. Balanced and simple-jitter wheels with the default option do not
+require ``mass``, ``Jt``, or ``Jg`` to be populated: those constant properties are accounted for in
+the hub instead.
+
+``JitterFullyCoupled`` always requires finite, positive ``mass``, ``Jt``, and ``Jg``, as well as the
+finite position and unit spin axis described above. Its ``U_s`` and ``U_d`` must be finite, the derived
+offset ``U_s / mass`` must remain finite, and the full rotor inertia tensor with ``J13 = U_d`` must
+be positive definite. With positive diagonal moments, this last check requires ``U_d**2 < Js*Jg``.
+These checks apply even when ``includeWheelMassProperties`` is ``False``, and occur before the
+derived wheel configuration is used. They run during state registration and ``Reset()``.
+
+Validation
+~~~~~~~~~~
+
+``test_reactionWheelMassProperties.py`` compares the enabled option with zero-imbalance,
+axisymmetric fully coupled wheels and with the default model using manually combined hub properties.
+It checks spacecraft mass, center of mass, inertia, translational and attitude histories, wheel
+speeds, energy, and angular momentum for balanced, simple-jitter, and mixed configurations. The
+tests use offset wheels and a nonzero hub center of mass. Free-motion cases verify energy and
+momentum conservation; motor-driven cases verify momentum conservation and matching energy histories.
+Additional cases check unchanged default accounting, invalid simplified and fully coupled
+configuration handling, and spin-inertia validation across all models.
 
 Initialization and Reset
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
+++ b/src/simulation/dynamics/reactionWheels/reactionWheelStateEffector.rst
@@ -1,14 +1,49 @@
 Executive Summary
 -----------------
 
-Class that is used to implement an effector impacting a dynamic body
-that does not itself maintain a state or represent a changing component of
-the body (for example: gravity, thrusters, solar radiation pressure, etc.)
+This state effector models reaction wheels attached to a spacecraft hub, including wheel-speed states,
+motor torques, friction, and the resulting spacecraft coupling. It supports balanced wheels, simple
+jitter, and fully coupled jitter. The jitter models also maintain wheel-angle states.
 
 The module
 :download:`PDF Description </../../src/simulation/dynamics/reactionWheels/_Documentation/Basilisk-REACTIONWHEELSTATEEFFECTOR-20170816.pdf>`
 contains further information on this module's function,
 how to run it, as well as testing.
+
+
+Module Assumptions and Limitations
+----------------------------------
+
+The wheel model determines how mass properties are accounted for. A balanced wheel has constant
+mass properties, but these properties are not automatically added to the spacecraft by the balanced
+model. The same convention applies to the simple-jitter model.
+
+.. list-table:: Wheel mass-property accounting
+    :header-rows: 1
+    :widths: 20 40 40
+
+    * - ``RWModel``
+      - Effector contribution
+      - Required hub configuration
+    * - ``BalancedWheels``
+      - No mass, first mass moment, or constant inertia contribution.
+      - Include the wheel's constant mass properties in the hub.
+    * - ``JitterSimple``
+      - No mass, first mass moment, or constant inertia contribution. Imbalance is approximated
+        through applied forces and torques.
+      - Include the wheel's constant mass properties in the hub, as for balanced wheels.
+    * - ``JitterFullyCoupled``
+      - Adds the configured wheel mass, center-of-mass contribution, inertia, and their applicable
+        time derivatives, including imbalance effects.
+      - Exclude the mass properties already represented by this wheel effector from the hub.
+
+Setting a nonzero ``mass`` on a ``BalancedWheels`` or ``JitterSimple`` wheel does not increase the
+spacecraft mass. Likewise, setting ``rWB_B``, ``Jt``, or ``Jg`` does not add the wheel's constant
+center-of-mass or inertia contribution in these two models. The spin-axis inertia ``Js`` is still
+used in wheel acceleration, spacecraft rotational coupling, angular momentum, and energy; it must
+be configured even when the wheel's constant inertia is included in the hub.
+
+See :ref:`reactionWheelMassAccounting` for the hub inputs and model-switching guidance.
 
 
 Message Connection Descriptions
@@ -33,6 +68,64 @@ User Guide
 The reaction wheel state effector module provides functionality for simulating reaction wheels in a spacecraft.
 It includes safety mechanisms to prevent numerical instability that can occur with excessive wheel acceleration
 or when using unlimited torque with small spacecraft inertia.
+
+.. _reactionWheelMassAccounting:
+
+Configuring Hub and Wheel Mass Properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For ``BalancedWheels`` and ``JitterSimple``, configure the hub to include the wheels as if they were
+locked relative to the body. The effector separately models their relative spin. Update all three
+hub inputs consistently:
+
+* ``hub.mHub``: combined mass of the rigid hub and the wheels accounted for in the hub, in kg.
+* ``hub.r_BcB_B``: location of that combined center of mass relative to body-frame origin
+  :math:`B`, expressed in body-frame components, in m.
+* ``hub.IHubPntBc_B``: combined inertia about that combined center of mass :math:`B_c`, expressed
+  in body-frame components, in kg m\ :sup:`2`. Include each wheel's full constant inertia,
+  including its spin-axis inertia, and the parallel-axis contributions from its location.
+
+For example, let :math:`m_0`, :math:`\mathbf r_0`, and :math:`I_0` describe the rigid hub before adding
+the wheels, with :math:`I_0` taken about its own center of mass. For each wheel to be included in
+the hub, let :math:`m_i`, :math:`\mathbf r_i`, and :math:`I_i` be its mass, nominal center-of-mass
+location, and constant inertia about its own center of mass. All position vectors are measured from
+:math:`B`, and all vectors and inertia tensors are expressed in body-frame components. Then set:
+
+.. math::
+
+    m_h = m_0 + \sum_i m_i, \qquad
+    \mathbf r_h = \frac{m_0\mathbf r_0 + \sum_i m_i\mathbf r_i}{m_h}
+
+.. math::
+
+    \begin{aligned}
+    I_h &= I_0 + m_0 P(\mathbf r_0 - \mathbf r_h)
+        + \sum_i \left[I_i + m_i P(\mathbf r_i - \mathbf r_h)\right], \\
+    P(\mathbf a) &= (\mathbf a^T\mathbf a)\mathbf 1_3 - \mathbf a\mathbf a^T
+    \end{aligned}
+
+Here :math:`\mathbf 1_3` is the identity matrix. Assign :math:`m_h`, :math:`\mathbf r_h`, and
+:math:`I_h` to ``mHub``, ``r_BcB_B``, and ``IHubPntBc_B``, respectively. Rotate wheel inertia tensors
+into the body frame before combining them. For an axisymmetric balanced wheel, the constant tensor
+about its center of mass is :math:`I_i = J_t\mathbf 1_3 + (J_s-J_t)\hat{\mathbf g}_s\hat{\mathbf g}_s^T`,
+where :math:`J_g=J_t` and :math:`\hat{\mathbf g}_s` is ``gsHat_B``. Other state effectors continue to
+contribute their own mass properties separately.
+
+For ``JitterFullyCoupled``, the effector performs the wheel mass-property accounting. Its wheel
+center of mass is ``rWB_B + d * w2Hat_B``, with ``d = U_s / mass``. It rotates the wheel inertia
+defined by ``Js``, ``Jt``, ``Jg``, and ``J13 = U_d`` into the body frame and includes the parallel-axis
+contribution about :math:`B`. Include only the remaining rigid structure in the hub; any stationary
+wheel housing not represented by the configured wheel mass properties still belongs in the hub.
+Check the selected factory's mass and inertia definitions when partitioning the hardware.
+
+.. warning::
+
+    Count each wheel's mass properties exactly once. If the hub inputs already describe the assembled
+    spacecraft with balanced or simple-jitter wheels, do not add those wheels again. When switching
+    to ``JitterFullyCoupled``, remove the mass properties represented by those wheels from the hub
+    and recompute its center of mass and inertia about that center. When switching back, include them
+    again. Changing ``RWModel`` does not adjust the hub inputs automatically. For mixed wheel models,
+    apply this convention to each wheel individually.
 
 Initialization and Reset
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/utilities/simIncludeRW.py
+++ b/src/utilities/simIncludeRW.py
@@ -90,10 +90,15 @@ class rwFactory(object):
 
         Notes
         -----
-        ``BalancedWheels`` is the default model. For this model and ``JitterSimple``, the wheel's
+        ``BalancedWheels`` is the default model. By default, for this model and ``JitterSimple``, the wheel's
         constant mass, center-of-mass contribution, and full constant inertia must already be
         included in the hub mass and inertia inputs. Setting the wheel's ``mass`` does not add it to the spacecraft
         mass in these modes. ``Js`` is still required for the wheel's spin dynamics.
+
+        To include these properties through the effector instead, set its
+        ``includeWheelMassProperties`` option to ``True`` before simulation initialization and
+        exclude the wheel properties from the hub. This requires positive wheel mass and
+        axisymmetric inertia (``Jt = Jg``).
 
         ``JitterFullyCoupled`` adds the configured wheel mass properties through the effector;
         exclude those same properties from the hub. See :ref:`reactionWheelMassAccounting` for

--- a/src/utilities/simIncludeRW.py
+++ b/src/utilities/simIncludeRW.py
@@ -87,6 +87,17 @@ class rwFactory(object):
         -------
         RWConfigSimMsg : message structure
             A handle to the RW configuration message
+
+        Notes
+        -----
+        ``BalancedWheels`` is the default model. For this model and ``JitterSimple``, the wheel's
+        constant mass, center-of-mass contribution, and full constant inertia must already be
+        included in the hub mass and inertia inputs. Setting the wheel's ``mass`` does not add it to the spacecraft
+        mass in these modes. ``Js`` is still required for the wheel's spin dynamics.
+
+        ``JitterFullyCoupled`` adds the configured wheel mass properties through the effector;
+        exclude those same properties from the hub. See :ref:`reactionWheelMassAccounting` for
+        the hub configuration and model-switching conventions.
         """
 
         # create the blank RW object


### PR DESCRIPTION
* **Tickets addressed:** #600
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Adds the opt-in `includeWheelMassProperties` setting to `reactionWheelStateEffector`. Balanced and simple-jitter wheels can now contribute their constant mass, center-of-mass offset, inertia, energy, and angular momentum through the effector.

The default remains `False`, preserving existing simulations that include these properties in the hub. When enabling the option, users must remove the corresponding wheel properties from the hub to avoid double-counting. Fully coupled wheel mass accounting remains unchanged.

Initialization validates spin inertia in every model and the additional mass, inertia, and imbalance inputs used by models contributing mass properties. This is an enhancement to mass accounting and configuration guidance.

## Verification

* All 82 reaction-wheel tests passed.
* Added comparisons against zero-imbalance, axisymmetric fully coupled wheels and manually combined hub properties.
* Verified mass properties, trajectories, wheel speeds, energy, and angular momentum across balanced, simple-jitter, and mixed configurations.
* Tested free-motion conservation, commanded motor torques, default compatibility, and invalid configurations.
* Revised the fully coupled acceptance test to verify conservation with equal transverse inertias and nonzero dynamic imbalance.
* Native build, header isolation compilation, Sphinx build with warnings treated as errors, and whitespace checks passed.

## Documentation

Updated the module guide and wheel factory documentation with model-specific mass accounting, parallel-axis calculations, configuration requirements, and migration guidance. Corrected the module executive summary and added release notes.

## Future work
None