### PR TITLE
clarify spinning-body command indexing and guard NDOF array bounds

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -21,6 +21,13 @@ Version |release|
   its original source through a Python reference until the payload is released.
   Reference cycles created by caching a payload view on its source message can
   also be garbage collected.
+- GitHub issue 571: Spinning-body lock and motor torque arrays index degrees of freedom
+  within one module. Separate module instances require separate messages for independent
+  commands; each OneDOF instance reads element ``[0]``. The documentation now explains
+  this mapping and corrects the lock-message examples. For
+  :ref:`spinningBodyNDOFStateEffector`, keep chains using either array input at or below
+  ``MAX_EFF_CNT`` (currently 36) bodies. The module still lacks a capacity check and can
+  read beyond the payload arrays with larger chains.
 - GitHub issue 1542: macOS builds could emit a benign ``__common`` section alignment warning
   when linking :ref:`simpleAntenna`. The Python build script now builds cfitsio with
   ``-fno-common`` on non-Windows platforms and includes the flag in its Conan package ID

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -25,9 +25,10 @@ Version |release|
   within one module. Separate module instances require separate messages for independent
   commands; each OneDOF instance reads element ``[0]``. The documentation now explains
   this mapping and corrects the lock-message examples. For
-  :ref:`spinningBodyNDOFStateEffector`, keep chains using either array input at or below
-  ``MAX_EFF_CNT`` (currently 36) bodies. The module still lacks a capacity check and can
-  read beyond the payload arrays with larger chains.
+  :ref:`spinningBodyNDOFStateEffector`, chains with more than ``MAX_EFF_CNT`` (currently
+  36) bodies could read beyond a linked lock or motor torque payload. Initialization,
+  reset, and input processing now reject these configurations with ``BasiliskError``.
+  Larger chains remain supported when neither array input is linked.
 - GitHub issue 1542: macOS builds could emit a benign ``__common`` section alignment warning
   when linking :ref:`simpleAntenna`. The Python build script now builds cfitsio with
   ``-fno-common`` on non-Windows platforms and includes the flag in its Conan package ID

--- a/docs/source/Support/bskReleaseNotesSnippets/571-spinning-body-command-bounds.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/571-spinning-body-command-bounds.rst
@@ -1,0 +1,1 @@
+- Fixed out-of-bounds lock and motor torque command reads in :ref:`spinningBodyNDOFStateEffector` by rejecting chains larger than ``MAX_EFF_CNT`` when either array input is linked, including subscriptions added after initialization.

--- a/docs/source/Support/bskReleaseNotesSnippets/571-spinning-body-lock-documentation.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/571-spinning-body-lock-documentation.rst
@@ -1,0 +1,1 @@
+- Clarified lock and motor torque array indexing within spinning-body modules, documented independent lock messages for separate instances and the current NDOF command-array capacity limit, and corrected the OneDOF, TwoDOF, and NDOF setup examples.

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFResetChecks.py
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/_UnitTest/test_spinningBodyNDOFResetChecks.py
@@ -22,17 +22,21 @@
 #
 
 """
-Regression tests for issue #1534: state-effector configuration validation.
+Regression tests for issues #1534 and #571: state-effector configuration validation.
 
 When its spacecraft registers states, ``SpinningBodyNDOFStateEffector``
 validates that each attached body's ``dcm_S0P`` is a proper rotation and each
 ``ISPntSc_S`` is a symmetric, positive-definite inertia tensor. These tests
 break exactly one precondition at a time and assert initialization raises a
 ``BasiliskError``. (``sHat_S`` is validated by its own setter.)
+
+Command-array tests exercise the payload capacity during reset, spacecraft
+initialization, and input processing, including the last valid array entry.
 """
 
 import pytest
 
+from Basilisk.architecture import messaging
 from Basilisk.architecture.bskLogging import BasiliskError
 from Basilisk.simulation import spacecraft, spinningBodyNDOFStateEffector
 from Basilisk.utilities import SimulationBaseClass, macros
@@ -166,6 +170,98 @@ def test_spinningBodyNDOF_rejectsEmptyChain(validationPath):
 
     with pytest.raises(BasiliskError, match="at least one spinning body"):
         unitTestSim.InitializeSimulation()
