### PR TITLE
Add GoogleTest scalar and vector comparison assertions

### DIFF
--- a/docs/source/Support/bskKnownIssues.rst
+++ b/docs/source/Support/bskKnownIssues.rst
@@ -10,6 +10,12 @@ Basilisk Known Issues
 
 Version |release|
 -----------------
+- GitHub issue 329: Scalar test comparators could accept NaN values or invalid tolerances.
+  They now reject non-finite operands and non-finite or negative tolerances. The new
+  ``EXPECT_NEAR_REL``, ``EXPECT_VECTOR3_NEAR``, and ``EXPECT_VECTOR3_NEAR_REL`` assertions
+  apply these checks and provide comparison diagnostics. Relative comparisons use the
+  first operand as the reference; a zero reference requires exact equality. The legacy
+  ``v3IsEqual`` and ``v3IsEqualRel`` utility functions retain their existing behavior.
 - GitHub issue 469: :ref:`ExtPulsedTorque` advanced its pulse on every dynamics evaluation, so
   intermediate integrator stages changed the pulse duration. It now evaluates the waveform from
   simulation time using the explicit ``pulseInterval`` in seconds. Set this interval to the desired

--- a/docs/source/Support/bskReleaseNotesSnippets/329-gtest-comparators.rst
+++ b/docs/source/Support/bskReleaseNotesSnippets/329-gtest-comparators.rst
@@ -1,0 +1,1 @@
+- Added ``EXPECT_NEAR_REL``, ``EXPECT_VECTOR3_NEAR``, and ``EXPECT_VECTOR3_NEAR_REL`` GoogleTest assertions with operand diagnostics, explicit zero-reference behavior, and rejection of non-finite values and invalid tolerances. Shared scalar test comparators now reject invalid inputs as well.

--- a/src/architecture/utilities/tests/CMakeLists.txt
+++ b/src/architecture/utilities/tests/CMakeLists.txt
@@ -10,6 +10,12 @@ add_executable(test_orbitalMotion test_orbitalMotion.cpp)
 target_link_libraries(test_orbitalMotion GTest::gtest_main)
 target_link_libraries(test_orbitalMotion ArchitectureUtilities)
 
+add_executable(test_unitTestComparators
+    test_unitTestComparators.cpp
+    test_unitTestComparatorsHeader.cpp
+    test_unitTestComparators_c.c)
+target_link_libraries(test_unitTestComparators GTest::gtest_main)
+
 add_executable(test_saturate test_saturate.cpp)
 target_link_libraries(test_saturate GTest::gtest_main)
 target_link_libraries(test_saturate ArchitectureUtilities)
@@ -45,6 +51,7 @@ endif()
 gtest_discover_tests(test_discretize)
 gtest_discover_tests(test_gaussMarkov)
 gtest_discover_tests(test_orbitalMotion)
+gtest_discover_tests(test_unitTestComparators)
 gtest_discover_tests(test_saturate)
 gtest_discover_tests(test_geodeticConversion)
 gtest_discover_tests(test_avsEigenMRP)

