### PR TITLE
Remove beta status of mujoco

### DIFF
--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -112,7 +112,7 @@ The script accepts the following options to customize this process.
     * - ``mujoco``
       - Boolean
       - False
-      - :beta:`Mujoco Support` Includes the `MuJoCo <https://mujoco.org>`_ dependencies
+      - Includes the `MuJoCo <https://mujoco.org>`_ dependencies
     * - ``rustModules``
       - Boolean
       - False

--- a/docs/source/Learn/makingModules/advancedTopics/mujocoDynObject.rst
+++ b/docs/source/Learn/makingModules/advancedTopics/mujocoDynObject.rst
@@ -3,12 +3,6 @@
 Multi-body Dynamics with MuJoCo
 ===============================
 
-.. warning::
-
-    :beta:`Mujoco Support` The following feature is a work in progress! Extensive validation has not been performed.
-    Some features might be missing, and APIs are subject to change between releases.
-
-
 ``DynamicObject`` subclasses are Basilisk modules that require the integration of
 ordinate differential equations (ODEs) to propagate their internal state (see :ref:`bskPrinciples-9`).
 The :ref:`spacecraft` module is the most commonly used ``DynamicObject`` in Basilisk, and is ideal to

--- a/docs/source/Support/bskReleaseNotesSnippets/mujoco-general-availability.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/mujoco-general-availability.rst
@@ -1,0 +1,1 @@
+- MuJoCo support is now generally available. Removed its beta labels and preliminary-use warnings from the documentation.


### PR DESCRIPTION
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
MuJoCo dynamics engine is no longer in beta status.

## Verification
Documentation built without issues.

## Documentation
Remove mujoco-beta related labels and language

## Future work
None