+
+
+def _command_bounds_simulation(body_count):
+    """Attach a valid chain without scheduling the effector's reset or update."""
+    sim = SimulationBaseClass.SimBaseClass()
+    process = sim.CreateNewProcess("testProcess")
+    time_step = macros.sec2nano(0.01)  # [ns]
+    process.addTask(sim.CreateNewTask("testTask", time_step))
+    sc = spacecraft.Spacecraft()
+    sc.hub.mHub = 750.0  # [kg]
+    sc.hub.IHubPntBc_B = [[900.0, 0.0, 0.0], [0.0, 800.0, 0.0], [0.0, 0.0, 600.0]]  # [kg*m^2]
+    effector = spinningBodyNDOFStateEffector.SpinningBodyNDOFStateEffector()
+    for _ in range(body_count):
+        effector.addSpinningBody(_validBody())
+    sc.addStateEffector(effector)
+    sim.AddModelToTask("testTask", sc)
+    return sim, effector
+
+
+def _link_command_inputs(effector, inputs, written):
+    """Connect the requested command inputs and retain their message objects."""
+    messages = []
+    if inputs in ("lock", "both"):
+        message = messaging.ArrayEffectorLockMsg()
+        if written:
+            message.write(messaging.ArrayEffectorLockMsgPayload())
+        effector.motorLockInMsg.subscribeTo(message)
+        messages.append(message)
+    if inputs in ("torque", "both"):
+        message = messaging.ArrayMotorTorqueMsg()
+        if written:
+            message.write(messaging.ArrayMotorTorqueMsgPayload())
+        effector.motorTorqueInMsg.subscribeTo(message)
+        messages.append(message)
+    return messages
+
+
+@pytest.mark.parametrize("validation_path", ["reset", "attachment"])
+@pytest.mark.parametrize("extra_bodies", [0, 1])
+@pytest.mark.parametrize("inputs, written", [
+    ("none", False), ("lock", False), ("lock", True),
+    ("torque", False), ("torque", True), ("both", True),
+])
+def test_command_array_capacity_validation(validation_path, extra_bodies, inputs, written):
+    """Reject oversized chains only when an array input is linked, even if unwritten."""
+    sim, effector = _command_bounds_simulation(messaging.MAX_EFF_CNT + extra_bodies)
+    messages = _link_command_inputs(effector, inputs, written)
+    validate = (lambda: effector.Reset(0)) if validation_path == "reset" else sim.InitializeSimulation
+    if extra_bodies and messages:
+        with pytest.raises(BasiliskError, match="MAX_EFF_CNT"):
+            validate()
+    else:
+        validate()
+
+
+@pytest.mark.parametrize("inputs", ["lock", "torque"])
+@pytest.mark.parametrize("written", [False, True])
+def test_command_array_linked_after_initialization(inputs, written):
+    """Reject an oversized array subscription added after configuration validation."""
+    sim, effector = _command_bounds_simulation(messaging.MAX_EFF_CNT + 1)
+    sim.InitializeSimulation()
+    messages = _link_command_inputs(effector, inputs, written)
+    with pytest.raises(BasiliskError, match="MAX_EFF_CNT"):
+        effector.UpdateState(0)
+    assert len(messages) == 1
+
+
+@pytest.mark.parametrize("lock_last", [False, True])
+def test_command_array_last_entry(lock_last):
+    """The final valid torque and lock entries control the final body's motion."""
+    sim, effector = _command_bounds_simulation(messaging.MAX_EFF_CNT)
+    lock_payload = messaging.ArrayEffectorLockMsgPayload()
+    lock_payload.effectorLockFlag = [1] * (messaging.MAX_EFF_CNT - 1) + [int(lock_last)]
+    lock_message = messaging.ArrayEffectorLockMsg().write(lock_payload)
+    effector.motorLockInMsg.subscribeTo(lock_message)
+    torque_payload = messaging.ArrayMotorTorqueMsgPayload()
+    torque_payload.motorTorque = [0.0] * (messaging.MAX_EFF_CNT - 1) + [0.1]  # [Nm]
+    torque_message = messaging.ArrayMotorTorqueMsg().write(torque_payload)
+    effector.motorTorqueInMsg.subscribeTo(torque_message)
+    sim.AddModelToTask("testTask", effector)
+    recorder = effector.spinningBodyOutMsgs[-1].recorder()
+    sim.AddModelToTask("testTask", recorder)
+    sim.InitializeSimulation()
+    stop_time = macros.sec2nano(0.02)  # [ns]
+    sim.ConfigureStopTime(stop_time)
+    sim.ExecuteSimulation()
+    if lock_last:
+        assert recorder.theta[-1] == 0.0
+        assert recorder.thetaDot[-1] == 0.0
+    else:
+        assert recorder.theta[-1] > 0.0
+        assert recorder.thetaDot[-1] > 0.0
 
 
 if __name__ == "__main__":

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.cpp
@@ -19,6 +19,7 @@
 
 #include "spinningBodyNDOFStateEffector.h"
 #include "architecture/utilities/avsEigenSupport.h"