--- a/src/architecture/utilities/tests/test_orbitalMotion.cpp
+++ b/src/architecture/utilities/tests/test_orbitalMotion.cpp
@@ -68,8 +68,7 @@ TEST(OrbitalMotion, atmosphericDrag) {
 
     v3Set(-2.8245395411253663e-007, -2.5420855870128297e-006, -2.8245395411253663e-007, check);
     atmosphericDrag(Cd, A, m, r, v, ans);
-    // @TODO refactor later to be a Google Test MATCHER
-    EXPECT_TRUE(v3IsEqual(ans, check, 11));
+    EXPECT_VECTOR3_NEAR(ans, check, 11);  // [km/s^2]
 }
 
 TEST(OrbitalMotion, jPerturb_order_6) {
@@ -80,7 +79,7 @@ TEST(OrbitalMotion, jPerturb_order_6) {
 
     v3Set(-7.3080959003487213e-006, -1.1787251452175358e-007, -1.1381118473672282e-005, check);
     jPerturb(r, order, ans);
-    EXPECT_TRUE(v3IsEqual(ans, check, 11));
+    EXPECT_VECTOR3_NEAR(ans, check, 11);  // [km/s^2]
 }
 
 TEST(OrbitalMotion, solarRadiationPressure) {
@@ -92,7 +91,7 @@ TEST(OrbitalMotion, solarRadiationPressure) {
 
     v3Set(-1.9825487816e-10, -5.94764634479e-11, 3.96509756319e-11, check);
     solarRad(A, m, r, ans);
-    EXPECT_TRUE(v3IsEqual(ans, check, 11));
+    EXPECT_VECTOR3_NEAR(ans, check, 11);  // [km/s^2]
 }
 
 TEST(OrbitalMotion, elem2rv1DEccentric)
@@ -136,7 +135,8 @@ TEST(OrbitalMotion, elem2rv1DHyperbolic)
     elem2rv(MU_EARTH, &elements, r, v);
     v3Set(-152.641873349816, -469.543156608544, 362.375968124408, r2);
     v3Set(-9.17378720883851, -28.2195763820421, 21.7788208976681, v3_2);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 class TwoDimensionHyperbolic : public ::testing::Test {
@@ -166,20 +166,21 @@ protected:
 TEST_F(TwoDimensionHyperbolic, elem2rv)
 {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(TwoDimensionHyperbolic, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, -7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.e, 1.4, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.i, 40.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.Omega, 133.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.omega, 113.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, 23.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag, 3145.881340612725, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap,3000.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, -18000., orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, -7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.e, 1.4, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.i, 40.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.Omega, 133.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.omega, 113.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, 23.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag, 3145.881340612725, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap,3000.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, -18000., orbitalElementsAccuracy);
 }
 
 class TwoDimensionParabolic : public ::testing::Test {
@@ -206,21 +207,22 @@ protected:
 
 TEST_F(TwoDimensionParabolic, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(TwoDimensionParabolic, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
     EXPECT_NEAR(elements.alpha, 0.0, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.a, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.e, 1.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.i, 40.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.Omega, 133.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.omega, 113.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, 123.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag, 32940.89997480352, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap,7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 0.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.e, 1.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.i, 40.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.Omega, 133.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.omega, 113.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, 123.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag, 32940.89997480352, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap,7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 0.0, orbitalElementsAccuracy);
 }
 
 class TwoDimensionElliptical : public ::testing::Test {
@@ -249,20 +251,21 @@ protected:
 
 TEST_F(TwoDimensionElliptical, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(TwoDimensionElliptical, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.e, 0.5, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.i, 40.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.Omega, 133.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.omega, 113.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, 123.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag, 7730.041048693483, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap, 3750.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 11250.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.e, 0.5, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.i, 40.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.Omega, 133.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.omega, 113.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, 123.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag, 7730.041048693483, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap, 3750.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 11250.0, orbitalElementsAccuracy);
 }
 
 class NonCircularEquitorial : public ::testing::Test {
@@ -287,20 +290,21 @@ protected:
 
 TEST_F(NonCircularEquitorial, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(NonCircularEquitorial, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.00, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.e, 0.5, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.i, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.Omega, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.omega, (133+113)*D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, 123.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag,   7730.041048693483, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap,3750.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 11250.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.00, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.e, 0.5, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.i, 0.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.Omega, 0.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.omega, (133+113)*D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, 123.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag,   7730.041048693483, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap,3750.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 11250.0, orbitalElementsAccuracy);
 }
 
 class NonCircularNearEquitorial : public ::testing::Test {
@@ -326,19 +330,20 @@ protected:
 
 TEST_F(NonCircularNearEquitorial, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(NonCircularNearEquitorial, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.00, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.e, 0.5, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.00, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.e, 0.5, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.i, eps2, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, wrapToPi(elements.Omega+elements.omega), (133+113-360.)*D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, 123.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag,   7730.041048693483, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap,3750.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 11250.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(wrapToPi(elements.Omega+elements.omega), (133+113-360.)*D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, 123.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag,   7730.041048693483, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap,3750.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 11250.0, orbitalElementsAccuracy);
 }
 
 class NonCircularNearEquitorial180Degree : public ::testing::Test {
@@ -364,19 +369,20 @@ protected:
 
 TEST_F(NonCircularNearEquitorial180Degree, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(NonCircularNearEquitorial180Degree, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.00, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.e, 0.5, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.00, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.e, 0.5, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.i, eps2, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, wrapToPi(elements.Omega+elements.omega), (133+113-360.)*D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, 123.0 * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag,   7730.041048693483, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap,3750.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 11250.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(wrapToPi(elements.Omega+elements.omega), (133+113-360.)*D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, 123.0 * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag,   7730.041048693483, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap,3750.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 11250.0, orbitalElementsAccuracy);
 }
 
 class CircularInclined : public ::testing::Test {
@@ -401,19 +407,20 @@ protected:
 
 TEST_F(CircularInclined, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(CircularInclined, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.00, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.00, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.e, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.i, 40. * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.Omega, 133. * D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, wrapToPi(elements.omega+elements.f), (113+123-360.)*D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.i, 40. * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.Omega, 133. * D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(wrapToPi(elements.omega+elements.f), (113+123-360.)*D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 7500.0, orbitalElementsAccuracy);
 }
 
 class CircularEquitorial : public ::testing::Test {
@@ -438,20 +445,21 @@ protected:
 
 TEST_F(CircularEquitorial, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(CircularEquitorial, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.00, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.00, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.e, 0.0, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.i, 0.0, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.Omega, 0.0, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.omega, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, (133+113+123-360)*D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, (133+113+123-360)*D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 7500.0, orbitalElementsAccuracy);
 }
 
 class CircularEquitorialRetrograde : public ::testing::Test {
@@ -476,20 +484,21 @@ protected:
 
 TEST_F(CircularEquitorialRetrograde, elem2rv) {
     elem2rv(MU_EARTH, &elements, r, v);
-    EXPECT_TRUE(v3IsEqualRel(r, r2, orbitalElementsAccuracy) && v3IsEqualRel(v, v3_2, orbitalElementsAccuracy));
+    EXPECT_VECTOR3_NEAR_REL(r, r2, orbitalElementsAccuracy);
+    EXPECT_VECTOR3_NEAR_REL(v, v3_2, orbitalElementsAccuracy);
 }
 
 TEST_F(CircularEquitorialRetrograde, rv2elem) {
     rv2elem(MU_EARTH, r2, v3_2, &elements);
-    EXPECT_PRED3(isEqualRel, elements.a, 7500.00, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.a, 7500.00, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.e, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.i, M_PI, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.i, M_PI, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.Omega, 0.0, orbitalElementsAccuracy);
     EXPECT_NEAR(elements.omega, 0.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.f, (-133+113+123)*D2R, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rmag, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rPeriap, 7500.0, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements.rApoap, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.f, (-133+113+123)*D2R, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rmag, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rPeriap, 7500.0, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements.rApoap, 7500.0, orbitalElementsAccuracy);
 }
 
 TEST(OrbitalMotion, classicElementsToMeanElements) {
@@ -504,12 +513,12 @@ TEST(OrbitalMotion, classicElementsToMeanElements) {
     double J2 = 1e-3;
     ClassicElements elements_p;
     clMeanOscMap(req, J2, &elements, &elements_p, 1);
-    EXPECT_PRED3(isEqualRel, elements_p.a, 1000.07546442015950560744386166334152, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_p.a, 1000.07546442015950560744386166334152, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_p.e, 0.20017786852908628358882481279579, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements_p.i, 0.20000333960738947425284095515963, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_p.i, 0.20000333960738947425284095515963, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_p.Omega, 0.15007256499303692209856819772540, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_p.omega, 0.50011857315729335571319325026707, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements_p.f, 0.19982315726261962174348241205735, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_p.f, 0.19982315726261962174348241205735, orbitalElementsAccuracy);
 }
 
 TEST(OrbitalMotion, classicElementsToEquinoctialElements) {
@@ -523,11 +532,11 @@ TEST(OrbitalMotion, classicElementsToEquinoctialElements) {
     equinoctialElements elements_eq;
     clElem2eqElem(&elements, &elements_eq);
 
-    EXPECT_PRED3(isEqualRel, elements_eq.a, 1000.00000000000000000000000000000000, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_eq.a, 1000.00000000000000000000000000000000, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_eq.P1, 0.12103728114720790909331071816268, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements_eq.P2, 0.15921675970981119530023306651856, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_eq.P2, 0.15921675970981119530023306651856, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_eq.Q1, 0.01499382601880069713906618034116, orbitalElementsAccuracy);
     EXPECT_NEAR(elements_eq.Q2, 0.09920802187229026125603326136115, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements_eq.l, 0.78093005232114087732497864635661, orbitalElementsAccuracy);
-    EXPECT_PRED3(isEqualRel, elements_eq.L, 0.85000000000000008881784197001252, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_eq.l, 0.78093005232114087732497864635661, orbitalElementsAccuracy);
+    EXPECT_NEAR_REL(elements_eq.L, 0.85000000000000008881784197001252, orbitalElementsAccuracy);
 }

--- a/src/architecture/utilities/tests/test_unitTestComparators.cpp
+++ b/src/architecture/utilities/tests/test_unitTestComparators.cpp
@@ -1,0 +1,247 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "unitTestComparators.h"
+#include <gtest/gtest-spi.h>
+#include <limits>
+#include <string>
+
+namespace {
+constexpr double notANumber = std::numeric_limits<double>::quiet_NaN();
+constexpr double infinity = std::numeric_limits<double>::infinity();
+}
+
+/** @brief Verify inclusive scalar bounds, signs, and use of the first argument as reference. */
+TEST(UnitTestComparators, scalarRelativeTolerance)
+{
+    EXPECT_NEAR_REL(8.0, 9.0, 0.125);
+    EXPECT_NEAR_REL(-8.0, -9.0, 0.125);
+    EXPECT_NEAR_REL(9.0, 8.0, 0.12);
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(8.0, 9.0, 0.12), "Relative comparison failed");
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(8.0, -8.0, 1.0), "Relative comparison failed");
+}
+
+/** @brief Require exact equality for zero references and zero tolerances. */
+TEST(UnitTestComparators, scalarZeros)
+{
+    EXPECT_NEAR_REL(0.0, -0.0, 0.0);
+    EXPECT_NEAR_REL(8.0, 8.0, 0.0);
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(0.0, 1.0, 10.0), "zero reference");
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(1.0, 0.0, 0.5), "Relative comparison failed");
+    EXPECT_NEAR_REL(1.0, 0.0, 1.0);
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(8.0, 9.0, 0.0), "zero tolerance");
+}
+
+/** @brief Reject non-finite scalar values and invalid tolerances, even for equal operands. */
+TEST(UnitTestComparators, scalarInvalidInputs)
+{
+    for (double invalid : { notANumber, infinity, -infinity }) {
+        EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(invalid, 1.0, 0.1), "finite");
+        EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(1.0, invalid, 0.1), "finite");
+        EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(invalid, invalid, 0.1), "finite");
+    }
+    for (double invalid : { -1.0, notANumber, infinity, -infinity }) {
+        EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(1.0, 1.0, invalid), "nonnegative");
+    }
+}
+
+/** @brief Check componentwise absolute and norm-scaled relative vector tolerances. */
+TEST(UnitTestComparators, vectorTolerance)
+{
+    const double reference[3] = { 3.0, 4.0, 0.0 };
+    const double boundary[3] = { 3.5, 3.5, 0.5 };
+    EXPECT_VECTOR3_NEAR(reference, boundary, 0.5);
+    EXPECT_VECTOR3_NEAR_REL(reference, boundary, 0.1);
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(reference, boundary, 0.49), "component 0");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, boundary, 0.09), "component 0");
+
+    for (int i = 0; i < 3; ++i) {
+        double different[3] = { 3.0, 4.0, 0.0 };
+        different[i] += 1.0;
+        const std::string component = "component " + std::to_string(i);
+        EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(reference, different, 0.5), component);
+        EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, different, 0.1), component);
+    }
+    const double smaller[3] = { 4.0, 0.0, 0.0 };
+    const double larger[3] = { 5.0, 0.0, 0.0 };
+    EXPECT_VECTOR3_NEAR_REL(larger, smaller, 0.2);
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(smaller, larger, 0.2), "component 0");
+}
+
+/** @brief Test zero-vector references, exact comparisons, and absolute tolerance around zero. */
+TEST(UnitTestComparators, vectorZeros)
+{
+    const double zero[3] = {};
+    const double nonzero[3] = { 0.0, 0.0, 1.0 };
+    EXPECT_VECTOR3_NEAR(zero, zero, 0.0);
+    EXPECT_VECTOR3_NEAR_REL(zero, zero, 0.0);
+    EXPECT_VECTOR3_NEAR_REL(nonzero, nonzero, 0.0);
+    EXPECT_VECTOR3_NEAR(zero, nonzero, 1.0);
+    EXPECT_VECTOR3_NEAR_REL(nonzero, zero, 1.0);
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(zero, nonzero, 10.0), "zero reference");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(nonzero, zero, 0.0), "component 2");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(nonzero, zero, 0.0), "component 2");
+}
+
+/** @brief Reject invalid vector components in either operand and invalid tolerances. */
+TEST(UnitTestComparators, vectorInvalidInputs)
+{
+    const double reference[3] = { 3.0, 4.0, 0.0 };
+    for (double invalid : { notANumber, infinity, -infinity }) {
+        for (int i = 0; i < 3; ++i) {
+            double different[3] = { 3.0, 4.0, 0.0 };
+            different[i] = invalid;
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(reference, different, 0.5), "Non-finite");
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(different, reference, 0.5), "Non-finite");
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, different, 0.1), "Non-finite");
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(different, reference, 0.1), "Non-finite");
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(different, different, 0.1), "Non-finite");
+        }
+    }
+    for (double invalid : { -1.0, notANumber, infinity, -infinity }) {
+        EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(reference, reference, invalid), "nonnegative");
+        EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, reference, invalid), "nonnegative");
+    }
+}
+
+/** @brief Avoid intermediate overflow and preserve relative comparisons of very small values. */
+TEST(UnitTestComparators, extremeFiniteValues)
+{
+    const double largest = std::numeric_limits<double>::max();
+    const double smallest = std::numeric_limits<double>::denorm_min();
+    EXPECT_NEAR_REL(largest, -largest, 2.0);
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(largest, -largest, 1.0), "Relative comparison failed");
+    EXPECT_NEAR_REL(smallest, 2.0 * smallest, 1.0);
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(smallest, 2.0 * smallest, 0.5), "Relative comparison failed");
+
+    const double huge[3] = { largest, largest, largest };
+    const double opposite[3] = { -largest, -largest, -largest };
+    EXPECT_VECTOR3_NEAR_REL(huge, opposite, 1.2);
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(huge, opposite, 1.0), "component 0");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(huge, opposite, largest), "component 0");
+    const double tiny[3] = { smallest, 0.0, 0.0 };
+    const double twiceTiny[3] = { 2.0 * smallest, 0.0, 0.0 };
+    EXPECT_VECTOR3_NEAR_REL(tiny, twiceTiny, 1.0);
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(tiny, twiceTiny, 0.5), "component 0");
+}
+
+/** @brief Preserve relative tolerance decisions when multi-component references become subnormal. */
+TEST(UnitTestComparators, subnormalVectorReferences)
+{
+    for (double magnitude : { 1.0, std::numeric_limits<double>::denorm_min() }) {
+        const double reference[3] = { 2.0 * magnitude, 2.0 * magnitude, 0.0 };
+        const double other[3] = { 3.0 * magnitude, 2.0 * magnitude, 0.0 };
+        // The relative error is 1 / sqrt(8), approximately 0.353553.
+        EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, other, 0.34), "component 0");
+        EXPECT_VECTOR3_NEAR_REL(reference, other, 0.36);
+
+        const double diagonal[3] = { magnitude, magnitude, magnitude };
+        const double displaced[3] = { 2.0 * magnitude, magnitude, magnitude };
+        // The relative error is 1 / sqrt(3), approximately 0.577350.
+        EXPECT_VECTOR3_NEAR_REL(diagonal, displaced, 0.75);
+        EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(diagonal, displaced, 0.5), "component 0");
+    }
+}
+
+/** @brief Keep a representable relative error finite when normalization would overflow midway. */
+TEST(UnitTestComparators, subnormalReferenceWithLargeRelativeError)
+{
+    const double smallest = std::numeric_limits<double>::denorm_min();
+    const double largest = std::numeric_limits<double>::max();
+    const double reference[3] = { smallest, smallest, smallest };
+    const double other[3] = { 1.5 * (smallest * largest), smallest, smallest };
+    // The first component error is approximately sqrt(3) / 2 times the largest double.
+    EXPECT_VECTOR3_NEAR_REL(reference, other, 0.9 * largest);
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, other, 0.8 * largest), "component 0");
+}
+
+/** @brief Evaluate every macro argument once on both success and failure. */
+TEST(UnitTestComparators, argumentsEvaluatedOnce)
+{
+    for (bool fail : { false, true }) {
+        int firstCalls = 0;
+        int secondCalls = 0;
+        int toleranceCalls = 0;
+        auto first = [&]() {
+            ++firstCalls;
+            return 8.0;
+        };
+        auto second = [&]() {
+            ++secondCalls;
+            return fail ? 10.0 : 8.0;
+        };
+        auto tolerance = [&]() {
+            ++toleranceCalls;
+            return 0.125;
+        };
+        if (fail) {
+            EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(first(), second(), tolerance()), "Relative comparison failed");
+        } else {
+            EXPECT_NEAR_REL(first(), second(), tolerance());
+        }
+        EXPECT_EQ(firstCalls, 1);
+        EXPECT_EQ(secondCalls, 1);
+        EXPECT_EQ(toleranceCalls, 1);
+
+        const double vector[3] = { 3.0, 4.0, 0.0 };
+        const double other[3] = { 3.0, 4.0, 1.0 };
+        auto firstVector = [&]() {
+            ++firstCalls;
+            return vector;
+        };
+        auto secondVector = [&]() {
+            ++secondCalls;
+            return fail ? other : vector;
+        };
+        if (fail) {
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(firstVector(), secondVector(), tolerance()), "component 2");
+            EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(firstVector(), secondVector(), tolerance()), "component 2");
+        } else {
+            EXPECT_VECTOR3_NEAR(firstVector(), secondVector(), tolerance());
+            EXPECT_VECTOR3_NEAR_REL(firstVector(), secondVector(), tolerance());
+        }
+        EXPECT_EQ(firstCalls, 3);
+        EXPECT_EQ(secondCalls, 3);
+        EXPECT_EQ(toleranceCalls, 3);
+    }
+}
+
+/** @brief Preserve expression names, values, streamed context, and surrounding if/else behavior. */
+TEST(UnitTestComparators, diagnosticsAndControlFlow)
+{
+    const double reference[3] = { 3.0, 4.0, 0.0 };
+    const double other[3] = { 3.0, 4.0, 1.0 };
+    EXPECT_NONFATAL_FAILURE(EXPECT_NEAR_REL(8.0, 9.0, 0.0) << "scalar context", "scalar context");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(reference, other, 0.0) << "vector context", "vector context");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, other, 0.0) << "relative context", "relative context");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR(reference, other, 0.0), "reference = [3, 4, 0]");
+    EXPECT_NONFATAL_FAILURE(EXPECT_VECTOR3_NEAR_REL(reference, other, 0.0), "other = [3, 4, 1]");
+    if (true)
+        EXPECT_NEAR_REL(1.0, 1.0, 0.0);
+    else
+        ADD_FAILURE();
+    if (true)
+        EXPECT_VECTOR3_NEAR(reference, reference, 0.0);
+    else
+        ADD_FAILURE();
+    if (true)
+        EXPECT_VECTOR3_NEAR_REL(reference, reference, 0.0);
+    else
+        ADD_FAILURE();
+}

