### PR TITLE
Support invoking conanfile.py from outside the repository

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -914,7 +914,7 @@ if __name__ == "__main__":
     print(shlex.join(buildCmd))
     buildEnvironment = create_conan_build_environment(args.offline)
     try:
-        subprocess.run(buildCmd, check=True, env=buildEnvironment)
+        subprocess.run(buildCmd, check=True, env=buildEnvironment, cwd=REPOSITORY_ROOT)
     except subprocess.CalledProcessError as error:
         if args.offline:
             print(

--- a/docs/source/Build/installBuild.rst
+++ b/docs/source/Build/installBuild.rst
@@ -27,6 +27,13 @@ Basilisk root directory, this is done simply using::
 
     python3 conanfile.py
 
+You can also invoke the script from another directory using its absolute or relative path::
+
+    python3 /path/to/basilisk/conanfile.py
+
+The build is created in the repository's ``dist3`` folder. Relative ``--pathToExternalModules`` paths
+are resolved from the directory where you invoke the script.
+
 This one-line step will use ``conan`` to:
 
 - pull and compile any resource dependencies such a protobuffer, etc.

--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,9 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
+- GitHub issue 515: Running ``conanfile.py`` from outside the repository could fail to find the Conan recipe
+  or select a different recipe in the caller's directory. The build subprocess now runs from the Basilisk
+  repository root, while relative external-module paths remain relative to the caller's directory.
 - ``simHelpers.timeStringToGregorianUTCMsg()`` retained every returned epoch message
   for the lifetime of the process, causing memory growth during repeated simulation setup.
   The obsolete registry has been removed. Messages now remain alive while callers,

--- a/docs/source/Support/bskReleaseNotesSnippets/515-conan-working-directory.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/515-conan-working-directory.rst
@@ -1,0 +1,1 @@
+- Fixed invoking ``conanfile.py`` from outside the Basilisk repository so Conan selects the correct recipe and builds in the repository's ``dist3`` folder.

--- a/src/tests/test_conan_command.py
+++ b/src/tests/test_conan_command.py
@@ -20,7 +20,12 @@
 import argparse
 import importlib
 import importlib.util
+import os
 from pathlib import Path
+import runpy
+import shutil
+import sys
+from unittest.mock import Mock
 
 import pytest
 
@@ -91,6 +96,59 @@ def test_single_command_installs_missing_dependencies_and_builds(conanfile_modul
     assert "&:clean=True" in options
     assert "&:rustModules=True" in options
     assert "&:buildTesting=True" in options
+
+
+@pytest.mark.parametrize("script_path_kind", ["absolute", "relative"])
+def test_script_builds_repository_from_another_directory(
+        conanfile_module, tmp_path, monkeypatch, script_path_kind,
+):
+    """Resolve the recipe at dispatch while keeping external paths relative to the caller."""
+    repo_root = Path(__file__).resolve().parents[2]
+    if script_path_kind == "relative":
+        # Keep both ends of the relative path on the same Windows drive.
+        source_root = repo_root
+        repo_root = tmp_path / "repository with spaces"
+        for resource in (
+                "conanfile.py",
+                "docs/source/bskVersion.txt",
+                "src/utilities/makeDraftModule.py",
+        ):
+            destination = repo_root / resource
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_root / resource, destination)
+    caller_directory = tmp_path / "caller directory"
+    caller_directory.mkdir()
+    external_modules = caller_directory / "external modules"
+    external_modules.mkdir()
+    # A different recipe in the caller's directory must not be selected.
+    (caller_directory / "conanfile.py").write_text("raise RuntimeError('wrong recipe')\n")
+    monkeypatch.chdir(caller_directory)
+    script_path = repo_root / "conanfile.py"
+    if script_path_kind == "relative":
+        script_path = os.path.relpath(script_path, caller_directory)
+    monkeypatch.setattr(sys, "argv", [
+        str(script_path), "--offline", "--pathToExternalModules", "external modules",
+    ])
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+    monkeypatch.setattr(conanfile_module.subprocess, "check_output", Mock(return_value=b""))
+    generator = conanfile_module.makeDraftModule.moduleGenerator
+    monkeypatch.setattr(generator, "createCppModule", Mock())
+    monkeypatch.setattr(generator, "createCModule", Mock())
+    build_process = Mock()
+    monkeypatch.setattr(conanfile_module.subprocess, "run", build_process)
+
+    runpy.run_path(str(script_path), run_name="__main__")
+
+    build_process.assert_called_once()
+    command = build_process.call_args.args[0]
+    subprocess_options = build_process.call_args.kwargs
+    build_directory = Path(subprocess_options.get("cwd", Path.cwd()))
+    recipe_directory = (build_directory / command[4]).resolve()
+    assert recipe_directory == repo_root.resolve()
+    assert f"&:pathToExternalModules={external_modules}" in option_values(command, "-o")
+    assert subprocess_options["check"] is True
+    assert subprocess_options["env"]["CARGO_NET_OFFLINE"] == "true"
+    assert Path.cwd() == caller_directory
 
 
 def test_offline_command_uses_only_cached_binary_packages(conanfile_module):


### PR DESCRIPTION
* **Tickets addressed:** #515
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
Run the Conan build subprocess from the Basilisk repository root so invoking `conanfile.py` from another directory selects the correct recipe. Relative external-module paths continue to resolve from the caller’s directory.

## Verification
All 39 targeted Conan command, cleanup, and generator tests passed. Regression coverage checks absolute and relative script invocation, paths containing spaces, and caller-relative external-module paths. The relative-path fixture accommodates Windows drive boundaries.

Pre-commit and diff checks passed. Windows execution and a full native rebuild were not performed.

## Documentation
Updated the build instructions and known issues, and added a release-note snippet describing the fix.

## Future work
None planned.