+#include "architecture/utilities/macroDefinitions.h"
 #include "architecture/utilities/rigidBodyKinematics.h"
 #include <string>
 
@@ -59,6 +60,8 @@ void SpinningBodyNDOFStateEffector::Reset(uint64_t CurrentClock [[maybe_unused]]
 /*! Validate the user-supplied spinning-body chain configuration. */
 void SpinningBodyNDOFStateEffector::validateConfiguration()
 {
+    this->validateCommandCapacity();
+
     if (this->spinningBodyVec.empty()) {
         bskLogger.bskError("spinningBodyNDOFStateEffector: at least one spinning body is required.");
         return;
@@ -76,6 +79,17 @@ void SpinningBodyNDOFStateEffector::validateConfiguration()
         if (body->mass > 0.0 && !eigenIsValidInertiaMatrix(body->ISPntSc_S)) {
             bskLogger.bskError("spinningBodyNDOFStateEffector: a spinning body's ISPntSc_S is not a valid inertia tensor. It may not have been set properly by the user.");
         }
+    }
+}
+
+/*! @brief Reject body chains that exceed the capacity of a linked command array. */
+void SpinningBodyNDOFStateEffector::validateCommandCapacity()
+{
+    if (this->spinningBodyVec.size() > MAX_EFF_CNT
+        && (this->motorLockInMsg.isLinked() || this->motorTorqueInMsg.isLinked())) {
+        bskLogger.bskError("spinningBodyNDOFStateEffector: number of degrees of freedom (%zu) exceeds "
+                           "MAX_EFF_CNT (%d) with a linked motorLockInMsg or motorTorqueInMsg.",
+                           this->spinningBodyVec.size(), MAX_EFF_CNT);
     }
 }
 
@@ -148,6 +162,9 @@ std::shared_ptr<SpinningBody> SpinningBodyNDOFStateEffector::getSpinningBody(uin
 
 void SpinningBodyNDOFStateEffector::readInputMessages()
 {
+    // Recheck capacity in case an array input was linked after initialization.
+    this->validateCommandCapacity();
+
     if (this->motorTorqueInMsg.isLinked() && this->motorTorqueInMsg.isWritten()) {
         ArrayMotorTorqueMsgPayload incomingCmdBuffer;
         incomingCmdBuffer = this->motorTorqueInMsg();

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.h
@@ -21,7 +21,13 @@
 #define SPINNING_BODY_N_DOF_STATE_EFFECTOR_H
 
 #include <Eigen/Dense>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 #include "simulation/dynamics/_GeneralModuleFiles/stateEffector.h"
+#include "simulation/dynamics/_GeneralModuleFiles/dynParamManager.h"
 #include "simulation/dynamics/_GeneralModuleFiles/dynamicEffector.h"
 #include "simulation/dynamics/_GeneralModuleFiles/stateData.h"
 #include "architecture/_GeneralModuleFiles/sys_model.h"
@@ -178,6 +184,7 @@ public:
 
 private:
     void validateConfiguration();
+    void validateCommandCapacity();
     static uint64_t effectorID;
 
     int numberOfDegreesOfFreedom = 0;

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.rst
@@ -17,9 +17,9 @@ The following table lists all the module input and output messages.  The module 
     output spinningBodyOutMsgs HingedRigidBodyMsgPayload
         Output vector of messages containing the spinning body state angle and angle rate.
     input motorTorqueInMsg ArrayMotorTorqueMsgPayload
-        (Optional) Input message of the motor torque value.
+        (Optional) Motor torques for the axes in the order bodies were added with ``addSpinningBody()``.
     input motorLockInMsg ArrayEffectorLockMsgPayload
-        (Optional) Input message for locking the axis.
+        (Optional) Lock commands for the axes in the order bodies were added with ``addSpinningBody()``.
     output spinningBodyConfigLogOutMsgs SCStatesMsgPayload
         Output vector of messages containing the spinning body inertial position and attitude states.
 
@@ -28,6 +28,28 @@ Detailed Module Description
 ---------------------------
 
 An N-DoF spinning body has 2N states: ``theta``, ``thetaDot`` for each degree of freedom.
+
+Command Array Indexing
+^^^^^^^^^^^^^^^^^^^^^^
+One lock message controls the degrees of freedom within this module. Element
+``effectorLockFlag[i]`` controls the axis of the body added by the ``i``-th call to
+``addSpinningBody()``, counting from zero. Use ``0`` for a free axis and ``1`` for a
+locked axis. For a three-body chain, ``[1, 0, 1]`` locks the first and third axes and
+leaves the second free to rotate. Motor torque commands use the same ordering in
+``motorTorque[i]``. Set one entry for every body in the chain.
+
+These indexes identify degrees of freedom within a single module, independently of
+``effectorID`` and the order in which module instances are added to the spacecraft.
+Connect the messages to ``spinningBodyEffector``, which owns the chain, rather than to
+an individual ``SpinningBody``. Use separate lock and torque messages for module
+instances that need independent commands. Instances sharing a message read the same
+array starting at element ``[0]``. See :ref:`spinningBodyOneDOFStateEffector` for an
+example of independent lock messages.
+
+The lock and motor torque payload arrays each contain ``MAX_EFF_CNT`` entries
+(currently 36). When using either input message, limit the chain to that many degrees
+of freedom. Configuration validation does not currently enforce this limit; a larger
+chain can read beyond the command array when processing a written message.
 
 Mathematical Modeling
 ^^^^^^^^^^^^^^^^^^^^^
@@ -79,22 +101,22 @@ This section is to outline the steps needed to setup a Spinning Body N DoF State
 
 #. (Optional) Define a unique name for each state.  If you have multiple spinning bodies, they each must have a unique name.  If these names are not specified, then the default names are used which are incremented by the effector number::
 
-    spinningBodyEffector.setNameOfThetaState = "spinningBodyTheta"
-    spinningBodyEffector.setNameOfThetaDotState = "spinningBodyThetaDot"
+    spinningBodyEffector.setNameOfThetaState("spinningBodyTheta")
+    spinningBodyEffector.setNameOfThetaDotState("spinningBodyThetaDot")
 
-#. (Optional) Connect a command torque message::
+#. (Optional) Connect a command torque message. This example commands the single body added above::
 
     cmdArray = messaging.ArrayMotorTorqueMsgPayload()
     cmdArray.motorTorque = [cmdTorque]  # [Nm]
     cmdMsg = messaging.ArrayMotorTorqueMsg().write(cmdArray)
-    spinningBody.motorTorqueInMsg.subscribeTo(cmdMsg)
+    spinningBodyEffector.motorTorqueInMsg.subscribeTo(cmdMsg)
 
-#. (Optional) Connect an axis-locking message (0 means the axis is free to rotate and 1 locks the axis)::
+#. (Optional) Connect an axis-locking message. This example locks the single body added above::
 
     lockArray = messaging.ArrayEffectorLockMsgPayload()
-    lockArray.motorTorque = [1]
+    lockArray.effectorLockFlag = [1]
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
-    spinningBody.motorLockInMsg.subscribeTo(lockMsg)
+    spinningBodyEffector.motorLockInMsg.subscribeTo(lockMsg)
 
 #. The angular states of the body are created using an output vector of messages ``spinningBodyOutMsgs``.
 
@@ -102,13 +124,13 @@ This section is to outline the steps needed to setup a Spinning Body N DoF State
 
 #. Add the effector to your spacecraft::
 
-    scObject.addStateEffector(spinningBody)
+    scObject.addStateEffector(spinningBodyEffector)
 
    See :ref:`spacecraft` documentation on how to set up a spacecraft object.
 
 #. Add the module to the task list::
 
-    unitTestSim.AddModelToTask(unitTaskName, spinningBody)
+    unitTestSim.AddModelToTask(unitTaskName, spinningBodyEffector)
 
 Initialization and Reset
 ------------------------

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesNDOF/spinningBodyNDOFStateEffector.rst
@@ -48,8 +48,10 @@ example of independent lock messages.
 
 The lock and motor torque payload arrays each contain ``MAX_EFF_CNT`` entries
 (currently 36). When using either input message, limit the chain to that many degrees
-of freedom. Configuration validation does not currently enforce this limit; a larger
-chain can read beyond the command array when processing a written message.
+of freedom. Spacecraft initialization and ``Reset()`` raise a ``BasiliskError`` if
+either input is linked and the chain exceeds this limit, even if the message has not
+been written. Input processing repeats the check to catch messages connected after
+initialization. Larger chains are allowed when neither array input is linked.
 
 Mathematical Modeling
 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesOneDOF/spinningBodyOneDOFStateEffector.rst
@@ -15,9 +15,9 @@ The following table lists all the module input and output messages.  The module 
     output spinningBodyOutMsg HingedRigidBodyMsgPayload
         Output message containing the spinning body state angle and angle rate.
     input motorTorqueInMsg ArrayMotorTorqueMsgPayload
-        (Optional) Input message of the motor torque value.
+        (Optional) Motor torque for this module's axis, read from ``motorTorque[0]``.
     input motorLockInMsg ArrayEffectorLockMsgPayload
-        (Optional) Input message for locking the axis.
+        (Optional) Lock command for this module's axis, read from ``effectorLockFlag[0]``.
     input spinningBodyRefInMsg HingedRigidBodyMsgPayload
         (Optional) Input message for prescribing the angle and angle rate.
     output spinningBodyConfigLogOutMsg SCStatesMsgPayload
@@ -28,6 +28,20 @@ Detailed Module Description
 ---------------------------
 
 A 1 DoF spinning body has 2 states: ``theta`` and ``thetaDot``. The angle and angle rate can change due to the interaction with the hub, but also because of applied torques (control, spring and damper). The angle remains fixed and the angle rate is set to zero when the axis is locked.
+
+Command Array Indexing
+^^^^^^^^^^^^^^^^^^^^^^
+Each module instance reads only element ``[0]`` of its lock and motor torque messages.
+For the spinning-body modules, array elements correspond to degrees of freedom within
+one module; they are not selected by ``effectorID`` or by the order in which module
+instances are added to the spacecraft. The shared message payloads use arrays sized by
+``MAX_EFF_CNT``, but that capacity does not assign an element to each module instance.
+
+Use a separate ``ArrayEffectorLockMsg`` for each OneDOF instance that needs independent
+locking. If two instances subscribe to the same message, both read
+``effectorLockFlag[0]``: ``[1, 0]`` locks both, and ``[0, 1]`` leaves both free to rotate.
+The same rule applies to independent motor torque commands using
+``ArrayMotorTorqueMsg``. Use ``0`` for a free axis and ``1`` for a locked axis.
 
 Mathematical Modeling
 ^^^^^^^^^^^^^^^^^^^^^
@@ -86,7 +100,7 @@ This section is to outline the steps needed to setup a Spinning Body State Effec
 #. (Optional) Connect an axis-locking message (0 means the axis is free to rotate and 1 locks the axis)::
 
     lockArray = messaging.ArrayEffectorLockMsgPayload()
-    lockArray.motorTorque = [1]
+    lockArray.effectorLockFlag = [1]
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
     spinningBody.motorLockInMsg.subscribeTo(lockMsg)
 
@@ -111,6 +125,27 @@ This section is to outline the steps needed to setup a Spinning Body State Effec
 #. Add the module to the task list::
 
     unitTestSim.AddModelToTask(unitTaskName, spinningBody)
+
+Locking Multiple Module Instances
+----------------------------------
+For two configured OneDOF instances named ``solar_array1`` and ``solar_array2``, the
+following example locks the first axis and leaves the second free to rotate::
+
+    from Basilisk.architecture import messaging
+
+    lock_payload1 = messaging.ArrayEffectorLockMsgPayload()
+    lock_payload1.effectorLockFlag = [1]
+    lock_msg1 = messaging.ArrayEffectorLockMsg().write(lock_payload1)
+    solar_array1.motorLockInMsg.subscribeTo(lock_msg1)
+
+    lock_payload2 = messaging.ArrayEffectorLockMsgPayload()
+    lock_payload2.effectorLockFlag = [0]
+    lock_msg2 = messaging.ArrayEffectorLockMsg().write(lock_payload2)
+    solar_array2.motorLockInMsg.subscribeTo(lock_msg2)
+
+Keep both message objects available for the simulation. To change a lock command,
+update its payload and write it to the corresponding message again. Add both effectors
+to the spacecraft and to a simulation task as shown above so they process the commands.
 
 Initialization and Reset
 ------------------------

--- a/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.rst
+++ b/src/simulation/dynamics/spinningBodies/spinningBodiesTwoDOF/spinningBodyTwoDOFStateEffector.rst
@@ -17,9 +17,9 @@ The following table lists all the module input and output messages.  The module 
     output spinningBodyOutMsgs HingedRigidBodyMsgPayload
         Output vector of messages containing the spinning body state angle and angle rate.
     input motorTorqueInMsg ArrayMotorTorqueMsgPayload
-        (Optional) Input message of the motor torque value.
+        (Optional) Motor torques for this module's two axes, read from ``motorTorque[0:2]``.
     input motorLockInMsg ArrayEffectorLockMsgPayload
-        (Optional) Input message for locking the axis.
+        (Optional) Lock commands for this module's two axes, read from ``effectorLockFlag[0:2]``.
     input spinningBodyRefInMsgs HingedRigidBodyMsgPayload
         (Optional) Input array of messages for prescribing the angles and angle rates.
     output spinningBodyConfigLogOutMsgs SCStatesMsgPayload
@@ -30,6 +30,21 @@ Detailed Module Description
 ---------------------------
 
 A 2 DoF spinning body has 4 states: ``theta1``, ``theta2``, ``theta1Dot`` and ``theta2Dot``.
+
+Command Array Indexing
+^^^^^^^^^^^^^^^^^^^^^^
+One lock message controls both degrees of freedom in this module.
+``effectorLockFlag[0]`` controls the first axis (``theta1``), and
+``effectorLockFlag[1]`` controls the second axis (``theta2``). Use ``0`` for a free axis
+and ``1`` for a locked axis. For example, ``[1, 0]`` locks the first axis and leaves
+the second free to rotate. Motor torque commands use the same ordering in
+``motorTorque[0]`` and ``motorTorque[1]``. Remaining array elements are ignored.
+
+These indexes identify degrees of freedom within a single module, independently of
+``effectorID`` and the order in which module instances are added to the spacecraft.
+Use separate lock and torque messages for module instances that need independent
+commands. Instances sharing a message receive the same pair of axis commands. See
+:ref:`spinningBodyOneDOFStateEffector` for an example of independent lock messages.
 
 Mathematical Modeling
 ^^^^^^^^^^^^^^^^^^^^^
@@ -45,13 +60,13 @@ User Guide
 ----------
 This section is to outline the steps needed to setup a Spinning Body 2 DoF State Effector in Python using Basilisk.
 
-#. Import the spinningBody2DOFStateEffector class::
+#. Import the spinningBodyTwoDOFStateEffector class::
 
-    from Basilisk.simulation import spinningBody2DOFStateEffector
+    from Basilisk.simulation import spinningBodyTwoDOFStateEffector
 
 #. Create an instantiation of a Spinning body::
 
-    spinningBody = spinningBody2DOFStateEffector.SpinningBody2DOFStateEffector()
+    spinningBody = spinningBodyTwoDOFStateEffector.SpinningBodyTwoDOFStateEffector()
 
 #. Define all physical parameters for both spinning bodies. For example::
 
@@ -99,7 +114,7 @@ This section is to outline the steps needed to setup a Spinning Body 2 DoF State
 #. (Optional) Connect an axis-locking message (0 means the axis is free to rotate and 1 locks the axis)::
 
     lockArray = messaging.ArrayEffectorLockMsgPayload()
-    lockArray.motorTorque = [1, 0]
+    lockArray.effectorLockFlag = [1, 0]
     lockMsg = messaging.ArrayEffectorLockMsg().write(lockArray)
     spinningBody.motorLockInMsg.subscribeTo(lockMsg)
 


### PR DESCRIPTION
* **Tickets addressed:** #571
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Clarifies that spinning-body command arrays index degrees of freedom within one module. Separate module instances require separate messages for independent control.

Adds a shared capacity check to `spinningBodyNDOFStateEffector`. Chains exceeding `MAX_EFF_CNT` raise `BasiliskError` when either the lock or motor torque input is linked, including unwritten messages. Validation runs during spacecraft initialization, reset, and input processing to cover subscriptions added after initialization. Larger chains remain supported when neither array input is linked.

Changes are organized as documentation corrections followed by bounds checks and regression tests.

## Verification
- All 46 NDOF unit tests passed.
- Added regression coverage for capacity limits, linked but unwritten messages, subscriptions added after initialization, and control through the last valid array entry.
- Verified oversized chains remain accepted without linked array inputs.
- Rebuilt the NDOF module and compiled its header independently using the owning target's build flags.
- Built Sphinx documentation with warnings treated as errors; no warnings remained.

## Documentation
- Clarified command indexing in the OneDOF, TwoDOF, and NDOF guides.
- Added an example using separate messages to lock OneDOF instances independently.
- Corrected lock payload fields, TwoDOF class names, and NDOF setup examples.
- Documented the enforced NDOF capacity limit and updated known issues and release-note snippets.

## Future work
None required for #571.