--- a/src/architecture/utilities/tests/test_unitTestComparatorsHeader.cpp
+++ b/src/architecture/utilities/tests/test_unitTestComparatorsHeader.cpp
@@ -1,0 +1,54 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+// Include the header first in a second C++ translation unit to check self-containment and linkage.
+#include "unitTestComparators.h"
+#include <limits>
+
+extern "C" int
+compareAbsoluteFromC(double first, double second, double tolerance);
+extern "C" int
+compareRelativeFromC(double first, double second, double tolerance);
+
+/** @brief Verify C and C++ consumers share valid, finite comparison behavior. */
+TEST(UnitTestComparators, cAndCppHeaderCompatibility)
+{
+    EXPECT_TRUE(isEqual(8.0, 9.0, 1.0));
+    EXPECT_FALSE(isEqual(8.0, 9.0, 0.5));
+    EXPECT_NEAR_REL(8.0, 9.0, 0.125);
+    EXPECT_TRUE(compareAbsoluteFromC(8.0, 9.0, 1.0));
+    EXPECT_FALSE(compareAbsoluteFromC(8.0, 9.0, 0.5));
+    EXPECT_TRUE(compareRelativeFromC(8.0, 9.0, 0.125));
+    EXPECT_FALSE(compareRelativeFromC(8.0, 9.0, 0.1));
+    EXPECT_TRUE(compareRelativeFromC(0.0, 0.0, 0.0));
+    EXPECT_FALSE(compareRelativeFromC(0.0, 1.0, 10.0));
+    for (double invalid : { std::numeric_limits<double>::quiet_NaN(),
+                            std::numeric_limits<double>::infinity(),
+                            -std::numeric_limits<double>::infinity() }) {
+        EXPECT_FALSE(isEqual(invalid, 1.0, 1.0));
+        EXPECT_FALSE(compareAbsoluteFromC(invalid, 1.0, 1.0));
+        EXPECT_FALSE(compareAbsoluteFromC(1.0, invalid, 1.0));
+        EXPECT_FALSE(compareRelativeFromC(invalid, 1.0, 1.0));
+        EXPECT_FALSE(compareRelativeFromC(1.0, invalid, 1.0));
+        EXPECT_FALSE(compareAbsoluteFromC(1.0, 1.0, invalid));
+        EXPECT_FALSE(compareRelativeFromC(1.0, 1.0, invalid));
+    }
+    EXPECT_FALSE(compareAbsoluteFromC(1.0, 1.0, -1.0));
+    EXPECT_FALSE(compareRelativeFromC(1.0, 1.0, -1.0));
+}

--- a/src/architecture/utilities/tests/test_unitTestComparators_c.c
+++ b/src/architecture/utilities/tests/test_unitTestComparators_c.c
@@ -1,0 +1,46 @@
+/*
+ ISC License
+
+ Copyright (c) 2026, Autonomous Vehicle Systems Lab, University of Colorado at Boulder
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+ */
+
+#include "unitTestComparators.h"
+
+/**
+ * @brief Exercise the shared absolute comparator from a C translation unit.
+ * @param first First scalar.
+ * @param second Second scalar, in the same units as first.
+ * @param tolerance Absolute tolerance, in the same units as first.
+ * @return The absolute comparison result.
+ */
+int
+compareAbsoluteFromC(double first, double second, double tolerance)
+{
+    return isEqual(first, second, tolerance);
+}
+
+/**
+ * @brief Exercise the shared relative comparator from a C translation unit.
+ * @param first Reference scalar.
+ * @param second Second scalar, in the same units as first.
+ * @param tolerance Dimensionless relative tolerance.
+ * @return The relative comparison result.
+ */
+int
+compareRelativeFromC(double first, double second, double tolerance)
+{
+    return isEqualRel(first, second, tolerance);
+}

--- a/src/architecture/utilities/tests/unitTestComparators.h
+++ b/src/architecture/utilities/tests/unitTestComparators.h
@@ -22,20 +22,182 @@
 
 #include <math.h>
 
-int isEqual(double a, double b, double accuracy)
+/**
+ * @brief Compare finite scalars with an inclusive absolute tolerance.
+ * @param a First value, in the same units as b and accuracy.
+ * @param b Second value.
+ * @param accuracy Finite, nonnegative absolute tolerance.
+ * @return Nonzero if the values satisfy the tolerance, otherwise zero.
+ */
+static inline int
+isEqual(double a, double b, double accuracy)
 {
-    if(fabs(a - b) > accuracy) {
-        return 0;
-    }
-    return 1;
+    return isfinite(a) && isfinite(b) && isfinite(accuracy) && accuracy >= 0.0 && fabs(a - b) <= accuracy;
 }
 
-int isEqualRel(double a, double b, double accuracy)
+/**
+ * @brief Compare finite scalars relative to the magnitude of the first value.
+ * @param a Reference value, in the same units as b.
+ * @param b Second value.
+ * @param accuracy Finite, nonnegative relative tolerance (dimensionless).
+ * @return Nonzero if abs(a - b) / abs(a) is at most accuracy, otherwise zero.
+ * @note A zero reference or zero tolerance requires exact equality. NaN and
+ * infinity are rejected, including equal infinities.
+ */
+static inline int
+isEqualRel(double a, double b, double accuracy)
 {
-    if(fabs(a - b)/fabs(a) > accuracy) {
+    if (!isfinite(a) || !isfinite(b) || !isfinite(accuracy) || accuracy < 0.0) {
         return 0;
     }
-    return 1;
+    if (a == 0.0 || accuracy == 0.0) {
+        return a == b;
+    }
+    const double difference = fabs(a - b);
+    // Divide before subtracting only when subtraction overflows.
+    const double relativeError = isfinite(difference) ? difference / fabs(a) : fabs(a / fabs(a) - b / fabs(a));
+    return relativeError <= accuracy;
 }
 
-#endif //UNITTESTCOMPARATORS_H
+#ifdef __cplusplus
+
+#include <algorithm>
+#include <cmath>
+#include <gtest/gtest.h>
+
+namespace unitTestComparators {
+
+/**
+ * @brief Format a scalar relative-comparison failure for GoogleTest.
+ * @param firstExpression Source expression for first.
+ * @param secondExpression Source expression for second.
+ * @param toleranceExpression Source expression for tolerance.
+ * @param first Reference value, in the same units as second.
+ * @param second Value to compare.
+ * @param tolerance Finite, nonnegative relative tolerance (dimensionless).
+ * @return An assertion result with the operands and tolerance on failure.
+ */
+static inline ::testing::AssertionResult
+scalarNearRel(const char* firstExpression,
+              const char* secondExpression,
+              const char* toleranceExpression,
+              double first,
+              double second,
+              double tolerance)
+{
+    if (isEqualRel(first, second, tolerance)) {
+        return ::testing::AssertionSuccess();
+    }
+    return ::testing::AssertionFailure()
+           << "Relative comparison failed: " << firstExpression << " = " << first << ", " << secondExpression << " = "
+           << second << ", " << toleranceExpression << " = " << tolerance
+           << ". Required: abs(first - second) / abs(first) <= tolerance; a zero reference or zero tolerance "
+              "requires exact equality. Values must be finite and tolerance must be finite and nonnegative.";
+}
+
+/**
+ * @brief Compare three finite vector components and format the first failure.
+ * @param firstExpression Source expression for first.
+ * @param secondExpression Source expression for second.
+ * @param toleranceExpression Source expression for tolerance.
+ * @param first Reference vector with three readable components.
+ * @param second Vector with three readable components, in the same units as first.
+ * @param tolerance Finite, nonnegative tolerance; dimensionless for relative comparisons.
+ * @tparam relative Whether to divide each component error by the Euclidean norm of first.
+ * @return An assertion result including both vectors and the failing component on failure.
+ * @note A zero reference vector or zero tolerance requires exact equality. NaN and
+ * infinity are rejected, including equal infinities. Absolute comparisons use the
+ * vector's units and check each component independently.
+ */
+template<bool relative>
+inline ::testing::AssertionResult
+vector3Near(const char* firstExpression,
+            const char* secondExpression,
+            const char* toleranceExpression,
+            const double* first,
+            const double* second,
+            double tolerance)
+{
+    if (!std::isfinite(tolerance) || tolerance < 0.0) {
+        return ::testing::AssertionFailure()
+               << toleranceExpression << " = " << tolerance << "; tolerance must be finite and nonnegative.";
+    }
+    for (int i = 0; i < 3; ++i) {
+        if (!std::isfinite(first[i]) || !std::isfinite(second[i])) {
+            return ::testing::AssertionFailure()
+                   << "Non-finite vector component " << i << ": " << firstExpression << "[" << i << "] = " << first[i]
+                   << ", " << secondExpression << "[" << i << "] = " << second[i];
+        }
+    }
+
+    double scale = 1.0;      // [-] Absolute comparisons do not normalize the error.
+    double scaledNorm = 1.0; // [-]
+    if (relative) {
+        scale = std::hypot(std::hypot(first[0], first[1]), first[2]);
+        if (!std::isfinite(scale) || std::fpclassify(scale) == FP_SUBNORMAL) {
+            // Keep the norm factored to avoid overflow and rounding in the subnormal range.
+            scale = std::max({ std::fabs(first[0]), std::fabs(first[1]), std::fabs(first[2]) });
+            scaledNorm = std::hypot(std::hypot(first[0] / scale, first[1] / scale), first[2] / scale);
+        }
+    }
+    for (int i = 0; i < 3; ++i) {
+        const double difference = std::fabs(first[i] - second[i]);
+        double error = scale == 0.0 ? difference
+                                    : (std::isfinite(difference) ? difference / scale
+                                                                 : std::fabs(first[i] / scale - second[i] / scale)) /
+                                        scaledNorm;
+        if (std::isinf(error) && std::isfinite(difference) && scaledNorm > 1.0) {
+            // Dividing by a tiny scale can overflow before the scaled norm reduces the result.
+            error = (difference / scaledNorm) / scale;
+        }
+        const bool equal = (scale == 0.0 || tolerance == 0.0) ? first[i] == second[i] : error <= tolerance;
+        if (!equal) {
+            return ::testing::AssertionFailure()
+                   << (relative ? "Relative" : "Absolute") << " vector comparison failed at component " << i << ": "
+                   << firstExpression << " = [" << first[0] << ", " << first[1] << ", " << first[2] << "], "
+                   << secondExpression << " = [" << second[0] << ", " << second[1] << ", " << second[2] << "], "
+                   << toleranceExpression << " = " << tolerance << ", component error = " << error
+                   << (relative ? ". Errors are normalized by norm(first); a zero reference requires exact equality."
+                                : ". Errors are absolute component differences.");
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
+} // namespace unitTestComparators
+
+/**
+ * @brief Nonfatal scalar assertion using abs(first - second) / abs(first) <= tolerance.
+ * @param first Finite reference scalar.
+ * @param second Finite scalar in the same units as first.
+ * @param tolerance Finite, nonnegative dimensionless relative tolerance.
+ * @note A zero reference or zero tolerance requires exact equality. Each argument
+ * is evaluated once. A diagnostic can be appended with the stream operator.
+ */
+#define EXPECT_NEAR_REL(first, second, tolerance)                                                                      \
+    EXPECT_PRED_FORMAT3(::unitTestComparators::scalarNearRel, first, second, tolerance)
+
+/**
+ * @brief Nonfatal assertion that each of three component errors is at most tolerance.
+ * @param first Pointer or array containing three finite reference components.
+ * @param second Pointer or array containing three finite components in the same units as first.
+ * @param tolerance Finite, nonnegative absolute tolerance, in the vector's units.
+ * @note Each argument is evaluated once. A diagnostic can be appended with the stream operator.
+ */
+#define EXPECT_VECTOR3_NEAR(first, second, tolerance)                                                                  \
+    EXPECT_PRED_FORMAT3(::unitTestComparators::vector3Near<false>, first, second, tolerance)
+
+/**
+ * @brief Nonfatal assertion that each component error / norm(first) is at most tolerance.
+ * @param first Pointer or array containing three finite reference components.
+ * @param second Pointer or array containing three finite components in the same units as first.
+ * @param tolerance Finite, nonnegative dimensionless relative tolerance.
+ * @note A zero reference vector or zero tolerance requires exact equality. Each argument
+ * is evaluated once. A diagnostic can be appended with the stream operator.
+ */
+#define EXPECT_VECTOR3_NEAR_REL(first, second, tolerance)                                                              \
+    EXPECT_PRED_FORMAT3(::unitTestComparators::vector3Near<true>, first, second, tolerance)
+
+#endif // __cplusplus
+
+#endif // UNITTESTCOMPARATORS_H


### PR DESCRIPTION
* **Tickets addressed:** #329
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description

Adds `EXPECT_NEAR_REL`, `EXPECT_VECTOR3_NEAR`, and `EXPECT_VECTOR3_NEAR_REL` with diagnostic messages showing comparison values, tolerances, and failing vector components.

Relative comparisons preserve the existing convention of using the first operand as the reference. The assertions reject non-finite operands and invalid tolerances, require exact equality for zero references, and handle subnormal values and intermediate overflow. Shared scalar predicates receive the same input validation, while legacy vector utility functions retain their existing behavior.

The three commits contain:
1. Assertion implementations and regression tests, including C compatibility and header linkage checks.
2. Migration of orbital-motion assertions, preserving existing tolerances.
3. Release notes and known-issues documentation.

## Verification

- All 43 targeted GoogleTest cases passed, including new comparator tests and migrated orbital-motion tests.
- All 6 legacy C self-check tests passed.
- Regression tests reproduced incorrect subnormal comparison results before the fix and passed afterward.
- An additional numerical probe matched 31,750 cases against a 100-digit reference calculation, with no undefined-behavior sanitizer findings.
- Formatting, whitespace, and focused Doxygen/Breathe/Sphinx documentation checks passed.

Validation was performed on macOS. A full clean build, the full test suite, and Windows/Linux validation remain outstanding.

## Documentation

Added Doxygen documentation for the comparison helpers and assertion macros, including tolerance conventions, zero-reference behavior, and argument evaluation.

Updated `bskKnownIssues.rst` and added the `329-gtest-comparators.rst` release-note snippet.

## Future work

Additional C++ tests can adopt these assertions as they are maintained. Changes to legacy vector comparison utilities are outside this PR’s scope.